### PR TITLE
chore: refactor duplicated types into shared lib

### DIFF
--- a/client/src/hooks/use-eligible-containers.ts
+++ b/client/src/hooks/use-eligible-containers.ts
@@ -1,22 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
+import type { StackAdoptionCandidate, StackAdoptionCandidatesResponse } from "@mini-infra/types";
 
-export interface EligibleContainer {
-  id: string;
-  name: string;
-  image: string;
-  imageTag: string;
-  status: string;
-  ports: Array<{ containerPort: number; protocol: string }>;
-  isSelf: boolean;
-  isManagedByStack: boolean;
-  managedByStack?: string;
-}
-
-interface EligibleContainersResponse {
-  success: boolean;
-  data: EligibleContainer[];
-  message?: string;
-}
+export type { StackAdoptionCandidate as EligibleContainer };
 
 function generateCorrelationId(): string {
   return `eligible-containers-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
@@ -24,7 +9,7 @@ function generateCorrelationId(): string {
 
 async function fetchEligibleContainers(
   environmentId: string,
-): Promise<EligibleContainersResponse> {
+): Promise<StackAdoptionCandidatesResponse> {
   const correlationId = generateCorrelationId();
   const url = new URL("/api/stacks/eligible-containers", window.location.origin);
   url.searchParams.set("environmentId", environmentId);
@@ -44,7 +29,7 @@ async function fetchEligibleContainers(
     );
   }
 
-  const data: EligibleContainersResponse = await response.json();
+  const data: StackAdoptionCandidatesResponse = await response.json();
   if (!data.success) {
     throw new Error(data.message || "Failed to fetch eligible containers");
   }

--- a/client/src/hooks/use-self-update.ts
+++ b/client/src/hooks/use-self-update.ts
@@ -2,39 +2,10 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { toast } from "sonner";
 import { Channel, ServerEvent } from "@mini-infra/types";
+import type { SelfUpdateStatus, SelfUpdateCheckResult } from "@mini-infra/types";
 import { useOperationProgress } from "./use-operation-progress";
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface SelfUpdateStatus {
-  state:
-    | "idle"
-    | "pending"
-    | "checking"
-    | "pulling"
-    | "inspecting"
-    | "stopping"
-    | "creating"
-    | "health-checking"
-    | "complete"
-    | "rolling-back"
-    | "rollback-complete"
-    | "failed";
-  targetTag?: string;
-  progress?: number;
-  error?: string;
-  startedAt?: string;
-  updatedAt?: string;
-}
-
-export interface SelfUpdateCheckResult {
-  success: boolean;
-  available: boolean;
-  reason?: string;
-  containerId?: string;
-}
+export type { SelfUpdateStatus, SelfUpdateCheckResult };
 
 interface SelfUpdateLocalState {
   updateInProgress: boolean;

--- a/client/src/hooks/use-system-settings.ts
+++ b/client/src/hooks/use-system-settings.ts
@@ -1,30 +1,11 @@
 import { useMutation } from "@tanstack/react-query";
+import type { TestDockerRegistryRequest, TestDockerRegistryResponse } from "@mini-infra/types";
+
+export type { TestDockerRegistryRequest, TestDockerRegistryResponse };
 
 // Generate correlation ID for debugging
 function generateCorrelationId(): string {
   return `system-settings-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
-}
-
-// ====================
-// System Settings API Types
-// ====================
-
-export interface TestDockerRegistryRequest {
-  type: "backup" | "restore";
-  image: string;
-  registryUsername?: string;
-  registryPassword?: string;
-}
-
-export interface TestDockerRegistryResponse {
-  success: boolean;
-  message: string;
-  details: {
-    image: string;
-    authenticated: boolean;
-    pullTimeMs?: number;
-    errorCode?: string;
-  };
 }
 
 // ====================

--- a/client/src/hooks/use-validate-ports.ts
+++ b/client/src/hooks/use-validate-ports.ts
@@ -1,25 +1,13 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  HAProxyPortConfig,
   HAProxyPortValidationResult,
   Channel,
   ServerEvent,
 } from "@mini-infra/types";
+import type { PortValidationResponse } from "@mini-infra/types";
 import { useSocket, useSocketChannel, useSocketEvent } from "./use-socket";
 
-// ====================
-// Types
-// ====================
-
-export interface PortValidationResponse {
-  success: boolean;
-  data: {
-    config?: HAProxyPortConfig;
-    validation: HAProxyPortValidationResult;
-  };
-  error?: string;
-  message?: string;
-}
+export type { PortValidationResponse };
 
 // ====================
 // API Functions

--- a/lib/types/deployments.ts
+++ b/lib/types/deployments.ts
@@ -558,3 +558,17 @@ export interface MigrationResultResponse {
   data: MigrationResult;
   message: string;
 }
