### PR TITLE
Add dev server restart via sentinel file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ Thumbs.db
 
 # Test coverage
 coverage/
+
+# Dev server restart sentinel
+.restart-dev

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,10 @@
 
 For browser automation and browser testing tasks, use the Playwright CLI skill defined in `.claude/skills/playwright-cli/SKILL.md`. This skill provides browser interaction capabilities including navigation, form filling, screenshots, and web testing.
 
+## Restarting the Dev Server
+
+Run `touch .restart-dev` in the project root to trigger a full dev server restart (lib, server, and client). The file is automatically deleted after the restart is triggered.
+
 ## Important Instructions
 
 * NOTE: NEVER run `docker-compose` as it no longer exists, instead run `docker compose`

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lib"
   ],
   "scripts": {
-    "dev": "concurrently \"npm run dev:lib\" \"npm run dev:server\" \"npm run dev:client\"",
+    "dev": "node scripts/dev-with-restart.mjs",
+    "dev:all": "concurrently \"npm run dev:lib\" \"npm run dev:server\" \"npm run dev:client\"",
     "dev:lib": "cd lib && npm run dev",
     "dev:client": "cd client && npm run dev",
     "dev:server": "cd server && npm run dev",

--- a/scripts/dev-with-restart.mjs
+++ b/scripts/dev-with-restart.mjs
@@ -1,0 +1,70 @@
+import { spawn } from "child_process";
+import { existsSync, unlinkSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+const RESTART_FILE = resolve(ROOT, ".restart-dev");
+const POLL_INTERVAL = 500;
+
+let child = null;
+let shuttingDown = false;
+
+function startDev() {
+  console.log("\x1b[36m[dev-restart]\x1b[0m Starting dev server...");
+
+  child = spawn("npx", ["concurrently", "npm run dev:lib", "npm run dev:server", "npm run dev:client"], {
+    cwd: ROOT,
+    stdio: "inherit",
+  });
+
+  child.on("exit", (code) => {
+    child = null;
+    if (!shuttingDown) {
+      startDev();
+    } else {
+      process.exit(code ?? 0);
+    }
+  });
+}
+
+function watchForRestart() {
+  setInterval(() => {
+    if (existsSync(RESTART_FILE)) {
+      try {
+        unlinkSync(RESTART_FILE);
+      } catch {
+        // File may have been deleted between check and unlink
+        return;
+      }
+      console.log("\n\x1b[36m[dev-restart]\x1b[0m Restart triggered by .restart-dev file");
+      if (child) {
+        child.kill("SIGTERM");
+        // child's 'exit' handler will call startDev()
+      } else {
+        startDev();
+      }
+    }
+  }, POLL_INTERVAL);
+}
+
+function shutdown() {
+  shuttingDown = true;
+  if (child) {
+    child.kill("SIGTERM");
+  } else {
+    process.exit(0);
+  }
+}
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+
+// Clean up any stale restart file
+if (existsSync(RESTART_FILE)) {
+  unlinkSync(RESTART_FILE);
+}
+
+startDev();
+watchForRestart();


### PR DESCRIPTION
## Summary
- Adds a `touch .restart-dev` sentinel file mechanism to trigger a full dev server restart
- Wraps the existing `concurrently` dev command in a new `scripts/dev-with-restart.mjs` script that watches for the sentinel file
- Updates `.gitignore` to exclude the sentinel file and documents the feature in `CLAUDE.md`

## Test plan
- [ ] Run `npm run dev` and verify all three services (lib, server, client) start normally
- [ ] Run `touch .restart-dev` in the project root and verify all services restart
- [ ] Verify `.restart-dev` file is automatically deleted after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)