### PR TITLE
chore: bump server TypeScript to ^5.9.3 (Prisma 7 prep)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14338,7 +14338,7 @@
         "rimraf": "^6.1.3",
         "supertest": "^7.2.2",
         "tsx": "^4.21.0",
-        "typescript": "^5.1.6",
+        "typescript": "^5.9.3",
         "typescript-eslint": "^8.58.1",
         "vitest": "^4.1.4"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -50,7 +50,7 @@
         "rimraf": "^6.1.3",
         "supertest": "^7.2.2",
         "tsx": "^4.21.0",
-        "typescript": "^5.1.6",
+        "typescript": "^5.9.3",
         "typescript-eslint": "^8.58.1",
         "vitest": "^4.1.4"
     },


### PR DESCRIPTION
## Summary
- Bumps `server` workspace TypeScript from `^5.1.6` → `^5.9.3`
- Prisma 7 requires TypeScript >= 5.4; doing this ahead of the Prisma 7 upgrade isolates any TS-only fallout from the Prisma changes

This is PR 1 of a 2-PR Prisma 6 → 7 upgrade. PR 2 will do the actual Prisma bump, add the driver adapter, migrate imports, and update `prisma.config.ts` / `docker-entrypoint.sh`.

## Test plan
- [x] `npm run build -w server` passes on TS 5.9.3
- [x] `npm test -w server` passes — 1264/1264 tests green (68 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)