+
+// ====================
+// HAProxy Port Validation Response
+// ====================
+
+export interface PortValidationResponse {
+  success: boolean;
+  data: {
+    config?: HAProxyPortConfig;
+    validation: HAProxyPortValidationResult;
+  };
+  error?: string;
+  message?: string;
+}

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -74,6 +74,9 @@ export * from "./stack-templates";
 // Socket.IO event types
 export * from "./socket-events";
 
+// Self-update types
+export * from "./self-update";
+
 // ====================
 // Type Utilities
 // ====================

--- a/lib/types/self-update.ts
+++ b/lib/types/self-update.ts
@@ -1,0 +1,33 @@
+// ====================
+// Self-Update Types
+// ====================
+
+export type SelfUpdateState =
+  | "idle"
+  | "pending"
+  | "checking"
+  | "pulling"
+  | "inspecting"
+  | "stopping"
+  | "creating"
+  | "health-checking"
+  | "complete"
+  | "rolling-back"
+  | "rollback-complete"
+  | "failed";
+
+export interface SelfUpdateStatus {
+  state: SelfUpdateState;
+  targetTag?: string;
+  progress?: number;
+  error?: string;
+  startedAt?: string;
+  updatedAt?: string;
+}
+
+export interface SelfUpdateCheckResult {
+  success: boolean;
+  available: boolean;
+  reason?: string;
+  containerId?: string;
+}

--- a/lib/types/settings.ts
+++ b/lib/types/settings.ts
@@ -264,3 +264,25 @@ export interface ValidateServiceResponse {
   timestamp: string;
   requestId?: string;
 }
+
+// ====================
+// Docker Registry Test Types
+// ====================
+
+export interface TestDockerRegistryRequest {
+  type: "backup" | "restore";
+  image: string;
+  registryUsername?: string;
+  registryPassword?: string;
+}
+
+export interface TestDockerRegistryResponse {
+  success: boolean;
+  message: string;
+  details: {
+    image: string;
+    authenticated: boolean;
+    pullTimeMs?: number;
+    errorCode?: string;
+  };
+}

--- a/lib/types/stacks.ts
+++ b/lib/types/stacks.ts
@@ -561,3 +561,28 @@ export interface StackApplyStartedResponse {
   data: { started: true; stackId: string };
   message?: string;
 }
+
+// ====================
+// Stack Adoption Types
+// ====================
+
+// Container eligible for adoption into an AdoptedWeb stack service.
+// NOTE: This is distinct from EligibleContainer in deployments.ts, which is
+// for the HAProxy manual-frontend context.
+export interface StackAdoptionCandidate {
+  id: string;
+  name: string;
+  image: string;
+  imageTag: string;
+  status: string;
+  ports: Array<{ containerPort: number; protocol: string }>;
+  isSelf: boolean;
+  isManagedByStack: boolean;
+  managedByStack?: string;
+}
+
+export interface StackAdoptionCandidatesResponse {
+  success: boolean;
+  data: StackAdoptionCandidate[];
+  message?: string;
+}

--- a/server/src/routes/stacks.ts
+++ b/server/src/routes/stacks.ts
@@ -36,7 +36,7 @@ import {
   isDockerConnectionError,
   mapContainerStatus,
 } from '../services/stacks/utils';
