### PR TITLE
Remove aggregate app-all.log to fix log file bloat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,7 +326,6 @@ The application uses a sophisticated multi-file logging architecture built on Pi
 
 Logs are found in `server/logs/` directory with the following files:
  - `app.log.1` - Application logs
- - `app-all.log.1` - All logs aggregated together
  - `app-http.log.1` - http request and response logs
  - `app-services.log.1` - log from services that run from `server/src/service/*.ts`
  - `app-dockerexecutor.log.1` - logs from container execution

--- a/server/src/lib/logger-factory.ts
+++ b/server/src/lib/logger-factory.ts
@@ -145,34 +145,6 @@ function createBaseLoggerOptions(config: LoggerConfig): pino.LoggerOptions {
       });
     }
 
-    // Add aggregate log file target (app-all.log) for all loggers
-    const aggregateDestination = path.resolve("logs/app-all.log");
-    ensureLogDirectory(aggregateDestination);
-
-    if (config.rotation?.enabled) {
-      // Use pino-roll for aggregate log rotation in production
-      targets.push({
-        target: "pino-roll",
-        options: {
-          file: aggregateDestination,
-          frequency: "daily",
-          mkdir: true,
-          ...(config.rotation.maxSize && { size: config.rotation.maxSize }),
-          ...(config.rotation.maxFiles && { limit: { count: parseInt(config.rotation.maxFiles) } }),
-        },
-        level: config.level,
-      });
-    } else {
-      // Simple aggregate file destination without rotation
-      targets.push({
-        target: "pino/file",
-        options: {
-          destination: aggregateDestination,
-          mkdir: true,
-        },
-        level: config.level,
-      });
-    }
   }
 
   // Add console output with pretty print for development


### PR DESCRIPTION
## Summary
- Each domain logger independently created its own pino-roll transport for `app-all.log`, meaning ~10 transports all rotated the same file with independent counters
- This prevented cleanup from working — old rotated files accumulated to 345 files / 416MB
- Removes the aggregate log target from `logger-factory.ts` since per-domain logs already capture everything
- Updates CLAUDE.md to remove `app-all.log` from the logging docs

## Test plan
- [ ] Start dev server and verify domain-specific logs still write correctly
- [ ] Confirm no `app-all.log` files are created
- [ ] Check that log rotation cleanup works as expected (max 10 files per domain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)