### PR TITLE
chore: extract duplicate cross-boundary types into shared lib (#177)

### DIFF
--- a/client/src/app/monitoring/ContainerMetricsTable.tsx
+++ b/client/src/app/monitoring/ContainerMetricsTable.tsx
@@ -13,12 +13,12 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import type { PrometheusQueryResponse } from "@/hooks/use-monitoring";
+import type { PrometheusQueryResult } from "@mini-infra/types";
 import { formatCpu, formatBytes } from "@/lib/format-metrics";
 
 interface ContainerMetricsTableProps {
-  cpuData?: PrometheusQueryResponse;
-  memoryData?: PrometheusQueryResponse;
+  cpuData?: PrometheusQueryResult;
+  memoryData?: PrometheusQueryResult;
 }
 
 interface ContainerMetric {
@@ -86,8 +86,8 @@ export function ContainerMetricsTable({
 }
 
 function mergeMetrics(
-  cpuData?: PrometheusQueryResponse,
-  memoryData?: PrometheusQueryResponse
+  cpuData?: PrometheusQueryResult,
+  memoryData?: PrometheusQueryResult
 ): ContainerMetric[] {
   const metricsMap = new Map<string, ContainerMetric>();
 

--- a/client/src/app/monitoring/MetricsChart.tsx
+++ b/client/src/app/monitoring/MetricsChart.tsx
@@ -13,12 +13,12 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
-import type { PrometheusQueryResponse } from "@/hooks/use-monitoring";
+import type { PrometheusQueryResult } from "@mini-infra/types";
 
 interface MetricsChartProps {
   title: string;
   description: string;
-  data?: PrometheusQueryResponse;
+  data?: PrometheusQueryResult;
   icon: React.ReactNode;
   valueFormatter: (value: number) => string;
   color: "blue" | "green" | "purple" | "orange";

--- a/client/src/hooks/use-monitoring.ts
+++ b/client/src/hooks/use-monitoring.ts
@@ -1,37 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import type { StackInfo } from "@mini-infra/types";
-import { Channel, ServerEvent } from "@mini-infra/types";
+import { Channel, ServerEvent, MonitoringStatusResponse, PrometheusQueryResult } from "@mini-infra/types";
 import { useSocket, useSocketChannel, useSocketEvent } from "./use-socket";
+
+export type { MonitoringStatusResponse };
 
 function generateCorrelationId(): string {
   return `monitoring-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
-}
-
-// Types for monitoring API responses
-export interface MonitoringStatusResponse {
-  stack: StackInfo | null;
-  containerStatus: Array<{
-    serviceName: string;
-    containerId: string;
-    containerName: string;
-    image: string;
-    state: string;
-    status: string;
-  }>;
-  running: boolean;
-  message?: string;
-}
-
-export interface PrometheusQueryResponse {
-  status: string;
-  data: {
-    resultType: string;
-    result: Array<{
-      metric: Record<string, string>;
-      value?: [number, string];
-      values?: Array<[number, string]>;
-    }>;
-  };
 }
 
 // Fetch monitoring status (stack-based)
@@ -59,7 +33,7 @@ async function fetchMonitoringStatus(
 async function fetchPrometheusQuery(
   query: string,
   correlationId: string
-): Promise<PrometheusQueryResponse> {
+): Promise<PrometheusQueryResult> {
   const params = new URLSearchParams({ query });
   const response = await fetch(`/api/monitoring/query?${params}`, {
     credentials: "include",
@@ -83,7 +57,7 @@ async function fetchPrometheusRangeQuery(
   end: string,
   step: string,
   correlationId: string
-): Promise<PrometheusQueryResponse> {
+): Promise<PrometheusQueryResult> {
   const params = new URLSearchParams({ query, start, end, step });
   const response = await fetch(`/api/monitoring/query_range?${params}`, {
     credentials: "include",

--- a/client/src/hooks/use-stacks.ts
+++ b/client/src/hooks/use-stacks.ts
@@ -19,6 +19,8 @@ import type {
   StackListResponse,
   StackResponse,
   StackPlanResponse,
+  StackValidationError,
+  StackValidationResult,
 } from "@mini-infra/types";
 import { useSocket, useSocketChannel, useSocketEvent } from "./use-socket";
 
@@ -302,21 +304,7 @@ async function updateStackParameterValues(
   return await response.json();
 }
 
-// ====================
-// Stack Types
-// ====================
-
-export interface StackValidationError {
-  name: string;
-  description?: string;
-  error: string;
-}
-
-export interface StackValidationResult {
-  success: boolean;
-  valid: boolean;
-  errors: StackValidationError[];
-}
+export type { StackValidationError, StackValidationResult };
 
 // ====================
 // Stack Hooks

--- a/lib/types/monitoring.ts
+++ b/lib/types/monitoring.ts
@@ -1,4 +1,5 @@
 import { ServiceStatus, ApplicationServiceHealthStatus, ServiceMetadata, ServiceHealth } from './services';
+import type { StackInfo } from './stacks';
 
 export interface HostService {
   id: string;
@@ -46,6 +47,22 @@ export interface PrometheusQueryResult {
       values?: Array<[number, string]>;
     }>;
   };
+}
+
+export interface MonitoringContainerStatus {
+  serviceName: string;
+  containerId: string;
+  containerName: string;
+  image: string;
+  state: string;
+  status: string;
+}
+
+export interface MonitoringStatusResponse {
+  stack: StackInfo | null;
+  containerStatus: MonitoringContainerStatus[];
+  running: boolean;
+  message?: string;
 }
 
 export interface MonitoringTargetsResponse {

--- a/lib/types/stacks.ts
+++ b/lib/types/stacks.ts
@@ -567,6 +567,18 @@ export interface StackApplyStartedResponse {
   message?: string;
 }
 
+export interface StackValidationError {
+  name: string;
+  description?: string;
+  error: string;
+}
+
+export interface StackValidationResult {
+  success: boolean;
+  valid: boolean;
+  errors: StackValidationError[];
+}
+
 // ====================
 // Stack Adoption Types
 // ====================

--- a/lib/types/tls.ts
+++ b/lib/types/tls.ts
@@ -1,5 +1,7 @@
 import type { OperationStep } from './operations';
 
+export type AcmeProvider = "letsencrypt" | "letsencrypt-staging" | "buypass" | "zerossl";
+
 export interface TlsCertificate {
   id: string;
 
@@ -95,7 +97,7 @@ export interface CreateCertificateRequest {
 
 export interface TlsSettings {
   certificate_blob_container: string;
-  default_acme_provider: "letsencrypt" | "letsencrypt-staging";
+  default_acme_provider: AcmeProvider;
   default_acme_email: string;
   renewal_check_cron: string;
   renewal_days_before_expiry: string;

--- a/server/src/routes/monitoring.ts
+++ b/server/src/routes/monitoring.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import { requirePermission } from '../middleware/auth';
 import prisma from '../lib/prisma';
 import { appLogger } from '../lib/logger-factory';
+import { MonitoringStatusResponse } from '@mini-infra/types';
 import { DockerExecutorService } from '../services/docker-executor';
 import { StackReconciler } from '../services/stacks/stack-reconciler';
 import { serializeStack, mapContainerStatus, isDockerConnectionError } from '../services/stacks/utils';
@@ -37,7 +38,7 @@ router.get('/status', requirePermission('monitoring:read'), async (_req, res) =>
       });
     }
 
-    let containerStatus: ReturnType<typeof mapContainerStatus>[] = [];
+    let containerStatus: MonitoringStatusResponse['containerStatus'] = [];
     let running = false;
     try {
       const dockerExecutor = new DockerExecutorService();
@@ -60,11 +61,12 @@ router.get('/status', requirePermission('monitoring:read'), async (_req, res) =>
       // Docker unavailable
     }
 
-    res.json({
+    const response: MonitoringStatusResponse = {
       stack: serializeStack(stack),
       containerStatus,
       running,
-    });
+    };
+    res.json(response);
   } catch (error) {
     logger.error({ error }, 'Failed to get monitoring status');
     res.status(500).json({ error: 'Failed to get monitoring status' });

--- a/server/src/routes/stacks.ts
+++ b/server/src/routes/stacks.ts
@@ -36,7 +36,7 @@ import {
   isDockerConnectionError,
   mapContainerStatus,
 } from '../services/stacks/utils';
-import { Channel, ServerEvent, StackNetwork, StackVolume, StackParameterDefinition, StackParameterValue, ResourceResult, ResourceType, ServiceApplyResult, StackServiceDefinition, DockerContainerInfo, StackServiceRouting, StackAdoptionCandidate, StackAdoptionCandidatesResponse } from '@mini-infra/types';
+import { Channel, ServerEvent, StackNetwork, StackVolume, StackParameterDefinition, StackParameterValue, ResourceResult, ResourceType, ServiceApplyResult, StackServiceDefinition, DockerContainerInfo, StackServiceRouting, StackAdoptionCandidate, StackAdoptionCandidatesResponse, StackValidationResult } from '@mini-infra/types';
 import { UserEventService } from '../services/user-events';
 import {
   formatPlanStep,
@@ -494,7 +494,7 @@ router.get('/:stackId/validate', requirePermission('stacks:read'), async (req, r
       (stack.parameterValues as unknown as Record<string, StackParameterValue>) ?? {}
     );
 
-    const errors: Array<{ name: string; description?: string; error: string }> = [];
+    const errors: StackValidationResult['errors'] = [];
     for (const def of paramDefs) {
       const value = paramValues[def.name];
       if (value === '' || value === undefined || value === null) {
@@ -502,11 +502,12 @@ router.get('/:stackId/validate', requirePermission('stacks:read'), async (req, r
       }
     }
 
-    res.json({
+    const result: StackValidationResult = {
       success: true,
       valid: errors.length === 0,
       errors,
-    });
+    };
+    res.json(result);
   } catch (error) {
     res.status(500).json({ success: false, message: (error instanceof Error ? error.message : null) ?? 'Validation failed' });
   }

--- a/server/src/services/tls/tls-config.ts
+++ b/server/src/services/tls/tls-config.ts
@@ -3,6 +3,7 @@ import {
   ValidationResult,
   ServiceHealthStatus,
   ConnectivityStatusType,
+  AcmeProvider,
 } from "@mini-infra/types";
 import { ConfigurationService } from "../configuration-base";
 import { servicesLogger } from "../../lib/logger-factory";
@@ -19,11 +20,6 @@ const TLS_SETTINGS_KEYS = {
   RENEWAL_CHECK_CRON: "renewal_check_cron",
   RENEWAL_DAYS_BEFORE_EXPIRY: "renewal_days_before_expiry",
 } as const;
-
-/**
- * ACME Provider types
- */
-export type AcmeProvider = "letsencrypt" | "letsencrypt-staging" | "buypass" | "zerossl";
 
 /**
  * ACME Account Configuration

--- a/server/src/services/tls/types.ts
+++ b/server/src/services/tls/types.ts
@@ -5,6 +5,9 @@
  * ACME protocol integration, Azure Key Vault storage, and certificate lifecycle operations.
  */
 
+import { AcmeProvider } from "@mini-infra/types";
+export type { AcmeProvider };
+
 /**
  * Certificate metadata parsed from X.509 certificate
  */
@@ -64,11 +67,6 @@ export interface RenewalCheckResult {
     error: string;
   }>;
 }
-
-/**
- * ACME provider configuration
- */
-export type AcmeProvider = 'letsencrypt' | 'letsencrypt-staging' | 'buypass' | 'zerossl';
 
 /**
  * ACME account configuration


### PR DESCRIPTION
## Summary

- Add `AcmeProvider` to `lib/types/tls.ts` — was duplicated identically in `server/src/services/tls/tls-config.ts` and `server/src/services/tls/types.ts`; also fixes the incomplete `TlsSettings.default_acme_provider` type (was missing `"buypass"` and `"zerossl"`)
- Add `StackValidationError` + `StackValidationResult` to `lib/types/stacks.ts` — the server's `GET /:stackId/validate` route was returning this shape as an anonymous inline type while the client defined its own matching interface; both now share the contract from lib
- Add `MonitoringStatusResponse` + `MonitoringContainerStatus` to `lib/types/monitoring.ts` — same pattern: server `GET /api/monitoring/status` was untyped, client hook had a local definition; now both use the shared type
- Remove `PrometheusQueryResponse` from the client monitoring hook — it was a structural duplicate of the existing `PrometheusQueryResult` in `lib/types/monitoring.ts` under a different name; `ContainerMetricsTable` and `MetricsChart` updated to import directly from `@mini-infra/types`

## Test plan

- [x] `npm run build:lib` passes
- [x] `npm run build:server` passes
- [x] `npm run build -w client` passes
- [x] Full `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)