### PR TITLE
chore: extract const arrays and eliminate duplicate type declarations

### DIFF
--- a/client/src/components/environments/environment-create-dialog.tsx
+++ b/client/src/components/environments/environment-create-dialog.tsx
@@ -3,6 +3,8 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import {
   CreateEnvironmentRequest,
+  ENVIRONMENT_TYPES,
+  ENVIRONMENT_NETWORK_TYPES,
 } from "@mini-infra/types";
 import { useCreateEnvironment } from "@/hooks/use-environments";
 import {
@@ -45,8 +47,8 @@ const createEnvironmentSchema = z.object({
       "Name must contain only letters, numbers, underscores, and hyphens",
     ),
   description: z.string().optional(),
-  type: z.enum(["production", "nonproduction"] as const),
-  networkType: z.enum(["local", "internet"] as const).optional(),
+  type: z.enum(ENVIRONMENT_TYPES),
+  networkType: z.enum(ENVIRONMENT_NETWORK_TYPES).optional(),
 });
 
 type CreateEnvironmentFormData = z.infer<typeof createEnvironmentSchema>;

--- a/client/src/components/environments/environment-edit-dialog.tsx
+++ b/client/src/components/environments/environment-edit-dialog.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { Environment, UpdateEnvironmentRequest } from "@mini-infra/types";
+import { Environment, UpdateEnvironmentRequest, ENVIRONMENT_TYPES } from "@mini-infra/types";
 import { useUpdateEnvironment } from "@/hooks/use-environments";
 import {
   Dialog,
@@ -36,7 +36,7 @@ import { IconLoader2 } from "@tabler/icons-react";
 
 const updateEnvironmentSchema = z.object({
   description: z.string().optional(),
-  type: z.enum(["production", "nonproduction"] as const).optional(),
+  type: z.enum(ENVIRONMENT_TYPES).optional(),
   tunnelId: z.string().optional(),
   tunnelServiceUrl: z.string().optional(),
 });

--- a/client/src/components/haproxy/edit-backend-dialog.tsx
+++ b/client/src/components/haproxy/edit-backend-dialog.tsx
@@ -29,11 +29,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useUpdateBackend } from "@/hooks/use-haproxy-backends";
-import { HAProxyBackendInfo } from "@mini-infra/types";
+import { HAProxyBackendInfo, BALANCE_ALGORITHMS } from "@mini-infra/types";
 import { toast } from "sonner";
 
 const editBackendSchema = z.object({
-  balanceAlgorithm: z.enum(["roundrobin", "leastconn", "source"]),
+  balanceAlgorithm: z.enum(BALANCE_ALGORITHMS),
   checkTimeout: z.number().int().min(100).optional(),
   connectTimeout: z.number().int().min(100).optional(),
   serverTimeout: z.number().int().min(100).optional(),

--- a/client/src/components/haproxy/frontend-status-badge.tsx
+++ b/client/src/components/haproxy/frontend-status-badge.tsx
@@ -6,8 +6,9 @@ import {
   IconAlertCircle,
   IconTrash,
 } from "@tabler/icons-react";
+import type { HAProxyFrontendInfo } from "@mini-infra/types";
 
-type FrontendStatus = "active" | "pending" | "failed" | "removed";
+type FrontendStatus = HAProxyFrontendInfo["status"];
 
 interface FrontendStatusBadgeProps {
   status: FrontendStatus;

--- a/client/src/components/postgres-server/server-modal.tsx
+++ b/client/src/components/postgres-server/server-modal.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import type { PostgresServerInfo } from "@mini-infra/types";
+import { POSTGRES_SSL_MODES } from "@mini-infra/types";
 import { toast } from "sonner";
 import {
   useCreatePostgresServer,
@@ -51,7 +52,7 @@ const createServerSchema = z.object({
   port: z.number().min(1).max(65535),
   adminUsername: z.string().min(1, "Admin username is required"),
   adminPassword: z.string().min(1, "Admin password is required"),
-  sslMode: z.enum(["prefer", "require", "disable"]),
+  sslMode: z.enum(POSTGRES_SSL_MODES),
   tags: z.string().optional(),
   linkedContainerId: z.string().optional(),
   linkedContainerName: z.string().optional(),
@@ -63,7 +64,7 @@ const updateServerSchema = z.object({
   port: z.number().min(1).max(65535),
   adminUsername: z.string().min(1, "Admin username is required"),
   adminPassword: z.string().optional(), // Optional for updates
-  sslMode: z.enum(["prefer", "require", "disable"]),
+  sslMode: z.enum(POSTGRES_SSL_MODES),
   tags: z.string().optional(),
   linkedContainerId: z.string().optional(),
   linkedContainerName: z.string().optional(),

--- a/client/src/components/postgres/schemas.ts
+++ b/client/src/components/postgres/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { POSTGRES_SSL_MODES, BACKUP_FORMATS } from "@mini-infra/types";
 
 export const postgresDbSchema = z.object({
   name: z
@@ -26,7 +27,7 @@ export const postgresDbSchema = z.object({
     .string()
     .min(1, "Password is required")
     .max(255, "Password must be less than 255 characters"),
-  sslMode: z.enum(["require", "disable", "prefer"]),
+  sslMode: z.enum(POSTGRES_SSL_MODES),
   tags: z.array(z.string()),
 });
 
@@ -48,7 +49,7 @@ export const postgresConnectionSchema = z.object({
     .string()
     .min(1, "Password is required")
     .max(255, "Password must be less than 255 characters"),
-  sslMode: z.enum(["require", "disable", "prefer"]),
+  sslMode: z.enum(POSTGRES_SSL_MODES),
 });
 
 export type PostgresDbFormData = z.infer<typeof postgresDbSchema>;
@@ -67,7 +68,7 @@ export const backupConfigSchema = z.object({
     .int()
     .min(1, "Retention must be at least 1 day")
     .max(365, "Retention cannot exceed 365 days"),
-  backupFormat: z.enum(["custom", "plain", "tar"]),
+  backupFormat: z.enum(BACKUP_FORMATS),
   compressionLevel: z
     .number()
     .int()

--- a/client/src/components/stack-templates/create-template-dialog.tsx
+++ b/client/src/components/stack-templates/create-template-dialog.tsx
@@ -29,6 +29,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useCreateStackTemplate } from "@/hooks/use-stack-templates";
+import { STACK_TEMPLATE_SCOPES } from "@mini-infra/types";
 import { toast } from "sonner";
 import { IconLoader2 } from "@tabler/icons-react";
 
@@ -42,7 +43,7 @@ const createTemplateSchema = z.object({
     ),
   displayName: z.string().min(1, "Display name is required"),
   description: z.string().optional(),
-  scope: z.enum(["host", "environment"], {
+  scope: z.enum(STACK_TEMPLATE_SCOPES, {
     message: "Scope is required",
   }),
   category: z.string().optional(),

--- a/client/src/components/stack-templates/parameter-edit-dialog.tsx
+++ b/client/src/components/stack-templates/parameter-edit-dialog.tsx
@@ -6,6 +6,7 @@ import type {
   StackParameterDefinition,
   StackParameterValue,
 } from "@mini-infra/types";
+import { STACK_PARAMETER_TYPES } from "@mini-infra/types";
 import {
   Dialog,
   DialogContent,
@@ -40,7 +41,7 @@ const parameterSchema = z.object({
       /^[a-z_][a-z0-9_]*$/,
       "Name must start with a letter or underscore, and contain only lowercase letters, digits, or underscores",
     ),
-  type: z.enum(["string", "number", "boolean"]),
+  type: z.enum(STACK_PARAMETER_TYPES),
   defaultValue: z.string(),
   description: z.string().optional(),
 });

--- a/client/src/components/stack-templates/service-edit-dialog.tsx
+++ b/client/src/components/stack-templates/service-edit-dialog.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/components/ui/select";
 import { IconPlus, IconTrash } from "@tabler/icons-react";
 import type { StackServiceDefinition } from "@mini-infra/types";
+import { STACK_SERVICE_TYPES, RESTART_POLICIES } from "@mini-infra/types";
 
 const serviceSchema = z.object({
   serviceName: z
@@ -38,12 +39,12 @@ const serviceSchema = z.object({
       /^[a-z0-9][a-z0-9-]*$/,
       "Must start with a letter or digit and contain only lowercase letters, digits, or hyphens",
     ),
-  serviceType: z.enum(["Stateful", "StatelessWeb", "AdoptedWeb"]),
+  serviceType: z.enum(STACK_SERVICE_TYPES),
   dockerImage: z.string().min(1, "Docker image is required"),
   dockerTag: z.string().min(1, "Docker tag is required"),
   order: z.coerce.number().int().min(1, "Order must be at least 1"),
   command: z.string().optional(),
-  restartPolicy: z.enum(["no", "always", "unless-stopped", "on-failure"]),
+  restartPolicy: z.enum(RESTART_POLICIES),
   ports: z.array(
     z.object({
       containerPort: z.coerce

--- a/client/src/lib/application-schemas.ts
+++ b/client/src/lib/application-schemas.ts
@@ -1,4 +1,8 @@
 import { z } from "zod";
+import {
+  STACK_SERVICE_TYPES,
+  RESTART_POLICIES,
+} from "@mini-infra/types";
 
 // ---- Shared sub-schemas for application forms ----
 
@@ -48,7 +52,7 @@ export const createApplicationFormSchema = z.object({
   displayName: z.string().min(1, "Application name is required").max(100),
   description: z.string().max(500).optional(),
   serviceName: serviceNameSchema,
-  serviceType: z.enum(["Stateful", "StatelessWeb", "AdoptedWeb"]),
+  serviceType: z.enum(STACK_SERVICE_TYPES),
   environmentId: z.string().min(1, "Environment is required"),
   dockerImage: z.string().min(1, "Docker image is required"),
   dockerTag: z.string().min(1, "Tag is required"),
@@ -57,7 +61,7 @@ export const createApplicationFormSchema = z.object({
   volumeMounts: z.array(volumeMountSchema),
   enableRouting: z.boolean(),
   routing: routingSchema.optional(),
-  restartPolicy: z.enum(["no", "always", "unless-stopped", "on-failure"]),
+  restartPolicy: z.enum(RESTART_POLICIES),
   enableHealthCheck: z.boolean(),
   healthCheck: healthCheckSchema.optional(),
   deployImmediately: z.boolean(),
@@ -98,7 +102,7 @@ export const editApplicationFormSchema = z.object({
   displayName: z.string().min(1, "Application name is required").max(100),
   description: z.string().max(500).optional(),
   serviceName: serviceNameSchema,
-  serviceType: z.enum(["Stateful", "StatelessWeb", "AdoptedWeb"]),
+  serviceType: z.enum(STACK_SERVICE_TYPES),
   dockerImage: z.string().min(1, "Docker image is required"),
   dockerTag: z.string().min(1, "Tag is required"),
   ports: z.array(portMappingSchema),
@@ -106,7 +110,7 @@ export const editApplicationFormSchema = z.object({
   volumeMounts: z.array(volumeMountSchema),
   enableRouting: z.boolean(),
   routing: routingSchema.optional(),
-  restartPolicy: z.enum(["no", "always", "unless-stopped", "on-failure"]),
+  restartPolicy: z.enum(RESTART_POLICIES),
 });
 
 export type EditApplicationFormData = z.infer<

--- a/lib/types/environments.ts
+++ b/lib/types/environments.ts
@@ -1,5 +1,7 @@
-export type EnvironmentType = 'production' | 'nonproduction';
-export type EnvironmentNetworkType = 'local' | 'internet';
+export const ENVIRONMENT_TYPES = ['production', 'nonproduction'] as const;
+export type EnvironmentType = typeof ENVIRONMENT_TYPES[number];
+export const ENVIRONMENT_NETWORK_TYPES = ['local', 'internet'] as const;
+export type EnvironmentNetworkType = typeof ENVIRONMENT_NETWORK_TYPES[number];
 export type EnvironmentNetworkPurpose = 'custom';
 
 export interface Environment {

--- a/lib/types/postgres.ts
+++ b/lib/types/postgres.ts
@@ -179,7 +179,8 @@ export interface PostgresDatabaseInfo {
 
 export type DatabaseHealthStatus = "healthy" | "unhealthy" | "unknown";
 
-export type PostgreSSLMode = "require" | "disable" | "prefer";
+export const POSTGRES_SSL_MODES = ['require', 'disable', 'prefer'] as const;
+export type PostgreSSLMode = typeof POSTGRES_SSL_MODES[number];
 
 // ====================
 // API Request Types
@@ -393,7 +394,8 @@ export interface BackupConfigurationInfo {
   updatedAt: string;
 }
 
-export type BackupFormat = "custom" | "plain" | "tar";
+export const BACKUP_FORMATS = ['custom', 'plain', 'tar'] as const;
+export type BackupFormat = typeof BACKUP_FORMATS[number];
 
 // ====================
 // Backup Operation Types

--- a/lib/types/stack-templates.ts
+++ b/lib/types/stack-templates.ts
@@ -19,7 +19,8 @@ import type {
 
 // Enum mirrors
 export type StackTemplateSource = 'system' | 'user';
-export type StackTemplateScope = 'host' | 'environment';
+export const STACK_TEMPLATE_SCOPES = ['host', 'environment'] as const;
+export type StackTemplateScope = typeof STACK_TEMPLATE_SCOPES[number];
 export type StackTemplateVersionStatus = 'draft' | 'published' | 'archived';
 
 // DB model types (Date fields)

--- a/lib/types/stacks.ts
+++ b/lib/types/stacks.ts
@@ -4,12 +4,14 @@
 
 // Status and service type unions (mirror Prisma enums)
 export type StackStatus = 'synced' | 'drifted' | 'pending' | 'error' | 'undeployed' | 'removed';
-export type StackServiceType = 'Stateful' | 'StatelessWeb' | 'AdoptedWeb';
+export const STACK_SERVICE_TYPES = ['Stateful', 'StatelessWeb', 'AdoptedWeb'] as const;
+export type StackServiceType = typeof STACK_SERVICE_TYPES[number];
 export type ServiceActionType = 'create' | 'recreate' | 'remove' | 'no-op';
 
 // Stack parameter types
 
-export type StackParameterType = 'string' | 'number' | 'boolean';
+export const STACK_PARAMETER_TYPES = ['string', 'number', 'boolean'] as const;
+export type StackParameterType = typeof STACK_PARAMETER_TYPES[number];
 
 export type StackParameterValue = string | number | boolean;
 
@@ -28,6 +30,9 @@ export interface StackParameterDefinition {
 
 // JSON field shape interfaces
 
+export const RESTART_POLICIES = ['no', 'always', 'unless-stopped', 'on-failure'] as const;
+export const BALANCE_ALGORITHMS = ['roundrobin', 'leastconn', 'source'] as const;
+
 export interface StackContainerConfig {
   command?: string[];
   entrypoint?: string[];
@@ -38,7 +43,7 @@ export interface StackContainerConfig {
   labels?: Record<string, string>;
   joinNetworks?: string[];
   joinResourceNetworks?: string[];
-  restartPolicy?: 'no' | 'always' | 'unless-stopped' | 'on-failure';
+  restartPolicy?: typeof RESTART_POLICIES[number];
   healthcheck?: {
     test: string[];
     interval: number;
@@ -81,7 +86,7 @@ export interface StackServiceRouting {
   dnsRecord?: string;
   tunnelIngress?: string;
   backendOptions?: {
-    balanceAlgorithm?: 'roundrobin' | 'leastconn' | 'source';
+    balanceAlgorithm?: typeof BALANCE_ALGORITHMS[number];
     checkTimeout?: number;
     connectTimeout?: number;
     serverTimeout?: number;

--- a/server/src/services/docker-executor/index.ts
+++ b/server/src/services/docker-executor/index.ts
@@ -21,6 +21,7 @@ import type {
   DockerRegistryTestOptions,
   DockerRegistryTestResult,
 } from "./types";
+import { RESTART_POLICIES } from "@mini-infra/types";
 
 // Re-export all types for consumers
 export type {
@@ -263,7 +264,7 @@ export class DockerExecutorService {
         ReadOnly?: boolean;
       }>;
       networks?: string[];
-      restartPolicy?: 'no' | 'on-failure' | 'unless-stopped' | 'always';
+      restartPolicy?: typeof RESTART_POLICIES[number];
       healthcheck?: {
         Test: string[];
         Interval?: number;

--- a/server/src/services/docker-executor/long-running-container.ts
+++ b/server/src/services/docker-executor/long-running-container.ts
@@ -2,6 +2,7 @@ import Docker, { Container } from "dockerode";
 import { servicesLogger } from "../../lib/logger-factory";
 import ContainerLabelManager from "../container/container-label-manager";
 import type { ContainerExecutionOptions } from "./types";
+import { RESTART_POLICIES } from "@mini-infra/types";
 import { generateTaskId } from "./utils";
 
 /**
@@ -33,7 +34,7 @@ export class LongRunningContainerManager {
         ReadOnly?: boolean;
       }>;
       networks?: string[];
-      restartPolicy?: 'no' | 'on-failure' | 'unless-stopped' | 'always';
+      restartPolicy?: typeof RESTART_POLICIES[number];
       healthcheck?: {
         Test: string[];
         Interval?: number;

--- a/server/src/services/haproxy/haproxy-service.ts
+++ b/server/src/services/haproxy/haproxy-service.ts
@@ -4,11 +4,13 @@ import Dockerode from 'dockerode';
 import {
   IApplicationService,
   ServiceStatus,
+  ServiceStatusValues,
   ServiceHealth,
   ServiceMetadata,
   ServiceStatusInfo,
   StartupResult,
   HealthStatus,
+  HealthStatusValues,
   NetworkRequirement,
   VolumeRequirement,
 } from '../interfaces/application-service';
@@ -18,7 +20,7 @@ export class HAProxyService implements IApplicationService {
   private readonly projectName: string;
   private readonly mainContainerName: string;
   private readonly logger = servicesLogger();
-  private currentStatus: ServiceStatus = ServiceStatus.UNINITIALIZED;
+  private currentStatus: ServiceStatus = ServiceStatusValues.UNINITIALIZED;
   private startedAt?: Date;
   private stoppedAt?: Date;
   private lastError?: { message: string; timestamp: Date; details?: Record<string, unknown> };
@@ -109,20 +111,20 @@ export class HAProxyService implements IApplicationService {
    * Initialize the HAProxy service
    */
   async initialize(networks?: NetworkRequirement[], volumes?: VolumeRequirement[]): Promise<void> {
-    this.currentStatus = ServiceStatus.INITIALIZING;
+    this.currentStatus = ServiceStatusValues.INITIALIZING;
     try {
       // Store the provided networks and volumes
       this.availableNetworks = networks || [];
       this.availableVolumes = volumes || [];
 
       await this.dockerExecutor.initialize();
-      this.currentStatus = ServiceStatus.INITIALIZED;
+      this.currentStatus = ServiceStatusValues.INITIALIZED;
       this.logger.info({
         networksCount: this.availableNetworks.length,
         volumesCount: this.availableVolumes.length
       }, 'HAProxy service initialized with provided resources');
     } catch (error) {
-      this.currentStatus = ServiceStatus.FAILED;
+      this.currentStatus = ServiceStatusValues.FAILED;
       this.lastError = {
         message: error instanceof Error ? error.message : 'Failed to initialize',
         timestamp: new Date(),
@@ -137,7 +139,7 @@ export class HAProxyService implements IApplicationService {
    */
   async start(): Promise<StartupResult> {
     const startTime = Date.now();
-    this.currentStatus = ServiceStatus.RUNNING;
+    this.currentStatus = ServiceStatusValues.RUNNING;
     this.startedAt = new Date();
     this.stoppedAt = undefined;
     this.lastError = undefined;
@@ -153,14 +155,14 @@ export class HAProxyService implements IApplicationService {
    * Stop the HAProxy service (implements IApplicationService)
    */
   async stopAndCleanup(): Promise<void> {
-    this.currentStatus = ServiceStatus.STOPPING;
+    this.currentStatus = ServiceStatusValues.STOPPING;
     try {
       await this.removeHAProxy();
-      this.currentStatus = ServiceStatus.STOPPED;
+      this.currentStatus = ServiceStatusValues.STOPPED;
       this.stoppedAt = new Date();
       this.logger.info('HAProxy service stopped successfully');
     } catch (error) {
-      this.currentStatus = ServiceStatus.FAILED;
+      this.currentStatus = ServiceStatusValues.FAILED;
       this.lastError = {
         message: error instanceof Error ? error.message : 'Failed to stop',
         timestamp: new Date(),
@@ -241,7 +243,7 @@ export class HAProxyService implements IApplicationService {
 
       if (runningContainers.length === 0) {
         return {
-          status: HealthStatus.UNHEALTHY,
+          status: HealthStatusValues.UNHEALTHY,
           message: 'No HAProxy containers are running',
           lastChecked: new Date(),
           details: { totalContainers: containers.length, runningContainers: 0 }
@@ -255,7 +257,7 @@ export class HAProxyService implements IApplicationService {
 
       if (haproxyContainers.length === 0) {
         return {
-          status: HealthStatus.UNHEALTHY,
+          status: HealthStatusValues.UNHEALTHY,
           message: 'Main HAProxy container not found',
           lastChecked: new Date(),
           details: { containers: containers.map(c => c.Names) }
@@ -265,7 +267,7 @@ export class HAProxyService implements IApplicationService {
       const mainContainer = haproxyContainers[0];
       if (mainContainer.State !== 'running') {
         return {
-          status: HealthStatus.UNHEALTHY,
+          status: HealthStatusValues.UNHEALTHY,
           message: `Main HAProxy container is ${mainContainer.State}`,
           lastChecked: new Date(),
           details: { containerState: mainContainer.State }
@@ -273,7 +275,7 @@ export class HAProxyService implements IApplicationService {
       }
 
       return {
-        status: HealthStatus.HEALTHY,
+        status: HealthStatusValues.HEALTHY,
         message: 'HAProxy service is healthy',
         lastChecked: new Date(),
         details: {
@@ -284,7 +286,7 @@ export class HAProxyService implements IApplicationService {
       };
     } catch (error) {
       return {
-        status: HealthStatus.UNKNOWN,
+        status: HealthStatusValues.UNKNOWN,
         message: error instanceof Error ? error.message : 'Health check failed',
         lastChecked: new Date(),
         details: { error: error instanceof Error ? error.message : 'Unknown error' }
@@ -301,9 +303,9 @@ export class HAProxyService implements IApplicationService {
       await this.dockerExecutor.initialize();
 
       // Check if we're in a state that allows starting
-      return this.currentStatus === ServiceStatus.INITIALIZED ||
-        this.currentStatus === ServiceStatus.STOPPED ||
-        this.currentStatus === ServiceStatus.FAILED;
+      return this.currentStatus === ServiceStatusValues.INITIALIZED ||
+        this.currentStatus === ServiceStatusValues.STOPPED ||
+        this.currentStatus === ServiceStatusValues.FAILED;
     } catch (error) {
       this.logger.warn({ error }, 'HAProxy service readiness check failed');
       return false;

--- a/server/src/services/interfaces/application-service.ts
+++ b/server/src/services/interfaces/application-service.ts
@@ -5,81 +5,35 @@
  * centrally with consistent lifecycle management and status reporting.
  */
 
-export enum ServiceStatus {
-  UNINITIALIZED = 'uninitialized',
-  INITIALIZING = 'initializing',
-  INITIALIZED = 'initialized',
-  STARTING = 'starting',
-  RUNNING = 'running',
-  STOPPING = 'stopping',
-  STOPPED = 'stopped',
-  FAILED = 'failed',
-  DEGRADED = 'degraded'
-}
+import {
+  ServiceStatus,
+  ServiceStatusValues,
+  ApplicationServiceHealthStatus as HealthStatus,
+  ApplicationServiceHealthStatusValues as HealthStatusValues,
+  ServiceHealth,
+  NetworkRequirement,
+  VolumeRequirement,
+  PortRequirement,
+  ServiceMetadata,
+  StartupResult,
+  ServiceStatusInfo,
+} from '@mini-infra/types';
 
-export enum HealthStatus {
-  HEALTHY = 'healthy',
-  UNHEALTHY = 'unhealthy',
-  UNKNOWN = 'unknown'
-}
+// Re-export values under canonical names used by this module's consumers
+export { ServiceStatusValues, HealthStatusValues };
 
-export interface ServiceHealth {
-  status: HealthStatus;
-  message?: string;
-  lastChecked: Date;
-  details?: Record<string, unknown>;
-}
-
-export interface NetworkRequirement {
-  name: string;
-  driver?: string;
-  options?: Record<string, unknown>;
-}
-
-export interface VolumeRequirement {
-  name: string;
-  driver?: string;
-  options?: Record<string, unknown>;
-}
-
-export interface PortRequirement {
-  name: string;
-  containerPort: number;
-  hostPort: number;
-  protocol?: 'tcp' | 'udp';
-  description?: string;
-}
-
-export interface ServiceMetadata {
-  name: string;
-  version: string;
-  description?: string;
-  dependencies: string[];
-  tags?: string[];
-  requiredNetworks: NetworkRequirement[];
-  requiredVolumes: VolumeRequirement[];
-  exposedPorts: PortRequirement[];
-}
-
-export interface StartupResult {
-  success: boolean;
-  message?: string;
-  details?: Record<string, unknown>;
-  duration?: number;
-}
-
-export interface ServiceStatusInfo {
-  status: ServiceStatus;
-  health: ServiceHealth;
-  startedAt?: Date;
-  stoppedAt?: Date;
-  metadata: ServiceMetadata;
-  lastError?: {
-    message: string;
-    timestamp: Date;
-    details?: Record<string, unknown>;
-  };
-}
+// Re-export types (interfaces and type aliases)
+export type {
+  ServiceStatus,
+  HealthStatus,
+  ServiceHealth,
+  NetworkRequirement,
+  VolumeRequirement,
+  PortRequirement,
+  ServiceMetadata,
+  StartupResult,
+  ServiceStatusInfo,
+};
 
 export interface IApplicationService {
   /**

--- a/server/src/services/monitoring/monitoring-service.ts
+++ b/server/src/services/monitoring/monitoring-service.ts
@@ -6,11 +6,13 @@ import { servicesLogger } from '../../lib/logger-factory';
 import {
   IApplicationService,
   ServiceStatus,
+  ServiceStatusValues,
   ServiceHealth,
   ServiceMetadata,
   ServiceStatusInfo,
   StartupResult,
   HealthStatus,
+  HealthStatusValues,
   NetworkRequirement,
   VolumeRequirement,
 } from '../interfaces/application-service';
@@ -23,7 +25,7 @@ export class MonitoringService implements IApplicationService {
   private readonly lokiContainerName: string;
   private readonly alloyContainerName: string;
   private readonly logger = servicesLogger();
-  private currentStatus: ServiceStatus = ServiceStatus.UNINITIALIZED;
+  private currentStatus: ServiceStatus = ServiceStatusValues.UNINITIALIZED;
   private startedAt?: Date;
   private stoppedAt?: Date;
   private lastError?: { message: string; timestamp: Date; details?: Record<string, unknown> };
@@ -96,19 +98,19 @@ export class MonitoringService implements IApplicationService {
   }
 
   async initialize(networks?: NetworkRequirement[], volumes?: VolumeRequirement[]): Promise<void> {
-    this.currentStatus = ServiceStatus.INITIALIZING;
+    this.currentStatus = ServiceStatusValues.INITIALIZING;
     try {
       this.availableNetworks = networks || [];
       this.availableVolumes = volumes || [];
 
       await this.dockerExecutor.initialize();
-      this.currentStatus = ServiceStatus.INITIALIZED;
+      this.currentStatus = ServiceStatusValues.INITIALIZED;
       this.logger.info({
         networksCount: this.availableNetworks.length,
         volumesCount: this.availableVolumes.length
       }, 'Monitoring service initialized with provided resources');
     } catch (error) {
-      this.currentStatus = ServiceStatus.FAILED;
+      this.currentStatus = ServiceStatusValues.FAILED;
       this.lastError = {
         message: error instanceof Error ? error.message : 'Failed to initialize',
         timestamp: new Date(),
@@ -120,7 +122,7 @@ export class MonitoringService implements IApplicationService {
 
   async start(): Promise<StartupResult> {
     const startTime = Date.now();
-    this.currentStatus = ServiceStatus.RUNNING;
+    this.currentStatus = ServiceStatusValues.RUNNING;
     this.startedAt = new Date();
     this.stoppedAt = undefined;
     this.lastError = undefined;
@@ -133,7 +135,7 @@ export class MonitoringService implements IApplicationService {
   }
 
   async stopAndCleanup(): Promise<void> {
-    this.currentStatus = ServiceStatus.STOPPING;
+    this.currentStatus = ServiceStatusValues.STOPPING;
     try {
       // removeProject handles already-stopped containers gracefully
       await this.dockerExecutor.removeProject(this.projectName);
@@ -142,7 +144,7 @@ export class MonitoringService implements IApplicationService {
       // (e.g. orphans from a failed deploy)
       await this.removeStaleContainers();
 
-      this.currentStatus = ServiceStatus.STOPPED;
+      this.currentStatus = ServiceStatusValues.STOPPED;
       this.stoppedAt = new Date();
       this.logger.info('Monitoring service stopped successfully - network and volumes retained');
     } catch (error) {
@@ -151,13 +153,13 @@ export class MonitoringService implements IApplicationService {
       const staleContainers = await this.findMonitoringContainers().catch(() => []);
 
       if (containers.length === 0 && staleContainers.length === 0) {
-        this.currentStatus = ServiceStatus.STOPPED;
+        this.currentStatus = ServiceStatusValues.STOPPED;
         this.stoppedAt = new Date();
         this.logger.info('Monitoring containers already removed - treating as stopped');
         return;
       }
 
-      this.currentStatus = ServiceStatus.FAILED;
+      this.currentStatus = ServiceStatusValues.FAILED;
       this.lastError = {
         message: error instanceof Error ? error.message : 'Failed to stop',
         timestamp: new Date(),
@@ -234,7 +236,7 @@ export class MonitoringService implements IApplicationService {
 
       if (runningContainers.length === 0) {
         return {
-          status: HealthStatus.UNHEALTHY,
+          status: HealthStatusValues.UNHEALTHY,
           message: 'No monitoring containers are running',
           lastChecked: new Date(),
           details: { totalContainers: containers.length, runningContainers: 0 }
@@ -262,7 +264,7 @@ export class MonitoringService implements IApplicationService {
           `Alloy=${alloyRunning ? 'running' : 'stopped'}`
         ].join(', ');
         return {
-          status: HealthStatus.UNHEALTHY,
+          status: HealthStatusValues.UNHEALTHY,
           message: `Monitoring degraded: ${services}`,
           lastChecked: new Date(),
           details: { telegrafRunning, prometheusRunning, lokiRunning, alloyRunning }
@@ -270,7 +272,7 @@ export class MonitoringService implements IApplicationService {
       }
 
       return {
-        status: HealthStatus.HEALTHY,
+        status: HealthStatusValues.HEALTHY,
         message: 'Monitoring service is healthy',
         lastChecked: new Date(),
         details: {
@@ -284,7 +286,7 @@ export class MonitoringService implements IApplicationService {
       };
     } catch (error) {
       return {
-        status: HealthStatus.UNKNOWN,
+        status: HealthStatusValues.UNKNOWN,
         message: error instanceof Error ? error.message : 'Health check failed',
         lastChecked: new Date(),
         details: { error: error instanceof Error ? error.message : 'Unknown error' }
@@ -296,9 +298,9 @@ export class MonitoringService implements IApplicationService {
     try {
       await this.dockerExecutor.initialize();
 
-      return this.currentStatus === ServiceStatus.INITIALIZED ||
-        this.currentStatus === ServiceStatus.STOPPED ||
-        this.currentStatus === ServiceStatus.FAILED;
+      return this.currentStatus === ServiceStatusValues.INITIALIZED ||
+        this.currentStatus === ServiceStatusValues.STOPPED ||
+        this.currentStatus === ServiceStatusValues.FAILED;
     } catch (error) {
       this.logger.warn({ error }, 'Monitoring service readiness check failed');
       return false;
@@ -358,7 +360,7 @@ export class MonitoringService implements IApplicationService {
       }
     }
 
-    this.currentStatus = ServiceStatus.STOPPED;
+    this.currentStatus = ServiceStatusValues.STOPPED;
     this.stoppedAt = new Date();
     this.logger.info({ removed, errors }, 'Force remove completed');
 
@@ -371,7 +373,7 @@ export class MonitoringService implements IApplicationService {
    * while containers are still running from a previous session.
    */
   markAsRunning(): void {
-    this.currentStatus = ServiceStatus.RUNNING;
+    this.currentStatus = ServiceStatusValues.RUNNING;
     this.startedAt = this.startedAt || new Date();
     this.lastError = undefined;
   }

--- a/server/src/services/stacks/schemas.ts
+++ b/server/src/services/stacks/schemas.ts
@@ -1,4 +1,9 @@
 import { z } from "zod";
+import {
+  STACK_SERVICE_TYPES,
+  RESTART_POLICIES,
+  BALANCE_ALGORITHMS,
+} from '@mini-infra/types';
 
 // Template string pattern: allows {{params.key-name}} references
 const templateStringPattern = /\{\{params\.[a-zA-Z0-9_-]+\}\}/;
@@ -92,7 +97,7 @@ export const stackContainerConfigSchema = z.object({
   joinNetworks: z.array(z.string().min(1)).optional(),
   joinResourceNetworks: z.array(z.string().min(1)).optional(),
   restartPolicy: z
-    .enum(["no", "always", "unless-stopped", "on-failure"])
+    .enum(RESTART_POLICIES)
     .optional(),
   healthcheck: z
     .object({
@@ -133,7 +138,7 @@ export const stackServiceRoutingSchema = z.object({
   healthCheckEndpoint: z.string().max(500).optional(),
   backendOptions: z
     .object({
-      balanceAlgorithm: z.enum(["roundrobin", "leastconn", "source"]).optional(),
+      balanceAlgorithm: z.enum(BALANCE_ALGORITHMS).optional(),
       checkTimeout: numberOrTemplateMin0.optional(),
       connectTimeout: numberOrTemplateMin0.optional(),
       serverTimeout: numberOrTemplateMin0.optional(),
@@ -211,7 +216,7 @@ export const stackServiceDefinitionSchema = z
         nameRegex,
         "Service name can only contain letters, numbers, hyphens, and underscores"
       ),
-    serviceType: z.enum(["Stateful", "StatelessWeb", "AdoptedWeb"]),
+    serviceType: z.enum(STACK_SERVICE_TYPES),
     dockerImage: z.string().min(1),
     dockerTag: z.string().min(1),
     containerConfig: stackContainerConfigSchema,
@@ -305,7 +310,7 @@ export const updateStackSchema = z.object({
 });
 
 export const updateStackServiceSchema = z.object({
-  serviceType: z.enum(["Stateful", "StatelessWeb", "AdoptedWeb"]).optional(),
+  serviceType: z.enum(STACK_SERVICE_TYPES).optional(),
   dockerImage: z.string().min(1).optional(),
   dockerTag: z.string().min(1).optional(),
   containerConfig: stackContainerConfigSchema.optional(),

--- a/server/src/services/stacks/template-file-loader.ts
+++ b/server/src/services/stacks/template-file-loader.ts
@@ -12,6 +12,7 @@ import {
   stackResourceInputSchema,
 } from "./schemas";
 import type { StackTemplateConfigFileInput } from "@mini-infra/types";
+import { STACK_SERVICE_TYPES } from "@mini-infra/types";
 
 // =====================
 // Template File Schema
@@ -36,7 +37,7 @@ const templateConfigFileSchema = z.object({
 
 const templateServiceSchema = z.object({
   serviceName: z.string().min(1).max(100).regex(nameRegex, "Service name can only contain letters, numbers, hyphens, and underscores"),
-  serviceType: z.enum(["Stateful", "StatelessWeb", "AdoptedWeb"]),
+  serviceType: z.enum(STACK_SERVICE_TYPES),
   dockerImage: z.string().min(1),
   dockerTag: z.string().min(1),
   containerConfig: stackContainerConfigSchema,
@@ -105,7 +106,7 @@ export interface LoadedTemplate {
     volumes: z.infer<typeof stackVolumeSchema>[];
     services: Array<{
       serviceName: string;
-      serviceType: "Stateful" | "StatelessWeb" | "AdoptedWeb";
+      serviceType: typeof STACK_SERVICE_TYPES[number];
       dockerImage: string;
       dockerTag: string;
       containerConfig: z.infer<typeof stackContainerConfigSchema>;


### PR DESCRIPTION
## Summary

- **lib**: Added `as const` tuple arrays for all enum-like values (`STACK_SERVICE_TYPES`, `RESTART_POLICIES`, `BALANCE_ALGORITHMS`, `STACK_PARAMETER_TYPES`, `ENVIRONMENT_TYPES`, `ENVIRONMENT_NETWORK_TYPES`, `STACK_TEMPLATE_SCOPES`, `POSTGRES_SSL_MODES`, `BACKUP_FORMATS`) so Zod schemas in both workspaces reference a single source of truth instead of hardcoding strings independently
- **server**: Removed ~100 lines of duplicate interface/enum declarations from `interfaces/application-service.ts` — `ServiceHealth`, `NetworkRequirement`, `VolumeRequirement`, `ServiceMetadata`, `StartupResult`, `ServiceStatusInfo`, `ServiceStatus`, and `HealthStatus` were all re-declared identically to what already existed in `lib/types/services.ts`; `haproxy-service.ts` and `monitoring-service.ts` updated to use `ServiceStatusValues`/`HealthStatusValues` const objects
- **client**: 8 component/schema files updated to use shared const arrays in Zod enums; `FrontendStatus` local type in `frontend-status-badge.tsx` now derived from `HAProxyFrontendInfo['status']` in lib

## Test plan

- [x] `npm run build:lib` — clean
- [x] `npm run build:server` — clean
- [x] `npm run build -w client` — clean
- [x] `npm test -w server` — 1198 passed (pre-existing failure unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)