### PR TITLE
chore: remove langsmith dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -516,7 +516,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -526,7 +526,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -536,7 +536,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -561,7 +561,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -4919,12 +4919,6 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "license": "MIT"
-    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -6239,15 +6233,6 @@
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
-      }
-    },
-    "node_modules/console-table-printer": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
-      "integrity": "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==",
-      "license": "MIT",
-      "dependencies": {
-        "simple-wcswidth": "^1.1.2"
       }
     },
     "node_modules/content-disposition": {
@@ -8651,69 +8636,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/langsmith": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.13.tgz",
-      "integrity": "sha512-arD4XzLdMTyb3rrKVainpXG9vtJPL3urOc/fC/yMHeoorK5KSHsvBWkogZUgjCsLkhtH8FdfSEAAG8Am8DNoYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/uuid": "^10.0.0",
-        "chalk": "^5.6.2",
-        "console-table-printer": "^2.12.1",
-        "p-queue": "^6.6.2",
-        "semver": "^7.6.3",
-        "uuid": "^10.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "*",
-        "@opentelemetry/exporter-trace-otlp-proto": "*",
-        "@opentelemetry/sdk-trace-base": "*",
-        "openai": "*",
-        "ws": ">=7"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@opentelemetry/exporter-trace-otlp-proto": {
-          "optional": true
-        },
-        "@opentelemetry/sdk-trace-base": {
-          "optional": true
-        },
-        "openai": {
-          "optional": true
-        },
-        "ws": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/langsmith/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/langsmith/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -10418,15 +10340,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -10457,34 +10370,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-queue": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
-      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^4.0.4",
-        "p-timeout": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-      "license": "MIT",
-      "dependencies": {
-        "p-finally": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -12058,12 +11943,6 @@
         "simple-concat": "^1.0.0"
       }
     },
-    "node_modules/simple-wcswidth": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
-      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
-      "license": "MIT"
-    },
     "node_modules/socket.io": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
@@ -13402,7 +13281,6 @@
         "form-data": "^4.0.4",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
-        "langsmith": "^0.5.7",
         "node-cache": "^5.1.2",
         "node-cron": "^4.2.1",
         "node-forge": "^1.3.3",

--- a/server/package.json
+++ b/server/package.json
@@ -80,7 +80,6 @@
         "form-data": "^4.0.4",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
-        "langsmith": "^0.5.7",
         "node-cache": "^5.1.2",
         "node-cron": "^4.2.1",
         "node-forge": "^1.3.3",

--- a/server/src/lib/agent-sdk.ts
+++ b/server/src/lib/agent-sdk.ts
@@ -1,33 +1,8 @@
-import * as originalSdk from "@anthropic-ai/claude-agent-sdk";
-import { agentLogger } from "./logger-factory";
-
-const logger = agentLogger();
-
-let sdk: typeof originalSdk = originalSdk;
-
-if (process.env.LANGSMITH_TRACING === "true") {
-  try {
-    const { wrapClaudeAgentSDK } = require("langsmith/experimental/anthropic");
-    sdk = wrapClaudeAgentSDK(originalSdk);
-    logger.info(
-      {
-        project: process.env.LANGSMITH_PROJECT ?? "(default)",
-        endpoint:
-          process.env.LANGSMITH_ENDPOINT ?? "https://api.smith.langchain.com",
-      },
-      "LangSmith tracing enabled for Claude Agent SDK",
-    );
-  } catch (err) {
-    logger.warn(
-      { err },
-      "LANGSMITH_TRACING is enabled but failed to load langsmith wrapper — tracing will be disabled",
-    );
-  }
-}
-
-export const query = sdk.query;
-export const tool = sdk.tool;
-export const createSdkMcpServer = sdk.createSdkMcpServer;
+export {
+  query,
+  tool,
+  createSdkMcpServer,
+} from "@anthropic-ai/claude-agent-sdk";
 
 // Re-export types unchanged
 export type {


### PR DESCRIPTION
## Summary
- Removes the `langsmith` package from server dependencies
- Simplifies `agent-sdk.ts` to a direct re-export from `@anthropic-ai/claude-agent-sdk` (no more conditional tracing wrapper)

## Test plan
- [x] Server and lib build cleanly with no errors
- [x] `langsmith` package confirmed removed from `node_modules`

🤖 Generated with [Claude Code](https://claude.com/claude-code)