### PR TITLE
chore: type-safe stack template serializer (drop SerializableTemplate/Version any)

### DIFF
--- a/client/src/app/applications/page.tsx
+++ b/client/src/app/applications/page.tsx
@@ -67,9 +67,9 @@ function getAppServiceType(
     const svc = stacks[0].services?.[0];
     if (svc) return svc.serviceType;
   }
-  // Fall back to template version services
-  const templateSvc = app.currentVersion?.services?.[0];
-  if (templateSvc) return templateSvc.serviceType;
+  // Fall back to template version service types (summary list only carries types, not full service objects)
+  const templateServiceType = app.currentVersion?.serviceTypes?.[0];
+  if (templateServiceType) return templateServiceType;
   return null;
 }
 

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -36,20 +36,21 @@ Zone/tunnel fields with type mismatches (optional vs required, `null` vs `undefi
 enum supersets) are bridged with `?? default` or narrow casts at the mapping boundary.
 Tunnel config raw fetch responses cast to `CloudflareTunnelConfig` at the parse site.
 
-## 3. Stack-template-service serializer shape
+## 3. Stack-template-service serializer shape ✅ Resolved
 
-**File:** `server/src/services/stacks/stack-template-service.ts`
+Resolved in `chore/stack-template-serializer-types`. Two Prisma payload types replace `any`:
 
-- `SerializableTemplate = any` and `SerializableVersion = any` with
-  `// eslint-disable-next-line`.
+- `VersionDetailPayload` — `GetPayload<{ include: typeof versionWithDetails }>` — full services + configFiles
+- `VersionSummaryPayload` — `GetPayload<{ select: typeof versionSummary }>` — service count + serviceType per service
 
-  **Why:** `serializeTemplate` / `serializeVersion` accept multiple
-  Prisma payload shapes depending on the caller's `include` set (list vs
-  detail vs update). Every strict union I tried cascaded into errors
-  against the runtime `as unknown as ...` casts for JSON columns.
+`SerializableVersion = VersionDetailPayload | VersionSummaryPayload` with a `configFiles in v` type guard. The
+`SerializableTemplate` interface covers all template query shapes structurally (optional relations, Prisma enum
+types are compatible string unions). JSON columns use `as unknown as` double-assertion. `versionSummary` was
+updated to include `resourceOutputs` and `resourceInputs` so both payload types expose those fields.
 
-  **Proper fix:** Discriminated union per caller shape, or a single
-  loose shape with runtime validation.
+`StackTemplateVersionInfo` gained `serviceTypes?: StackServiceType[]` — populated for both shapes. The
+applications page now reads `serviceTypes?.[0]` instead of the previously incorrect `services?.[0]?.serviceType`
+(which was silently returning partial service objects with only `serviceType` set).
 
 ## 4. Client task-tracker registry
 

--- a/docs/upgrade-cleanup-todo.md
+++ b/docs/upgrade-cleanup-todo.md
@@ -26,10 +26,11 @@ type aliases where a full refactor would have ballooned the diff:
   `CloudflareApiResponse = any` alias for SDK pagination / response shapes.~~
   **Fixed**: SDK types used directly; `SdkRecord` intersection bridges the
   runtime fields the SDK omits (see `chore/type-cleanup`).
-- `server/src/services/stacks/stack-template-service.ts` —
+- ~~`server/src/services/stacks/stack-template-service.ts` —
   `SerializableTemplate` / `SerializableVersion` aliased to `any` because each caller
-  loads a different Prisma `include`/`select` subset. Proper fix is a discriminated
-  union per include shape.
+  loads a different Prisma `include`/`select` subset.~~
+  **Fixed**: Two Prisma `GetPayload` types replace `any`; `configFiles in v` type guard discriminates
+  detail vs summary. `StackTemplateVersionInfo` gained `serviceTypes?` for list views (see `chore/stack-template-serializer-types`).
 - `client/src/lib/task-type-registry.ts`,
   `client/src/components/task-tracker/task-tracker-provider.tsx` —
   `EventPayload = any` for heterogeneous Socket.IO payloads; normalizers narrow locally.