-import { Channel, ServerEvent, StackNetwork, StackVolume, StackParameterDefinition, StackParameterValue, ResourceResult, ResourceType, ServiceApplyResult, StackServiceDefinition, DockerContainerInfo, StackServiceRouting } from '@mini-infra/types';
+import { Channel, ServerEvent, StackNetwork, StackVolume, StackParameterDefinition, StackParameterValue, ResourceResult, ResourceType, ServiceApplyResult, StackServiceDefinition, DockerContainerInfo, StackServiceRouting, StackAdoptionCandidate, StackAdoptionCandidatesResponse } from '@mini-infra/types';
 import { UserEventService } from '../services/user-events';
 import {
   formatPlanStep,
@@ -170,7 +170,7 @@ router.get('/eligible-containers', requirePermission('stacks:read'), async (req,
     const { getOwnContainerId } = await import('../services/self-update');
     const ownContainerId = getOwnContainerId();
 
-    const eligible = allContainers.map((c) => {
+    const eligible: StackAdoptionCandidate[] = allContainers.map((c) => {
       const hasStackLabel = !!c.labels['mini-infra.stack-id'];
       const isSelf = ownContainerId && c.id.startsWith(ownContainerId);
       const ports = c.ports.map((p) => ({
@@ -191,7 +191,8 @@ router.get('/eligible-containers', requirePermission('stacks:read'), async (req,
       };
     }).filter((c) => !c.isManagedByStack || c.isSelf); // Exclude stack-managed unless it's Mini Infra itself
 
-    res.json({ success: true, data: eligible });
+    const response: StackAdoptionCandidatesResponse = { success: true, data: eligible };
+    res.json(response);
   } catch (error) {
     logger.error({ error }, 'Failed to list eligible containers');
     res.status(500).json({ success: false, message: 'Failed to list eligible containers' });

--- a/server/src/routes/system-settings.ts
+++ b/server/src/routes/system-settings.ts
@@ -6,6 +6,10 @@ import express, {
 } from "express";
 import { z } from "zod";
 import { appLogger } from "../lib/logger-factory";
+import type {
+  TestDockerRegistryRequest,
+  TestDockerRegistryResponse,
+} from "@mini-infra/types";
 
 const logger = appLogger();
 import { requirePermission, getAuthenticatedUser } from "../middleware/auth";
@@ -25,29 +29,8 @@ const testDockerRegistrySchema = z.object({
   registryPassword: z.string().optional(),
 });
 
-interface TestDockerRegistryRequest extends Request {
-  body: {
-    type: "backup" | "restore";
-    image: string;
-    registryUsername?: string;
-    registryPassword?: string;
-  };
-}
-
-interface TestDockerRegistryResponse {
-  success: boolean;
-  message: string;
-  details: {
-    image: string;
-    authenticated: boolean;
-    pullTimeMs?: number;
-    errorCode?: string;
-  };
-}
-
-
 router.post("/test-docker-registry", requirePermission('settings:write') as RequestHandler, (async (
-  req: TestDockerRegistryRequest,
+  req: Request<{}, TestDockerRegistryResponse, TestDockerRegistryRequest>,
   res: Response<TestDockerRegistryResponse>,
   _next: NextFunction,
 ) => {

--- a/server/src/services/self-update.ts
+++ b/server/src/services/self-update.ts
@@ -5,6 +5,7 @@ import DockerService from "./docker";
 import prisma from "../lib/prisma";
 import { RegistryCredentialService } from "./registry-credential";
 import { RegistryManager } from "./docker-executor/registry-manager";
+import type { SelfUpdateState, SelfUpdateStatus } from "@mini-infra/types";
 
 const logger = servicesLogger();
 
@@ -35,28 +36,7 @@ export function releaseLaunchLock(): void {
   launchInProgress = false;
 }
 
-export type SelfUpdateState =
-  | "idle"
-  | "pending"
-  | "checking"
-  | "pulling"
-  | "inspecting"
-  | "stopping"
-  | "creating"
-  | "health-checking"
-  | "complete"
-  | "rolling-back"
-  | "rollback-complete"
-  | "failed";
-
-export interface SelfUpdateStatus {
-  state: SelfUpdateState;
-  targetTag?: string;
-  progress?: number;
-  error?: string;
-  startedAt?: string;
-  updatedAt?: string;
-}
+export type { SelfUpdateState, SelfUpdateStatus };
 
 export interface UpdateCheckResult {
   currentImage: string;


### PR DESCRIPTION
## Summary

- Move four sets of types that were duplicated across client and server into `@mini-infra/types` so there is a single source of truth
- Resolves a naming collision between two unrelated `EligibleContainer` types

## Changes

| Type(s) | Added to shared lib | Removed from |
|---|---|---|
| `SelfUpdateState`, `SelfUpdateStatus`, `SelfUpdateCheckResult` | New `lib/types/self-update.ts` | `server/src/services/self-update.ts`, `client/src/hooks/use-self-update.ts` |
| `StackAdoptionCandidate`, `StackAdoptionCandidatesResponse` | `lib/types/stacks.ts` | `client/src/hooks/use-eligible-containers.ts` (inline server object also typed) |
| `TestDockerRegistryRequest`, `TestDockerRegistryResponse` | `lib/types/settings.ts` | `server/src/routes/system-settings.ts`, `client/src/hooks/use-system-settings.ts` |
| `PortValidationResponse` | `lib/types/deployments.ts` | `client/src/hooks/use-validate-ports.ts` |

**Naming collision fix:** `lib/types/deployments.ts` already had an `EligibleContainer` for the HAProxy manual-frontend context. The client's `use-eligible-containers.ts` had a local `EligibleContainer` with a completely different shape (stacks adoption context). The stacks version is now properly named `StackAdoptionCandidate` in `lib/types/stacks.ts`. The client hook re-exports it as `EligibleContainer` for backwards compatibility with existing consumers.

## Test plan

- [x] `npm run build:lib` passes
- [x] `npm run build:server` passes
- [x] `npm run build -w client` passes
- [x] Full `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
