### PR TITLE
Add help docs for Getting Started and Containers

### DIFF
--- a/client/src/lib/route-config.ts
+++ b/client/src/lib/route-config.ts
@@ -49,6 +49,7 @@ export const routeConfig: Record<string, RouteConfig> = {
     showInNav: true,
     navGroup: "main",
     description: "System overview and status",
+    helpDoc: "getting-started/overview",
   },
 
   "/containers": {
@@ -59,7 +60,7 @@ export const routeConfig: Record<string, RouteConfig> = {
     navGroup: "main",
     navSection: "applications",
     description: "Docker container management",
-    helpDoc: "getting-started/managing-containers",
+    helpDoc: "containers/viewing-containers",
   },
 
   "/postgres-server": {

--- a/client/src/user-docs/containers/container-actions.md
+++ b/client/src/user-docs/containers/container-actions.md
@@ -1,0 +1,73 @@
+---
+title: Container Actions
+description: What Start, Stop, Restart, and Remove do at the Docker level.
+category: Containers
+order: 2
+tags:
+  - containers
+  - docker
+  - start
+  - stop
+  - restart
+  - remove
+---
+
+# Container Actions
+
+Mini Infra exposes four lifecycle actions for Docker containers: Start, Stop, Restart, and Remove. Each maps directly to a Docker API operation.
+
+## How to access actions
+
+Actions are available in two places:
+
+- **Container list** — Click the three-dot menu on any container row.
+- **Container detail page** — Action buttons appear in the header next to the container name.
+
+Buttons are enabled or disabled based on the container's current state. You can't start a container that's already running, and you can't remove a container that's still running.
+
+## Start
+
+Starts a stopped container using its existing configuration (image, environment variables, volumes, network settings). This is the equivalent of `docker start`.
+
+The container resumes with the same filesystem state it had when it was stopped. Any data written inside the container (not in a volume) is preserved from the previous run.
+
+## Stop
+
+Sends `SIGTERM` to the container's main process, giving it 10 seconds to shut down gracefully. If the process doesn't exit within that window, Docker sends `SIGKILL` to force termination.
+
+This matches the behaviour of `docker stop` with the default timeout.
+
+## Restart
+
+Performs a stop followed by a start. The container goes through the full shutdown sequence (SIGTERM, grace period, SIGKILL if needed) before starting again.
+
+Use restart when you need a container to pick up configuration changes or recover from a stuck state.
+
+## Remove
+
+Deletes the container entirely. This is equivalent to `docker rm` and is irreversible.
+
+Remove is only available when the container is stopped. You must stop a running container before you can remove it.
+
+**What gets deleted:**
+
+- The container's writable filesystem layer (any files created or modified inside the container that aren't in a volume).
+- The container's metadata and configuration.
+
+**What is preserved:**
+
+- Named volumes attached to the container remain intact. They can be reattached to a new container.
+- The Docker image the container was based on is not removed.
+
+## PostgreSQL container integration
+
+Mini Infra automatically detects containers running PostgreSQL images. These containers show additional buttons in the container list:
+
+- **Add** — Registers the PostgreSQL container in Mini Infra's database management system, making it available for backup configuration and monitoring.
+- **Manage** — Appears for containers already registered. Links directly to the PostgreSQL server management page for that instance.
+
+## What to watch out for
+
+- Stop gives the process 10 seconds. Applications that need longer to drain connections or flush data may be killed before completing their shutdown sequence.
+- Remove cannot be undone. If you need the container's filesystem contents, inspect and copy them before removing.
+- Removing a container does not free up the port it was using immediately in all cases. If you recreate a container on the same port right after removal, you may see a brief "port in use" error. Wait a moment and try again.

--- a/client/src/user-docs/containers/container-logs.md
+++ b/client/src/user-docs/containers/container-logs.md
@@ -1,0 +1,50 @@
+---
+title: Container Logs
+description: How real-time log streaming works and what the log viewer controls do.
+category: Containers
+order: 3
+tags:
+  - containers
+  - docker
+  - logs
+  - streaming
+  - sse
+---
+
+# Container Logs
+
+The log viewer on the container detail page streams output from a container's stdout and stderr in real time. It connects using server-sent events (SSE), so new log lines appear as they're written without polling.
+
+## How it works
+
+When you open a container's detail page, the log viewer establishes an SSE connection to the backend. The backend in turn attaches to the Docker container's log stream and forwards each line to your browser.
+
+This means you're seeing live output — the same content you'd get from running `docker logs --follow` on the command line. These are Docker-captured logs (stdout and stderr), not application log files written to disk inside the container.
+
+## Log viewer controls
+
+The toolbar above the log output provides several controls:
+
+| Control | What it does |
+|---------|-------------|
+| **Connection status** | Shows **Connected** (green), **Disconnected** (red), or **Connecting** (yellow). Indicates whether the SSE stream is active. |
+| **Line count** | Displays how many log lines are currently loaded. |
+| **Tail lines** | Choose how many historical lines to load when connecting: 50, 100, or 500. New lines continue to stream in after the initial load. |
+| **Search** | Text filter that highlights matching lines in yellow. Filters in the browser only — the backend still streams all lines. |
+| **Timestamps** | Toggle to show or hide a `[HH:MM:SS]` prefix on each line. |
+| **Auto-scroll** | When enabled (the default), the viewer scrolls to the bottom as new lines arrive. Disable it to freeze your scroll position while reading older output. |
+| **Clear** | Removes all lines from the viewer. New lines continue to arrive from the stream. |
+| **Reconnect** | Drops the current SSE connection and establishes a new one. Useful if the stream stalled. |
+| **Download** | Downloads the currently loaded log lines as a text file. |
+
+## ANSI colour support
+
+The log viewer renders ANSI colour codes. If your application outputs coloured text (common with many logging frameworks), you'll see those colours preserved in the viewer. Stderr output is styled differently from stdout to help distinguish error output.
+
+## What to watch out for
+
+- Logs are streamed from Docker, not stored by Mini Infra. If a container is removed, its logs are gone. Download them first if you need to keep them.
+- The tail setting (50/100/500) only affects the initial load. Once connected, every new line is streamed regardless of this setting.
+- Search filters what's displayed in the browser. It doesn't reduce the data coming from the stream. Very high-volume containers still consume bandwidth even when you're filtering.
+- If the connection status shows **Disconnected**, the container may have stopped, or the SSE connection may have been interrupted. Click **Reconnect** to re-establish the stream.
+- Containers that write logs at extremely high volume can slow the browser tab. If you're seeing performance issues, reduce the tail lines setting and use the search filter to focus on what you need.

--- a/client/src/user-docs/containers/troubleshooting.md
+++ b/client/src/user-docs/containers/troubleshooting.md
@@ -1,0 +1,93 @@
+---
+title: Container Troubleshooting
+description: Common container issues and how to diagnose them.
+category: Containers
+order: 4
+tags:
+  - containers
+  - docker
+  - troubleshooting
+  - errors
+  - debugging
+---
+
+# Container Troubleshooting
+
+Common issues with Docker containers in Mini Infra and how to investigate them.
+
+---
+
+## Container won't start
+
+**Symptom:** You click Start but the container immediately returns to a stopped state, or never transitions to Running.
+
+**Likely cause:** The container's entrypoint or command is failing on startup. Common reasons include a missing configuration file, a required environment variable that isn't set, or a port conflict with another container.
+
+**What to check:**
+
+- Open the container detail page and look at the **Logs** section. Docker captures output from the failed start attempt — error messages usually appear there.
+- Check if another container is already using the same published port. Filter the container list by `running` status and look for port conflicts.
+- Verify the Docker image still exists on the host. If the image was removed, Docker can't start the container.
+
+**Fix:** Address the issue shown in the logs. For port conflicts, stop the conflicting container first or change the port mapping by recreating the container.
+
+---
+
+## Container keeps restarting
+
+**Symptom:** The container status cycles between Running and Restarting, or the container runs for a few seconds before exiting and restarting.
+
+**Likely cause:** The application inside the container is crashing. If the container has a restart policy of `always` or `unless-stopped`, Docker keeps restarting it automatically.
+
+**What to check:**
+
+- Check the container logs for crash output. Look for stack traces, out-of-memory errors, or "killed" messages.
+- On the container detail page, check the restart count. A high number confirms the restart loop.
+- If the logs mention "OOM" or "Killed", the container may be exceeding its memory limit.
+
+**Fix:** Fix the underlying application error. If you need to stop the restart loop to investigate, use **Stop** to halt the container and then read the logs from the last run.
+
+---
+
+## Logs not appearing
+
+**Symptom:** The log viewer shows "Connected" but no log lines appear, or it shows "Disconnected".
+
+**Likely cause:** The container isn't producing output on stdout/stderr, or the container is stopped.
+
+**What to check:**
+
+- Verify the container is in the **Running** state. Stopped containers don't produce new log output.
+- Check the **tail lines** setting. If set to 50, and the container hasn't produced 50 lines of recent output, you might see fewer lines than expected.
+- Some applications write to log files inside the container instead of stdout. Docker can only capture stdout and stderr — file-based logs won't appear in the viewer.
+
+**Fix:** If the container writes to files, you may be able to access them through a volume mount. Check the **Volumes** section on the container detail page. If the application can be configured to log to stdout instead, that's the more reliable approach for Docker environments.
+
+---
+
+## Stale container status
+
+**Symptom:** The container list shows a status that doesn't match what you expect (e.g. showing as Running when you know it was stopped).
+
+**Likely cause:** The auto-refresh hasn't run since the state changed. The container list refreshes every 30 seconds.
+
+**What to check:**
+
+- Click the **Refresh** button to force an immediate update.
+- Check the Docker connectivity indicator in the header. If it's red, Mini Infra can't reach the Docker daemon, and status information is stale.
+
+**Fix:** If a manual refresh updates the status correctly, this was a timing issue. If the Docker connectivity indicator is red, investigate the Docker daemon connection from the **Docker** page under Connected Services.
+
+---
+
+## Container removed but still showing
+
+**Symptom:** A container you removed via `docker rm` on the command line still appears in the Mini Infra list.
+
+**Likely cause:** Same as stale status — the list hasn't refreshed yet.
+
+**What to check:**
+
+- Click **Refresh** in the container list.
+
+**Fix:** The container will disappear on the next refresh. Mini Infra doesn't cache container state — it reads directly from Docker on each request.

--- a/client/src/user-docs/containers/viewing-containers.md
+++ b/client/src/user-docs/containers/viewing-containers.md
@@ -1,0 +1,67 @@
+---
+title: Viewing Containers
+description: How the container list works, what each column means, and how to filter and sort.
+category: Containers
+order: 1
+tags:
+  - containers
+  - docker
+  - filtering
+  - sorting
+  - status
+---
+
+# Viewing Containers
+
+The Containers page shows every container on your Docker host — running, stopped, and paused. Navigate to **Containers** in the sidebar to open it.
+
+## How it works
+
+Mini Infra queries the Docker daemon directly through the Docker socket. The container list reflects the actual state of Docker on the host, not a cached copy. Data refreshes automatically every 30 seconds, and you can force an immediate refresh with the **Refresh** button in the top-right corner of the table.
+
+## The container table
+
+The main **Containers** tab displays a paginated table with up to 50 containers per page. Each row shows:
+
+| Column | What it shows |
+|--------|--------------|
+| **Name** | The container name as assigned by Docker or the compose project |
+| **Status** | A coloured badge — green for Running, red for Exited, yellow for Paused, blue for Restarting |
+| **Image** | The image name and tag the container was started from |
+| **Ports** | Published port mappings (e.g. `8080:3000/tcp`). If a container publishes more than two ports, a popover shows the full list |
+
+Click any container name to open its detail page.
+
+## Filtering
+
+Two filters work together to narrow the list:
+
+- **Search box** — Filters by container name or image name. Type part of a name and the table updates immediately.
+- **Status dropdown** — Show only containers in a specific state (running, stopped, etc.).
+
+These filters are additive. You can search for `api` with the status set to `running` to find only running containers with "api" in the name or image.
+
+## Sorting
+
+Click any column header to sort the table by that column. Click the same header again to reverse the sort direction. The current sort state persists for the duration of your browser session.
+
+## Pagination
+
+When you have more than 50 containers, pagination controls appear at the bottom of the table. The display shows which range of containers you're viewing (e.g. "Showing 1 to 50 of 73 containers").
+
+## Networks and Volumes tabs
+
+The Containers page has two additional tabs alongside the main container list:
+
+- **Networks** — Lists all Docker networks with their driver type, scope, and which containers are attached to each.
+- **Volumes** — Lists all named Docker volumes with their size, creation time, and which containers reference them.
+
+## Auto-refresh
+
+The container list fetches fresh data from Docker every 30 seconds. The refresh happens in the background without disrupting your current scroll position or filter state. To refresh immediately, click the **Refresh** button.
+
+## What to watch out for
+
+- Containers created outside Mini Infra (via `docker run` or `docker compose`) still appear in the list. Mini Infra sees everything Docker sees.
+- The status shown is the Docker-reported state. A container showing as "Running" might still be unhealthy at the application level if its health check is failing.
+- Port mappings only show published ports. Containers using host networking or exposing ports without publishing them won't display port information.

--- a/client/src/user-docs/getting-started/managing-containers.md
+++ b/client/src/user-docs/getting-started/managing-containers.md
@@ -2,7 +2,7 @@
 title: Managing Containers
 description: Learn how to view, start, stop, and inspect Docker containers in Mini Infra.
 category: Getting Started
-order: 1
+order: 2
 tags:
   - docker
   - containers

--- a/client/src/user-docs/getting-started/navigating-the-dashboard.md
+++ b/client/src/user-docs/getting-started/navigating-the-dashboard.md
@@ -1,0 +1,71 @@
+---
+title: Navigating the Dashboard
+description: How the dashboard layout, sidebar, and header controls work.
+category: Getting Started
+order: 3
+tags:
+  - dashboard
+  - navigation
+  - sidebar
+  - theme
+  - timezone
+---
+
+# Navigating the Dashboard
+
+This page covers the layout of Mini Infra: sidebar navigation, header controls, and personalisation options like dark mode and timezone settings.
+
+## Sidebar
+
+The sidebar on the left is your primary navigation. It groups features into collapsible sections:
+
+- **Applications** — Containers, Deployments, Environments
+- **Databases** — PostgreSQL Servers, PostgreSQL Backups
+- **Networking** — Cloudflare Tunnels, Load Balancer (with Frontends and Backends sub-pages), TLS Certificates
+- **Monitoring** — Events
+- **Connected Services** — Docker, Cloudflare, Azure Storage, GitHub
+- **Administration** — System Settings, Security Settings, Registry Credentials, Self-Backup, TLS Settings, GitHub Settings
+
+Click the hamburger menu icon at the top-left to collapse the sidebar on smaller screens. The sidebar slides away as an offcanvas panel and reappears when you open it again.
+
+When you navigate to the **Documentation** section, the sidebar switches to show help article navigation instead of the app menu. A **Back to app** button at the top returns you to normal navigation.
+
+## Header
+
+The header bar across the top shows:
+
+- **Breadcrumbs** — The current page path. On the dashboard itself, the page title is shown instead.
+- **Connectivity indicators** — Small coloured dots for Docker, Cloudflare, Azure, and GitHub. Green means connected and healthy. Red means the service check failed. Click any indicator to go to that service's connectivity page for details.
+- **Backup health indicator** — Shows the status of your most recent backup operations.
+- **Help button** — The **?** icon links to the help article most relevant to the current page. If the page doesn't have a specific help article, it links to the general documentation index.
+- **User menu** — Your profile picture or initial. Click to access User Settings or log out.
+
+## Dashboard cards
+
+The main dashboard page shows a container health overview:
+
+- **Total** — The number of containers Docker knows about (running, stopped, and paused combined).
+- **Running** — Containers currently in the `running` state (green).
+- **Stopped** — Containers in the `exited` state (red).
+- **Paused** — Containers in the `paused` state (yellow).
+
+Below the summary cards, a **Recently Died** section lists containers that exited in the last 24 hours (up to 3 shown). This helps you spot containers that crashed or stopped unexpectedly.
+
+## Dark mode and light mode
+
+Click the theme toggle in the sidebar footer to switch between dark and light mode. Your preference is saved in the browser and persists across sessions.
+
+## Timezone settings
+
+By default, timestamps throughout Mini Infra display in your browser's local timezone. To change this:
+
+1. Click your user avatar in the header and select **User Settings**.
+2. Use the timezone selector to search for and choose your preferred timezone.
+3. Click **Save**.
+
+All timestamps across the app — container uptimes, backup times, event logs — will display in your chosen timezone after saving.
+
+## What to watch out for
+
+- The connectivity indicators in the header only reflect the most recent health check. If a service was briefly unreachable but recovered, the dot turns green again on the next check cycle.
+- Timezone changes affect display only. Cron schedules for backups are configured independently with their own timezone setting.

--- a/client/src/user-docs/getting-started/overview.md
+++ b/client/src/user-docs/getting-started/overview.md
@@ -1,0 +1,59 @@
+---
+title: What is Mini Infra?
+description: An overview of Mini Infra and what it manages on your Docker host.
+category: Getting Started
+order: 1
+tags:
+  - overview
+  - getting-started
+  - introduction
+---
+
+# What is Mini Infra?
+
+Mini Infra is a web application for managing a single Docker host and the infrastructure around it. It gives you a unified interface for Docker containers, PostgreSQL database backups, zero-downtime deployments via HAProxy, and Cloudflare tunnel monitoring — without the overhead of Kubernetes or full-featured platforms like Portainer.
+
+## What it manages
+
+Mini Infra covers five areas of your infrastructure:
+
+- **Docker containers** — View, start, stop, restart, and inspect every container on the host. Stream logs in real time and browse volume contents.
+- **PostgreSQL backups** — Schedule automated backups of PostgreSQL databases to Azure Blob Storage. Browse stored backups and restore them to the same or a new database.
+- **Zero-downtime deployments** — Deploy Docker images using a blue-green model with HAProxy handling traffic switching. Health checks run before cutover, and rollback is automatic if they fail.
+- **Cloudflare tunnels** — Monitor the status of Cloudflare tunnels that expose your services to the internet.
+- **Connectivity monitoring** — Track the health of external service connections: Docker daemon, Azure Storage, Cloudflare API, and GitHub.
+
+## Logging in
+
+Mini Infra uses Google OAuth for authentication. On the login page, click **Continue with Google** and sign in with your Google account. After authentication, you're redirected to the dashboard.
+
+Sessions last 24 hours. When your session expires, you'll be redirected to the login page automatically.
+
+## The dashboard
+
+After login, the dashboard shows a high-level summary of your Docker host:
+
+- **Container summary cards** — Total containers, running count, stopped count, and paused count at a glance.
+- **Recently died containers** — An alert showing containers that exited in the last 24 hours, so you can spot unexpected failures quickly.
+- **Connectivity indicators** — Small status dots in the header for Docker, Cloudflare, Azure, and GitHub. Green means connected; red means the service is unreachable.
+
+## Finding your way around
+
+The sidebar organises features into sections:
+
+| Section | What's there |
+|---------|-------------|
+| **Applications** | Containers, Deployments, Environments |
+| **Databases** | PostgreSQL Servers, PostgreSQL Backups |
+| **Networking** | Cloudflare Tunnels, Load Balancer (HAProxy), TLS Certificates |
+| **Monitoring** | Events log |
+| **Connected Services** | Docker, Cloudflare, Azure, GitHub connectivity status |
+| **Administration** | System Settings, Security, Registry Credentials, Self-Backup, TLS Settings, GitHub Settings |
+
+Each page has a **?** button in the top-right corner of the header. Click it to open the relevant help article for the page you're on.
+
+## What to know before you start
+
+- Mini Infra connects directly to the Docker daemon on the host via the Docker socket. It can see and control all containers.
+- Backup and restore operations require Docker images for `pg_dump` and `pg_restore` to be configured in System Settings before use.
+- Deployment configs define how an application is deployed but don't trigger a deploy on their own — you start deploys manually from the deployment detail page.


### PR DESCRIPTION
## Summary

- Add 6 new help documentation pages covering **Getting Started** (overview, navigating the dashboard) and **Containers** (viewing, actions, logs, troubleshooting)
- Wire contextual help links from the Dashboard and Containers pages via `helpDoc` in route-config.ts
- Reorder existing `managing-containers.md` from order 1 to 2 so the new overview page takes the lead position

## Test plan

- [ ] Build passes (`npm run build:all`)
- [ ] Navigate to `/help` and verify 7 docs appear (3 Getting Started + 4 Containers)
- [ ] Sidebar shows correct categories and article ordering
- [ ] Click through each doc — markdown renders, TOC works, prev/next navigation works
- [ ] From `/dashboard`, click the `?` header button — links to Getting Started overview
- [ ] From `/containers`, click the `?` header button — links to Viewing Containers
- [ ] Search "container" on the help page — results appear from both categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)
