### PR TITLE
Fix inconsistent connectivity setup behavior

### DIFF
--- a/client/src/app/connectivity/azure/page.tsx
+++ b/client/src/app/connectivity/azure/page.tsx
@@ -36,6 +36,8 @@ import {
   useUpdateSystemSetting,
 } from "@/hooks/use-settings";
 import { useAdvancedSettingsValidation } from "@/hooks/use-settings-validation";
+import { useServiceTesting } from "@/hooks/use-service-testing";
+import { TestResultsPanel } from "@/components/TestResultsPanel";
 import {
   Database,
   CheckCircle,
@@ -103,7 +105,6 @@ const STATUS_VARIANTS = {
 
 export default function AzureSettingsPage() {
   const { formatDateTime } = useFormattedDate();
-  const [isTestingConnection, setIsTestingConnection] = useState(false);
   const [showConnectionString, setShowConnectionString] = useState(false);
   const [settings, setSettings] = useState<Record<string, SystemSettingsInfo>>(
     {},
@@ -132,96 +133,29 @@ export default function AzureSettingsPage() {
     mode: "onChange",
   });
 
-  // Watch form values for real-time validation
+  // Watch form values
   const formValues = form.watch();
-  const [debouncedValues, setDebouncedValues] = useState(formValues);
-  const [autoSaveStatus, setAutoSaveStatus] = useState<
-    "idle" | "saving" | "saved" | "error"
-  >("idle");
 
-  // Debounce form values for validation
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebouncedValues(formValues);
-    }, 500);
-    return () => clearTimeout(timer);
-  }, [formValues]);
-
-  // Auto-save functionality with debouncing
-  useEffect(() => {
-    if (!form.formState.isValid || !debouncedValues.connectionString) {
-      return;
-    }
-
-    // Only auto-save if the connection string has actually changed from the saved value
-    const currentSavedValue = settings.connection_string?.value || "";
-    if (debouncedValues.connectionString === currentSavedValue) {
-      return;
-    }
-
-    // Auto-save after debounce delay
-    const autoSaveTimer = setTimeout(async () => {
-      try {
-        setAutoSaveStatus("saving");
-
-        // Save or update connection string setting (encrypted)
-        if (settings.connection_string) {
-          await updateSetting.mutateAsync({
-            id: settings.connection_string.id,
-            setting: { value: debouncedValues.connectionString },
-          });
-        } else {
-          await createSetting.mutateAsync({
-            category: "azure",
-            key: "connection_string",
-            value: debouncedValues.connectionString,
-            isEncrypted: true,
-          });
-        }
-
-        setAutoSaveStatus("saved");
-        toast.success("Azure Storage settings auto-saved successfully");
-
-        // Clear saved status after a short delay
-        setTimeout(() => {
-          setAutoSaveStatus("idle");
-        }, 2000);
-      } catch (error) {
-        setAutoSaveStatus("error");
-        console.error("Auto-save failed:", error);
-        toast.error(`Auto-save failed: ${(error as Error).message}`);
-
-        // Clear error status after a delay
-        setTimeout(() => {
-          setAutoSaveStatus("idle");
-        }, 3000);
-      }
-    }, 1000); // 1 second delay for auto-save
-
-    return () => clearTimeout(autoSaveTimer);
-  }, [
-    debouncedValues.connectionString,
-    form.formState.isValid,
-    settings.connection_string,
-    updateSetting,
-    createSetting,
-  ]);
-
-  // Advanced validation with real-time connectivity testing
-  const validation = useAdvancedSettingsValidation(
-    "azure",
-    form.formState.isValid ? debouncedValues : undefined,
-    {
-      enabled: true, // Always enable connectivity monitoring
-      debounceDelay: 500,
-      onValidationSuccess: () => {
-        toast.success("Azure Storage connection validated successfully");
-      },
-      onValidationError: (_, error) => {
-        toast.error(`Azure Storage validation failed: ${error.message}`);
-      },
+  // Service testing hook for test-only validation
+  const serviceTesting = useServiceTesting("azure", {
+    onSuccess: () => {
+      toast.success("Azure Storage connection test successful");
     },
-  );
+    onError: (error) => {
+      toast.error(`Azure Storage test failed: ${error.message}`);
+    },
+  });
+
+  // Advanced validation for saved settings connectivity monitoring
+  const validation = useAdvancedSettingsValidation("azure", {
+    enabled: true,
+    onValidationSuccess: () => {
+      toast.success("Azure Storage connection validated successfully");
+    },
+    onValidationError: (_, error) => {
+      toast.error(`Azure Storage validation failed: ${error.message}`);
+    },
+  });
 
   // Update form when settings are loaded
   useEffect(() => {
@@ -259,18 +193,24 @@ export default function AzureSettingsPage() {
         });
       }
 
-      toast.success("Azure Storage settings saved successfully");
+      // Trigger immediate validation of saved settings
+      validation.validateManually();
+
+      toast.success("Azure Storage settings saved and connectivity check triggered");
     } catch (error) {
       toast.error(`Failed to save settings: ${(error as Error).message}`);
     }
   };
 
   const handleTestConnection = async () => {
-    setIsTestingConnection(true);
     try {
-      await validation.validateManually();
-    } finally {
-      setIsTestingConnection(false);
+      // Test connection with current form values (no database writes)
+      await serviceTesting.testConnection({
+        connection_string: formValues.connectionString,
+      });
+    } catch (error) {
+      // Error handling is done in the hook's onError callback
+      console.error("Test connection failed:", error);
     }
   };
 
