### PR TITLE
chore: replace connectivity status and validation middleware casts with typed wrappers

### DIFF
--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -99,6 +99,19 @@ Resolved in `chore/haproxy-action-body-types`.
 - With the above three fixes the fallback object literal is directly assignable to `ContainerConfig`
   — the `as unknown as ContainerConfig` cast is gone.
 
+## 5. Middleware `validatedQuery` / `validatedParams` ✅ Resolved
+
+Resolved in `chore/validation-typed-accessor`. The `declare global { namespace Express
+{ interface Request { validatedQuery?: unknown; ... } } }` augmentation is removed.
+
+Validated query/params data is now stored on the request under private symbol keys
+(`_validatedQuery`, `_validatedParams`) that are not exported. Callers retrieve typed
+data via `getValidatedQuery(req, schema)` and `getValidatedParams(req, schema)` —
+passing the same schema used at middleware registration lets TypeScript infer
+`z.output<TSchema>` without any cast at the call site. The two `as unknown as
+SymbolKeyed` double-assertions are contained inside the module and are the only casts
+required.
+
 ## 6. Connectivity status reads ✅ Resolved
 
 Resolved in `chore/connectivity-status-dto`. `getLatestConnectivityStatus()` now

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -99,25 +99,19 @@ Resolved in `chore/haproxy-action-body-types`.
 - With the above three fixes the fallback object literal is directly assignable to `ContainerConfig`
   — the `as unknown as ContainerConfig` cast is gone.
 
-## 6. Connectivity status reads
+## 6. Connectivity status reads ✅ Resolved
 
-**Files:** `server/src/services/azure-storage-service.ts`,
-`server/src/services/cloudflare/cloudflare-service.ts`,
-`server/src/services/docker-config.ts`,
-`server/src/services/github-service.ts`,
-`server/src/services/github-app/github-app-validation.ts`,
-`server/src/services/tls/tls-config.ts`
+Resolved in `chore/connectivity-status-dto`. `getLatestConnectivityStatus()` now
+returns `Promise<ConnectivityStatusRow | null>` instead of `Promise<Record<string,
+unknown> | null>`. The `ConnectivityStatusRow` DTO (exported from
+`configuration-base.ts`) converts Prisma's mismatched types at the source:
 
-- Each `getHealthStatus()` reads the return of
-  `getLatestConnectivityStatus()` (which returns `Record<string, unknown>`)
-  via a local `const row = latestStatus as { ... }` cast.
+- `BigInt | null` → `number | undefined` for `responseTimeMs`
+- `T | null` → `T | undefined` for all other optional fields
 
-  **Why:** Typing `getLatestConnectivityStatus` to the full Prisma
-  `ConnectivityStatus` payload triggers `Date | null` vs `Date | undefined`
-  / `bigint` vs `number` mismatches at every caller.
-
-  **Proper fix:** Return a narrow DTO from `getLatestConnectivityStatus`
-  that already converts nullable fields.
+All six `getHealthStatus()` callers drop their identical `const row = latestStatus as
+{ ... }` cast blocks and use `latestStatus` directly. The `GitHubAppValidationContext`
+interface in `github-app-constants.ts` is updated to match.
 
 ## 7. Client zod-resolver casts
 