@@ -46,13 +47,14 @@ intersection bridges runtime fields the SDK omits (`zone_id`, `zone_name`, `lock
 `data`). `Promise.race` now uses `Promise<never>` for the timeout arm so the SDK
 return type flows through unchanged.
 
-### 2. Stack-template-service serializer shape
+### ~~2. Stack-template-service serializer shape~~ ✅ Done
 
-**File:** `server/src/services/stacks/stack-template-service.ts`
-
-`serializeTemplate` / `serializeVersion` currently take `any` because every caller passes
-a different Prisma include shape. A discriminated union (one variant per include set) or
-a single loose shape with runtime validation would let us drop the `any`.
+`SerializableTemplate` / `SerializableVersion` `any` aliases removed. Two `Prisma.GetPayload` types
+cover the detail (full services + configFiles) and summary (count + serviceType per service) query shapes.
+A `configFiles in v` type guard discriminates between them in `serializeVersion`. `versionSummary`
+gained `resourceOutputs` / `resourceInputs` so both shapes expose those fields. `StackTemplateVersionInfo`
+gained `serviceTypes?: StackServiceType[]` populated for both shapes; the applications page updated
+to use `serviceTypes?.[0]` (the previous `services?.[0]?.serviceType` was silently broken).
 
 ### ~~3. HAProxy state-machine event unions~~ ✅ Done
 

--- a/lib/types/stack-templates.ts
+++ b/lib/types/stack-templates.ts
@@ -139,6 +139,7 @@ export interface StackTemplateVersionInfo {
   createdAt: string;
   createdById: string | null;
   serviceCount?: number;
+  serviceTypes?: StackServiceType[];
   services?: StackTemplateServiceInfo[];
   configFiles?: StackTemplateConfigFileInfo[];
 }

--- a/server/src/services/stacks/stack-template-service.ts
+++ b/server/src/services/stacks/stack-template-service.ts
@@ -12,6 +12,8 @@ import type {
   CreateStackFromTemplateRequest,
   StackTemplateSource,
   StackTemplateScope,
+  StackTemplateVersionStatus,
+  StackServiceType,
 } from "@mini-infra/types";
 import type {
   StackServiceDefinition,
@@ -24,17 +26,6 @@ import { toServiceCreateInput, serializeStack, mergeParameterValues } from "./ut
 import { CloudflareService } from "../cloudflare/cloudflare-service";
 import { networkUtils } from "../network-utils";
 
-// `serializeTemplate` / `serializeVersion` accept multiple Prisma payload
-// shapes depending on the caller's include set (list vs detail vs update).
-// Modelling every shape as a strict union produced cascading type errors
-// against the runtime `as unknown as ...` casts for JSON columns, so these
-// serializers take `any` with the rule disabled locally. Documented in
-// `docs/shortcuts.md`.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type SerializableTemplate = any;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type SerializableVersion = any;
-
 // Input shape for upserting system templates from builtin definitions
 export interface UpsertSystemTemplateInput {
   name: string;
@@ -46,11 +37,13 @@ export interface UpsertSystemTemplateInput {
   configFiles?: StackTemplateConfigFileInput[];
 }
 
-// Include helpers for Prisma queries
+// Include helpers for Prisma queries.
+// `as const` gives Prisma's GetPayload precise literal types so the generated
+// payload shapes carry the right field sets at the TypeScript level.
 const versionWithDetails = {
   services: { orderBy: { order: "asc" as const } },
   configFiles: true,
-};
+} as const;
 
 const versionSummary = {
   id: true,
@@ -60,6 +53,8 @@ const versionSummary = {
   notes: true,
   parameters: true,
   defaultParameterValues: true,
+  resourceOutputs: true,
+  resourceInputs: true,
   networks: true,
   volumes: true,
   publishedAt: true,
@@ -67,7 +62,57 @@ const versionSummary = {
   createdById: true,
   _count: { select: { services: true } },
   services: { select: { serviceType: true }, orderBy: { order: 'asc' as const } },
-};
+} as const;
+
+// The two version payload shapes Prisma can return. The detail shape (from
+// `include: versionWithDetails`) carries full services and configFiles.
+// The summary shape (from `select: versionSummary`) carries only a service
+// count and per-service serviceType — enough for list views.
+type VersionDetailPayload = Prisma.StackTemplateVersionGetPayload<{
+  include: typeof versionWithDetails;
+}>;
+
+type VersionSummaryPayload = Prisma.StackTemplateVersionGetPayload<{
+  select: typeof versionSummary;
+}>;
+
+type SerializableVersion = VersionDetailPayload | VersionSummaryPayload;
+
+// Structural interface covering all the different template query shapes
+// (list, detail, create, update). Relations are optional because different
+// callers include different subsets.
+interface SerializableTemplate {
+  id: string;
+  name: string;
+  displayName: string;
+  description: string | null;
+  source: StackTemplateSource;
+  scope: StackTemplateScope;
+  category: string | null;
+  environmentId: string | null;
+  isArchived: boolean;
+  currentVersionId: string | null;
+  draftVersionId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  createdById: string | null;
+  currentVersion?: SerializableVersion | null;
+  draftVersion?: SerializableVersion | null;
+  stacks?: Array<{
+    id: string;
+    name: string;
+    status: string;
+    version: number;
+    lastAppliedVersion: number | null;
+    lastAppliedAt: Date | null;
+    environmentId: string | null;
+  }>;
+}
+
+// Type guard: detail payload always has `configFiles`; summary payload never does.
+function isVersionDetailPayload(v: SerializableVersion): v is VersionDetailPayload {
+  return 'configFiles' in v;
+}
 
 export class StackTemplateService {
   constructor(private prisma: PrismaClient) {}
@@ -872,14 +917,6 @@ export class StackTemplateService {
   // Serialization
   // =====================
 
-  // Loose shape covering the different include sets callers pass in
-  // (list/detail queries include `_count`, `stacks`, `currentVersion`,
-  // `draftVersion` and `versions` selectively).
-  // NOTE: Keep in sync with `SerializableTemplate` / `SerializableVersion`
-  // below — both mirror fields from `Prisma.StackTemplateGetPayload` /
-  // `Prisma.StackTemplateVersionGetPayload` but with all relations
-  // optional so any subset of includes type-checks.
-
   serializeTemplate(template: SerializableTemplate): StackTemplateInfo {
     return {
       id: template.id,
@@ -907,7 +944,7 @@ export class StackTemplateService {
           ? null
           : undefined,
       ...(template.stacks ? {
-        linkedStacks: template.stacks.map((s: SerializableTemplate) => ({
+        linkedStacks: template.stacks.map((s) => ({
           id: s.id,
           name: s.name,
           status: s.status,
@@ -921,24 +958,42 @@ export class StackTemplateService {
   }
 
   serializeVersion(version: SerializableVersion): StackTemplateVersionInfo {
-    return {
+    // Fields common to both detail and summary payload shapes.
+    // JSON columns (parameters, networks, etc.) come back from Prisma as
+    // JsonValue and need a double-assertion to reach the domain types.
+    const base: StackTemplateVersionInfo = {
       id: version.id,
       templateId: version.templateId,
       version: version.version,
-      status: version.status,
+      status: version.status as StackTemplateVersionStatus,
       notes: version.notes,
-      parameters: (version.parameters as StackTemplateVersionInfo['parameters']) ?? [],
-      defaultParameterValues: (version.defaultParameterValues as StackTemplateVersionInfo['defaultParameterValues']) ?? {},
-      resourceOutputs: (version.resourceOutputs as StackTemplateVersionInfo['resourceOutputs']) ?? undefined,
-      resourceInputs: (version.resourceInputs as StackTemplateVersionInfo['resourceInputs']) ?? undefined,
-      networks: (version.networks as StackTemplateVersionInfo['networks']) ?? [],
-      volumes: (version.volumes as StackTemplateVersionInfo['volumes']) ?? [],
+      parameters: (version.parameters as unknown as StackTemplateVersionInfo['parameters']) ?? [],
+      defaultParameterValues: (version.defaultParameterValues as unknown as StackTemplateVersionInfo['defaultParameterValues']) ?? {},
+      resourceOutputs: (version.resourceOutputs as unknown as StackTemplateVersionInfo['resourceOutputs']) ?? undefined,
+      resourceInputs: (version.resourceInputs as unknown as StackTemplateVersionInfo['resourceInputs']) ?? undefined,
+      networks: (version.networks as unknown as StackTemplateVersionInfo['networks']) ?? [],
+      volumes: (version.volumes as unknown as StackTemplateVersionInfo['volumes']) ?? [],
       publishedAt: version.publishedAt?.toISOString() ?? null,
       createdAt: version.createdAt.toISOString(),
       createdById: version.createdById,
-      serviceCount: version._count?.services ?? version.services?.length,
-      services: version.services?.map(serializeTemplateService),
-      configFiles: version.configFiles?.map(serializeTemplateConfigFile),
+    };
+
+    if (isVersionDetailPayload(version)) {
+      // Detail shape: full services array + config files.
+      return {
+        ...base,
+        serviceCount: version.services.length,
+        serviceTypes: version.services.map((svc) => svc.serviceType as StackServiceType),
+        services: version.services.map(serializeTemplateService),
+        configFiles: version.configFiles.map(serializeTemplateConfigFile),
+      };
+    }
+
+    // Summary shape: service count from _count, service types only (no full service objects).
+    return {
+      ...base,
+      serviceCount: version._count.services,
+      serviceTypes: version.services.map((svc) => svc.serviceType as StackServiceType),
     };
   }
 }


### PR DESCRIPTION
## Summary

- Replaces `SerializableTemplate = any` and `SerializableVersion = any` in `stack-template-service.ts` with proper Prisma `GetPayload` types and a structural interface
- Fixes a silent bug where the list/summary code path was passing partial `{ serviceType }`-only objects through `serializeTemplateService`, producing garbage output with all fields except `serviceType` undefined

## What changed

**`server/src/services/stacks/stack-template-service.ts`**
- `VersionDetailPayload` — `Prisma.StackTemplateVersionGetPayload<{ include: typeof versionWithDetails }>` — carries full services + configFiles
- `VersionSummaryPayload` — `Prisma.StackTemplateVersionGetPayload<{ select: typeof versionSummary }>` — carries `_count` + `serviceType` per service only
- `SerializableVersion = VersionDetailPayload | VersionSummaryPayload` with a `'configFiles' in v` type guard to discriminate between them
- `SerializableTemplate` — structural interface covering all template query shapes (list, detail, create, update); all Prisma enum types are compatible string unions so no casts needed on scalar fields
- `versionSummary` gains `resourceOutputs` and `resourceInputs` (previously missing, needed by `serializeVersion`); both constants gain `as const` for precise Prisma type inference
- JSON column casts updated to `as unknown as` double-assertion (previously hidden by `any`)

**`lib/types/stack-templates.ts`**
- `StackTemplateVersionInfo` gains `serviceTypes?: StackServiceType[]` — populated for both payload shapes; clean semantic separation between "service type badges for list views" and "full service details for edit views"

**`client/src/app/applications/page.tsx`**
- Updated to use `currentVersion?.serviceTypes?.[0]` instead of `currentVersion?.services?.[0]?.serviceType` (the previous code was relying on the silently-broken partial objects)

## Test plan

- [x] `npx -w server tsc --noEmit` — no errors
- [x] `npx -w client tsc --noEmit` — no errors
- [x] `npm run lint -w server` — no errors
- [x] `npm test -w server` — 59 test files, 1199 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)