@@ -480,52 +420,31 @@ export default function AzureSettingsPage() {
                       variant="outline"
                       disabled={
                         !form.formState.isValid ||
-                        isTestingConnection ||
-                        validation.isValidating
+                        serviceTesting.isTesting
                       }
                       onClick={handleTestConnection}
                     >
-                      {isTestingConnection || validation.isValidating ? (
+                      {serviceTesting.isTesting ? (
                         <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                       ) : (
                         <TestTube className="mr-2 h-4 w-4" />
                       )}
                       Test Connection
                     </Button>
-
-                    {/* Auto-save status indicator */}
-                    {autoSaveStatus !== "idle" && (
-                      <div className="flex items-center gap-2 text-sm">
-                        {autoSaveStatus === "saving" && (
-                          <>
-                            <Loader2 className="h-4 w-4 animate-spin text-blue-600" />
-                            <span className="text-blue-600">
-                              Auto-saving...
-                            </span>
-                          </>
-                        )}
-                        {autoSaveStatus === "saved" && (
-                          <>
-                            <CheckCircle className="h-4 w-4 text-green-600" />
-                            <span className="text-green-600">Auto-saved</span>
-                          </>
-                        )}
-                        {autoSaveStatus === "error" && (
-                          <>
-                            <XCircle className="h-4 w-4 text-red-600" />
-                            <span className="text-red-600">
-                              Auto-save failed
-                            </span>
-                          </>
-                        )}
-                      </div>
-                    )}
                   </div>
                 </form>
               </Form>
             )}
           </CardContent>
         </Card>
+
+        {/* Test Results Panel */}
+        <TestResultsPanel
+          testResults={serviceTesting.testResults}
+          isTesting={serviceTesting.isTesting}
+          onClearResults={serviceTesting.clearTestResults}
+          className="mt-6"
+        />
 
         {/* Status Panels - Two Column Layout */}
         <div className="grid gap-6 md:grid-cols-2 mt-6">
@@ -535,6 +454,9 @@ export default function AzureSettingsPage() {
               <CardTitle className="text-sm font-medium">
                 Connection Status
               </CardTitle>
+              <CardDescription className="text-xs">
+                Status of saved configuration (updated when settings are saved)
+              </CardDescription>
             </CardHeader>
             <CardContent>
               {isLoading && !latestConnectivity ? (

--- a/client/src/app/connectivity/cloudflare/page.tsx
+++ b/client/src/app/connectivity/cloudflare/page.tsx
@@ -126,33 +126,17 @@ export default function CloudflareSettingsPage() {
     mode: "onChange",
   });
 
-  // Watch form values for real-time validation
-  const formValues = form.watch();
-  const [debouncedValues, setDebouncedValues] = useState(formValues);
 
-  // Debounce form values for validation
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebouncedValues(formValues);
-    }, 500);
-    return () => clearTimeout(timer);
-  }, [formValues]);
-
-  // Advanced validation with real-time connectivity testing
-  const validation = useAdvancedSettingsValidation(
-    "cloudflare",
-    form.formState.isValid ? debouncedValues : undefined,
-    {
-      enabled: true, // Always enable connectivity monitoring
-      debounceDelay: 500,
-      onValidationSuccess: () => {
-        toast.success("Cloudflare connection validated successfully");
-      },
-      onValidationError: (_, error) => {
-        toast.error(`Cloudflare validation failed: ${error.message}`);
-      },
-    }
-  );
+  // Advanced validation for saved settings connectivity monitoring
+  const validation = useAdvancedSettingsValidation("cloudflare", {
+    enabled: true,
+    onValidationSuccess: () => {
+      toast.success("Cloudflare connection validated successfully");
+    },
+    onValidationError: (_, error) => {
+      toast.error(`Cloudflare validation failed: ${error.message}`);
+    },
+  });
 
   // Update form when settings are loaded
   useEffect(() => {

--- a/client/src/app/connectivity/docker/page.tsx
+++ b/client/src/app/connectivity/docker/page.tsx
@@ -100,33 +100,17 @@ export default function DockerSettingsPage() {
     mode: "onChange",
   });
 
-  // Watch form values for real-time validation
-  const formValues = form.watch();
-  const [debouncedValues, setDebouncedValues] = useState(formValues);
 
-  // Debounce form values for validation
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebouncedValues(formValues);
-    }, 500);
-    return () => clearTimeout(timer);
-  }, [formValues]);
-
-  // Advanced validation with real-time connectivity testing
-  const validation = useAdvancedSettingsValidation(
-    "docker",
-    form.formState.isValid ? debouncedValues : undefined,
-    {
-      enabled: form.formState.isValid,
-      debounceDelay: 500,
-      onValidationSuccess: () => {
-        toast.success("Docker connection validated successfully");
-      },
-      onValidationError: (_, error) => {
-        toast.error(`Docker validation failed: ${error.message}`);
-      },
+  // Advanced validation for saved settings connectivity monitoring
+  const validation = useAdvancedSettingsValidation("docker", {
+    enabled: true,
+    onValidationSuccess: () => {
+      toast.success("Docker connection validated successfully");
     },
-  );
+    onValidationError: (_, error) => {
+      toast.error(`Docker validation failed: ${error.message}`);
+    },
+  });
 
   // Update form when settings are loaded
   useEffect(() => {

--- a/client/src/components/TestResultsPanel.tsx
+++ b/client/src/components/TestResultsPanel.tsx
@@ -1,0 +1,246 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  CheckCircle,
+  XCircle,
+  AlertCircle,
+  Loader2,
+  TestTube,
+  X,
+} from "lucide-react";
+import { useFormattedDate } from "@/hooks/use-formatted-date";
+import { TestResult } from "@/hooks/use-service-testing";
+
+// ====================
+// Test Results Panel Props
+// ====================
+
+export interface TestResultsPanelProps {
+  testResults: TestResult | null;
+  isTesting: boolean;
+  onClearResults?: () => void;
+  className?: string;
+}
+
+// ====================
+// Status Icon Mapping
+// ====================
+
+const getStatusIcon = (isValid: boolean, isTesting: boolean) => {
+  if (isTesting) {
+    return <Loader2 className="h-5 w-5 animate-spin text-blue-600" />;
+  }
+
+  if (isValid) {
+    return <CheckCircle className="h-5 w-5 text-green-600" />;
+  }
+
+  return <XCircle className="h-5 w-5 text-red-600" />;
+};
+
+const getStatusBadge = (isValid: boolean, isTesting: boolean) => {
+  if (isTesting) {
+    return (
+      <Badge variant="outline" className="border-blue-200 text-blue-600">
+        Testing...
+      </Badge>
+    );
+  }
+
+  if (isValid) {
+    return (
+      <Badge variant="default" className="bg-green-100 text-green-800 border-green-200">
+        Passed
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge variant="destructive" className="bg-red-100 text-red-800 border-red-200">
+      Failed
+    </Badge>
+  );
+};
+
+const getStatusBackground = (isValid: boolean, isTesting: boolean) => {
+  if (isTesting) {
+    return "bg-blue-50 border-blue-200";
+  }
+
+  if (isValid) {
+    return "bg-green-50 border-green-200";
+  }
+
+  return "bg-red-50 border-red-200";
+};
+
+// ====================
+// Test Results Panel Component
+// ====================
+
+export function TestResultsPanel({
+  testResults,
+  isTesting,
+  onClearResults,
+  className = "",
+}: TestResultsPanelProps) {
+  const { formatDateTime } = useFormattedDate();
+
+  // Don't render if no test results and not currently testing
+  if (!testResults && !isTesting) {
+    return null;
+  }
+
+  const isValid = testResults?.isValid ?? false;
+  const hasResults = testResults !== null;
+
+  return (
+    <Card className={className}>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <TestTube className="h-4 w-4 text-muted-foreground" />
+            <CardTitle className="text-sm font-medium">
+              Test Results
+            </CardTitle>
+          </div>
+          {hasResults && onClearResults && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onClearResults}
+              className="h-auto p-1"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+        <CardDescription className="text-xs">
+          {isTesting
+            ? "Testing connection with current form values..."
+            : "Results from testing connection (not saved configuration)"}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isTesting ? (
+          // Loading state
+          <div className="p-4 rounded-md border bg-blue-50 border-blue-200">
+            <div className="flex items-center gap-2 mb-2">
+              <Loader2 className="h-5 w-5 animate-spin text-blue-600" />
+              <Badge variant="outline" className="border-blue-200 text-blue-600">
+                Testing...
+              </Badge>
+            </div>
+            <div className="text-sm text-muted-foreground">
+              Validating connection with current form values
+            </div>
+          </div>
+        ) : testResults ? (
+          // Test results
+          <div className={`p-4 rounded-md border ${getStatusBackground(isValid, false)}`}>
+            <div className="flex items-center gap-2 mb-2">
+              {getStatusIcon(isValid, false)}
+              {getStatusBadge(isValid, false)}
+            </div>
+
+            {/* Response Time */}
+            {testResults.responseTimeMs !== undefined && (
+              <div className="text-sm text-muted-foreground mb-1">
+                Response time: {testResults.responseTimeMs}ms
+              </div>
+            )}
+
+            {/* Test Time */}
+            <div className="text-xs text-muted-foreground mb-2">
+              Tested: {formatDateTime(testResults.testedAt)}
+            </div>
+
+            {/* Error Message */}
+            {!isValid && testResults.error && (
+              <div className="text-sm text-red-600 mt-2 p-2 bg-red-50 rounded border border-red-100">
+                <strong>Error:</strong> {testResults.error}
+                {testResults.errorCode && (
+                  <div className="text-xs mt-1 text-red-500">
+                    Code: {testResults.errorCode}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Success Metadata */}
+            {isValid && testResults.metadata && (
+              <div className="text-sm text-green-700 mt-2 p-2 bg-green-50 rounded border border-green-100">
+                <strong>Connection details validated successfully</strong>
+                {testResults.metadata.accountName && (
+                  <div className="text-xs mt-1">
+                    Account: {testResults.metadata.accountName}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Warning about test-only nature */}
+            <div className="mt-3 p-2 bg-amber-50 border border-amber-200 rounded">
+              <div className="flex items-start gap-2">
+                <AlertCircle className="h-4 w-4 text-amber-600 mt-0.5 flex-shrink-0" />
+                <div className="text-xs text-amber-700">
+                  <strong>Test Only:</strong> These results are from testing your current form values.
+                  Use the Save button to persist settings and update the actual connection status.
+                </div>
+              </div>
+            </div>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ====================
+// Compact Test Results Panel
+// ====================
+
+export interface CompactTestResultsPanelProps {
+  testResults: TestResult | null;
+  isTesting: boolean;
+  className?: string;
+}
+
+export function CompactTestResultsPanel({
+  testResults,
+  isTesting,
+  className = "",
+}: CompactTestResultsPanelProps) {
+  // Don't render if no test results and not currently testing
+  if (!testResults && !isTesting) {
+    return null;
+  }
+
+  const isValid = testResults?.isValid ?? false;
+
+  return (
+    <div className={`flex items-center gap-2 text-sm ${className}`}>
+      {isTesting ? (
+        <>
+          <Loader2 className="h-4 w-4 animate-spin text-blue-600" />
+          <span className="text-blue-600">Testing connection...</span>
+        </>
+      ) : testResults ? (
+        <>
+          {getStatusIcon(isValid, false)}
+          <span className={isValid ? "text-green-600" : "text-red-600"}>
+            Test {isValid ? "passed" : "failed"}
+            {testResults.responseTimeMs && ` (${testResults.responseTimeMs}ms)`}
+          </span>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/client/src/hooks/use-service-testing.ts
+++ b/client/src/hooks/use-service-testing.ts
@@ -1,0 +1,190 @@
+import { useState, useCallback } from "react";
+import { useMutation } from "@tanstack/react-query";
+import {
+  SettingsCategory,
+  TestServiceResponse,
+} from "@mini-infra/types";
+
+// Generate correlation ID for debugging
+function generateCorrelationId(): string {
+  return `test-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+}
+
+// ====================
+// Test Service API Function
+// ====================
+
+async function testService(
+  service: SettingsCategory,
+  settings: Record<string, string>,
+  correlationId?: string,
+): Promise<TestServiceResponse> {
+  const response = await fetch(`/api/settings/test/${service}`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      ...(correlationId && { "X-Correlation-ID": correlationId }),
+    },
+    body: JSON.stringify({ settings }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to test ${service}: ${response.statusText}`);
+  }
+
+  const data: TestServiceResponse = await response.json();
+
+  if (!data.success) {
+    throw new Error(data.message || `Failed to test ${service}`);
+  }
+
+  return data;
+}
+
+// ====================
+// Test Result Types
+// ====================
+
+export interface TestResult {
+  service: SettingsCategory;
+  isValid: boolean;
+  responseTimeMs: number;
+  error?: string;
+  errorCode?: string;
+  metadata?: Record<string, any>;
+  testedAt: string;
+}
+
+// ====================
+// Service Testing Hook Options
+// ====================
+
+export interface UseServiceTestingOptions {
+  onSuccess?: (result: TestResult) => void;
+  onError?: (error: Error) => void;
+}
+
+// ====================
+// Service Testing Hook
+// ====================
+
+export function useServiceTesting(
+  service: SettingsCategory,
+  options: UseServiceTestingOptions = {}
+) {
+  const [testResults, setTestResults] = useState<TestResult | null>(null);
+  const correlationId = generateCorrelationId();
+
+  const testMutation = useMutation({
+    mutationFn: (settings: Record<string, string>) =>
+      testService(service, settings, correlationId),
+    onSuccess: (data) => {
+      const result: TestResult = {
+        service: data.data.service,
+        isValid: data.data.isValid,
+        responseTimeMs: data.data.responseTimeMs,
+        error: data.data.error,
+        errorCode: data.data.errorCode,
+        metadata: data.data.metadata,
+        testedAt: data.data.testedAt,
+      };
+
+      setTestResults(result);
+      options.onSuccess?.(result);
+    },
+    onError: (error) => {
+      // Create a failed test result for consistent UI state
+      const failedResult: TestResult = {
+        service,
+        isValid: false,
+        responseTimeMs: 0,
+        error: error instanceof Error ? error.message : "Unknown test error",
+        errorCode: "TEST_ERROR",
+        testedAt: new Date().toISOString(),
+      };
+
+      setTestResults(failedResult);
+      options.onError?.(error as Error);
+    },
+  });
+
+  const testConnection = useCallback(
+    async (settings: Record<string, string>) => {
+      try {
+        const result = await testMutation.mutateAsync(settings);
+        return result;
+      } catch (error) {
+        throw error;
+      }
+    },
+    [testMutation]
+  );
+
+  const clearTestResults = useCallback(() => {
+    setTestResults(null);
+  }, []);
+
+  const hasTestResults = testResults !== null;
+  const isTestingSuccessful = testResults?.isValid === true;
+  const isTestingFailed = testResults?.isValid === false;
+
+  return {
+    // Test results state
+    testResults,
+    hasTestResults,
+    isTestingSuccessful,
+    isTestingFailed,
+
+    // Test execution state
+    isTesting: testMutation.isPending,
+    testError: testMutation.error,
+
+    // Actions
+    testConnection,
+    clearTestResults,
+
+    // Raw mutation for advanced usage
+    testMutation,
+  };
+}
+
+// ====================
+// Helper Hook for Form Integration
+// ====================
+
+export interface UseFormTestingOptions extends UseServiceTestingOptions {
+  clearOnFormChange?: boolean;
+}
+
+export function useFormTesting(
+  service: SettingsCategory,
+  formValues: Record<string, string>,
+  options: UseFormTestingOptions = {}
+) {
+  const { clearOnFormChange = true, ...serviceTestingOptions } = options;
+
+  const serviceTestingHook = useServiceTesting(service, serviceTestingOptions);
+
+  // Clear test results when form values change (if enabled)
+  useState(() => {
+    if (clearOnFormChange) {
+      serviceTestingHook.clearTestResults();
+    }
+  });
+
+  const testCurrentFormValues = useCallback(async () => {
+    return serviceTestingHook.testConnection(formValues);
+  }, [serviceTestingHook, formValues]);
+
+  return {
+    ...serviceTestingHook,
+    testCurrentFormValues,
+  };
+}
+
+// ====================
+// Type Exports
+// ====================
+
+export type { TestServiceResponse };

--- a/client/src/hooks/use-settings-validation.ts
+++ b/client/src/hooks/use-settings-validation.ts
@@ -146,47 +146,26 @@ export function useConnectivityStatus(
 }
 
 // ====================
-// Settings Validator Hook with Debouncing
+// Settings Validator Hook (No Auto-Validation)
 // ====================
 
 export interface UseSettingsValidatorOptions {
   enabled?: boolean;
-  debounceDelay?: number;
   retry?: number | boolean | ((failureCount: number, error: Error) => boolean);
 }
 
 export function useSettingsValidator(
   service: SettingsCategory,
-  settings: Record<string, string> | undefined,
   options: UseSettingsValidatorOptions = {},
 ) {
-  const { enabled = true, debounceDelay = 500, retry = 1 } = options;
-
-  const [debouncedSettings, setDebouncedSettings] = useState(settings);
-  const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
+  const { enabled = true, retry = 1 } = options;
   const correlationId = generateCorrelationId();
 
-  // Debounce settings changes
-  useEffect(() => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-    }
-
-    timeoutRef.current = setTimeout(() => {
-      setDebouncedSettings(settings);
-    }, debounceDelay);
-
-    return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-    };
-  }, [settings, debounceDelay]);
-
+  // Only validate saved settings (no automatic validation of form changes)
   return useQuery({
-    queryKey: ["settingsValidator", service, debouncedSettings],
-    queryFn: () => validateService(service, debouncedSettings, correlationId),
-    enabled: enabled && !!service && !!debouncedSettings,
+    queryKey: ["settingsValidator", service],
+    queryFn: () => validateService(service, undefined, correlationId), // undefined = use saved settings
+    enabled: enabled && !!service,
     retry:
       typeof retry === "function"
         ? retry
@@ -464,7 +443,6 @@ export function useValidationRecovery(
 
 export interface UseAdvancedSettingsValidationOptions {
   enabled?: boolean;
-  debounceDelay?: number;
   pollingInterval?: number;
   maxRetries?: number;
   onValidationSuccess?: (
@@ -477,12 +455,10 @@ export interface UseAdvancedSettingsValidationOptions {
 
 export function useAdvancedSettingsValidation(
   service: SettingsCategory,
-  settings: Record<string, string> | undefined,
   options: UseAdvancedSettingsValidationOptions = {},
 ) {
   const {
     enabled = true,
-    debounceDelay = 500,
     pollingInterval = 30000,
     maxRetries = 3,
     onValidationSuccess,
@@ -490,10 +466,9 @@ export function useAdvancedSettingsValidation(
     onMaxRetriesExceeded,
   } = options;
 
-  // Individual hooks
-  const validator = useSettingsValidator(service, settings, {
+  // Individual hooks - no more automatic validation on form changes
+  const validator = useSettingsValidator(service, {
     enabled,
-    debounceDelay,
     retry: false, // Handle retries manually
   });
 
@@ -525,21 +500,18 @@ export function useAdvancedSettingsValidation(
 
   const optimistic = useOptimisticValidation();
 
-  // Manual validation with retry logic
+  // Manual validation with retry logic - validates saved settings only
   const validateWithRetry = useCallback(
-    async (
-      serviceToValidate: SettingsCategory,
-      settingsToValidate: Record<string, string>,
-    ) => {
-      optimistic.startValidation(serviceToValidate, settingsToValidate);
+    async (serviceToValidate: SettingsCategory) => {
+      optimistic.startValidation(serviceToValidate, {});
 
       try {
         const result = await validateService.mutateAsync({
           service: serviceToValidate,
-          settings: settingsToValidate,
+          settings: undefined, // Use saved settings
         });
 
-        optimistic.finishValidation(serviceToValidate, settingsToValidate, {
+        optimistic.finishValidation(serviceToValidate, {}, {
           isValid: result.data.isValid,
           message: result.message,
           responseTimeMs: result.data.responseTimeMs,
@@ -550,13 +522,13 @@ export function useAdvancedSettingsValidation(
       } catch (error) {
         const shouldRetry = recovery.retryValidation(
           serviceToValidate,
-          settingsToValidate,
-          () => validateWithRetry(serviceToValidate, settingsToValidate),
+          {},
+          () => validateWithRetry(serviceToValidate),
           error as Error,
         );
 
         if (!shouldRetry) {
-          optimistic.finishValidation(serviceToValidate, settingsToValidate, {
+          optimistic.finishValidation(serviceToValidate, {}, {
             isValid: false,
             message: (error as Error).message,
           });
@@ -575,9 +547,7 @@ export function useAdvancedSettingsValidation(
 
     // Actions
     validateManually: () => {
-      if (settings) {
-        validateWithRetry(service, settings);
-      }
+      validateWithRetry(service);
     },
     resetRetries: () => recovery.resetRetries(service),
 

--- a/lib/types/settings.ts
+++ b/lib/types/settings.ts
@@ -263,3 +263,43 @@ export interface ValidateServiceResponse {
   timestamp: string;
   requestId?: string;
 }
+
+// ====================
+// Test-Only Validation API Types
+// ====================
+
+export interface TestServiceRequest {
+  settings: Record<string, string>;
+}
+
+export interface TestServiceResponse {
+  success: boolean;
+  data: {
+    service: SettingsCategory;
+    isValid: boolean;
+    responseTimeMs: number;
+    error?: string;
+    errorCode?: string;
+    metadata?: Record<string, any>;
+    testedAt: string;
+  };
+  message: string;
+  timestamp: string;
+  requestId?: string;
+}
+
+// ====================
+// Save and Validate API Types
+// ====================
+
+export interface SaveAndValidateResponse {
+  success: boolean;
+  data: {
+    saved: boolean;
+    validated: boolean;
+    connectivity?: ConnectivityStatusInfo;
+  };
+  message: string;
+  timestamp: string;
+  requestId?: string;
+}

--- a/server/src/lib/connectivity-scheduler.ts
+++ b/server/src/lib/connectivity-scheduler.ts
@@ -401,6 +401,93 @@ export class ConnectivityScheduler {
   }
 
   /**
+   * Perform immediate health check for a specific service and store results in database
+   * This method is designed to be called after saving settings to get immediate feedback
+   * @param service - The service to check
+   * @returns Promise that resolves when health check is complete and stored
+   */
+  async performImmediateHealthCheck(service: SettingsCategory): Promise<void> {
+    const monitor = this.monitors.get(service);
+    if (!monitor) {
+      throw new Error(`Unsupported service: ${service}`);
+    }
+
+    logger.info({ service }, "Performing immediate health check with database storage");
+
+    try {
+      // Get the service instance for validation
+      const serviceInstance = this.factory.create({ category: service });
+
+      // Perform validation
+      const startTime = Date.now();
+      const result = await serviceInstance.validate();
+      const responseTime = Date.now() - startTime;
+
+      // Store results in ConnectivityStatus database
+      await this.prisma.connectivityStatus.create({
+        data: {
+          service,
+          status: result.isValid ? "connected" : "failed",
+          responseTimeMs: responseTime,
+          errorMessage: result.isValid ? null : result.message,
+          errorCode: result.errorCode || null,
+          lastSuccessfulAt: result.isValid ? new Date() : null,
+          checkInitiatedBy: "system", // Mark as system-initiated immediate check
+          metadata: result.metadata ? JSON.stringify(result.metadata) : null,
+        },
+      });
+
+      // Update SystemSettings validation status
+      await this.prisma.systemSettings.updateMany({
+        where: {
+          category: service,
+          isActive: true,
+        },
+        data: {
+          validationStatus: result.isValid ? "valid" : "invalid",
+          validationMessage: result.isValid ? null : result.message,
+          lastValidatedAt: new Date(),
+        },
+      });
+
+      logger.info(
+        {
+          service,
+          isValid: result.isValid,
+          responseTimeMs: responseTime,
+          errorCode: result.errorCode,
+        },
+        "Immediate health check completed and stored in database",
+      );
+    } catch (error) {
+      const responseTime = Date.now() - Date.now(); // Fallback time calculation
+      const errorMessage = error instanceof Error ? error.message : "Unknown validation error";
+
+      // Store failed validation in ConnectivityStatus database
+      await this.prisma.connectivityStatus.create({
+        data: {
+          service,
+          status: "error",
+          responseTimeMs: responseTime,
+          errorMessage,
+          errorCode: "IMMEDIATE_VALIDATION_ERROR",
+          checkInitiatedBy: "system",
+        },
+      });
+
+      logger.error(
+        {
+          error,
+          service,
+        },
+        "Immediate health check failed with error",
+      );
+
+      throw error;
+    }
+  }
+
+  /**
    * Get the current status of all services
    * @returns Map of service statuses
    */

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -11,6 +11,7 @@ const logger = appLogger();
 import { requireSessionOrApiKey, getAuthenticatedUser } from "../middleware/auth";
 import prisma from "../lib/prisma";
 import { ConfigurationServiceFactory } from "../services/configuration-factory";
+import { getConnectivityScheduler } from "../server";
 import {
   CreateSettingRequest,
   UpdateSettingRequest,
@@ -24,6 +25,8 @@ import {
   SettingsSortOptions,
   ValidateServiceRequest,
   ValidateServiceResponse,
+  TestServiceRequest,
+  TestServiceResponse,
   ConnectivityStatus,
   ConnectivityStatusInfo,
   ConnectivityStatusListResponse,
@@ -639,6 +642,173 @@ router.get("/connectivity", requireSessionOrApiKey, (async (
 }) as RequestHandler);
 
 /**
+ * POST /api/settings/test/:service - Test service connectivity without database persistence
+ */
+router.post("/test/:service", requireSessionOrApiKey, (async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const requestId = req.headers["x-request-id"] as string;
+  const user = getAuthenticatedUser(req);
+  const userId = user?.id;
+  const service = req.params.service;
+
+  logger.debug(
+    {
+      requestId,
+      userId,
+      service,
+    },
+    "Service test requested (read-only)",
+  );
+
+  try {
+    if (!user || !userId) {
+      return res.status(401).json({
+        error: "Unauthorized",
+        message: "User authentication required",
+        timestamp: new Date().toISOString(),
+        requestId,
+      });
+    }
+
+    // Validate service parameter
+    if (
+      ![
+        "docker",
+        "cloudflare",
+        "azure",
+        "postgres",
+        "system",
+        "deployments",
+      ].includes(service)
+    ) {
+      return res.status(400).json({
+        error: "Bad Request",
+        message: `Invalid service '${service}'. Must be one of: docker, cloudflare, azure, postgres, system, deployments`,
+        timestamp: new Date().toISOString(),
+        requestId,
+      });
+    }
+
+    // Validate request body
+    const testServiceSchema = z.object({
+      settings: z.record(z.string(), z.string()),
+    });
+
+    const bodyValidation = testServiceSchema.safeParse(req.body);
+    if (!bodyValidation.success) {
+      logger.warn(
+        {
+          requestId,
+          userId,
+          service,
+          validationErrors: bodyValidation.error.issues,
+        },
+        "Invalid request body for service test",
+      );
+
+      return res.status(400).json({
+        error: "Bad Request",
+        message: "Invalid request data",
+        details: bodyValidation.error.issues,
+        timestamp: new Date().toISOString(),
+        requestId,
+      });
+    }
+
+    const { settings } = bodyValidation.data;
+
+    // Create a temporary configuration service with the provided settings
+    // Note: This creates a service instance with test settings, not saved ones
+    const configService = configFactory.create({
+      category: service as SettingsCategory,
+    });
+
+    // Override the service's get method temporarily to use test settings
+    const originalGet = configService.get.bind(configService);
+    configService.get = async (key: string) => {
+      return settings[key] || null;
+    };
+
+    // Perform validation with timeout protection
+    const startTime = Date.now();
+    const validationResult = (await raceWithTimeout(
+      configService.validate(),
+      30000,
+      "Test validation timeout",
+    )) as any;
+
+    const responseTime = Date.now() - startTime;
+
+    // Restore original get method
+    configService.get = originalGet;
+
+    logger.debug(
+      {
+        requestId,
+        userId,
+        service,
+        isValid: validationResult.isValid,
+        responseTimeMs: responseTime,
+        errorCode: validationResult.errorCode,
+      },
+      "Service test completed (no database storage)",
+    );
+
+    const response: TestServiceResponse = {
+      success: true,
+      data: {
+        service: service as SettingsCategory,
+        isValid: validationResult.isValid,
+        responseTimeMs: responseTime,
+        error: validationResult.isValid ? undefined : validationResult.message,
+        errorCode: validationResult.errorCode,
+        metadata: validationResult.metadata,
+        testedAt: new Date().toISOString(),
+      },
+      message: validationResult.isValid
+        ? `${service} service test successful (read-only)`
+        : `${service} service test failed (read-only)`,
+      timestamp: new Date().toISOString(),
+      requestId,
+    };
+
+    res.json(response);
+  } catch (error) {
+    const responseTime = Date.now() - (Date.now() - 30000); // Fallback time calculation
+
+    logger.error(
+      {
+        error,
+        requestId,
+        userId,
+        service,
+      },
+      "Service test failed with error",
+    );
+
+    const response: TestServiceResponse = {
+      success: false,
+      data: {
+        service: service as SettingsCategory,
+        isValid: false,
+        responseTimeMs: responseTime,
+        error: error instanceof Error ? error.message : "Unknown test error",
+        errorCode: "TEST_ERROR",
+        testedAt: new Date().toISOString(),
+      },
+      message: `${service} service test failed`,
+      timestamp: new Date().toISOString(),
+      requestId,
+    };
+
+    res.status(500).json(response);
+  }
+}) as RequestHandler);
+
+/**
  * POST /api/settings/validate/:service - Validate external service connectivity
  */
 router.post("/validate/:service", requireSessionOrApiKey, (async (
@@ -762,6 +932,43 @@ router.post("/validate/:service", requireSessionOrApiKey, (async (
           lastValidatedAt: new Date(),
         },
       });
+
+      // Trigger immediate health check to update connectivity status
+      try {
+        const scheduler = getConnectivityScheduler();
+        if (scheduler) {
+          // Use the new immediate health check method for faster feedback
+          await scheduler.performImmediateHealthCheck(service as SettingsCategory);
+          logger.info(
+            {
+              requestId,
+              userId,
+              service,
+            },
+            "Immediate health check triggered after validation",
+          );
+        } else {
+          logger.warn(
+            {
+              requestId,
+              userId,
+              service,
+            },
+            "Connectivity scheduler not available for immediate health check",
+          );
+        }
+      } catch (schedulerError) {
+        // Log but don't fail the validation if scheduler fails
+        logger.error(
+          {
+            error: schedulerError,
+            requestId,
+            userId,
+            service,
+          },
+          "Failed to trigger immediate health check after validation",
+        );
+      }
     }
 
     logger.debug(

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -30,6 +30,11 @@ let backupScheduler: BackupSchedulerService | null = null;
 let restoreExecutorService: RestoreExecutorService | null = null;
 let postgresDatabaseHealthScheduler: PostgresDatabaseHealthScheduler | null = null;
 
+// Export function to get connectivity scheduler instance
+export function getConnectivityScheduler(): ConnectivityScheduler | null {
+  return connectivityScheduler;
+}
+
 // Initialize Docker connection and connectivity scheduler before starting server
 const initializeServices = async () => {
   try {


### PR DESCRIPTION
## Summary

Fixes GitHub issue #10 - Resolves inconsistent connectivity status behavior during initial service setup by separating test-only validation from saved configuration validation.

**Problem**: Connectivity setup pages showed unpredictable status changes due to mixed timing between test validation, auto-save, and background health checks.

**Solution**: Clear separation of concerns with distinct test vs. save behaviors.

## Changes

### 🔧 Backend Enhancements
- **New test-only endpoint**: `POST /api/settings/test/:service` for read-only validation without database writes
- **Enhanced ConnectivityScheduler**: Added `performImmediateHealthCheck()` method for instant feedback after saving settings
- **Modified validation endpoint**: Now triggers immediate health checks when settings are saved
- **New TypeScript types**: `TestServiceRequest`, `TestServiceResponse` for type-safe test-only operations

### 🎨 Frontend Improvements
- **New `useServiceTesting` hook**: Manages test-only validation with no database persistence
- **New `TestResultsPanel` component**: Displays temporary test results separately from saved configuration status
- **Updated Azure connectivity page**: Demonstrates new behavior with clear test/save separation
- **Removed auto-save**: Eliminates timing conflicts that caused inconsistent status
- **Modified `useAdvancedSettingsValidation`**: Now only validates saved settings, no real-time form validation

## New User Experience

### Before
- ❌ Test Connection creates database records → inconsistent status
- ❌ Save doesn't trigger immediate validation → delayed feedback  
- ❌ Auto-save + background timing → unpredictable status changes

### After  
- ✅ **Test Connection**: Read-only validation, results in separate panel, no database writes
- ✅ **Save Settings**: Saves configuration AND triggers immediate health check for instant feedback
- ✅ **Clear status separation**: Test results vs. saved configuration status are distinct
- ✅ **Consistent behavior**: Status always reflects actual saved configuration state

## Test Plan

- [ ] Test Connection button shows results in temporary panel without affecting connectivity status
- [ ] Save button immediately updates connectivity status after saving settings
- [ ] No more timing-based status inconsistencies during initial setup
- [ ] Clear visual separation between test results and saved configuration status
- [ ] Background connectivity monitoring continues to work as expected

## Screenshots

The Azure connectivity page now shows:
1. **Test Results Panel** - Temporary test-only validation results
2. **Connection Status Panel** - Actual saved configuration connectivity status

Resolves #10

🤖 Generated with [Claude Code](https://claude.ai/code)