--- a/docs/upgrade-cleanup-todo.md
+++ b/docs/upgrade-cleanup-todo.md
@@ -70,13 +70,12 @@ TStep, TCompleted>` + `defineTaskTypeConfig()` builder validate each normalizer 
 the real event payload. `RuntimeTaskTypeConfig` is the documented variance boundary
 for polymorphic access in `TaskEventListener` (see `chore/task-tracker-registry-types`).
 
-### 5. Middleware `validatedQuery` / `validatedParams`
+### ~~5. Middleware `validatedQuery` / `validatedParams`~~ ✅ Done
 
-**Files:** `server/src/middleware/validation.ts` (already cleaned to `unknown`)
-
-Consumers currently don't read these augmentations, but if they ever do they'll need
-explicit casts. A proper refactor would remove the Express module augmentation entirely
-and move validated data onto the request via a typed wrapper.
+Express module augmentation removed. Validated query/params stored under private
+symbol keys; `getValidatedQuery(req, schema)` / `getValidatedParams(req, schema)`
+return `z.output<TSchema>` without any cast at the call site
+(see `chore/validation-typed-accessor`).
 
 ### 6. Client zod-resolver casts
 

--- a/server/src/middleware/validation.ts
+++ b/server/src/middleware/validation.ts
@@ -4,20 +4,16 @@ import { servicesLogger } from '../lib/logger-factory';
 
 const logger = servicesLogger();
 
-// Extend Express Request type to include validated data
-// Express 5 makes req.query read-only, so we store validated query data separately
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace Express {
-    interface Request {
-      validatedQuery?: unknown;
-      validatedParams?: unknown;
-    }
-  }
-}
+// Private symbol keys — not exported, so callers must use the typed accessors below
+// and cannot bypass the type guarantee by reading req.validatedQuery directly.
+const _validatedQuery = Symbol('validatedQuery');
+const _validatedParams = Symbol('validatedParams');
 
-export function validateRequest(
-  schema: z.ZodSchema,
+// TypeScript 4.4+ supports symbol index signatures
+type SymbolKeyed = { [key: symbol]: unknown };
+
+export function validateRequest<TSchema extends z.ZodSchema>(
+  schema: TSchema,
   source: 'body' | 'query' | 'params' = 'body'
 ) {
   return (req: Request, res: Response, next: NextFunction) => {
@@ -51,15 +47,16 @@ export function validateRequest(
         });
       }
 
-      // Replace the original data with the parsed/transformed data
-      // Express 5 Note: req.query and req.params are read-only getters
-      // Store validated query/params in custom properties instead
+      // For body, write back to req.body (already typed as any in Express).
+      // For query/params, store under private symbol keys so the Express Request
+      // interface needs no augmentation — use getValidatedQuery/getValidatedParams
+      // to retrieve with the correct inferred type.
       if (source === 'body') {
         req.body = result.data;
       } else if (source === 'query') {
-        req.validatedQuery = result.data;
+        (req as unknown as SymbolKeyed)[_validatedQuery] = result.data;
       } else {
-        req.validatedParams = result.data;
+        (req as unknown as SymbolKeyed)[_validatedParams] = result.data;
       }
 
       next();
@@ -73,4 +70,24 @@ export function validateRequest(
       });
     }
   };
+}
+
+/**
+ * Retrieve the validated query string parsed by a preceding
+ * `validateRequest(schema, 'query')` middleware.  Pass the same schema to get
+ * a properly typed return value without any cast at the call site.
+ */
+export function getValidatedQuery<T extends z.ZodSchema>(req: Request, schema: T): z.output<T> {
+  void schema; // used only for type inference
+  return (req as unknown as SymbolKeyed)[_validatedQuery] as z.output<T>;
+}
+
+/**
+ * Retrieve the validated route params parsed by a preceding
+ * `validateRequest(schema, 'params')` middleware.  Pass the same schema to get
+ * a properly typed return value without any cast at the call site.
+ */
+export function getValidatedParams<T extends z.ZodSchema>(req: Request, schema: T): z.output<T> {
+  void schema; // used only for type inference
+  return (req as unknown as SymbolKeyed)[_validatedParams] as z.output<T>;
 }

--- a/server/src/services/azure-storage-service.ts
+++ b/server/src/services/azure-storage-service.ts
@@ -342,25 +342,16 @@ export class AzureStorageService extends ConfigurationService {
       };
     }
 
-    const row = latestStatus as {
-      status: string;
-      checkedAt: Date;
-      lastSuccessfulAt?: Date;
-      responseTimeMs?: number;
-      errorMessage?: string;
-      errorCode?: string;
-      metadata?: string;
-    };
     return {
       service: "azure",
-      status: row.status as ConnectivityStatusType,
-      lastChecked: row.checkedAt,
-      lastSuccessful: row.lastSuccessfulAt,
-      responseTime: row.responseTimeMs || undefined,
-      errorMessage: row.errorMessage || undefined,
-      errorCode: row.errorCode || undefined,
-      metadata: row.metadata
-        ? JSON.parse(row.metadata)
+      status: latestStatus.status as ConnectivityStatusType,
+      lastChecked: latestStatus.checkedAt,
+      lastSuccessful: latestStatus.lastSuccessfulAt,
+      responseTime: latestStatus.responseTimeMs || undefined,
+      errorMessage: latestStatus.errorMessage || undefined,
+      errorCode: latestStatus.errorCode || undefined,
+      metadata: latestStatus.metadata
+        ? JSON.parse(latestStatus.metadata)
         : undefined,
     };
   }

--- a/server/src/services/cloudflare/cloudflare-service.ts
+++ b/server/src/services/cloudflare/cloudflare-service.ts
@@ -414,25 +414,16 @@ export class CloudflareService extends ConfigurationService {
       };
     }
 
-    const row = latestStatus as {
-      status: string;
-      checkedAt: Date;
-      lastSuccessfulAt?: Date;
-      responseTimeMs?: number;
-      errorMessage?: string;
-      errorCode?: string;
-      metadata?: string;
-    };
     return {
       service: "cloudflare",
-      status: row.status as ConnectivityStatusType,
-      lastChecked: row.checkedAt,
-      lastSuccessful: row.lastSuccessfulAt,
-      responseTime: row.responseTimeMs || undefined,
-      errorMessage: row.errorMessage || undefined,
-      errorCode: row.errorCode || undefined,
-      metadata: row.metadata
-        ? JSON.parse(row.metadata)
+      status: latestStatus.status as ConnectivityStatusType,
+      lastChecked: latestStatus.checkedAt,
+      lastSuccessful: latestStatus.lastSuccessfulAt,
+      responseTime: latestStatus.responseTimeMs || undefined,
+      errorMessage: latestStatus.errorMessage || undefined,
+      errorCode: latestStatus.errorCode || undefined,
+      metadata: latestStatus.metadata
+        ? JSON.parse(latestStatus.metadata)
         : undefined,
     };
   }

--- a/server/src/services/configuration-base.ts
+++ b/server/src/services/configuration-base.ts
@@ -193,9 +193,9 @@ export abstract class ConfigurationService implements IConfigurationService {
    * Get the most recent connectivity status for this service
    * @returns Latest connectivity status or null if none exists
    */
-  protected async getLatestConnectivityStatus(): Promise<Record<string, unknown> | null> {
+  protected async getLatestConnectivityStatus(): Promise<ConnectivityStatusRow | null> {
     try {
-      return await this.prisma.connectivityStatus.findFirst({
+      const record = await this.prisma.connectivityStatus.findFirst({
         where: {
           service: this.category as ConnectivityService,
         },
@@ -203,6 +203,19 @@ export abstract class ConfigurationService implements IConfigurationService {
           checkedAt: "desc",
         },
       });
+      if (!record) return null;
+      return {
+        status: record.status,
+        checkedAt: record.checkedAt,
+        lastSuccessfulAt: record.lastSuccessfulAt ?? undefined,
+        responseTimeMs:
+          record.responseTimeMs != null
+            ? Number(record.responseTimeMs)
+            : undefined,
+        errorMessage: record.errorMessage ?? undefined,
+        errorCode: record.errorCode ?? undefined,
+        metadata: record.metadata ?? undefined,
+      };
     } catch (error) {
       servicesLogger().error(
         {
@@ -214,4 +227,22 @@ export abstract class ConfigurationService implements IConfigurationService {
       return null;
     }
   }
+}
+
+/**
+ * Narrow DTO returned by {@link ConfigurationService.getLatestConnectivityStatus}.
+ *
+ * Prisma stores `responseTimeMs` as `BigInt` and optional fields as `null`.
+ * This type converts both to the JS-friendly forms callers expect:
+ *  - `BigInt | null` → `number | undefined`
+ *  - `T | null`     → `T | undefined`
+ */
+export interface ConnectivityStatusRow {
+  status: string;
+  checkedAt: Date;
+  lastSuccessfulAt: Date | undefined;
+  responseTimeMs: number | undefined;
+  errorMessage: string | undefined;
+  errorCode: string | undefined;
+  metadata: string | undefined;
 }

--- a/server/src/services/docker-config.ts
+++ b/server/src/services/docker-config.ts
@@ -203,25 +203,16 @@ export class DockerConfigService extends ConfigurationService {
       };
     }
 
-    const row = latestStatus as {
-      status: string;
-      checkedAt: Date;
-      lastSuccessfulAt?: Date;
-      responseTimeMs?: number;
-      errorMessage?: string;
-      errorCode?: string;
-      metadata?: string;
-    };
     return {
       service: "docker" as ConnectivityService,
-      status: row.status as ConnectivityStatusType,
-      lastChecked: row.checkedAt,
-      lastSuccessful: row.lastSuccessfulAt || undefined,
-      responseTime: row.responseTimeMs || undefined,
-      errorMessage: row.errorMessage || undefined,
-      errorCode: row.errorCode || undefined,
-      metadata: row.metadata
-        ? JSON.parse(row.metadata)
+      status: latestStatus.status as ConnectivityStatusType,
+      lastChecked: latestStatus.checkedAt,
+      lastSuccessful: latestStatus.lastSuccessfulAt,
+      responseTime: latestStatus.responseTimeMs || undefined,
+      errorMessage: latestStatus.errorMessage || undefined,
+      errorCode: latestStatus.errorCode || undefined,
+      metadata: latestStatus.metadata
+        ? JSON.parse(latestStatus.metadata)
         : undefined,
     };
   }

--- a/server/src/services/github-app/github-app-constants.ts
+++ b/server/src/services/github-app/github-app-constants.ts
@@ -2,6 +2,7 @@ import { ErrorMapper } from "../circuit-breaker";
 import type { Logger } from "pino";
 import type { ConnectivityStatusType } from "@mini-infra/types";
 import type { CircuitBreaker } from "../circuit-breaker";
+import type { ConnectivityStatusRow } from "../configuration-base";
 
 // ====================
 // API Configuration
@@ -113,5 +114,5 @@ export interface GitHubAppValidationContext extends GitHubAppContext {
     metadata?: Record<string, unknown>,
     userId?: string,
   ): Promise<void>;
-  getLatestConnectivityStatus(): Promise<Record<string, unknown> | null>;
+  getLatestConnectivityStatus(): Promise<ConnectivityStatusRow | null>;
 }

--- a/server/src/services/github-app/github-app-validation.ts
+++ b/server/src/services/github-app/github-app-validation.ts
@@ -218,25 +218,16 @@ export class GitHubAppValidation {
       };
     }
 
-    const row = latestStatus as {
-      status: string;
-      checkedAt: Date;
-      lastSuccessfulAt?: Date;
-      responseTimeMs?: number;
-      errorMessage?: string;
-      errorCode?: string;
-      metadata?: string;
-    };
     return {
       service: "github-app",
-      status: row.status as ConnectivityStatusType,
-      lastChecked: row.checkedAt,
-      lastSuccessful: row.lastSuccessfulAt,
-      responseTime: row.responseTimeMs || undefined,
-      errorMessage: row.errorMessage || undefined,
-      errorCode: row.errorCode || undefined,
-      metadata: row.metadata
-        ? JSON.parse(row.metadata)
+      status: latestStatus.status as ConnectivityStatusType,
+      lastChecked: latestStatus.checkedAt,
+      lastSuccessful: latestStatus.lastSuccessfulAt,
+      responseTime: latestStatus.responseTimeMs || undefined,
+      errorMessage: latestStatus.errorMessage || undefined,
+      errorCode: latestStatus.errorCode || undefined,
+      metadata: latestStatus.metadata
+        ? JSON.parse(latestStatus.metadata)
         : undefined,
     };
   }

--- a/server/src/services/github-service.ts
+++ b/server/src/services/github-service.ts
@@ -461,25 +461,16 @@ export class GitHubService extends ConfigurationService {
       };
     }
 
-    const row = latestStatus as {
-      status: string;
-      checkedAt: Date;
-      lastSuccessfulAt?: Date;
-      responseTimeMs?: number;
-      errorMessage?: string;
-      errorCode?: string;
-      metadata?: string;
-    };
     return {
       service: "github",
-      status: row.status as ConnectivityStatusType,
-      lastChecked: row.checkedAt,
-      lastSuccessful: row.lastSuccessfulAt,
-      responseTime: row.responseTimeMs || undefined,
-      errorMessage: row.errorMessage || undefined,
-      errorCode: row.errorCode || undefined,
-      metadata: row.metadata
-        ? JSON.parse(row.metadata)
+      status: latestStatus.status as ConnectivityStatusType,
+      lastChecked: latestStatus.checkedAt,
+      lastSuccessful: latestStatus.lastSuccessfulAt,
+      responseTime: latestStatus.responseTimeMs || undefined,
+      errorMessage: latestStatus.errorMessage || undefined,
+      errorCode: latestStatus.errorCode || undefined,
+      metadata: latestStatus.metadata
+        ? JSON.parse(latestStatus.metadata)
         : undefined,
     };
   }

--- a/server/src/services/tls/tls-config.ts
+++ b/server/src/services/tls/tls-config.ts
@@ -207,24 +207,15 @@ export class TlsConfigService extends ConfigurationService {
       };
     }
 
-    const row = latestStatus as {
-      status: string;
-      checkedAt: Date;
-      lastSuccessfulAt?: Date;
-      responseTimeMs?: number | bigint;
-      errorMessage?: string;
-      errorCode?: string;
-      metadata?: string;
-    };
     return {
       service: "tls",
-      status: row.status as ConnectivityStatusType,
-      lastChecked: row.checkedAt,
-      lastSuccessful: row.lastSuccessfulAt || undefined,
-      responseTime: row.responseTimeMs ? Number(row.responseTimeMs) : undefined,
-      errorMessage: row.errorMessage || undefined,
-      errorCode: row.errorCode || undefined,
-      metadata: row.metadata ? JSON.parse(row.metadata) : undefined,
+      status: latestStatus.status as ConnectivityStatusType,
+      lastChecked: latestStatus.checkedAt,
+      lastSuccessful: latestStatus.lastSuccessfulAt,
+      responseTime: latestStatus.responseTimeMs || undefined,
+      errorMessage: latestStatus.errorMessage || undefined,
+      errorCode: latestStatus.errorCode || undefined,
+      metadata: latestStatus.metadata ? JSON.parse(latestStatus.metadata) : undefined,
     };
   }
 


### PR DESCRIPTION
## Summary

Resolves two deferred type-safety shortcuts from the `no-explicit-any` cleanup (items 5 and 6 in `docs/shortcuts.md`).

- **Connectivity status DTO**: `getLatestConnectivityStatus()` previously returned `Promise<Record<string, unknown> | null>` to dodge Prisma type mismatches (`BigInt` vs `number`, `Date | null` vs `Date | undefined`). This pushed an identical 8-line inline `as`-cast block into all six `getHealthStatus()` callers. A new `ConnectivityStatusRow` DTO (exported from `configuration-base.ts`) converts both mismatches at the source; callers drop their casts entirely. Also fixes a latent runtime bug where five callers were casting `BigInt` to `number` via TypeScript only — `Number()` is now correctly called in the DTO conversion.

- **Validation middleware typed accessors**: The `declare global { namespace Express { interface Request { validatedQuery?: unknown } } }` augmentation is removed. Since `unknown` can never carry per-route schema information (the global interface isn't generic), validated query/params are now stored under private symbol keys not exposed on `Request`. `getValidatedQuery(req, schema)` and `getValidatedParams(req, schema)` return `z.output<TSchema>` inferred from the passed schema — no cast needed at call sites. The two `as unknown as SymbolKeyed` double-assertions are contained inside the module.

## Test plan

- [x] `npm run build:server` passes with no type errors
- [x] `npm run lint -w server` passes clean
- [ ] Verify `getHealthStatus()` responses for each connected service still return correct shape
- [ ] Verify `validateRequest` middleware correctly rejects invalid input and passes valid input through to `getValidatedQuery`/`getValidatedParams`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
