### PR TITLE
chore: extract OperationStep into shared lib and eliminate duplicates

### DIFF
--- a/client/src/components/haproxy/frontend-type-badge.tsx
+++ b/client/src/components/haproxy/frontend-type-badge.tsx
@@ -1,7 +1,6 @@
 import { Badge } from "@/components/ui/badge";
 import { IconRocket, IconBrandDocker, IconRoute } from "@tabler/icons-react";
-
-type FrontendType = 'deployment' | 'manual' | 'shared';
+import type { FrontendType } from "@mini-infra/types";
 
 interface FrontendTypeBadgeProps {
   type: FrontendType | string;

--- a/client/src/hooks/use-operation-progress.ts
+++ b/client/src/hooks/use-operation-progress.ts
@@ -8,16 +8,12 @@
 import { useState, useCallback, useEffect, useRef, useContext } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import type { ServerToClientEvents, SocketChannel } from "@mini-infra/types";
+import type { ServerToClientEvents, SocketChannel, OperationStep } from "@mini-infra/types";
 import { useSocketChannel, useSocketEvent } from "./use-socket";
 import { TaskTrackerContext } from "@/lib/task-tracker-context";
 import type { TaskType } from "@/lib/task-tracker-types";
 
-export interface OperationStep {
-  step: string;
-  status: "completed" | "failed" | "skipped";
-  detail?: string;
-}
+export type { OperationStep };
 
 export type OperationPhase = "idle" | "executing" | "success" | "error";
 

--- a/lib/types/deployments.ts
+++ b/lib/types/deployments.ts
@@ -1,3 +1,5 @@
+import type { OperationStep } from './operations';
+
 // ====================
 // Container Primitive Types (shared by stacks)
 // ====================
@@ -259,11 +261,7 @@ export interface ForceDeleteServerResponse {
 // Async Manual Frontend Setup Types
 // ====================
 
-export interface ManualFrontendSetupStep {
-  step: string;
-  status: 'completed' | 'failed' | 'skipped';
-  detail?: string;
-}
+export type ManualFrontendSetupStep = OperationStep;
 
 export interface ManualFrontendSetupResult {
   success: boolean;
@@ -469,11 +467,7 @@ export interface RemediationPreview {
   };
 }
 
-export interface RemediateHAProxyStep {
-  step: string;
-  status: 'completed' | 'failed' | 'skipped';
-  detail?: string;
-}
+export type RemediateHAProxyStep = OperationStep;
 
 export interface RemediateHAProxyResponse {
   success: boolean;
@@ -541,11 +535,7 @@ export interface MigrationPreviewResponse {
   data: MigrationPreview;
 }
 
-export interface MigrationStep {
-  step: string;
-  status: 'completed' | 'failed' | 'skipped';
-  detail?: string;
-}
+export type MigrationStep = OperationStep;
 
 export interface MigrationResult {
   success: boolean;

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -77,6 +77,9 @@ export * from "./socket-events";
 // Self-update types
 export * from "./self-update";
 
+// Shared operation step types
+export * from "./operations";
+
 // ====================
 // Type Utilities
 // ====================

--- a/lib/types/operations.ts
+++ b/lib/types/operations.ts
@@ -1,0 +1,16 @@
+// ====================
+// Shared Operation Step Types
+// ====================
+
+export type StepStatus = 'completed' | 'failed' | 'skipped';
+
+/**
+ * A single step in a multi-step operation.
+ * Used by certificate issuance, HAProxy migration, remediation, manual frontend setup,
+ * self-update, and agent-sidecar startup flows.
+ */
+export interface OperationStep {
+  step: string;
+  status: StepStatus;
+  detail?: string;
+}

--- a/lib/types/tls.ts
+++ b/lib/types/tls.ts
@@ -1,3 +1,5 @@
+import type { OperationStep } from './operations';
+
 export interface TlsCertificate {
   id: string;
 
@@ -103,11 +105,7 @@ export interface TlsSettings {
 // Async Certificate Issuance Types
 // ====================
 
-export interface CertIssuanceStep {
-  step: string;
-  status: 'completed' | 'failed' | 'skipped';
-  detail?: string;
-}
+export type CertIssuanceStep = OperationStep;
 
 export interface CertIssuanceResult {
   success: boolean;

--- a/server/src/routes/agent-sidecar.ts
+++ b/server/src/routes/agent-sidecar.ts
@@ -15,7 +15,7 @@ import {
   SIDECAR_STARTUP_STEPS,
 } from "../services/agent-sidecar";
 import { emitToChannel } from "../lib/socket";
-import { Channel, ServerEvent } from "@mini-infra/types";
+import { Channel, ServerEvent, type OperationStep } from "@mini-infra/types";
 
 const logger = appLogger();
 const router = express.Router();
@@ -124,7 +124,7 @@ router.post(
 
       // Run in background
       (async () => {
-        const steps: Array<{ step: string; status: "completed" | "failed" | "skipped"; detail?: string }> = [];
+        const steps: OperationStep[] = [];
 
         try {
           emitToChannel(Channel.AGENT_SIDECAR, ServerEvent.SIDECAR_STARTUP_STARTED, {

--- a/server/src/routes/self-update.ts
+++ b/server/src/routes/self-update.ts
@@ -18,7 +18,7 @@ import {
   type SelfUpdateStatus,
 } from "../services/self-update";
 import { emitToChannel } from "../lib/socket";
-import { Channel, ServerEvent } from "@mini-infra/types";
+import { Channel, ServerEvent, type OperationStep } from "@mini-infra/types";
 
 const logger = appLogger();
 const router = express.Router();
@@ -244,7 +244,7 @@ router.post(
         iifeSpawned = true;
         const launchStartTime = Date.now();
         (async () => {
-          const steps: Array<{ step: string; status: "completed" | "failed" | "skipped"; detail?: string }> = [];
+          const steps: OperationStep[] = [];
 
           try {
             emitToChannel(Channel.SELF_UPDATE, ServerEvent.SELF_UPDATE_LAUNCH_STARTED, {

--- a/server/src/services/agent-sidecar.ts
+++ b/server/src/services/agent-sidecar.ts
@@ -6,6 +6,7 @@ import prisma from "../lib/prisma";
 import appConfig, { agentConfig } from "../lib/config-new";
 import { getEffectiveModel, getEffectiveApiKey } from "./agent-settings-service";
 import { getAgentApiKey } from "./agent-api-key";
+import type { OperationStep } from "@mini-infra/types";
 
 const logger = servicesLogger();
 
@@ -141,7 +142,7 @@ export function stopHealthChecks(): void {
 // ---------------------------------------------------------------------------
 
 export type SidecarProgressCallback = (
-  step: { step: string; status: "completed" | "failed" | "skipped"; detail?: string },
+  step: OperationStep,
   completedCount: number,
   totalSteps: number,
 ) => void;

--- a/server/src/services/haproxy/haproxy-migration-service.ts
+++ b/server/src/services/haproxy/haproxy-migration-service.ts
@@ -7,51 +7,11 @@ import {
   restoreHAProxyRuntimeState,
   getEnvironmentCertificateIds,
 } from './haproxy-post-apply';
+import type { MigrationPreview, MigrationResult, MigrationStep } from '@mini-infra/types';
 
 const logger = loadbalancerLogger();
 
-export interface MigrationPreview {
-  needsMigration: boolean;
-  /** Legacy HAProxy container found (not stack-managed) */
-  legacyContainer: {
-    name: string;
-    id: string;
-    status: string;
-  } | null;
-  /** Stack record for this environment */
-  stackStatus: {
-    id: string;
-    name: string;
-    status: string;
-  } | null;
-  /** Legacy volumes that will be removed */
-  legacyVolumes: string[];
-  /** Certificates that will be redeployed */
-  certificateCount: number;
-  /** Backends that will be recreated */
-  backendCount: number;
-  /** Servers that will be re-added to backends */
-  serverCount: number;
-  /** What happens after migration */
-  postMigration: {
-    newContainerName: string;
-    newVolumes: string[];
-    networkReused: string;
-    remediationNeeded: boolean;
-  };
-}
-
-export interface MigrationResult {
-  success: boolean;
-  steps: MigrationStep[];
-  errors: string[];
-}
-
-export interface MigrationStep {
-  step: string;
-  status: 'completed' | 'failed' | 'skipped';
-  detail?: string;
-}
+export type { MigrationPreview, MigrationResult, MigrationStep };
 
 export class HAProxyMigrationService {
   /**

--- a/server/src/services/haproxy/haproxy-post-apply.ts
+++ b/server/src/services/haproxy/haproxy-post-apply.ts
@@ -4,6 +4,7 @@ import { HAProxyDataPlaneClient } from './haproxy-dataplane-client';
 import { haproxyCertificateDeployer } from './haproxy-certificate-deployer';
 import { HAProxyFrontendManager } from './haproxy-frontend-manager';
 import DockerService from '../docker';
+import type { OperationStep } from '@mini-infra/types';
 
 const logger = loadbalancerLogger();
 
@@ -18,15 +19,9 @@ const PROMETHEUS_HTTP_REQUEST_RULE = {
   cond_test: '{ path /metrics }',
 } as const;
 
-export interface PostApplyStep {
-  step: string;
-  status: 'completed' | 'failed' | 'skipped';
-  detail?: string;
-}
-
 export interface PostApplyResult {
   success: boolean;
-  steps: PostApplyStep[];
+  steps: OperationStep[];
   errors: string[];
 }
 
@@ -46,7 +41,7 @@ export async function restoreHAProxyRuntimeState(
   environmentId: string,
   prisma: PrismaClient
 ): Promise<PostApplyResult> {
-  const steps: PostApplyStep[] = [];
+  const steps: OperationStep[] = [];
   const errors: string[] = [];
   const frontendManager = new HAProxyFrontendManager();
 

--- a/server/src/services/self-update.ts
+++ b/server/src/services/self-update.ts
@@ -5,7 +5,7 @@ import DockerService from "./docker";
 import prisma from "../lib/prisma";
 import { RegistryCredentialService } from "./registry-credential";
 import { RegistryManager } from "./docker-executor/registry-manager";
-import type { SelfUpdateState, SelfUpdateStatus } from "@mini-infra/types";
+import type { SelfUpdateState, SelfUpdateStatus, OperationStep } from "@mini-infra/types";
 
 const logger = servicesLogger();
 
@@ -45,7 +45,7 @@ export interface UpdateCheckResult {
 }
 
 export type UpdateProgressCallback = (
-  step: { step: string; status: "completed" | "failed" | "skipped"; detail?: string },
+  step: OperationStep,
   completedCount: number,
   totalSteps: number,
 ) => void;

--- a/server/src/services/tls/certificate-lifecycle-manager.ts
+++ b/server/src/services/tls/certificate-lifecycle-manager.ts
@@ -14,9 +14,10 @@ import { DnsChallenge01Provider } from "./dns-challenge-provider";
 import { CertificateDistributor } from "./certificate-distributor";
 import { parseCertificate } from "./certificate-format-helper";
 import { CertificateRequest } from "./types";
+import type { OperationStep, StepStatus } from '@mini-infra/types';
 
 export type IssuanceStepCallback = (
-  step: { step: string; status: 'completed' | 'failed' | 'skipped'; detail?: string },
+  step: OperationStep,
   completedCount: number,
   totalSteps: number,
 ) => void;
@@ -62,7 +63,7 @@ export class CertificateLifecycleManager {
     const totalSteps = request.deployToHaproxy ? 5 : 4;
     let stepCount = 0;
 
-    const emitStep = (step: string, status: 'completed' | 'failed' | 'skipped', detail?: string) => {
+    const emitStep = (step: string, status: StepStatus, detail?: string) => {
       stepCount++;
       try { onStep?.({ step, status, detail }, stepCount, totalSteps); } catch { /* never break issuance */ }
     };


### PR DESCRIPTION
## Summary

- Introduces `OperationStep` and `StepStatus` in `lib/types/operations.ts` as the single canonical type for the `{ step, status, detail? }` shape used by all multi-step async operations
- Replaces 7 identical inline/interface definitions across lib, server, and client with type aliases or direct imports
- Removes server-local `MigrationPreview`, `MigrationResult`, and `MigrationStep` types from `haproxy-migration-service.ts` that were exact duplicates of the lib definitions
- Fixes `FrontendTypeBadge` to import `FrontendType` from `@mini-infra/types` instead of redefining it locally with a spurious `'deployment'` variant that doesn't exist in the API

## What changed

| Location | Before | After |
|---|---|---|
| `lib/types/deployments.ts` | `ManualFrontendSetupStep`, `RemediateHAProxyStep`, `MigrationStep` as full interfaces | Type aliases for `OperationStep` |
| `lib/types/tls.ts` | `CertIssuanceStep` as full interface | Type alias for `OperationStep` |
| `server/services/haproxy/haproxy-post-apply.ts` | Local `PostApplyStep` interface | `OperationStep` from lib |
| `server/services/haproxy/haproxy-migration-service.ts` | Local `MigrationPreview`, `MigrationResult`, `MigrationStep` (duplicating lib) | Re-exports from `@mini-infra/types` |
| `server/services/tls/certificate-lifecycle-manager.ts` | Inline `{ step, status, detail? }` in callback type | `OperationStep` |
| `server/services/self-update.ts` | Inline in `UpdateProgressCallback` | `OperationStep` |
| `server/services/agent-sidecar.ts` | Inline in `SidecarProgressCallback` | `OperationStep` |
| `server/routes/self-update.ts` | Inline `Array<{ step, status, detail? }>` | `OperationStep[]` |
| `server/routes/agent-sidecar.ts` | Inline `Array<{ step, status, detail? }>` | `OperationStep[]` |
| `client/hooks/use-operation-progress.ts` | Local `OperationStep` interface | Imported from `@mini-infra/types` |
| `client/components/haproxy/frontend-type-badge.tsx` | Local `FrontendType` with bogus `'deployment'` variant | Imported from `@mini-infra/types` |

## Test plan

- [x] `npm run build:lib` passes
- [x] `npm run build -w server` passes
- [x] `npm run build -w client` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
