### PR TITLE
Add dedicated Update action for application containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,5 +64,4 @@ coverage/
 
 # Superpowers working files
 .superpowers/
-docs/superpowers/
 .worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ coverage/
 # Superpowers working files
 .superpowers/
 docs/superpowers/
+.worktrees/

--- a/client/src/app/applications/[id]/page.tsx
+++ b/client/src/app/applications/[id]/page.tsx
@@ -181,7 +181,7 @@ export default function ApplicationDetailPage() {
         ? {
             hostname: service.routing.hostname,
             listeningPort: service.routing.listeningPort,
-            enableSsl: service.routing.enableSsl,
+            enableSsl: !!service.routing.tlsCertificate,
           }
         : undefined,
       restartPolicy:

--- a/client/src/app/applications/page.tsx
+++ b/client/src/app/applications/page.tsx
@@ -6,6 +6,7 @@ import {
   IconFileImport,
   IconPlayerPlay,
   IconPlayerStop,
+  IconRefresh,
   IconDots,
   IconPencil,
   IconTrash,
@@ -49,6 +50,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { ImportDeploymentDialog } from "./import-deployment-dialog";
 import { DeployApplicationDialog } from "./deploy-application-dialog";
+import { UpdateApplicationDialog } from "./update-application-dialog";
 import type { StackTemplateInfo, StackInfo } from "@mini-infra/types";
 
 export default function ApplicationsPage() {
@@ -62,6 +64,7 @@ export default function ApplicationsPage() {
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<StackTemplateInfo | null>(null);
   const [deployTarget, setDeployTarget] = useState<StackTemplateInfo | null>(null);
+  const [updateTarget, setUpdateTarget] = useState<StackTemplateInfo | null>(null);
   const [stoppingId, setStoppingId] = useState<string | null>(null);
 
   const applications = data?.data ?? [];
@@ -327,6 +330,16 @@ export default function ApplicationsPage() {
                         size="sm"
                         variant="outline"
                         className="flex-1"
+                        disabled={!stackByTemplateId.has(app.id)}
+                        onClick={() => setUpdateTarget(app)}
+                      >
+                        <IconRefresh className="h-4 w-4 mr-1" />
+                        Update
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="flex-1"
                         disabled={stoppingId === app.id || !stackByTemplateId.has(app.id)}
                         onClick={() => handleStop(app)}
                       >
@@ -353,6 +366,16 @@ export default function ApplicationsPage() {
           if (!open) setDeployTarget(null);
         }}
         application={deployTarget}
+      />
+
+      {/* Update application dialog */}
+      <UpdateApplicationDialog
+        open={!!updateTarget}
+        onOpenChange={(open) => {
+          if (!open) setUpdateTarget(null);
+        }}
+        application={updateTarget}
+        stack={updateTarget ? stackByTemplateId.get(updateTarget.id) ?? null : null}
       />
 
       {/* Import deployment dialog */}

--- a/client/src/app/applications/update-application-dialog.tsx
+++ b/client/src/app/applications/update-application-dialog.tsx
@@ -8,7 +8,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { useUpdateApplication } from "@/hooks/use-applications";
+import { useRedeployApplication } from "@/hooks/use-applications";
 import { useTaskTracker } from "@/hooks/use-task-tracker";
 import { Channel } from "@mini-infra/types";
 import type { StackTemplateInfo, StackInfo } from "@mini-infra/types";
@@ -26,7 +26,7 @@ export function UpdateApplicationDialog({
   application,
   stack,
 }: UpdateApplicationDialogProps) {
-  const updateApplication = useUpdateApplication();
+  const redeployApplication = useRedeployApplication();
   const { registerTask } = useTaskTracker();
 
   const handleUpdate = async () => {
@@ -39,7 +39,7 @@ export function UpdateApplicationDialog({
         label: `Updating ${application?.displayName ?? application?.name ?? "application"}`,
         channel: Channel.STACKS,
       });
-      await updateApplication.mutateAsync(stack.id);
+      await redeployApplication.mutateAsync(stack.id);
       onOpenChange(false);
     } catch {
       // Error handled by mutation's onError
@@ -66,9 +66,9 @@ export function UpdateApplicationDialog({
           </Button>
           <Button
             onClick={handleUpdate}
-            disabled={updateApplication.isPending}
+            disabled={redeployApplication.isPending}
           >
-            {updateApplication.isPending && (
+            {redeployApplication.isPending && (
               <IconLoader2 className="h-4 w-4 mr-2 animate-spin" />
             )}
             Update

--- a/client/src/app/applications/update-application-dialog.tsx
+++ b/client/src/app/applications/update-application-dialog.tsx
@@ -1,0 +1,80 @@
+import { IconLoader2, IconRefresh } from "@tabler/icons-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useUpdateApplication } from "@/hooks/use-applications";
+import { useTaskTracker } from "@/hooks/use-task-tracker";
+import { Channel } from "@mini-infra/types";
+import type { StackTemplateInfo, StackInfo } from "@mini-infra/types";
+
+interface UpdateApplicationDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  application: StackTemplateInfo | null;
+  stack: StackInfo | null;
+}
+
+export function UpdateApplicationDialog({
+  open,
+  onOpenChange,
+  application,
+  stack,
+}: UpdateApplicationDialogProps) {
+  const updateApplication = useUpdateApplication();
+  const { registerTask } = useTaskTracker();
+
+  const handleUpdate = async () => {
+    if (!stack) return;
+
+    try {
+      registerTask({
+        id: stack.id,
+        type: "stack-update",
+        label: `Updating ${application?.displayName ?? application?.name ?? "application"}`,
+        channel: Channel.STACKS,
+      });
+      await updateApplication.mutateAsync(stack.id);
+      onOpenChange(false);
+    } catch {
+      // Error handled by mutation's onError
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <IconRefresh className="h-5 w-5" />
+            Update Application
+          </DialogTitle>
+          <DialogDescription>
+            This will pull the latest image and redeploy &quot;{application?.displayName ?? application?.name}&quot;.
+            Web services will be updated with zero downtime.
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleUpdate}
+            disabled={updateApplication.isPending}
+          >
+            {updateApplication.isPending && (
+              <IconLoader2 className="h-4 w-4 mr-2 animate-spin" />
+            )}
+            Update
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/task-tracker/task-detail-dialog.tsx
+++ b/client/src/components/task-tracker/task-detail-dialog.tsx
@@ -105,6 +105,8 @@ function getTaskTitle(type: TaskType): string {
       return "Stack Apply";
     case "stack-destroy":
       return "Stack Destroy";
+    case "stack-update":
+      return "Stack Update";
     case "migration":
       return "HAProxy Migration";
     case "sidecar-startup":
@@ -124,6 +126,8 @@ function getTaskIcon(type: TaskType) {
       return <IconStack2 className="h-5 w-5" />;
     case "stack-destroy":
       return <IconTrash className="h-5 w-5" />;
+    case "stack-update":
+      return <IconRefresh className="h-5 w-5" />;
     case "migration":
       return <IconArrowsShuffle className="h-5 w-5" />;
     case "sidecar-startup":

--- a/client/src/hooks/use-applications.ts
+++ b/client/src/hooks/use-applications.ts
@@ -332,6 +332,33 @@ async function destroyStack(
   return await response.json();
 }
 
+async function updateStack(
+  stackId: string,
+  correlationId: string,
+): Promise<{ success: boolean; data: { started: true; stackId: string } }> {
+  const response = await fetch(`/api/stacks/${stackId}/update`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Correlation-ID": correlationId,
+    },
+  });
+
+  if (!response.ok) {
+    let errorMessage = `Failed to update application: ${response.statusText}`;
+    try {
+      const errorData = await response.json();
+      errorMessage = errorData.message || errorMessage;
+    } catch {
+      // Use default error message
+    }
+    throw new Error(errorMessage);
+  }
+
+  return await response.json();
+}
+
 async function fetchUserStacks(
   correlationId: string,
 ): Promise<StackListResponse> {
@@ -535,6 +562,26 @@ export function useStopApplication() {
     },
     onError: (error: Error) => {
       toast.error(`Failed to stop application: ${error.message}`);
+    },
+  });
+}
+
+export function useUpdateApplication() {
+  const queryClient = useQueryClient();
+  const correlationId = generateCorrelationId();
+
+  return useMutation({
+    mutationFn: async (stackId: string) => {
+      await updateStack(stackId, correlationId);
+    },
+    onSuccess: () => {
+      toast.success("Application update started");
+      queryClient.invalidateQueries({ queryKey: ["applications"] });
+      queryClient.invalidateQueries({ queryKey: ["userStacks"] });
+      queryClient.invalidateQueries({ queryKey: ["stacks"] });
+    },
+    onError: (error: Error) => {
+      toast.error(`Failed to update application: ${error.message}`);
     },
   });
 }

--- a/client/src/hooks/use-applications.ts
+++ b/client/src/hooks/use-applications.ts
@@ -566,7 +566,7 @@ export function useStopApplication() {
   });
 }
 
-export function useUpdateApplication() {
+export function useRedeployApplication() {
   const queryClient = useQueryClient();
   const correlationId = generateCorrelationId();
 

--- a/client/src/lib/task-tracker-types.ts
+++ b/client/src/lib/task-tracker-types.ts
@@ -13,6 +13,7 @@ export type TaskType =
   | "connect-container"
   | "stack-apply"
   | "stack-destroy"
+  | "stack-update"
   | "migration"
   | "sidecar-startup"
   | "self-update-launch";

--- a/client/src/lib/task-type-registry.ts
+++ b/client/src/lib/task-type-registry.ts
@@ -118,6 +118,45 @@ export const TASK_TYPE_REGISTRY: Record<TaskType, TaskTypeConfig> = {
     ],
   },
 
+  "stack-update": {
+    channel: Channel.STACKS,
+    startedEvent: ServerEvent.STACK_APPLY_STARTED,
+    stepEvent: ServerEvent.STACK_APPLY_SERVICE_RESULT,
+    completedEvent: ServerEvent.STACK_APPLY_COMPLETED,
+    getId: (p) => p.stackId,
+    normalizeStarted: (p) => ({
+      totalSteps: p.totalActions,
+      plannedStepNames: (p.actions as Array<{ serviceName: string; action: string }>).map(
+        (a) => `update ${a.serviceName}`,
+      ),
+    }),
+    normalizeStep: (p) => ({
+      step: `update ${p.serviceName}`,
+      status: p.success ? "completed" : "failed",
+      detail: p.error ?? undefined,
+    }),
+    normalizeCompleted: (p) => ({
+      success: p.success,
+      steps: (p.serviceResults as Array<{ serviceName: string; action: string; success: boolean; error?: string }>).map(
+        (r) => ({
+          step: `update ${r.serviceName}`,
+          status: (r.success ? "completed" : "failed") as OperationStep["status"],
+          detail: r.error ?? undefined,
+        }),
+      ),
+      errors: p.error ? [p.error] : [],
+    }),
+    invalidateKeys: (taskId) => [
+      ["stacks"],
+      ["stack", taskId],
+      ["stackPlan", taskId],
+      ["stackStatus", taskId],
+      ["stackHistory", taskId],
+      ["applications"],
+      ["userStacks"],
+    ],
+  },
+
   "stack-destroy": {
     channel: Channel.STACKS,
     startedEvent: ServerEvent.STACK_DESTROY_STARTED,

--- a/docs/superpowers/plans/2026-03-28-application-update.md
+++ b/docs/superpowers/plans/2026-03-28-application-update.md
@@ -1,0 +1,941 @@
+# Application Update Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a dedicated "Update" action to Application cards that pulls the latest image and redeploys containers — blue-green for StatelessWeb, simple stop→pull→recreate for Stateful.
+
+**Architecture:** New `POST /api/stacks/:id/update` endpoint reuses the existing `StackReconciler.apply()` with `forcePull` semantics but records the action as `'update'`. StatelessWeb services use a new stripped-down blue-green update state machine (no frontend/DNS/TLS states). Frontend adds an Update button + confirmation dialog + Task Tracker integration.
+
+**Tech Stack:** Express.js, xstate, Prisma, React, TanStack Query, Socket.IO, Zod
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `server/src/services/haproxy/blue-green-update-state-machine.ts` | Simplified blue-green state machine without frontend/DNS states |
+| Modify | `server/src/services/stacks/stack-reconciler.ts` | Add `update()` method that uses forcePull + update state machine |
+| Modify | `server/src/routes/stacks.ts` | Add `POST /:stackId/update` endpoint |
+| Modify | `lib/types/stacks.ts` | Add `UpdateOptions` and `'update'` to action types |
+| Modify | `client/src/lib/task-tracker-types.ts` | Add `"stack-update"` to `TaskType` union |
+| Modify | `client/src/lib/task-type-registry.ts` | Add `"stack-update"` registry entry |
+| Modify | `client/src/hooks/use-applications.ts` | Add `useUpdateApplication()` hook + `updateStack()` API function |
+| Create | `client/src/app/applications/update-application-dialog.tsx` | Confirmation dialog |
+| Modify | `client/src/app/applications/page.tsx` | Add Update button to cards |
+
+---
+
+### Task 1: Create Blue-Green Update State Machine
+
+**Files:**
+- Create: `server/src/services/haproxy/blue-green-update-state-machine.ts`
+
+This is a copy of `blue-green-deployment-state-machine.ts` with `configuringFrontend`, `configuringDNS` states removed, and their rollback counterparts simplified.
+
+- [ ] **Step 1: Copy the deployment state machine as a starting point**
+
+```bash
+cp server/src/services/haproxy/blue-green-deployment-state-machine.ts server/src/services/haproxy/blue-green-update-state-machine.ts
+```
+
+- [ ] **Step 2: Strip frontend/DNS states and simplify**
+
+Edit `server/src/services/haproxy/blue-green-update-state-machine.ts`:
+
+1. Remove these imports (no longer needed):
+   - `ConfigureFrontend` from `./actions/configure-frontend`
+   - `ConfigureDNS` from `./actions/configure-dns`
+   - `RemoveFrontend` from `./actions/remove-frontend`
+
+2. Remove these action class instantiations:
+   - `const configureFrontend = new ConfigureFrontend();`
+   - `const configureDNS = new ConfigureDNS();`
+   - `const removeFrontend = new RemoveFrontend();`
+
+3. Rename the context interface to `BlueGreenUpdateContext` and the export to `blueGreenUpdateMachine`.
+
+4. Remove the `configuringFrontend` state (lines 945-970 in the original). Change `healthCheckWait`'s `SERVERS_HEALTHY` transition target from `'configuringFrontend'` to `'openingTraffic'`.
+
+5. Remove the `configuringDNS` state (lines 972-997 in the original).
+
+6. Remove the `configureGreenFrontend` and `configureGreenDNS` action implementations from the `actions` block.
+
+7. Remove the `frontendConfigured` and `dnsConfigured` context fields and their `assign()` calls.
+
+8. In rollback states, remove `rollbackDisableGreenTraffic` (it disables traffic that was never separately configured for frontend). The rollback path should go: `rollbackRestoreBlueTraffic` → `rollbackRemoveGreenHaproxyConfig` → `rollbackStoppingGreenApp` → `rollbackRemovingGreenApp` → `rollbackComplete`.
+
+9. The final exported machine should have these states:
+   ```
+   idle → deployingGreenApp → waitingGreenReady → initializingGreenLB
+     → healthCheckWait → openingTraffic → drainingBlue → waitingForDrain
+     → decommissioningBlueLB → stoppingBlueApp → removingBlueApp → completed
+
+   Rollback: rollbackRestoreBlueTraffic → rollbackRemoveGreenHaproxyConfig
+     → rollbackStoppingGreenApp → rollbackRemovingGreenApp → rollbackComplete
+
+   Terminal: completed, rollbackComplete, failed
+   ```
+
+- [ ] **Step 3: Verify the file compiles**
+
+Run: `npx -w server tsc --noEmit --pretty 2>&1 | head -30`
+Expected: No errors related to `blue-green-update-state-machine.ts`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/services/haproxy/blue-green-update-state-machine.ts
+git commit -m "feat: add blue-green update state machine without frontend/DNS states"
+```
+
+---
+
+### Task 2: Add Update Support to Shared Types
+
+**Files:**
+- Modify: `lib/types/stacks.ts`
+
+- [ ] **Step 1: Add `UpdateOptions` type**
+
+In `lib/types/stacks.ts`, after the `ApplyOptions` interface (line 384), add:
+
+```typescript
+export interface UpdateOptions {
+  triggeredBy?: string;
+  /** Called after each service action completes */
+  onProgress?: (result: ServiceApplyResult, completedCount: number, totalActions: number) => void;
+}
+```
+
+- [ ] **Step 2: Build the types**
+
+Run: `npm run build:lib`
+Expected: Successful build with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/types/stacks.ts
+git commit -m "feat: add UpdateOptions type for stack updates"
+```
+
+---
+
+### Task 3: Add `update()` Method to StackReconciler
+
+**Files:**
+- Modify: `server/src/services/stacks/stack-reconciler.ts`
+
+- [ ] **Step 1: Import the update state machine**
+
+At line 31 (after the existing blue-green import), add:
+
+```typescript
+import { blueGreenUpdateMachine } from '../haproxy/blue-green-update-state-machine';
+```
+
+Also add `UpdateOptions` to the import from `@mini-infra/types` on line 3-22.
+
+- [ ] **Step 2: Add the `update()` method**
+
+Add this method to the `StackReconciler` class, after the `apply()` method (after line 583):
+
+```typescript
+  /**
+   * Update a deployed stack by pulling fresh images and redeploying
+   * containers whose image digest has changed.
+   * StatelessWeb: uses blue-green update state machine (no frontend/DNS reconfiguration).
+   * Stateful: simple stop → remove → pull → create → start.
+   */
+  async update(stackId: string, options?: UpdateOptions): Promise<ApplyResult> {
+    const startTime = Date.now();
+    const log = servicesLogger().child({ operation: 'stack-update', stackId });
+
+    // 1. Compute plan and force-pull to detect image digest changes
+    const plan = await this.plan(stackId);
+    await this.promoteStalePullActions(plan, stackId, log);
+
+    // 2. Filter to only actions that need work (digest changed → promoted to 'recreate')
+    const actions = plan.actions.filter((a) => a.action !== 'no-op');
+
+    if (actions.length === 0) {
+      log.info('All images are up to date — nothing to update');
+      // Still record the update attempt
+      await this.prisma.stackDeployment.create({
+        data: {
+          stackId,
+          action: 'update',
+          success: true,
+          version: plan.stackVersion,
+          status: 'synced',
+          duration: Date.now() - startTime,
+          serviceResults: [],
+          triggeredBy: options?.triggeredBy ?? null,
+        },
+      });
+      return {
+        success: true,
+        stackId,
+        appliedVersion: plan.stackVersion,
+        serviceResults: [],
+        resourceResults: [],
+        duration: Date.now() - startTime,
+      };
+    }
+
+    // 3. Load stack
+    const stack = await this.prisma.stack.findUniqueOrThrow({
+      where: { id: stackId },
+      include: { services: { orderBy: { order: 'asc' } }, environment: true },
+    });
+
+    try {
+      const projectName = stack.environment ? `${stack.environment.name}-${stack.name}` : stack.name;
+      const params = mergeParameterValues(
+        (stack.parameters as unknown as StackParameterDefinition[]) ?? [],
+        (stack.parameterValues as unknown as Record<string, StackParameterValue>) ?? {}
+      );
+      const templateContext = buildStackTemplateContext(stack, params);
+      const serviceMap = new Map(stack.services.map((s) => [s.serviceName, s]));
+      const { resolvedConfigsMap, resolvedDefinitions, serviceHashes } = resolveServiceConfigs(stack.services, templateContext);
+
+      // Ensure environment networks exist
+      const envNetworkMap = await this.resolveEnvironmentNetworks(stack.environmentId, resolvedDefinitions);
+
+      // Get running containers for this stack
+      const docker = this.dockerExecutor.getDockerClient();
+      const containers = await docker.listContainers({
+        all: true,
+        filters: { label: [`mini-infra.stack-id=${stackId}`] },
+      });
+      const containerByService = buildContainerMap(containers);
+
+      const networkNames = (stack.networks as unknown as StackNetwork[]).map(
+        (n) => `${projectName}_${n.name}`
+      );
+
+      // 4. Execute actions
+      const serviceResults: ServiceApplyResult[] = [];
+      let completedCount = 0;
+
+      for (const action of actions) {
+        const svc = serviceMap.get(action.serviceName);
+        const serviceDef = resolvedDefinitions.get(action.serviceName) ?? null;
+        const actionStart = Date.now();
+
+        let result: ServiceApplyResult;
+
+        if (svc?.serviceType === 'StatelessWeb' && serviceDef) {
+          result = await this.updateStatelessWeb(
+            action, svc, serviceDef, projectName, stackId, stack,
+            networkNames, serviceHashes, resolvedConfigsMap,
+            containerByService, actionStart, log, envNetworkMap
+          );
+        } else {
+          // Stateful: reuse existing applyStateful with 'recreate' action
+          result = await this.applyStateful(
+            action, svc, serviceDef, projectName, stackId, stack,
+            networkNames, serviceHashes, resolvedConfigsMap,
+            containerByService, actionStart, log, envNetworkMap
+          );
+        }
+
+        // Override the action label to 'update' for audit clarity
+        result = { ...result, action: 'update' };
+        serviceResults.push(result);
+        completedCount++;
+        options?.onProgress?.(result, completedCount, actions.length);
+      }
+
+      const allSucceeded = serviceResults.every((r) => r.success);
+      const resultStatus = allSucceeded ? 'synced' : 'error';
+
+      // Update stack status + snapshot
+      await this.prisma.stack.update({
+        where: { id: stackId },
+        data: {
+          status: resultStatus,
+          lastAppliedVersion: stack.version,
+          lastAppliedAt: new Date(),
+          lastAppliedSnapshot: serializeStack({
+            ...stack,
+            services: stack.services.map((s) => ({
+              ...s,
+              serviceType: s.serviceType as StackServiceDefinition['serviceType'],
+              containerConfig: s.containerConfig as unknown as StackContainerConfig,
+              configFiles: (s.configFiles as unknown as StackConfigFile[]) ?? null,
+              initCommands: (s.initCommands as unknown as StackServiceDefinition['initCommands']) ?? null,
+              dependsOn: s.dependsOn as unknown as string[],
+              routing: (s.routing as unknown as StackServiceDefinition['routing']) ?? null,
+            })),
+          } as any) as any,
+          status: resultStatus,
+        },
+      });
+
+      // Record deployment history
+      await this.prisma.stackDeployment.create({
+        data: {
+          stackId,
+          action: 'update',
+          success: allSucceeded,
+          version: stack.version,
+          status: resultStatus,
+          duration: Date.now() - startTime,
+          serviceResults: serviceResults as any,
+          triggeredBy: options?.triggeredBy ?? null,
+        },
+      });
+
+      return {
+        success: allSucceeded,
+        stackId,
+        appliedVersion: stack.version,
+        serviceResults,
+        resourceResults: [],
+        duration: Date.now() - startTime,
+      };
+    } catch (err: any) {
+      const duration = Date.now() - startTime;
+      log.error({ error: err.message }, 'Update failed unexpectedly');
+      try {
+        await this.prisma.stackDeployment.create({
+          data: {
+            stackId,
+            action: 'update',
+            success: false,
+            version: stack.version,
+            status: 'error',
+            duration,
+            error: err.message,
+            triggeredBy: options?.triggeredBy ?? null,
+          },
+        });
+        await this.prisma.stack.update({
+          where: { id: stackId },
+          data: { status: 'error' },
+        });
+      } catch (dbErr) {
+        log.error({ error: dbErr }, 'Failed to record update failure');
+      }
+      throw err;
+    }
+  }
+```
+
+- [ ] **Step 3: Add the `updateStatelessWeb()` private method**
+
+Add this method after `applyStatelessWeb()` (after line 1208):
+
+```typescript
+  /**
+   * Update a StatelessWeb service using the blue-green update state machine
+   * (no frontend/DNS reconfiguration — those are already in place).
+   */
+  private async updateStatelessWeb(
+    action: ServiceAction,
+    svc: any,
+    serviceDef: StackServiceDefinition,
+    projectName: string,
+    stackId: string,
+    stack: any,
+    networkNames: string[],
+    serviceHashes: Map<string, string>,
+    resolvedConfigsMap: Map<string, StackConfigFile[]>,
+    containerByService: Map<string, Docker.ContainerInfo>,
+    actionStart: number,
+    log: any,
+    envNetworkMap: Map<string, string> = new Map()
+  ): Promise<ServiceApplyResult> {
+    const routing = serviceDef.routing;
+    if (!routing) {
+      throw new Error(`StatelessWeb service "${action.serviceName}" requires routing configuration`);
+    }
+
+    log.info({ service: action.serviceName }, 'Updating StatelessWeb service via blue-green update state machine');
+
+    const baseContext = await this.buildStateMachineContext(
+      action, serviceDef, projectName, stackId, stack, serviceHashes, envNetworkMap
+    );
+
+    const oldContainer = containerByService.get(action.serviceName);
+
+    await prepareServiceContainer(
+      this.containerManager,
+      svc,
+      resolvedConfigsMap.get(action.serviceName) ?? [],
+      projectName
+    );
+
+    const blueGreenContext = {
+      ...baseContext,
+      blueHealthy: false,
+      greenHealthy: false,
+      greenBackendConfigured: false,
+      trafficOpenedToGreen: false,
+      trafficValidated: false,
+      blueDraining: false,
+      blueDrained: false,
+      validationErrors: 0,
+      drainStartTime: undefined,
+      monitoringStartTime: undefined,
+      error: undefined,
+      retryCount: 0,
+      activeConnections: 0,
+      oldContainerId: oldContainer?.Id,
+      newContainerId: undefined,
+      containerIpAddress: undefined,
+    };
+
+    const finalState = await runStateMachineToCompletion(
+      blueGreenUpdateMachine,
+      blueGreenContext,
+      (actor) => actor.send({ type: 'START_DEPLOYMENT' })
+    );
+
+    const success = finalState.value === 'completed';
+    return {
+      serviceName: action.serviceName,
+      action: 'update',
+      success,
+      duration: Date.now() - actionStart,
+      containerId: (finalState.context as any).newContainerId,
+      error: success ? undefined : (finalState.context as any).error ?? 'Blue-green update failed',
+    };
+  }
+```
+
+- [ ] **Step 4: Verify the file compiles**
+
+Run: `npx -w server tsc --noEmit --pretty 2>&1 | head -30`
+Expected: No type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/services/stacks/stack-reconciler.ts
+git commit -m "feat: add update() and updateStatelessWeb() methods to StackReconciler"
+```
+
+---
+
+### Task 4: Add `POST /:stackId/update` Endpoint
+
+**Files:**
+- Modify: `server/src/routes/stacks.ts`
+
+- [ ] **Step 1: Add the update endpoint**
+
+After the apply endpoint (after line 604), add the following route handler:
+
+```typescript
+// POST /:stackId/update — Pull latest images and redeploy changed containers
+router.post('/:stackId/update', requirePermission('stacks:write'), async (req, res) => {
+  const stackId = String(req.params.stackId);
+  try {
+    // Prevent concurrent operations on the same stack
+    if (applyingStacks.has(stackId)) {
+      return res.status(409).json({ success: false, message: 'Stack operation already in progress' });
+    }
+
+    // Validate stack exists and is deployed
+    const stack = await prisma.stack.findUnique({
+      where: { id: stackId },
+      select: { id: true, name: true, status: true },
+    });
+    if (!stack) {
+      return res.status(404).json({ success: false, message: 'Stack not found' });
+    }
+    if (stack.status !== 'synced' && stack.status !== 'drifted') {
+      return res.status(400).json({
+        success: false,
+        message: `Stack must be deployed to update (current status: ${stack.status})`,
+      });
+    }
+
+    const dockerExecutor = new DockerExecutorService();
+    await dockerExecutor.initialize();
+    const routingManager = new StackRoutingManager(prisma, new HAProxyFrontendManager());
+    const resourceReconciler = await createResourceReconciler();
+    const reconciler = new StackReconciler(dockerExecutor, prisma, routingManager, resourceReconciler);
+
+    applyingStacks.add(stackId);
+
+    // Emit started event — use same STACK_APPLY events with action context
+    // We emit a generic "pull" action per service since we don't know which will change yet
+    const plan = await reconciler.plan(stackId);
+    const startedActions = plan.actions.map((a) => ({ serviceName: a.serviceName, action: 'update' }));
+
+    emitToChannel(Channel.STACKS, ServerEvent.STACK_APPLY_STARTED, {
+      stackId,
+      stackName: plan.stackName,
+      totalActions: startedActions.length,
+      actions: startedActions,
+      forcePull: true,
+    });
+
+    // Respond immediately
+    res.json({ success: true, data: { started: true, stackId } });
+
+    // Run update in background
+    const triggeredBy = (req as any).user?.id;
+    (async () => {
+      try {
+        const result = await reconciler.update(stackId, {
+          triggeredBy,
+          onProgress: (serviceResult, completedCount, totalActions) => {
+            try {
+              emitToChannel(Channel.STACKS, ServerEvent.STACK_APPLY_SERVICE_RESULT, {
+                stackId,
+                ...serviceResult,
+                completedCount,
+                totalActions,
+              } as any);
+            } catch { /* never break update */ }
+          },
+        });
+
+        emitToChannel(Channel.STACKS, ServerEvent.STACK_APPLY_COMPLETED, {
+          ...result,
+        });
+      } catch (error: any) {
+        logger.error({ error: error.message, stackId }, 'Background stack update failed');
+        emitToChannel(Channel.STACKS, ServerEvent.STACK_APPLY_COMPLETED, {
+          success: false,
+          stackId,
+          appliedVersion: 0,
+          serviceResults: [],
+          resourceResults: [],
+          duration: 0,
+          error: error.message,
+        });
+      } finally {
+        applyingStacks.delete(stackId);
+      }
+    })();
+  } catch (error: any) {
+    applyingStacks.delete(stackId);
+    if (isDockerConnectionError(error)) {
+      return res.status(503).json({ success: false, message: 'Docker is unavailable' });
+    }
+    logger.error({ error, stackId }, 'Failed to start stack update');
+    res.status(500).json({ success: false, message: error?.message ?? 'Failed to update stack' });
+  }
+});
+```
+
+- [ ] **Step 2: Verify the file compiles**
+
+Run: `npx -w server tsc --noEmit --pretty 2>&1 | head -30`
+Expected: No type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/src/routes/stacks.ts
+git commit -m "feat: add POST /stacks/:id/update endpoint"
+```
+
+---
+
+### Task 5: Add `"stack-update"` Task Type to Frontend
+
+**Files:**
+- Modify: `client/src/lib/task-tracker-types.ts`
+- Modify: `client/src/lib/task-type-registry.ts`
+
+- [ ] **Step 1: Add `"stack-update"` to the TaskType union**
+
+In `client/src/lib/task-tracker-types.ts`, line 11-18, add `"stack-update"` to the union:
+
+```typescript
+export type TaskType =
+  | "cert-issuance"
+  | "connect-container"
+  | "stack-apply"
+  | "stack-destroy"
+  | "stack-update"
+  | "migration"
+  | "sidecar-startup"
+  | "self-update-launch";
+```
+
+- [ ] **Step 2: Add registry entry for `"stack-update"`**
+
+In `client/src/lib/task-type-registry.ts`, after the `"stack-apply"` entry (after line 119), add:
+
+```typescript
+  "stack-update": {
+    channel: Channel.STACKS,
+    startedEvent: ServerEvent.STACK_APPLY_STARTED,
+    stepEvent: ServerEvent.STACK_APPLY_SERVICE_RESULT,
+    completedEvent: ServerEvent.STACK_APPLY_COMPLETED,
+    getId: (p) => p.stackId,
+    normalizeStarted: (p) => ({
+      totalSteps: p.totalActions,
+      plannedStepNames: (p.actions as Array<{ serviceName: string; action: string }>).map(
+        (a) => `update ${a.serviceName}`,
+      ),
+    }),
+    normalizeStep: (p) => ({
+      step: `update ${p.serviceName}`,
+      status: p.success ? "completed" : "failed",
+      detail: p.error ?? undefined,
+    }),
+    normalizeCompleted: (p) => ({
+      success: p.success,
+      steps: (p.serviceResults as Array<{ serviceName: string; action: string; success: boolean; error?: string }>).map(
+        (r) => ({
+          step: `update ${r.serviceName}`,
+          status: (r.success ? "completed" : "failed") as OperationStep["status"],
+          detail: r.error ?? undefined,
+        }),
+      ),
+      errors: p.error ? [p.error] : [],
+    }),
+    invalidateKeys: (taskId) => [
+      ["stacks"],
+      ["stack", taskId],
+      ["stackPlan", taskId],
+      ["stackStatus", taskId],
+      ["stackHistory", taskId],
+      ["applications"],
+      ["userStacks"],
+    ],
+  },
+```
+
+- [ ] **Step 3: Verify frontend compiles**
+
+Run: `npm run build -w client 2>&1 | tail -5`
+Expected: Successful build.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/lib/task-tracker-types.ts client/src/lib/task-type-registry.ts
+git commit -m "feat: add stack-update task type to task tracker registry"
+```
+
+---
+
+### Task 6: Add `useUpdateApplication` Hook
+
+**Files:**
+- Modify: `client/src/hooks/use-applications.ts`
+
+- [ ] **Step 1: Add `updateStack()` API function**
+
+After the `destroyStack()` function (after line 333), add:
+
+```typescript
+async function updateStack(
+  stackId: string,
+  correlationId: string,
+): Promise<{ success: boolean; data: { started: true; stackId: string } }> {
+  const response = await fetch(`/api/stacks/${stackId}/update`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Correlation-ID": correlationId,
+    },
+  });
+
+  if (!response.ok) {
+    let errorMessage = `Failed to update application: ${response.statusText}`;
+    try {
+      const errorData = await response.json();
+      errorMessage = errorData.message || errorMessage;
+    } catch {
+      // Use default error message
+    }
+    throw new Error(errorMessage);
+  }
+
+  return await response.json();
+}
+```
+
+- [ ] **Step 2: Add `useUpdateApplication()` hook**
+
+After the `useStopApplication()` hook (after line 540), add:
+
+```typescript
+export function useUpdateApplication() {
+  const queryClient = useQueryClient();
+  const correlationId = generateCorrelationId();
+
+  return useMutation({
+    mutationFn: async (stackId: string) => {
+      await updateStack(stackId, correlationId);
+    },
+    onSuccess: () => {
+      toast.success("Application update started");
+      queryClient.invalidateQueries({ queryKey: ["applications"] });
+      queryClient.invalidateQueries({ queryKey: ["userStacks"] });
+      queryClient.invalidateQueries({ queryKey: ["stacks"] });
+    },
+    onError: (error: Error) => {
+      toast.error(`Failed to update application: ${error.message}`);
+    },
+  });
+}
+```
+
+- [ ] **Step 3: Verify frontend compiles**
+
+Run: `npm run build -w client 2>&1 | tail -5`
+Expected: Successful build.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/hooks/use-applications.ts
+git commit -m "feat: add useUpdateApplication hook and updateStack API function"
+```
+
+---
+
+### Task 7: Create Update Application Dialog
+
+**Files:**
+- Create: `client/src/app/applications/update-application-dialog.tsx`
+
+- [ ] **Step 1: Create the confirmation dialog**
+
+Create `client/src/app/applications/update-application-dialog.tsx`:
+
+```tsx
+import { IconLoader2, IconRefresh } from "@tabler/icons-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useUpdateApplication } from "@/hooks/use-applications";
+import { useTaskTracker } from "@/components/task-tracker/task-tracker-context";
+import { Channel } from "@mini-infra/types";
+import type { StackTemplateInfo, StackInfo } from "@mini-infra/types";
+
+interface UpdateApplicationDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  application: StackTemplateInfo | null;
+  stack: StackInfo | null;
+}
+
+export function UpdateApplicationDialog({
+  open,
+  onOpenChange,
+  application,
+  stack,
+}: UpdateApplicationDialogProps) {
+  const updateApplication = useUpdateApplication();
+  const { trackTask } = useTaskTracker();
+
+  const handleUpdate = async () => {
+    if (!stack) return;
+
+    try {
+      trackTask({
+        id: stack.id,
+        type: "stack-update",
+        label: `Updating ${application?.displayName ?? application?.name ?? "application"}`,
+        channel: Channel.STACKS,
+      });
+      await updateApplication.mutateAsync(stack.id);
+      onOpenChange(false);
+    } catch {
+      // Error handled by mutation's onError
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <IconRefresh className="h-5 w-5" />
+            Update Application
+          </DialogTitle>
+          <DialogDescription>
+            This will pull the latest image and redeploy &quot;{application?.displayName ?? application?.name}&quot;.
+            Web services will be updated with zero downtime.
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleUpdate}
+            disabled={updateApplication.isPending}
+          >
+            {updateApplication.isPending && (
+              <IconLoader2 className="h-4 w-4 mr-2 animate-spin" />
+            )}
+            Update
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 2: Verify frontend compiles**
+
+Run: `npm run build -w client 2>&1 | tail -5`
+Expected: Successful build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/app/applications/update-application-dialog.tsx
+git commit -m "feat: add UpdateApplicationDialog confirmation component"
+```
+
+---
+
+### Task 8: Add Update Button to Applications Page
+
+**Files:**
+- Modify: `client/src/app/applications/page.tsx`
+
+- [ ] **Step 1: Add imports**
+
+Add to the existing imports at the top of `client/src/app/applications/page.tsx`:
+
+```typescript
+import { IconRefresh } from "@tabler/icons-react";
+import { useUpdateApplication } from "@/hooks/use-applications";
+import { UpdateApplicationDialog } from "./update-application-dialog";
+```
+
+- [ ] **Step 2: Add state for update target**
+
+In the component, alongside the existing state declarations (near `deployTarget`, `stoppingId`), add:
+
+```typescript
+const [updateTarget, setUpdateTarget] = useState<StackTemplateInfo | null>(null);
+```
+
+- [ ] **Step 3: Add the Update button to card actions**
+
+In the card's button group (where Deploy and Stop buttons are rendered), add an Update button between Deploy and Stop:
+
+```tsx
+<Button
+  size="sm"
+  variant="outline"
+  className="flex-1"
+  disabled={!stackByTemplateId.has(app.id)}
+  onClick={() => setUpdateTarget(app)}
+>
+  <IconRefresh className="h-4 w-4 mr-1" />
+  Update
+</Button>
+```
+
+- [ ] **Step 4: Add the dialog**
+
+Near the existing `<DeployApplicationDialog>` (around line 349), add the update dialog:
+
+```tsx
+<UpdateApplicationDialog
+  open={!!updateTarget}
+  onOpenChange={(open) => {
+    if (!open) setUpdateTarget(null);
+  }}
+  application={updateTarget}
+  stack={updateTarget ? stackByTemplateId.get(updateTarget.id) ?? null : null}
+/>
+```
+
+- [ ] **Step 5: Verify frontend compiles**
+
+Run: `npm run build -w client 2>&1 | tail -5`
+Expected: Successful build.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/app/applications/page.tsx
+git commit -m "feat: add Update button to application cards"
+```
+
+---
+
+### Task 9: Integration Test — Update Endpoint
+
+**Files:**
+- Modify: Add test to existing test file or create if needed
+
+- [ ] **Step 1: Find existing stack route tests**
+
+Run: `find server/src -name "*.test.*" | grep -i stack | head -10`
+
+Check if there's an existing test file for stack routes. If there is, add tests there. If not, this step validates the endpoint works via build + manual testing.
+
+- [ ] **Step 2: Verify full build succeeds**
+
+Run: `npm run build:lib && npx -w server tsc --noEmit --pretty 2>&1 | tail -10`
+Expected: No type errors.
+
+Run: `npm run build -w client 2>&1 | tail -5`
+Expected: Successful build.
+
+- [ ] **Step 3: Run existing tests to confirm no regressions**
+
+Run: `npm test -w server 2>&1 | tail -20`
+Expected: All existing tests pass.
+
+Run: `npm test -w client 2>&1 | tail -20`
+Expected: All existing tests pass.
+
+- [ ] **Step 4: Commit if any test files were added**
+
+```bash
+git add -A
+git commit -m "test: verify no regressions from update feature"
+```
+
+---
+
+### Task 10: Final Verification
+
+- [ ] **Step 1: Verify full build**
+
+```bash
+npm run build:lib && npm run build -w client
+```
+
+- [ ] **Step 2: Run all tests**
+
+```bash
+npm test -w server && npm test -w client
+```
+
+- [ ] **Step 3: Review all changes**
+
+```bash
+git log --oneline main..HEAD
+git diff main --stat
+```
+
+Verify the commit history covers:
+1. Blue-green update state machine
+2. Shared types (`UpdateOptions`)
+3. Reconciler `update()` + `updateStatelessWeb()` methods
+4. `POST /stacks/:id/update` endpoint
+5. Task tracker types + registry
+6. `useUpdateApplication` hook
+7. `UpdateApplicationDialog`
+8. Update button on Applications page

--- a/docs/superpowers/specs/2026-03-28-application-update-design.md
+++ b/docs/superpowers/specs/2026-03-28-application-update-design.md
@@ -1,0 +1,148 @@
+# Application Update Feature
+
+## Overview
+
+A dedicated "Update" action on Application cards that pulls the latest image and redeploys running containers. StatelessWeb services get zero-downtime blue-green updates via a simplified state machine. Stateful services get a simple stop → pull → recreate cycle with brief downtime.
+
+This is distinct from "recreate" (triggered by definition changes) — an update means "same config, fresh image."
+
+## Backend
+
+### New Endpoint: `POST /api/stacks/:id/update`
+
+- **Auth**: `requirePermission('stacks:write')`
+- **Request body**: `{}` — no parameters. Pulls the latest of each service's configured tag.
+- **Validation**:
+  - Stack exists and has status `synced` or `drifted` (i.e., is deployed and running)
+  - Not already being applied/updated (reuse existing `applyingStacks` concurrency guard, return 409 if in progress)
+- **Response**: `202 Accepted` with `{ success: true, data: { started: true, stackId } }`
+
+### Background Execution Flow
+
+1. Pull all service images using `forcePull` digest comparison
+2. For services where the image digest changed:
+   - **StatelessWeb**: Run through the new blue-green update state machine (zero-downtime)
+   - **Stateful**: Stop → remove → pull → create → start (brief downtime)
+3. Services with unchanged digests: skip (no-op)
+4. Record `StackDeployment` with `action: 'update'`
+5. Emit `STACK_APPLY_COMPLETED` with results
+
+### Blue-Green Update State Machine
+
+Copy `blue-green-deployment-state-machine.ts` to `blue-green-update-state-machine.ts` and strip out the TLS, DNS, and frontend configuration states (and their rollback counterparts). These resources are already configured from the initial deploy/apply — an update only swaps the container behind existing routing.
+
+**State flow**:
+```
+idle
+ → deployingGreen (15%)         Pull image, create new container
+ → waitingGreenReady (30%)      Wait for container startup
+ → addingGreenToLB (45%)        Register green in HAProxy backend
+ → healthCheckGreen (60%)       Health checks against green
+ → openingTrafficToGreen (75%)  Switch HAProxy traffic to green
+ → validatingGreen (85%)        Validate green is serving
+ → drainingBlue (90%)           Drain connections from old container
+ → removingBlue (95%)           Stop and remove old container
+ → completed (100%)
+```
+
+**Removed from the deployment machine**: `configuringFrontend`, `configuringDNS` states and their associated rollback states.
+
+**Rollback**: On health check failure, the machine rolls back to the blue container (restore traffic, remove green) — same as the deployment machine minus the DNS/TLS rollback steps.
+
+### Stateful Update Flow
+
+Simple sequential execution within the reconciler (no state machine needed):
+
+1. Stop existing container
+2. Remove existing container
+3. Pull image with `pullImageWithAutoAuth()`
+4. Create new container with same definition
+5. Start container
+6. Wait for healthcheck
+
+### Stack Reconciler Changes
+
+Add a new method or parameterize the existing `apply()` to support update mode:
+
+- Uses `forcePull` semantics to detect image digest changes
+- Uses the update state machine (not deployment machine) for StatelessWeb services
+- Skips resource reconciliation (TLS/DNS/tunnel) — resources are already in place
+- Records the action as `'update'` in `StackDeployment`
+
+### Schema Change
+
+Add `'update'` to `StackDeployment.action`. Currently the field stores `'apply' | 'destroy'` as a string — extend validation to accept `'update'`.
+
+### Socket.IO Events
+
+Reuse existing events — they're generic enough:
+- `STACK_APPLY_STARTED` — with `action: 'update'` in payload
+- `STACK_APPLY_SERVICE_RESULT` — per-service progress
+- `STACK_APPLY_COMPLETED` — final result
+
+The `action` field in the payload distinguishes update from apply.
+
+## Frontend
+
+### Update Button (Applications Page)
+
+In `client/src/app/applications/page.tsx`, add an "Update" button to each Application card. Visible only when the app has an active deployed stack (same condition used for the Stop button — `stackByTemplateId.has(app.id)` with a running stack).
+
+### UpdateApplicationDialog
+
+New file: `client/src/app/applications/update-application-dialog.tsx`
+
+- Confirmation dialog: "Update [app name]? This will pull the latest image and redeploy."
+- Cancel and Update buttons
+- On confirm: calls `useUpdateApplication()` mutation
+- On success: toast "Application update started", close dialog
+
+### useUpdateApplication Hook
+
+In `client/src/hooks/use-applications.ts`:
+
+```typescript
+export function useUpdateApplication() {
+  return useMutation({
+    mutationFn: async (stackId: string) => {
+      return apiClient.post(`/api/stacks/${stackId}/update`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['applications'] });
+      queryClient.invalidateQueries({ queryKey: ['userStacks'] });
+      queryClient.invalidateQueries({ queryKey: ['stacks'] });
+    },
+  });
+}
+```
+
+### Task Tracker Integration
+
+New entry in `client/src/lib/task-type-registry.ts`:
+
+Task type: `'stack-update'` with steps derived from the update state machine states. Bound to the existing `STACK_APPLY_*` Socket.IO events (filtered by `action: 'update'` in payload).
+
+Steps for StatelessWeb services:
+- Pulling image
+- Starting new container
+- Adding to load balancer
+- Health checking
+- Switching traffic
+- Validating
+- Draining old container
+- Removing old container
+- Complete
+
+Steps for Stateful services:
+- Stopping container
+- Pulling image
+- Starting new container
+- Health checking
+- Complete
+
+## Out of Scope
+
+- Per-service update from stack detail view
+- Tag override in the update dialog
+- Rollback for stateful updates
+- Update from the Deployments page (separate system)

--- a/lib/types/stacks.ts
+++ b/lib/types/stacks.ts
@@ -383,6 +383,12 @@ export interface ApplyOptions {
   onProgress?: (result: ServiceApplyResult | ResourceResult, completedCount: number, totalActions: number) => void;
 }
 
+export interface UpdateOptions {
+  triggeredBy?: string;
+  /** Called after each service action completes */
+  onProgress?: (result: ServiceApplyResult, completedCount: number, totalActions: number) => void;
+}
+
 export interface ApplyResult {
   success: boolean;
   stackId: string;

--- a/server/src/routes/stacks.ts
+++ b/server/src/routes/stacks.ts
@@ -603,6 +603,99 @@ router.post('/:stackId/apply', requirePermission('stacks:write'), async (req, re
   }
 });
 
+// POST /:stackId/update — Pull latest images and redeploy changed containers
+router.post('/:stackId/update', requirePermission('stacks:write'), async (req, res) => {
+  const stackId = String(req.params.stackId);
+  try {
+    // Prevent concurrent operations on the same stack
+    if (applyingStacks.has(stackId)) {
+      return res.status(409).json({ success: false, message: 'Stack operation already in progress' });
+    }
+
+    // Validate stack exists and is deployed
+    const stack = await prisma.stack.findUnique({
+      where: { id: stackId },
+      select: { id: true, name: true, status: true },
+    });
+    if (!stack) {
+      return res.status(404).json({ success: false, message: 'Stack not found' });
+    }
+    if (stack.status !== 'synced' && stack.status !== 'drifted') {
+      return res.status(400).json({
+        success: false,
+        message: `Stack must be deployed to update (current status: ${stack.status})`,
+      });
+    }
+
+    const dockerExecutor = new DockerExecutorService();
+    await dockerExecutor.initialize();
+    const routingManager = new StackRoutingManager(prisma, new HAProxyFrontendManager());
+    const resourceReconciler = await createResourceReconciler();
+    const reconciler = new StackReconciler(dockerExecutor, prisma, routingManager, resourceReconciler);
+
+    applyingStacks.add(stackId);
+
+    // Emit started event — use same STACK_APPLY events with action context
+    const plan = await reconciler.plan(stackId);
+    const startedActions = plan.actions.map((a) => ({ serviceName: a.serviceName, action: 'update' }));
+
+    emitToChannel(Channel.STACKS, ServerEvent.STACK_APPLY_STARTED, {
+      stackId,
+      stackName: plan.stackName,
+      totalActions: startedActions.length,
+      actions: startedActions,
+      forcePull: true,
+    });
+
+    // Respond immediately
+    res.json({ success: true, data: { started: true, stackId } });
+
+    // Run update in background
+    const triggeredBy = (req as any).user?.id;
+    (async () => {
+      try {
+        const result = await reconciler.update(stackId, {
+          triggeredBy,
+          onProgress: (serviceResult, completedCount, totalActions) => {
+            try {
+              emitToChannel(Channel.STACKS, ServerEvent.STACK_APPLY_SERVICE_RESULT, {
+                stackId,
+                ...serviceResult,
+                completedCount,
+                totalActions,
+              } as any);
+            } catch { /* never break update */ }
+          },
+        });
+
+        emitToChannel(Channel.STACKS, ServerEvent.STACK_APPLY_COMPLETED, {
+          ...result,
+        });
+      } catch (error: any) {
+        logger.error({ error: error.message, stackId }, 'Background stack update failed');
+        emitToChannel(Channel.STACKS, ServerEvent.STACK_APPLY_COMPLETED, {
+          success: false,
+          stackId,
+          appliedVersion: 0,
+          serviceResults: [],
+          resourceResults: [],
+          duration: 0,
+          error: error.message,
+        });
+      } finally {
+        applyingStacks.delete(stackId);
+      }
+    })();
+  } catch (error: any) {
+    applyingStacks.delete(stackId);
+    if (isDockerConnectionError(error)) {
+      return res.status(503).json({ success: false, message: 'Docker is unavailable' });
+    }
+    logger.error({ error, stackId }, 'Failed to start stack update');
+    res.status(500).json({ success: false, message: error?.message ?? 'Failed to update stack' });
+  }
+});
+
 // POST /:stackId/destroy — Destroy stack: remove containers, networks, volumes, and DB record
 router.post('/:stackId/destroy', requirePermission('stacks:write'), async (req, res) => {
   const stackId = String(req.params.stackId);

--- a/server/src/services/haproxy/blue-green-update-state-machine.ts
+++ b/server/src/services/haproxy/blue-green-update-state-machine.ts
@@ -1,0 +1,1101 @@
+import { assign, setup } from 'xstate';
+import { deploymentLogger } from '../../lib/logger-factory';
+import { ContainerLifecycleManager } from '../container';
+import { DeployApplicationContainers } from './actions/deploy-application-containers';
+import { MonitorContainerStartup } from './actions/monitor-container-startup';
+import { AddContainerToLB } from './actions/add-container-to-lb';
+import { PerformHealthChecks } from './actions/perform-health-checks';
+import { InitiateDrain } from './actions/initiate-drain';
+import { MonitorDrain } from './actions/monitor-drain';
+import { RemoveContainerFromLB } from './actions/remove-container-from-lb';
+import { StopApplication } from './actions/stop-application';
+import { RemoveApplication } from './actions/remove-application';
+import { LogDeploymentSuccess } from './actions/log-deployment-success';
+import { AlertOperationsTeam } from './actions/alert-operations-team';
+import { CleanupTempResources } from './actions/cleanup-temp-resources';
+import { EnableTraffic } from './actions/enable-traffic';
+
+// Create instances of action classes
+const deployApplicationContainers = new DeployApplicationContainers();
+const monitorContainerStartup = new MonitorContainerStartup();
+const addContainerToLB = new AddContainerToLB();
+const performHealthChecks = new PerformHealthChecks();
+const initiateDrain = new InitiateDrain();
+const monitorDrain = new MonitorDrain();
+const removeContainerFromLB = new RemoveContainerFromLB();
+const stopApplication = new StopApplication();
+const removeApplication = new RemoveApplication();
+const logDeploymentSuccess = new LogDeploymentSuccess();
+const alertOperationsTeam = new AlertOperationsTeam();
+const cleanupTempResources = new CleanupTempResources();
+const enableTraffic = new EnableTraffic();
+
+// Types for context and events
+// Note in a blue green update Blue is the old container set, Green is the new container set
+interface BlueGreenUpdateContext {
+    // Deployment identifiers
+    deploymentId: string;
+    configurationId: string;
+    deploymentConfigId: string;
+    applicationName: string;
+    dockerImage: string;
+
+    // User event tracking
+    userEventId?: string;
+
+    // Environment context
+    environmentId: string;
+    environmentName: string;
+    haproxyContainerId: string;
+    haproxyNetworkName: string;
+
+    // Container state
+    blueHealthy: boolean;
+    greenHealthy: boolean;
+    greenBackendConfigured: boolean;
+    trafficOpenedToGreen: boolean;
+    trafficValidated: boolean;
+    blueDraining: boolean;
+    blueDrained: boolean;
+    validationErrors: number;
+    drainStartTime?: number;
+    monitoringStartTime?: number;
+    error?: string;
+    retryCount: number;
+    activeConnections: number;
+    oldContainerId?: string;
+    newContainerId?: string;
+    containerName?: string;
+    containerIpAddress?: string;
+    containerPort?: number;
+
+    // Deployment metadata
+    triggerType: string;
+    triggeredBy?: string;
+    startTime: number;
+
+    // Configuration
+    config?: any;
+
+    // Source-agnostic configuration (used by actions instead of DB lookups)
+    // When set, actions read from these fields directly.
+    // When unset, actions fall back to context.config / DB lookups for backwards compatibility.
+    hostname?: string;
+    enableSsl?: boolean;
+    tlsCertificateId?: string;
+    certificateStatus?: string;
+    networkType?: string;
+    healthCheckEndpoint?: string;
+    healthCheckInterval?: number;
+    healthCheckRetries?: number;
+    containerPorts?: { containerPort: number; hostPort: number; protocol: string }[];
+    containerVolumes?: string[];
+    containerEnvironment?: Record<string, string>;
+    containerLabels?: Record<string, string>;
+    containerNetworks?: string[];
+}
+
+type BlueGreenUpdateEvent =
+    // Deployment initiation
+    | { type: 'START_DEPLOYMENT' }
+
+    // Green deployment events
+    | { type: 'DEPLOYMENT_SUCCESS'; containerId: string; containerName?: string }
+    | { type: 'DEPLOYMENT_ERROR'; error: string }
+    | { type: 'CONTAINERS_RUNNING'; containerIpAddress: string; containerPort: number; containerName?: string }
+    | { type: 'STARTUP_TIMEOUT' }
+
+    // Load balancer configuration events
+    | { type: 'LB_CONFIGURED' }
+    | { type: 'LB_CONFIG_ERROR'; error: string }
+
+    // Health check events
+    | { type: 'SERVERS_HEALTHY' }
+    | { type: 'HEALTH_CHECK_TIMEOUT' }
+
+    // Traffic management events
+    | { type: 'TRAFFIC_ENABLED' }
+    | { type: 'TRAFFIC_ENABLE_FAILED'; error: string }
+    | { type: 'TRAFFIC_VALIDATED' }
+    | { type: 'VALIDATION_FAILED'; error: string }
+
+    // Blue draining events
+    | { type: 'DRAIN_INITIATED' }
+    | { type: 'DRAIN_COMPLETE' }
+    | { type: 'DRAIN_TIMEOUT' }
+    | { type: 'DRAIN_ISSUES'; error: string }
+
+    // Blue decommission events
+    | { type: 'LB_REMOVAL_SUCCESS' }
+    | { type: 'LB_REMOVAL_FAILED'; error: string }
+    | { type: 'BLUE_APP_STOPPED' }
+    | { type: 'BLUE_APP_STOP_ERROR'; error: string }
+    | { type: 'STOP_SUCCESS' }
+    | { type: 'STOP_FAILED'; error: string }
+    | { type: 'BLUE_APP_REMOVED' }
+    | { type: 'BLUE_APP_REMOVAL_ERROR'; error: string }
+    | { type: 'REMOVAL_SUCCESS' }
+    | { type: 'REMOVAL_FAILED'; error: string }
+
+    // Rollback events
+    | { type: 'ROLLBACK_BLUE_TRAFFIC_RESTORED' }
+    | { type: 'ROLLBACK_GREEN_CONFIG_REMOVED' }
+    | { type: 'ROLLBACK_GREEN_APP_STOPPED' }
+    | { type: 'ROLLBACK_GREEN_APP_REMOVED' }
+    | { type: 'ROLLBACK_COMPLETE' }
+    | { type: 'ROLLBACK_ERROR'; error: string }
+    | { type: 'GREEN_LB_REMOVAL_ERROR'; error: string }
+
+    // Completion events
+    | { type: 'DEPLOYMENT_COMPLETE' }
+    | { type: 'RESET' }
+    | { type: 'MANUAL_INTERVENTION_COMPLETE' };
+
+// The Blue-Green Update State Machine using setup
+export const blueGreenUpdateMachine = setup({
+    types: {
+        context: {} as BlueGreenUpdateContext,
+        events: {} as BlueGreenUpdateEvent,
+        input: {} as BlueGreenUpdateContext
+    },
+    actions: {
+        // Green deployment actions
+        deployGreenApplicationContainers: ({ context, self }) => {
+            deployApplicationContainers.execute(context, (event) => self.send(event));
+        },
+
+        monitorGreenContainerStartup: ({ context, self }) => {
+            monitorContainerStartup.execute(context, (event) => self.send(event));
+        },
+
+        // Load balancer configuration actions
+        initializeGreenLB: ({ context, self }) => {
+            const logger = deploymentLogger();
+            logger.info({
+                deploymentId: context.deploymentId,
+                applicationName: context.applicationName,
+                newContainerId: context.newContainerId,
+                containerIpAddress: context.containerIpAddress,
+                containerPort: context.containerPort,
+                currentState: 'initializingGreenLB'
+            }, 'State machine: Entering initializeGreenLB action');
+
+            // Map newContainerId to containerId for the action
+            const contextWithContainerId = {
+                ...context,
+                containerId: context.newContainerId
+            };
+
+            addContainerToLB.execute(contextWithContainerId, (event) => {
+                logger.info({
+                    deploymentId: context.deploymentId,
+                    applicationName: context.applicationName,
+                    event,
+                    currentState: 'initializingGreenLB'
+                }, 'State machine: Received event from initializeGreenLB action');
+                self.send(event);
+            });
+        },
+
+        performGreenHealthChecks: ({ context, self }) => {
+            // Map newContainerId to containerId for the action
+            const contextWithContainerId = {
+                ...context,
+                containerId: context.newContainerId
+            };
+            performHealthChecks.execute(contextWithContainerId, (event) => self.send(event));
+        },
+
+        // Traffic management actions
+        openTrafficToGreen: ({ context, self }) => {
+            // Map newContainerId to containerId for the action
+            const contextWithContainerId = {
+                ...context,
+                containerId: context.newContainerId
+            };
+            enableTraffic.execute(contextWithContainerId, (event) => self.send(event));
+        },
+
+
+        // Blue draining actions
+        initiateBlueDrain: ({ context, self }) => {
+            // Map newContainerId to containerId for the action
+            const contextWithContainerId = {
+                ...context,
+                containerId: context.newContainerId
+            };
+            initiateDrain.execute(contextWithContainerId, (event) => self.send(event));
+        },
+
+        setDrainStartTime: assign({
+            drainStartTime: () => Date.now()
+        }),
+
+        monitorBlueDrain: ({ context, self }) => {
+            // Start monitoring the drain status
+            monitorDrain.execute(context, (event) => self.send(event));
+        },
+
+        // Blue decommission actions
+        removeBlueFromLB: ({ context, self }) => {
+            // Map oldContainerId to containerId for the action
+            const contextWithContainerId = {
+                ...context,
+                containerId: context.oldContainerId
+            };
+            removeContainerFromLB.execute(contextWithContainerId, (event) => {
+                self.send(event);
+            }).catch((error) => {
+                self.send({
+                    type: 'LB_REMOVAL_FAILED',
+                    error: error.message || 'Unknown error'
+                });
+            });
+        },
+
+        stopBlueApplication: ({ context, self }) => {
+            // Map oldContainerId to containerId for the action
+            const contextWithContainerId = {
+                ...context,
+                containerId: context.oldContainerId
+            };
+            stopApplication.execute(contextWithContainerId, (event) => {
+                self.send(event);
+            }).catch((error) => {
+                self.send({
+                    type: 'BLUE_APP_STOP_ERROR',
+                    error: error.message || 'Unknown error'
+                });
+            });
+        },
+
+        removeBlueApplication: ({ context, self }) => {
+            // Map oldContainerId to containerId for the action
+            const contextWithContainerId = {
+                ...context,
+                containerId: context.oldContainerId
+            };
+            removeApplication.execute(contextWithContainerId, (event) => {
+                self.send(event);
+            }).catch((error) => {
+                self.send({
+                    type: 'BLUE_APP_REMOVAL_ERROR',
+                    error: error.message || 'Unknown error'
+                });
+            });
+        },
+
+        // Rollback actions
+        restoreBlueTraffic: ({ context, self }) => {
+            // Map oldContainerId to containerId for the action
+            const contextWithContainerId = {
+                ...context,
+                containerId: context.oldContainerId
+            };
+            enableTraffic.execute(contextWithContainerId, (event) => {
+                // Map the standard traffic events to rollback events
+                if (event.type === 'TRAFFIC_ENABLED') {
+                    self.send({ type: 'ROLLBACK_BLUE_TRAFFIC_RESTORED' });
+                } else if (event.type === 'TRAFFIC_ENABLE_FAILED') {
+                    self.send({ type: 'ROLLBACK_ERROR', error: event.error });
+                } else {
+                    self.send(event);
+                }
+            });
+        },
+
+        removeGreenHAProxyConfig: ({ context, self }) => {
+            // Map newContainerId to containerId for the action
+            const contextWithContainerId = {
+                ...context,
+                containerId: context.newContainerId
+            };
+            removeContainerFromLB.execute(contextWithContainerId, (event) => {
+                // Map the standard LB removal events to rollback events
+                if (event.type === 'LB_REMOVAL_SUCCESS') {
+                    self.send({ type: 'ROLLBACK_GREEN_CONFIG_REMOVED' });
+                } else if (event.type === 'LB_REMOVAL_FAILED') {
+                    self.send({ type: 'ROLLBACK_ERROR', error: event.error });
+                } else {
+                    self.send(event);
+                }
+            }).catch((error) => {
+                self.send({
+                    type: 'ROLLBACK_ERROR',
+                    error: error.message || 'Unknown error'
+                });
+            });
+        },
+
+        stopGreenApplication: ({ context, self }) => {
+            // Map newContainerId to containerId for the action
+            const contextWithContainerId = {
+                ...context,
+                containerId: context.newContainerId
+            };
+            stopApplication.execute(contextWithContainerId, (event) => {
+                // Map stop events to rollback events
+                if (event.type === 'STOP_SUCCESS') {
+                    self.send({ type: 'ROLLBACK_GREEN_APP_STOPPED' });
+                } else if (event.type === 'STOP_FAILED') {
+                    self.send({ type: 'ROLLBACK_ERROR', error: event.error });
+                } else {
+                    self.send(event);
+                }
+            }).catch((error) => {
+                self.send({
+                    type: 'ROLLBACK_ERROR',
+                    error: error.message || 'Unknown error'
+                });
+            });
+        },
+
+        removeGreenApplication: ({ context, self }) => {
+            // Map newContainerId to containerId for the action
+            const contextWithContainerId = {
+                ...context,
+                containerId: context.newContainerId
+            };
+            removeApplication.execute(contextWithContainerId, (event) => {
+                // Map removal events to rollback events
+                if (event.type === 'REMOVAL_SUCCESS') {
+                    self.send({ type: 'ROLLBACK_GREEN_APP_REMOVED' });
+                } else if (event.type === 'REMOVAL_FAILED') {
+                    self.send({ type: 'ROLLBACK_ERROR', error: event.error });
+                } else {
+                    self.send(event);
+                }
+            }).catch((error) => {
+                self.send({
+                    type: 'ROLLBACK_ERROR',
+                    error: error.message || 'Unknown error'
+                });
+            });
+        },
+
+        // Monitoring and completion actions
+        startExtendedMonitoring: assign({
+            monitoringStartTime: () => Date.now()
+        }),
+
+        logDeploymentSuccess: ({ context }) => {
+            logDeploymentSuccess.execute(context);
+        },
+
+        alertOperationsTeam: ({ context }) => {
+            alertOperationsTeam.execute(context);
+        },
+
+        cleanupTempResources: ({ context }) => {
+            cleanupTempResources.execute(context);
+        },
+
+        cleanupFailedDeployment: async ({ context }) => {
+            const logger = deploymentLogger();
+            logger.warn({
+                deploymentId: context.deploymentId,
+                applicationName: context.applicationName,
+                newContainerId: context.newContainerId?.slice(0, 12),
+                error: context.error
+            }, 'Attempting best-effort cleanup of failed deployment');
+
+            // Best-effort cleanup - don't fail if any step fails
+            try {
+                // If we have a green container, try to remove it and its HAProxy config
+                if (context.newContainerId) {
+                    logger.info({
+                        deploymentId: context.deploymentId,
+                        containerId: context.newContainerId.slice(0, 12)
+                    }, 'Attempting to clean up green container from failed deployment');
+
+                    // Try to remove from HAProxy first
+                    try {
+                        const contextWithContainerId = {
+                            ...context,
+                            containerId: context.newContainerId
+                        };
+                        await removeContainerFromLB.execute(contextWithContainerId, () => {});
+                        logger.info({
+                            deploymentId: context.deploymentId,
+                            containerId: context.newContainerId.slice(0, 12)
+                        }, 'Removed green container from HAProxy');
+                    } catch (lbError) {
+                        logger.warn({
+                            deploymentId: context.deploymentId,
+                            containerId: context.newContainerId.slice(0, 12),
+                            error: lbError instanceof Error ? lbError.message : 'Unknown error'
+                        }, 'Failed to remove container from HAProxy during cleanup');
+                    }
+
+                    // Try to stop and remove the container
+                    try {
+                        const contextWithContainerId = {
+                            ...context,
+                            containerId: context.newContainerId
+                        };
+                        await stopApplication.execute(contextWithContainerId, () => {});
+                        await removeApplication.execute(contextWithContainerId, () => {});
+                        logger.info({
+                            deploymentId: context.deploymentId,
+                            containerId: context.newContainerId.slice(0, 12)
+                        }, 'Stopped and removed green container');
+                    } catch (containerError) {
+                        logger.warn({
+                            deploymentId: context.deploymentId,
+                            containerId: context.newContainerId.slice(0, 12),
+                            error: containerError instanceof Error ? containerError.message : 'Unknown error'
+                        }, 'Failed to stop/remove container during cleanup');
+                    }
+                }
+
+                logger.info({
+                    deploymentId: context.deploymentId,
+                    applicationName: context.applicationName
+                }, 'Failed deployment cleanup completed (best-effort)');
+            } catch (error) {
+                logger.error({
+                    deploymentId: context.deploymentId,
+                    applicationName: context.applicationName,
+                    error: error instanceof Error ? error.message : 'Unknown error'
+                }, 'Unexpected error during failed deployment cleanup');
+            }
+        },
+
+        // Context management actions
+        preserveErrorContext: assign({
+            error: ({ event }) => {
+                if ('error' in event) {
+                    return event.error;
+                }
+                return undefined;
+            }
+        }),
+
+        incrementRetryCount: assign({
+            retryCount: ({ context }) => context.retryCount + 1
+        }),
+
+        resetState: assign(() => ({
+            // Keep deployment identifiers and environment context
+            // Only reset deployment state
+            blueHealthy: false,
+            greenHealthy: false,
+            greenBackendConfigured: false,
+            trafficOpenedToGreen: false,
+            trafficValidated: false,
+            blueDraining: false,
+            blueDrained: false,
+            validationErrors: 0,
+            drainStartTime: undefined,
+            monitoringStartTime: undefined,
+            error: undefined,
+            retryCount: 0,
+            activeConnections: 0,
+            newContainerId: undefined,
+            oldContainerId: undefined,
+            containerName: undefined,
+            containerIpAddress: undefined,
+            containerPort: undefined,
+        }))
+    },
+    guards: {
+        greenContainersRunning: ({ context }) => {
+            return context.greenHealthy;
+        },
+
+        greenServersHealthy: ({ context }) => {
+            return context.greenHealthy && context.greenBackendConfigured;
+        },
+
+        trafficValidationPassed: ({ context }) => {
+            return context.trafficValidated && context.validationErrors === 0;
+        },
+
+        blueConnectionsDrained: ({ context }) => {
+            return context.activeConnections === 0;
+        },
+
+        drainTimeoutExceeded: ({ context }) => {
+            if (!context.drainStartTime) return false;
+            const elapsed = Date.now() - context.drainStartTime;
+            return elapsed >= 120000; // 2 minutes
+        },
+
+        monitoringPeriodComplete: ({ context }) => {
+            if (!context.monitoringStartTime) return false;
+            const elapsed = Date.now() - context.monitoringStartTime;
+            return elapsed >= 300000; // 5 minutes
+        },
+
+        canRetry: ({ context }) => {
+            return context.retryCount < 3;
+        }
+    }
+}).createMachine({
+    id: 'blueGreenUpdate',
+    initial: 'idle',
+    context: ({ input }: { input: BlueGreenUpdateContext }) => ({
+        // Use input data if provided, otherwise use defaults
+        deploymentId: input?.deploymentId || "",
+        configurationId: input?.configurationId || "",
+        deploymentConfigId: input?.deploymentConfigId || input?.configurationId || "",
+        applicationName: input?.applicationName || "",
+        dockerImage: input?.dockerImage || "",
+
+        // User event tracking
+        userEventId: input?.userEventId,
+
+        // Environment context
+        environmentId: input?.environmentId || "",
+        environmentName: input?.environmentName || "",
+        haproxyContainerId: input?.haproxyContainerId || "",
+        haproxyNetworkName: input?.haproxyNetworkName || "",
+
+        // Container state (always start with defaults)
+        blueHealthy: false,
+        greenHealthy: false,
+        greenBackendConfigured: false,
+        trafficOpenedToGreen: false,
+        trafficValidated: false,
+        blueDraining: false,
+        blueDrained: false,
+        validationErrors: 0,
+        retryCount: 0,
+        activeConnections: 0,
+        oldContainerId: input?.oldContainerId,
+        newContainerId: input?.newContainerId,
+        containerName: input?.containerName,
+        containerIpAddress: input?.containerIpAddress,
+        containerPort: input?.containerPort,
+
+        // Deployment metadata
+        triggerType: input?.triggerType || "manual",
+        triggeredBy: input?.triggeredBy,
+        startTime: input?.startTime || Date.now(),
+
+        // Configuration
+        config: input?.config,
+
+        // Source-agnostic configuration
+        hostname: input?.hostname,
+        enableSsl: input?.enableSsl,
+        tlsCertificateId: input?.tlsCertificateId,
+        certificateStatus: input?.certificateStatus,
+        networkType: input?.networkType,
+        healthCheckEndpoint: input?.healthCheckEndpoint,
+        healthCheckInterval: input?.healthCheckInterval,
+        healthCheckRetries: input?.healthCheckRetries,
+        containerPorts: input?.containerPorts,
+        containerVolumes: input?.containerVolumes,
+        containerEnvironment: input?.containerEnvironment,
+        containerLabels: input?.containerLabels,
+        containerNetworks: input?.containerNetworks,
+    }),
+
+    states: {
+        idle: {
+            description: 'System is ready for deployment, no active deployment in progress',
+            on: {
+                START_DEPLOYMENT: {
+                    target: 'deployingGreenApp'
+                    // NOTE: Do NOT call resetState here - it would clear oldContainerId and other container tracking fields
+                    // The context is already properly initialized from input when the actor is created
+                }
+            }
+        },
+
+        deployingGreenApp: {
+            description: 'Deploying green application containers',
+            entry: [
+                ({ context }) => {
+                    const logger = deploymentLogger();
+                    logger.info({
+                        deploymentId: context.deploymentId,
+                        applicationName: context.applicationName,
+                        dockerImage: context.dockerImage,
+                        environmentName: context.environmentName,
+                        oldContainerId: context.oldContainerId?.slice(0, 12)
+                    }, 'State machine: Entering deployingGreenApp state');
+
+                    // Capture existing container (blue/old) for deployment tracking
+                    if (context.oldContainerId) {
+                        // Handle container capture asynchronously without blocking state machine progression
+                        Promise.resolve().then(async () => {
+                            try {
+                                const containerManager = new ContainerLifecycleManager();
+                                await containerManager.captureContainerForDeployment({
+                                    deploymentId: context.deploymentId,
+                                    containerId: context.oldContainerId!,
+                                    containerRole: 'blue'
+                                });
+
+                                logger.info({
+                                    deploymentId: context.deploymentId,
+                                    containerId: context.oldContainerId?.slice(0, 12)
+                                }, 'Existing container (blue) captured for deployment tracking');
+                            } catch (error: any) {
+                                logger.warn({
+                                    deploymentId: context.deploymentId,
+                                    containerId: context.oldContainerId?.slice(0, 12),
+                                    error: error.message
+                                }, 'Failed to capture existing container (blue) for deployment tracking');
+                            }
+                        }).catch((error: any) => {
+                            // Additional catch for any Promise.resolve().then() errors
+                            logger.error({
+                                deploymentId: context.deploymentId,
+                                containerId: context.oldContainerId?.slice(0, 12),
+                                error: error.message
+                            }, 'Unexpected error in container capture promise handling');
+                        });
+                    }
+                },
+                'deployGreenApplicationContainers'
+            ],
+            on: {
+                DEPLOYMENT_SUCCESS: {
+                    target: 'waitingGreenReady',
+                    actions: [
+                        assign({
+                            newContainerId: ({ event }) => {
+                                if (event.type === 'DEPLOYMENT_SUCCESS') {
+                                    return event.containerId;
+                                }
+                                return undefined;
+                            },
+                            containerName: ({ event }) => {
+                                if (event.type === 'DEPLOYMENT_SUCCESS') {
+                                    return event.containerName;
+                                }
+                                return undefined;
+                            }
+                        }),
+                        ({ context, event }) => {
+                            const logger = deploymentLogger();
+                            logger.info({
+                                deploymentId: context.deploymentId,
+                                applicationName: context.applicationName,
+                                containerId: 'containerId' in event ? event.containerId : 'unknown',
+                                containerName: 'containerName' in event ? event.containerName : 'unknown'
+                            }, 'State machine: DEPLOYMENT_SUCCESS - transitioning to waitingGreenReady');
+                        }
+                    ]
+                },
+                DEPLOYMENT_ERROR: {
+                    target: 'failed',
+                    actions: [
+                        'preserveErrorContext',
+                        ({ context, event }) => {
+                            const logger = deploymentLogger();
+                            logger.error({
+                                deploymentId: context.deploymentId,
+                                applicationName: context.applicationName,
+                                error: 'error' in event ? event.error : 'Unknown error'
+                            }, 'State machine: DEPLOYMENT_ERROR - transitioning to failed');
+                        }
+                    ]
+                }
+            }
+        },
+
+        waitingGreenReady: {
+            description: 'Waiting for green application containers to be ready',
+            entry: [
+                ({ context }) => {
+                    const logger = deploymentLogger();
+                    logger.info({
+                        deploymentId: context.deploymentId,
+                        applicationName: context.applicationName,
+                        newContainerId: context.newContainerId
+                    }, 'State machine: Entering waitingGreenReady state');
+                },
+                'monitorGreenContainerStartup'
+            ],
+            on: {
+                CONTAINERS_RUNNING: {
+                    target: 'initializingGreenLB',
+                    actions: [
+                        assign({
+                            greenHealthy: true,
+                            containerIpAddress: ({ event }) => {
+                                if (event.type === 'CONTAINERS_RUNNING' && 'containerIpAddress' in event) {
+                                    return event.containerIpAddress;
+                                }
+                                return undefined;
+                            },
+                            containerPort: ({ event }) => {
+                                if (event.type === 'CONTAINERS_RUNNING' && 'containerPort' in event) {
+                                    return event.containerPort;
+                                }
+                                return undefined;
+                            },
+                            containerName: ({ event }) => {
+                                if (event.type === 'CONTAINERS_RUNNING' && 'containerName' in event) {
+                                    return event.containerName;
+                                }
+                                return undefined;
+                            }
+                        }),
+                        ({ context, event }) => {
+                            const logger = deploymentLogger();
+                            logger.info({
+                                deploymentId: context.deploymentId,
+                                applicationName: context.applicationName,
+                                containerIpAddress: 'containerIpAddress' in event ? event.containerIpAddress : 'unknown',
+                                containerPort: 'containerPort' in event ? event.containerPort : 'unknown',
+                                containerName: 'containerName' in event ? event.containerName : 'unknown'
+                            }, 'State machine: CONTAINERS_RUNNING - transitioning to initializingGreenLB');
+                        }
+                    ]
+                },
+                STARTUP_TIMEOUT: {
+                    target: 'rollbackRemovingGreenApp',
+                    actions: [
+                        assign({ error: 'Green container startup timeout' }),
+                        ({ context }) => {
+                            const logger = deploymentLogger();
+                            logger.error({
+                                deploymentId: context.deploymentId,
+                                applicationName: context.applicationName
+                            }, 'State machine: STARTUP_TIMEOUT - transitioning to rollbackRemovingGreenApp');
+                        }
+                    ]
+                }
+            },
+            after: {
+                120000: { // 2 minute timeout
+                    target: 'rollbackRemovingGreenApp',
+                    actions: [
+                        assign({ error: 'Green application startup timeout' }),
+                        ({ context }) => {
+                            const logger = deploymentLogger();
+                            logger.error({
+                                deploymentId: context.deploymentId,
+                                applicationName: context.applicationName
+                            }, 'State machine: Startup timeout (120s) - transitioning to rollbackRemovingGreenApp');
+                        }
+                    ]
+                }
+            }
+        },
+
+        initializingGreenLB: {
+            description: 'Preparing HAProxy configuration for green backend and registering servers',
+            entry: [
+                ({ context }) => {
+                    const logger = deploymentLogger();
+                    logger.info({
+                        deploymentId: context.deploymentId,
+                        applicationName: context.applicationName,
+                        newContainerId: context.newContainerId,
+                        containerIpAddress: context.containerIpAddress,
+                        containerPort: context.containerPort,
+                        environmentName: context.environmentName,
+                        haproxyContainerId: context.haproxyContainerId,
+                        config: context.config ? 'present' : 'missing'
+                    }, 'State machine: Entering initializingGreenLB state');
+                },
+                'initializeGreenLB'
+            ],
+            on: {
+                LB_CONFIGURED: {
+                    target: 'healthCheckWait',
+                    actions: [
+                        assign({ greenBackendConfigured: true }),
+                        ({ context }) => {
+                            const logger = deploymentLogger();
+                            logger.info({
+                                deploymentId: context.deploymentId,
+                                applicationName: context.applicationName,
+                                currentState: 'initializingGreenLB'
+                            }, 'State machine: LB_CONFIGURED - transitioning to healthCheckWait');
+                        }
+                    ]
+                },
+                LB_CONFIG_ERROR: {
+                    target: 'rollbackStoppingGreenApp',
+                    actions: [
+                        'preserveErrorContext',
+                        ({ context, event }) => {
+                            const logger = deploymentLogger();
+                            logger.error({
+                                deploymentId: context.deploymentId,
+                                applicationName: context.applicationName,
+                                error: 'error' in event ? event.error : 'Unknown error',
+                                currentState: 'initializingGreenLB'
+                            }, 'State machine: LB_CONFIG_ERROR - transitioning to rollbackStoppingGreenApp');
+                        }
+                    ]
+                }
+            }
+        },
+
+        healthCheckWait: {
+            description: 'Waiting for green servers to become healthy',
+            entry: 'performGreenHealthChecks',
+            on: {
+                SERVERS_HEALTHY: {
+                    target: 'openingTraffic',
+                    actions: assign({ greenHealthy: true })
+                },
+                HEALTH_CHECK_TIMEOUT: {
+                    target: 'rollbackRemoveGreenHaproxyConfig',
+                    actions: assign({ error: 'Green health check timeout' })
+                }
+            },
+            after: {
+                90000: { // 90 second timeout
+                    target: 'rollbackRemoveGreenHaproxyConfig',
+                    actions: assign({ error: 'Health check timeout after 90 seconds' })
+                }
+            }
+        },
+
+        openingTraffic: {
+            description: 'Enabling traffic to green environment alongside blue',
+            entry: 'openTrafficToGreen',
+            on: {
+                TRAFFIC_ENABLED: {
+                    target: 'drainingBlue',
+                    actions: assign({ trafficOpenedToGreen: true, trafficValidated: true })
+                },
+                TRAFFIC_ENABLE_FAILED: {
+                    target: 'rollbackRemoveGreenHaproxyConfig',
+                    actions: 'preserveErrorContext'
+                }
+            }
+        },
+
+
+        drainingBlue: {
+            description: 'Initiating connection drain from blue environment',
+            entry: ['initiateBlueDrain', 'setDrainStartTime'],
+            on: {
+                DRAIN_INITIATED: {
+                    target: 'waitingForDrain',
+                    actions: assign({ blueDraining: true })
+                },
+                DRAIN_ISSUES: {
+                    target: 'rollbackRestoreBlueTraffic',
+                    actions: 'preserveErrorContext'
+                }
+            }
+        },
+
+        waitingForDrain: {
+            description: 'Waiting for all blue connections to close',
+            entry: 'monitorBlueDrain',
+            on: {
+                DRAIN_COMPLETE: {
+                    target: 'decommissioningBlueLB',
+                    actions: assign({
+                        blueDrained: true,
+                        activeConnections: 0
+                    })
+                },
+                DRAIN_TIMEOUT: {
+                    target: 'rollbackRestoreBlueTraffic',
+                    actions: assign({ error: 'Blue connection drain timeout' })
+                },
+                DRAIN_ISSUES: {
+                    target: 'rollbackRestoreBlueTraffic',
+                    actions: 'preserveErrorContext'
+                }
+            },
+            after: {
+                120000: { // 2 minute drain timeout
+                    target: 'rollbackRestoreBlueTraffic',
+                    actions: assign({ error: 'Forced drain timeout after 2 minutes' })
+                }
+            }
+        },
+
+        decommissioningBlueLB: {
+            description: 'Removing blue backend from HAProxy configuration',
+            entry: 'removeBlueFromLB',
+            on: {
+                LB_REMOVAL_SUCCESS: {
+                    target: 'stoppingBlueApp'
+                },
+                LB_REMOVAL_FAILED: {
+                    target: 'stoppingBlueApp',
+                    actions: [
+                        assign({ error: 'Unable to remove blue backend (Non-Critical)' }),
+                        ({ context, event }) => {
+                            const logger = deploymentLogger();
+                            logger.warn({
+                                deploymentId: context.deploymentId,
+                                applicationName: context.applicationName,
+                                error: 'error' in event ? event.error : 'Unknown error'
+                            }, 'Blue LB removal failed post-PONR - continuing blue cleanup (green is live)');
+                        }
+                    ]
+                }
+            }
+        },
+
+        stoppingBlueApp: {
+            description: 'Stopping blue application containers',
+            entry: 'stopBlueApplication',
+            on: {
+                STOP_SUCCESS: {
+                    target: 'removingBlueApp'
+                },
+                BLUE_APP_STOP_ERROR: {
+                    target: 'removingBlueApp',
+                    actions: [
+                        assign({ error: 'Blue app stop failed (Non-Critical)' }),
+                        ({ context, event }) => {
+                            const logger = deploymentLogger();
+                            logger.warn({
+                                deploymentId: context.deploymentId,
+                                applicationName: context.applicationName,
+                                oldContainerId: context.oldContainerId?.slice(0, 12),
+                                error: 'error' in event ? event.error : 'Unknown error'
+                            }, 'Blue app stop failed post-PONR - continuing to removal (green is live)');
+                        }
+                    ]
+                },
+                STOP_FAILED: {
+                    target: 'removingBlueApp',
+                    actions: [
+                        assign({ error: 'Blue app stop failed (Non-Critical)' }),
+                        ({ context, event }) => {
+                            const logger = deploymentLogger();
+                            logger.warn({
+                                deploymentId: context.deploymentId,
+                                applicationName: context.applicationName,
+                                oldContainerId: context.oldContainerId?.slice(0, 12),
+                                error: 'error' in event ? event.error : 'Unknown error'
+                            }, 'Blue app stop failed post-PONR - continuing to removal (green is live)');
+                        }
+                    ]
+                }
+            }
+        },
+
+        removingBlueApp: {
+            description: 'Removing blue application resources',
+            entry: 'removeBlueApplication',
+            on: {
+                REMOVAL_SUCCESS: {
+                    target: 'completed'
+                },
+                BLUE_APP_REMOVAL_ERROR: {
+                    target: 'completed',
+                    actions: [
+                        assign({ error: 'Blue app removal failed (Non-Critical)' }),
+                        ({ context, event }) => {
+                            const logger = deploymentLogger();
+                            logger.warn({
+                                deploymentId: context.deploymentId,
+                                applicationName: context.applicationName,
+                                oldContainerId: context.oldContainerId?.slice(0, 12),
+                                error: 'error' in event ? event.error : 'Unknown error'
+                            }, 'Blue app removal failed post-PONR - completing deployment (green is live)');
+                        }
+                    ]
+                },
+                REMOVAL_FAILED: {
+                    target: 'completed',
+                    actions: [
+                        assign({ error: 'Blue app removal failed (Non-Critical)' }),
+                        ({ context, event }) => {
+                            const logger = deploymentLogger();
+                            logger.warn({
+                                deploymentId: context.deploymentId,
+                                applicationName: context.applicationName,
+                                oldContainerId: context.oldContainerId?.slice(0, 12),
+                                error: 'error' in event ? event.error : 'Unknown error'
+                            }, 'Blue app removal failed post-PONR - completing deployment (green is live)');
+                        }
+                    ]
+                }
+            }
+        },
+
+        // Rollback states
+        rollbackRestoreBlueTraffic: {
+            description: 'Restoring traffic to the blue application during rollback',
+            entry: 'restoreBlueTraffic',
+            on: {
+                ROLLBACK_BLUE_TRAFFIC_RESTORED: {
+                    target: 'rollbackRemoveGreenHaproxyConfig'
+                },
+                ROLLBACK_ERROR: {
+                    target: 'rollbackRemoveGreenHaproxyConfig',
+                    actions: 'preserveErrorContext'
+                }
+            }
+        },
+
+        rollbackRemoveGreenHaproxyConfig: {
+            description: 'Remove green haproxy server and backends during rollback',
+            entry: 'removeGreenHAProxyConfig',
+            on: {
+                ROLLBACK_GREEN_CONFIG_REMOVED: {
+                    target: 'rollbackStoppingGreenApp'
+                },
+                ROLLBACK_ERROR: {
+                    target: 'failed',
+                    actions: assign({ error: 'Cannot rollback green config' })
+                }
+            }
+        },
+
+        rollbackStoppingGreenApp: {
+            description: 'Stopping failed green application containers during rollback',
+            entry: 'stopGreenApplication',
+            on: {
+                ROLLBACK_GREEN_APP_STOPPED: {
+                    target: 'rollbackRemovingGreenApp'
+                },
+                ROLLBACK_ERROR: {
+                    target: 'rollbackRemovingGreenApp',
+                    actions: assign({ error: 'Green app stop failed - continuing cleanup' })
+                }
+            }
+        },
+
+        rollbackRemovingGreenApp: {
+            description: 'Cleaning up green application resources during rollback',
+            entry: 'removeGreenApplication',
+            on: {
+                ROLLBACK_GREEN_APP_REMOVED: {
+                    target: 'rollbackComplete'
+                },
+                ROLLBACK_ERROR: {
+                    target: 'rollbackComplete',
+                    actions: assign({ error: 'Green app removal had errors - rollback completed with warnings' })
+                }
+            }
+        },
+
+        rollbackComplete: {
+            type: 'final' as const,
+            description: 'Rollback successfully completed - deployment failed but cleaned up',
+            entry: ['alertOperationsTeam', 'cleanupTempResources']
+        },
+
+        completed: {
+            type: 'final' as const,
+            description: 'Deployment successfully completed',
+            entry: ['logDeploymentSuccess', 'cleanupTempResources'],
+            on: {
+                RESET: {
+                    target: 'idle',
+                    actions: 'resetState'
+                }
+            }
+        },
+
+        failed: {
+            type: 'final' as const,
+            description: 'Deployment failed - attempting best-effort cleanup',
+            entry: [
+                'alertOperationsTeam',
+                'cleanupFailedDeployment'
+            ]
+        }
+    }
+});

--- a/server/src/services/stacks/stack-reconciler.ts
+++ b/server/src/services/stacks/stack-reconciler.ts
@@ -15,6 +15,7 @@ import {
   StackVolume,
   ApplyOptions,
   ApplyResult,
+  UpdateOptions,
   DestroyResult,
   ServiceApplyResult,
   ResourceResult,
@@ -29,6 +30,7 @@ import { HAProxyDataPlaneClient } from '../haproxy';
 import { servicesLogger } from '../../lib/logger-factory';
 import { initialDeploymentMachine } from '../haproxy/initial-deployment-state-machine';
 import { blueGreenDeploymentMachine } from '../haproxy/blue-green-deployment-state-machine';
+import { blueGreenUpdateMachine } from '../haproxy/blue-green-update-state-machine';
 import { removalDeploymentMachine } from '../haproxy/removal-deployment-state-machine';
 import { runStateMachineToCompletion } from './state-machine-runner';
 import { EnvironmentValidationService } from '../environment';
@@ -577,6 +579,169 @@ export class StackReconciler {
         });
       } catch (dbErr) {
         log.error({ error: dbErr }, 'Failed to record deployment failure');
+      }
+      throw err;
+    }
+  }
+
+  async update(stackId: string, options?: UpdateOptions): Promise<ApplyResult> {
+    const startTime = Date.now();
+    const log = servicesLogger().child({ operation: 'stack-update', stackId });
+
+    const plan = await this.plan(stackId);
+    await this.promoteStalePullActions(plan, stackId, log);
+
+    const actions = plan.actions.filter((a) => a.action !== 'no-op');
+
+    if (actions.length === 0) {
+      log.info('All images are up to date — nothing to update');
+      await this.prisma.stackDeployment.create({
+        data: {
+          stackId,
+          action: 'update',
+          success: true,
+          version: plan.stackVersion,
+          status: 'synced',
+          duration: Date.now() - startTime,
+          serviceResults: [],
+          triggeredBy: options?.triggeredBy ?? null,
+        },
+      });
+      return {
+        success: true,
+        stackId,
+        appliedVersion: plan.stackVersion,
+        serviceResults: [],
+        resourceResults: [],
+        duration: Date.now() - startTime,
+      };
+    }
+
+    const stack = await this.prisma.stack.findUniqueOrThrow({
+      where: { id: stackId },
+      include: { services: { orderBy: { order: 'asc' } }, environment: true },
+    });
+
+    try {
+      const projectName = stack.environment ? `${stack.environment.name}-${stack.name}` : stack.name;
+      const params = mergeParameterValues(
+        (stack.parameters as unknown as StackParameterDefinition[]) ?? [],
+        (stack.parameterValues as unknown as Record<string, StackParameterValue>) ?? {}
+      );
+      const templateContext = buildStackTemplateContext(stack, params);
+      const serviceMap = new Map(stack.services.map((s) => [s.serviceName, s]));
+      const { resolvedConfigsMap, resolvedDefinitions, serviceHashes } = resolveServiceConfigs(stack.services, templateContext);
+
+      const envNetworkMap = await this.resolveEnvironmentNetworks(stack.environmentId, resolvedDefinitions);
+
+      const docker = this.dockerExecutor.getDockerClient();
+      const containers = await docker.listContainers({
+        all: true,
+        filters: { label: [`mini-infra.stack-id=${stackId}`] },
+      });
+      const containerByService = buildContainerMap(containers);
+
+      const networkNames = (stack.networks as unknown as StackNetwork[]).map(
+        (n) => `${projectName}_${n.name}`
+      );
+
+      const serviceResults: ServiceApplyResult[] = [];
+      let completedCount = 0;
+
+      for (const action of actions) {
+        const svc = serviceMap.get(action.serviceName);
+        const serviceDef = resolvedDefinitions.get(action.serviceName) ?? null;
+        const actionStart = Date.now();
+
+        let result: ServiceApplyResult;
+
+        if (svc?.serviceType === 'StatelessWeb' && serviceDef) {
+          result = await this.updateStatelessWeb(
+            action, svc, serviceDef, projectName, stackId, stack,
+            networkNames, serviceHashes, resolvedConfigsMap,
+            containerByService, actionStart, log, envNetworkMap
+          );
+        } else {
+          result = await this.applyStateful(
+            action, svc, serviceDef, projectName, stackId, stack,
+            networkNames, serviceHashes, resolvedConfigsMap,
+            containerByService, actionStart, log, envNetworkMap
+          );
+        }
+
+        result = { ...result, action: 'update' };
+        serviceResults.push(result);
+        completedCount++;
+        options?.onProgress?.(result, completedCount, actions.length);
+      }
+
+      const allSucceeded = serviceResults.every((r) => r.success);
+      const resultStatus = allSucceeded ? 'synced' : 'error';
+
+      await this.prisma.stack.update({
+        where: { id: stackId },
+        data: {
+          status: resultStatus,
+          lastAppliedVersion: stack.version,
+          lastAppliedAt: new Date(),
+          lastAppliedSnapshot: serializeStack({
+            ...stack,
+            services: stack.services.map((s) => ({
+              ...s,
+              serviceType: s.serviceType as StackServiceDefinition['serviceType'],
+              containerConfig: s.containerConfig as unknown as StackContainerConfig,
+              configFiles: (s.configFiles as unknown as StackConfigFile[]) ?? null,
+              initCommands: (s.initCommands as unknown as StackServiceDefinition['initCommands']) ?? null,
+              dependsOn: s.dependsOn as unknown as string[],
+              routing: (s.routing as unknown as StackServiceDefinition['routing']) ?? null,
+            })),
+          } as any) as any,
+        },
+      });
+
+      await this.prisma.stackDeployment.create({
+        data: {
+          stackId,
+          action: 'update',
+          success: allSucceeded,
+          version: stack.version,
+          status: resultStatus,
+          duration: Date.now() - startTime,
+          serviceResults: serviceResults as any,
+          triggeredBy: options?.triggeredBy ?? null,
+        },
+      });
+
+      return {
+        success: allSucceeded,
+        stackId,
+        appliedVersion: stack.version,
+        serviceResults,
+        resourceResults: [],
+        duration: Date.now() - startTime,
+      };
+    } catch (err: any) {
+      const duration = Date.now() - startTime;
+      log.error({ error: err.message }, 'Update failed unexpectedly');
+      try {
+        await this.prisma.stackDeployment.create({
+          data: {
+            stackId,
+            action: 'update',
+            success: false,
+            version: stack.version,
+            status: 'error',
+            duration,
+            error: err.message,
+            triggeredBy: options?.triggeredBy ?? null,
+          },
+        });
+        await this.prisma.stack.update({
+          where: { id: stackId },
+          data: { status: 'error' },
+        });
+      } catch (dbErr) {
+        log.error({ error: dbErr }, 'Failed to record update failure');
       }
       throw err;
     }
@@ -1205,6 +1370,78 @@ export class StackReconciler {
       default:
         throw new Error(`Unknown action: ${action.action}`);
     }
+  }
+
+  private async updateStatelessWeb(
+    action: ServiceAction,
+    svc: any,
+    serviceDef: StackServiceDefinition,
+    projectName: string,
+    stackId: string,
+    stack: any,
+    networkNames: string[],
+    serviceHashes: Map<string, string>,
+    resolvedConfigsMap: Map<string, StackConfigFile[]>,
+    containerByService: Map<string, Docker.ContainerInfo>,
+    actionStart: number,
+    log: any,
+    envNetworkMap: Map<string, string> = new Map()
+  ): Promise<ServiceApplyResult> {
+    const routing = serviceDef.routing;
+    if (!routing) {
+      throw new Error(`StatelessWeb service "${action.serviceName}" requires routing configuration`);
+    }
+
+    log.info({ service: action.serviceName }, 'Updating StatelessWeb service via blue-green update state machine');
+
+    const baseContext = await this.buildStateMachineContext(
+      action, serviceDef, projectName, stackId, stack, serviceHashes, envNetworkMap
+    );
+
+    const oldContainer = containerByService.get(action.serviceName);
+
+    await prepareServiceContainer(
+      this.containerManager,
+      svc,
+      resolvedConfigsMap.get(action.serviceName) ?? [],
+      projectName
+    );
+
+    const blueGreenContext = {
+      ...baseContext,
+      blueHealthy: false,
+      greenHealthy: false,
+      greenBackendConfigured: false,
+      trafficOpenedToGreen: false,
+      trafficValidated: false,
+      blueDraining: false,
+      blueDrained: false,
+      validationErrors: 0,
+      drainStartTime: undefined,
+      monitoringStartTime: undefined,
+      error: undefined,
+      retryCount: 0,
+      activeConnections: 0,
+      oldContainerId: oldContainer?.Id,
+      newContainerId: undefined,
+      containerIpAddress: undefined,
+    };
+
+    const finalState = await runStateMachineToCompletion(
+      blueGreenUpdateMachine,
+      blueGreenContext,
+      (actor) => actor.send({ type: 'START_DEPLOYMENT' })
+    );
+
+    const success = finalState.value === 'completed';
+    return {
+      serviceName: action.serviceName,
+      action: 'update',
+      success,
+      duration: Date.now() - actionStart,
+      containerId: (finalState.context as any).newContainerId,
+      error: success ? undefined : (finalState.context as any).error ?? 'Blue-green update failed',
+    };
   }
 
   private async removeConflictingContainer(


### PR DESCRIPTION
## Summary

- **New "Update" button** on Application cards that pulls the latest image and redeploys containers
- **StatelessWeb services**: zero-downtime blue-green update via a new simplified state machine (no frontend/DNS reconfiguration)
- **Stateful services**: simple stop → pull → recreate cycle
- **New `POST /api/stacks/:id/update` endpoint** with proper concurrency guards and Socket.IO progress events
- **Task Tracker integration** for real-time step-by-step update progress
- **Fix**: pre-existing build error (`enableSsl` → `tlsCertificate` mapping in edit app form)

## Test plan

- [ ] Server tests pass (1297/1297 verified)
- [ ] Frontend builds cleanly (zero TS errors verified)
- [ ] Deploy a StatelessWeb app, click Update — verify blue-green swap with zero downtime
- [ ] Deploy a Stateful app, click Update — verify stop/pull/recreate cycle
- [ ] Click Update when image hasn't changed — verify no-op with success toast
- [ ] Verify Task Tracker popover shows update progress
- [ ] Verify Update button is disabled when app is not deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)