### PR TITLE
chore: bump sidecar @types/node to ^24 and @types/dockerode to ^4

### DIFF
--- a/agent-sidecar/package-lock.json
+++ b/agent-sidecar/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@types/express": "^5.0.3",
-        "@types/node": "^22.16.0",
+        "@types/node": "^24.12.2",
         "tsx": "^4.21.0",
         "typescript": "^5.1.6",
         "vitest": "^4.1.3"
@@ -831,21 +831,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
-    },
-    "node_modules/@types/node/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.3",
@@ -3382,6 +3375,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "13.0.0",

--- a/agent-sidecar/package.json
+++ b/agent-sidecar/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.3",
-    "@types/node": "^22.16.0",
+    "@types/node": "^24.12.2",
     "tsx": "^4.21.0",
     "typescript": "^5.1.6",
     "vitest": "^4.1.3"

--- a/update-sidecar/package-lock.json
+++ b/update-sidecar/package-lock.json
@@ -13,8 +13,8 @@
         "pino-pretty": "^13.1.3"
       },
       "devDependencies": {
-        "@types/dockerode": "^3.3.43",
-        "@types/node": "^20.4.0",
+        "@types/dockerode": "^4.0.1",
+        "@types/node": "^24.12.2",
         "tsx": "^4.21.0",
         "typescript": "^5.1.6"
       }
@@ -608,9 +608,9 @@
       }
     },
     "node_modules/@types/dockerode": {
-      "version": "3.3.47",
-      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.47.tgz",
-      "integrity": "sha512-ShM1mz7rCjdssXt7Xz0u1/R2BJC7piWa3SJpUBiVjCf2A3XNn4cP6pUVaD8bLanpPVVn4IKzJuw3dOvkJ8IbYw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-4.0.1.tgz",
+      "integrity": "sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -620,12 +620,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/ssh2": {
@@ -1495,9 +1495,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/util-deprecate": {

--- a/update-sidecar/package.json
+++ b/update-sidecar/package.json
@@ -15,8 +15,8 @@
     "pino-pretty": "^13.1.3"
   },
   "devDependencies": {
-    "@types/dockerode": "^3.3.43",
-    "@types/node": "^20.4.0",
+    "@types/dockerode": "^4.0.1",
+    "@types/node": "^24.12.2",
     "tsx": "^4.21.0",
     "typescript": "^5.1.6"
   }


### PR DESCRIPTION
## Summary
- Bump `@types/node` in both sidecars to `^24` to match the `node:24-alpine` runtime they run under
- Bump `@types/dockerode` in update-sidecar from `^3.3.43` to `^4.0.1` (major)

## Test plan
- [x] `npm run build` in `update-sidecar/`
- [x] `npm run build` + `npm test` in `agent-sidecar/` (8/8 pass)
- [x] `./deployment/development/start.sh` rebuilds agent-sidecar image and main app; `mini-infra-dev` comes up healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)