### PR TITLE
Implement Stage 3: Fix blue-green deployment state machine event integration

### DIFF
--- a/server/src/services/haproxy/blue-green-deployment-state-machine.ts
+++ b/server/src/services/haproxy/blue-green-deployment-state-machine.ts
@@ -87,8 +87,8 @@ type BlueGreenDeploymentEvent =
     | { type: 'HEALTH_CHECK_TIMEOUT' }
 
     // Traffic management events
-    | { type: 'TRAFFIC_OPENED' }
-    | { type: 'TRAFFIC_OPEN_FAILED'; error: string }
+    | { type: 'TRAFFIC_ENABLED' }
+    | { type: 'TRAFFIC_ENABLE_FAILED'; error: string }
     | { type: 'TRAFFIC_VALIDATED' }
     | { type: 'VALIDATION_FAILED'; error: string }
 
@@ -200,7 +200,16 @@ export const blueGreenDeploymentMachine = setup({
 
         // Rollback actions
         restoreBlueTraffic: ({ context, self }) => {
-            enableTraffic.execute(context, (event) => self.send(event)); // Open traffic back to the blue container
+            enableTraffic.execute(context, (event) => {
+                // Map the standard traffic events to rollback events
+                if (event.type === 'TRAFFIC_ENABLED') {
+                    self.send({ type: 'ROLLBACK_BLUE_TRAFFIC_RESTORED' });
+                } else if (event.type === 'TRAFFIC_ENABLE_FAILED') {
+                    self.send({ type: 'ROLLBACK_ERROR', error: event.error });
+                } else {
+                    self.send(event);
+                }
+            });
         },
 
         disableGreenTraffic: ({ context, self }) => {
@@ -454,11 +463,11 @@ export const blueGreenDeploymentMachine = setup({
             description: 'Enabling traffic to green environment alongside blue',
             entry: 'openTrafficToGreen',
             on: {
-                TRAFFIC_OPENED: {
+                TRAFFIC_ENABLED: {
                     target: 'validatingTraffic',
                     actions: assign({ trafficOpenedToGreen: true })
                 },
-                TRAFFIC_OPEN_FAILED: {
+                TRAFFIC_ENABLE_FAILED: {
                     target: 'rollbackDisableGreenTraffic',
                     actions: 'preserveErrorContext'
                 }


### PR DESCRIPTION
## Summary
- Updated blue-green deployment state machine to use correct event names that match EnableTraffic action output
- Fixed event mapping in restoreBlueTraffic action for proper rollback functionality  
- Ensured consistent event naming between actions and state machine transitions

## Changes Made
- Changed `TRAFFIC_OPENED`/`TRAFFIC_OPEN_FAILED` events to `TRAFFIC_ENABLED`/`TRAFFIC_ENABLE_FAILED` to match what EnableTraffic action actually sends
- Added event mapping in `restoreBlueTraffic` action to convert `TRAFFIC_ENABLED` → `ROLLBACK_BLUE_TRAFFIC_RESTORED`
- Updated state transitions in `openingTraffic` state to expect the correct events

## Test Plan
- [x] Build: TypeScript compilation successful
- [x] Lint: Code passes linting checks  
- [x] Verified event names align between actions and state machine expectations
- [x] Confirmed proper integration with existing initial deployment state machine

## Related to Issue #36
Completes Stage 3 of the blue-green deployment implementation plan.

🤖 Generated with [Claude Code](https://claude.ai/code)