### PR TITLE
Add System Diagnostics page with memory stats and heap snapshot download

### DIFF
--- a/API-ROUTES.md
+++ b/API-ROUTES.md
@@ -544,3 +544,10 @@
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/api/routes` | List all registered API routes |
+
+## Diagnostics (`/api/diagnostics`)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/diagnostics/memory` | Current process memory and V8 heap statistics (`settings:read`) |
+| POST | `/api/diagnostics/heap-snapshot` | Write a V8 heap snapshot to disk and return its path (`settings:write`) |

--- a/client/src/app/system-diagnostics/page.tsx
+++ b/client/src/app/system-diagnostics/page.tsx
@@ -9,6 +9,8 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
 import {
   Table,
   TableBody,
@@ -24,6 +26,48 @@ import {
   IconLoader2,
   IconRefresh,
 } from "@tabler/icons-react";
+
+const PROCESS_EXPLANATIONS: Record<string, string> = {
+  RSS: "Resident Set Size — total RAM the process holds, including heap, code, stacks, and native allocations.",
+  "Heap used": "JavaScript objects currently alive in the V8 heap.",
+  "Heap total": "Size V8 has committed for the heap; grows as needed up to the limit.",
+  External:
+    "Memory held by C++ objects bound to JS (Buffers, native addons, etc.) — lives outside the V8 heap.",
+  "Array buffers":
+    "Bytes allocated for ArrayBuffers / SharedArrayBuffers. Counted within External.",
+};
+
+const HEAP_EXPLANATIONS: Record<string, string> = {
+  Used: "Live JS objects in the heap right now.",
+  Total: "Committed heap size — what V8 has reserved from the OS.",
+  Physical:
+    "Heap pages actually backed by RAM. Can be lower than Total if pages were released.",
+  Available: "Headroom before hitting the heap size limit.",
+  Limit:
+    "Maximum heap V8 will grow to (controlled by --max-old-space-size). OOM crashes happen past this.",
+  Malloced: "V8's current internal C++ allocations (metadata, parser state, etc.).",
+  "Peak malloced": "Highest malloced value since process start — useful for spotting transient spikes.",
+  "Native contexts":
+    "Top-level JS contexts. Normally 1. Growing numbers usually indicate leaked vm/iframe contexts.",
+};
+
+const HEAP_SPACE_EXPLANATIONS: Record<string, string> = {
+  read_only_space: "Immutable V8 internals (builtins, snapshots). Shared, never GC'd.",
+  new_space:
+    "Young generation — where new allocations land. Collected frequently (scavenge GC).",
+  old_space: "Objects that survived enough young GCs to be promoted. Collected by mark-sweep.",
+  code_space: "JIT-compiled machine code for hot JS functions.",
+  shared_space: "Objects shared across isolates (worker threads).",
+  trusted_space: "V8 internal objects treated as trusted (sandbox-related).",
+  shared_trusted_space: "Trusted objects shared across isolates.",
+  new_large_object_space:
+    "Large allocations (≥~500 KB) made in the young generation — too big for new_space.",
+  large_object_space: "Large allocations in the old generation.",
+  code_large_object_space: "Oversized compiled code objects.",
+  shared_large_object_space: "Large shared objects across isolates.",
+  shared_trusted_large_object_space: "Large trusted shared objects.",
+  trusted_large_object_space: "Large trusted objects.",
+};
 
 interface MemoryDiagnostics {
   timestamp: string;
@@ -84,6 +128,7 @@ function formatUptime(seconds: number): string {
 
 export default function SystemDiagnosticsPage() {
   const [downloading, setDownloading] = useState(false);
+  const [showExplanations, setShowExplanations] = useState(false);
 
   const query = useQuery<MemoryDiagnostics>({
     queryKey: ["diagnostics", "memory"],
@@ -147,7 +192,17 @@ export default function SystemDiagnosticsPage() {
             Server process memory, V8 heap statistics, and heap snapshots.
           </p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            <Switch
+              id="show-explanations"
+              checked={showExplanations}
+              onCheckedChange={setShowExplanations}
+            />
+            <Label htmlFor="show-explanations" className="text-sm">
+              Show explanations
+            </Label>
+          </div>
           <Button
             variant="outline"
             size="sm"
@@ -198,23 +253,47 @@ export default function SystemDiagnosticsPage() {
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <dl className="grid grid-cols-2 gap-x-6 gap-y-3 md:grid-cols-5">
-                <Stat label="RSS" value={formatBytes(data.process.rss)} />
+              <dl
+                className={`grid gap-x-6 gap-y-3 ${
+                  showExplanations
+                    ? "grid-cols-1 md:grid-cols-2"
+                    : "grid-cols-2 md:grid-cols-5"
+                }`}
+              >
+                <Stat
+                  label="RSS"
+                  value={formatBytes(data.process.rss)}
+                  description={showExplanations ? PROCESS_EXPLANATIONS.RSS : undefined}
+                />
                 <Stat
                   label="Heap used"
                   value={formatBytes(data.process.heapUsed)}
+                  description={
+                    showExplanations ? PROCESS_EXPLANATIONS["Heap used"] : undefined
+                  }
                 />
                 <Stat
                   label="Heap total"
                   value={formatBytes(data.process.heapTotal)}
+                  description={
+                    showExplanations ? PROCESS_EXPLANATIONS["Heap total"] : undefined
+                  }
                 />
                 <Stat
                   label="External"
                   value={formatBytes(data.process.external)}
+                  description={
+                    showExplanations ? PROCESS_EXPLANATIONS.External : undefined
+                  }
                 />
                 <Stat
                   label="Array buffers"
                   value={formatBytes(data.process.arrayBuffers)}
+                  description={
+                    showExplanations
+                      ? PROCESS_EXPLANATIONS["Array buffers"]
+                      : undefined
+                  }
                 />
               </dl>
             </CardContent>
@@ -235,38 +314,60 @@ export default function SystemDiagnosticsPage() {
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <dl className="grid grid-cols-2 gap-x-6 gap-y-3 md:grid-cols-4">
+              <dl
+                className={`grid gap-x-6 gap-y-3 ${
+                  showExplanations
+                    ? "grid-cols-1 md:grid-cols-2"
+                    : "grid-cols-2 md:grid-cols-4"
+                }`}
+              >
                 <Stat
                   label="Used"
                   value={formatBytes(data.heap.usedHeapSize)}
+                  description={showExplanations ? HEAP_EXPLANATIONS.Used : undefined}
                 />
                 <Stat
                   label="Total"
                   value={formatBytes(data.heap.totalHeapSize)}
+                  description={showExplanations ? HEAP_EXPLANATIONS.Total : undefined}
                 />
                 <Stat
                   label="Physical"
                   value={formatBytes(data.heap.totalPhysicalSize)}
+                  description={showExplanations ? HEAP_EXPLANATIONS.Physical : undefined}
                 />
                 <Stat
                   label="Available"
                   value={formatBytes(data.heap.totalAvailableSize)}
+                  description={
+                    showExplanations ? HEAP_EXPLANATIONS.Available : undefined
+                  }
                 />
                 <Stat
                   label="Limit"
                   value={formatBytes(data.heap.heapSizeLimit)}
+                  description={showExplanations ? HEAP_EXPLANATIONS.Limit : undefined}
                 />
                 <Stat
                   label="Malloced"
                   value={formatBytes(data.heap.mallocedMemory)}
+                  description={showExplanations ? HEAP_EXPLANATIONS.Malloced : undefined}
                 />
                 <Stat
                   label="Peak malloced"
                   value={formatBytes(data.heap.peakMallocedMemory)}
+                  description={
+                    showExplanations ? HEAP_EXPLANATIONS["Peak malloced"] : undefined
+                  }
                 />
                 <Stat
                   label="Native contexts"
                   value={data.heap.numberOfNativeContexts.toString()}
+                  description={
+                    showExplanations
+                      ? HEAP_EXPLANATIONS["Native contexts"]
+                      : undefined
+                  }
                 />
               </dl>
             </CardContent>
@@ -286,6 +387,7 @@ export default function SystemDiagnosticsPage() {
                     <TableHead className="text-right">Size</TableHead>
                     <TableHead className="text-right">Available</TableHead>
                     <TableHead className="text-right">Physical</TableHead>
+                    {showExplanations && <TableHead>What it holds</TableHead>}
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -306,6 +408,11 @@ export default function SystemDiagnosticsPage() {
                       <TableCell className="text-right">
                         {formatBytes(space.physical)}
                       </TableCell>
+                      {showExplanations && (
+                        <TableCell className="text-xs text-muted-foreground">
+                          {HEAP_SPACE_EXPLANATIONS[space.name] ?? "—"}
+                        </TableCell>
+                      )}
                     </TableRow>
                   ))}
                 </TableBody>
@@ -336,11 +443,22 @@ export default function SystemDiagnosticsPage() {
   );
 }
 
-function Stat({ label, value }: { label: string; value: string }) {
+function Stat({
+  label,
+  value,
+  description,
+}: {
+  label: string;
+  value: string;
+  description?: string;
+}) {
   return (
     <div>
       <dt className="text-xs uppercase text-muted-foreground">{label}</dt>
       <dd className="font-mono text-sm">{value}</dd>
+      {description && (
+        <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+      )}
     </div>
   );
 }

--- a/client/src/app/system-diagnostics/page.tsx
+++ b/client/src/app/system-diagnostics/page.tsx
@@ -1,0 +1,346 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  IconAlertCircle,
+  IconDownload,
+  IconLoader2,
+  IconRefresh,
+} from "@tabler/icons-react";
+
+interface MemoryDiagnostics {
+  timestamp: string;
+  uptimeSeconds: number;
+  pid: number;
+  nodeVersion: string;
+  process: {
+    rss: number;
+    heapTotal: number;
+    heapUsed: number;
+    external: number;
+    arrayBuffers: number;
+  };
+  heap: {
+    totalHeapSize: number;
+    totalHeapSizeExecutable: number;
+    totalPhysicalSize: number;
+    totalAvailableSize: number;
+    usedHeapSize: number;
+    heapSizeLimit: number;
+    mallocedMemory: number;
+    peakMallocedMemory: number;
+    numberOfNativeContexts: number;
+    numberOfDetachedContexts: number;
+  };
+  heapSpaces: Array<{
+    name: string;
+    size: number;
+    used: number;
+    available: number;
+    physical: number;
+  }>;
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes)) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit++;
+  }
+  return `${value.toFixed(value >= 10 ? 1 : 2)} ${units[unit]}`;
+}
+
+function formatUptime(seconds: number): string {
+  const d = Math.floor(seconds / 86400);
+  const h = Math.floor((seconds % 86400) / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+  if (d > 0) return `${d}d ${h}h ${m}m`;
+  if (h > 0) return `${h}h ${m}m ${s}s`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+export default function SystemDiagnosticsPage() {
+  const [downloading, setDownloading] = useState(false);
+
+  const query = useQuery<MemoryDiagnostics>({
+    queryKey: ["diagnostics", "memory"],
+    queryFn: async () => {
+      const res = await fetch("/api/diagnostics/memory");
+      if (!res.ok) throw new Error(`Failed to load memory diagnostics (${res.status})`);
+      return res.json();
+    },
+    refetchInterval: 5000,
+  });
+
+  const handleDownloadSnapshot = async () => {
+    setDownloading(true);
+    const toastId = toast.loading(
+      "Capturing heap snapshot — this can take several seconds and temporarily pause the server...",
+    );
+    try {
+      const res = await fetch("/api/diagnostics/heap-snapshot", {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(text || `Snapshot failed (${res.status})`);
+      }
+
+      const disposition = res.headers.get("Content-Disposition") ?? "";
+      const match = /filename="?([^";]+)"?/i.exec(disposition);
+      const filename = match?.[1] ?? `heap-${Date.now()}.heapsnapshot`;
+
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+
+      toast.success(`Heap snapshot downloaded (${formatBytes(blob.size)})`, {
+        id: toastId,
+      });
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to capture heap snapshot",
+        { id: toastId },
+      );
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  const data = query.data;
+
+  return (
+    <div className="container mx-auto max-w-5xl space-y-6 py-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">System Diagnostics</h1>
+          <p className="text-sm text-muted-foreground">
+            Server process memory, V8 heap statistics, and heap snapshots.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => query.refetch()}
+            disabled={query.isFetching}
+          >
+            {query.isFetching ? (
+              <IconLoader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <IconRefresh className="h-4 w-4" />
+            )}
+            Refresh
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleDownloadSnapshot}
+            disabled={downloading}
+          >
+            {downloading ? (
+              <IconLoader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <IconDownload className="h-4 w-4" />
+            )}
+            Download heap snapshot
+          </Button>
+        </div>
+      </div>
+
+      {query.isError && (
+        <Alert variant="destructive">
+          <IconAlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            {query.error instanceof Error
+              ? query.error.message
+              : "Failed to load diagnostics"}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {data && (
+        <>
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Process</CardTitle>
+              <CardDescription>
+                PID {data.pid} · Node {data.nodeVersion} · Uptime{" "}
+                {formatUptime(data.uptimeSeconds)}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <dl className="grid grid-cols-2 gap-x-6 gap-y-3 md:grid-cols-5">
+                <Stat label="RSS" value={formatBytes(data.process.rss)} />
+                <Stat
+                  label="Heap used"
+                  value={formatBytes(data.process.heapUsed)}
+                />
+                <Stat
+                  label="Heap total"
+                  value={formatBytes(data.process.heapTotal)}
+                />
+                <Stat
+                  label="External"
+                  value={formatBytes(data.process.external)}
+                />
+                <Stat
+                  label="Array buffers"
+                  value={formatBytes(data.process.arrayBuffers)}
+                />
+              </dl>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">V8 Heap</CardTitle>
+              <CardDescription>
+                Used {formatBytes(data.heap.usedHeapSize)} of{" "}
+                {formatBytes(data.heap.heapSizeLimit)} limit
+                {data.heap.numberOfDetachedContexts > 0 && (
+                  <span className="ml-2 text-destructive">
+                    · {data.heap.numberOfDetachedContexts} detached context
+                    {data.heap.numberOfDetachedContexts === 1 ? "" : "s"}
+                  </span>
+                )}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <dl className="grid grid-cols-2 gap-x-6 gap-y-3 md:grid-cols-4">
+                <Stat
+                  label="Used"
+                  value={formatBytes(data.heap.usedHeapSize)}
+                />
+                <Stat
+                  label="Total"
+                  value={formatBytes(data.heap.totalHeapSize)}
+                />
+                <Stat
+                  label="Physical"
+                  value={formatBytes(data.heap.totalPhysicalSize)}
+                />
+                <Stat
+                  label="Available"
+                  value={formatBytes(data.heap.totalAvailableSize)}
+                />
+                <Stat
+                  label="Limit"
+                  value={formatBytes(data.heap.heapSizeLimit)}
+                />
+                <Stat
+                  label="Malloced"
+                  value={formatBytes(data.heap.mallocedMemory)}
+                />
+                <Stat
+                  label="Peak malloced"
+                  value={formatBytes(data.heap.peakMallocedMemory)}
+                />
+                <Stat
+                  label="Native contexts"
+                  value={data.heap.numberOfNativeContexts.toString()}
+                />
+              </dl>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Heap Spaces</CardTitle>
+              <CardDescription>Per-space allocation breakdown</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Space</TableHead>
+                    <TableHead className="text-right">Used</TableHead>
+                    <TableHead className="text-right">Size</TableHead>
+                    <TableHead className="text-right">Available</TableHead>
+                    <TableHead className="text-right">Physical</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data.heapSpaces.map((space) => (
+                    <TableRow key={space.name}>
+                      <TableCell className="font-mono text-xs">
+                        {space.name}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {formatBytes(space.used)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {formatBytes(space.size)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {formatBytes(space.available)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {formatBytes(space.physical)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+
+          <Alert>
+            <IconAlertCircle className="h-4 w-4" />
+            <AlertDescription>
+              Heap snapshots can be large (tens to hundreds of MB) and
+              briefly pause the event loop while they&apos;re written. Load the
+              downloaded <code className="font-mono">.heapsnapshot</code> file
+              in Chrome DevTools → Memory tab to analyse retainers.
+            </AlertDescription>
+          </Alert>
+        </>
+      )}
+
+      {!data && query.isLoading && (
+        <Card>
+          <CardContent className="flex items-center justify-center py-12">
+            <IconLoader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-xs uppercase text-muted-foreground">{label}</dt>
+      <dd className="font-mono text-sm">{value}</dd>
+    </div>
+  );
+}

--- a/client/src/lib/route-config.ts
+++ b/client/src/lib/route-config.ts
@@ -498,6 +498,17 @@ export const routeConfig: Record<string, RouteConfig> = {
     helpDoc: "settings/ai-assistant",
   },
 
+  "/system-diagnostics": {
+    path: "/system-diagnostics",
+    title: "System Diagnostics",
+    breadcrumbLabel: "System Diagnostics",
+    icon: IconActivity,
+    showInNav: true,
+    navGroup: "main",
+    navSection: "administration",
+    description: "Server process memory and heap diagnostics",
+  },
+
   "/settings-self-update": {
     path: "/settings-self-update",
     title: "System Update",

--- a/client/src/lib/routes.tsx
+++ b/client/src/lib/routes.tsx
@@ -54,6 +54,7 @@ import BackendDetailsPage from "@/app/haproxy/backends/[backendName]/page";
 import HAProxyInstancesPage from "@/app/haproxy/instances/page";
 import HAProxyOverviewPage from "@/app/haproxy/page";
 import SelfUpdateSettingsPage from "@/app/settings/self-update/page";
+import SystemDiagnosticsPage from "@/app/system-diagnostics/page";
 import { HostPage } from "@/app/host/page";
 import { MonitoringPage } from "@/app/monitoring/page";
 import { LogsPage } from "@/app/logs/page";
@@ -315,6 +316,10 @@ export const router = createBrowserRouter([
       {
         path: "settings-self-update",
         element: <SelfUpdateSettingsPage />,
+      },
+      {
+        path: "system-diagnostics",
+        element: <SystemDiagnosticsPage />,
       },
       {
         path: "settings-users",

--- a/docs/zod-openapi-route-metadata.md
+++ b/docs/zod-openapi-route-metadata.md
@@ -1,0 +1,159 @@
+# Zod-OpenAPI Route Metadata — Design Note
+
+Status: **proposal, not implemented**. Captures the approach so we can pick it up later.
+
+## Problem
+
+The agent sidecar discovers Mini Infra's API surface by calling `GET /api/routes`, which uses `express-list-endpoints` to introspect the Express router. That gives the agent method + path + middleware names, but **no semantics** — it can't tell the agent what an endpoint does, what its side effects are, or when to use it.
+
+Example: the new `POST /api/diagnostics/heap-snapshot` endpoint briefly pauses the event loop and returns a multi-hundred-MB file. The agent has no way to know that from the route listing alone.
+
+We want a single source of truth where:
+
+- route metadata (summary, tags, side effects, auth requirements) lives next to the route handler
+- request/response shapes are typed and validated at runtime
+- the same definitions feed `/api/routes` output consumed by the agent
+- (optionally) we can emit a full OpenAPI 3.1 spec and host a Swagger UI
+
+## Why zod-openapi
+
+Two candidates were considered — `tsoa` and `zod-openapi`:
+
+| | tsoa | zod-openapi |
+|---|---|---|
+| Style | Decorators on controller classes, AST codegen | Zod schemas + explicit `registry.registerPath()` |
+| Routing | Owns your routing layer (generates `routes.ts`) | Drop-in — keeps existing Express routers |
+| Build step | Required (`tsoa spec-and-routes`) | None — runtime only |
+| Migration cost | High — every route becomes a controller | Low — adopt per-route, leave others alone |
+| Agent fit | Gives full OpenAPI spec | Gives full OpenAPI spec |
+
+We prefer **`zod-openapi`** (specifically `@asteasolutions/zod-to-openapi`) because it slots into the existing `Router` setup route-by-route. Routes that haven't been migrated still work; they just render without rich metadata.
+
+## Design
+
+### 1. Package
+
+Install `@asteasolutions/zod-to-openapi` (extends Zod's prototype with `.openapi()`).
+
+### 2. Shared schemas with metadata
+
+Define request/response schemas as Zod types, annotated with OpenAPI descriptions:
+
+```ts
+// server/src/routes/diagnostics.schemas.ts
+import { z } from "zod";
+import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
+
+extendZodWithOpenApi(z);
+
+export const MemoryDiagnostics = z
+  .object({
+    timestamp: z.string().datetime(),
+    uptimeSeconds: z.number().openapi({ description: "Process uptime in seconds" }),
+    pid: z.number(),
+    nodeVersion: z.string(),
+    process: z.object({
+      rss: z.number().openapi({ description: "Resident Set Size in bytes" }),
+      heapTotal: z.number(),
+      heapUsed: z.number(),
+      external: z.number(),
+      arrayBuffers: z.number(),
+    }),
+    // ...heap, heapSpaces
+  })
+  .openapi("MemoryDiagnostics");
+```
+
+### 3. A central registry
+
+```ts
+// server/src/lib/openapi-registry.ts
+import { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+
+export const openApiRegistry = new OpenAPIRegistry();
+```
+
+### 4. Route-side registration
+
+Each route registers its metadata next to the handler. Two ergonomic options:
+
+**Option A — explicit `registerPath` calls alongside the route:**
+
+```ts
+// server/src/routes/diagnostics.ts
+import { openApiRegistry } from "../lib/openapi-registry";
+import { MemoryDiagnostics } from "./diagnostics.schemas";
+
+openApiRegistry.registerPath({
+  method: "get",
+  path: "/api/diagnostics/memory",
+  summary: "Current server process memory and V8 heap statistics",
+  description:
+    "Returns a snapshot of process.memoryUsage(), v8.getHeapStatistics(), and heap spaces. Safe to poll — no side effects.",
+  tags: ["Diagnostics"],
+  security: [{ permission: ["settings:read"] }],
+  responses: {
+    200: {
+      description: "Memory snapshot",
+      content: { "application/json": { schema: MemoryDiagnostics } },
+    },
+  },
+});
+
+router.get("/memory", requirePermission("settings:read"), handler);
+```
+
+**Option B — thin wrapper that does both:**
+
+```ts
+describeRoute(router, "get", "/memory", {
+  summary: "Current server process memory and V8 heap statistics",
+  tags: ["Diagnostics"],
+  permission: "settings:read",
+  sideEffects: "none",
+  response: MemoryDiagnostics,
+}, handler);
+```
+
+The wrapper calls `router.get(...)` **and** `openApiRegistry.registerPath(...)` so you can't forget one. Recommended.
+
+### 5. Serving the spec and enriching `/api/routes`
+
+- `GET /api/openapi.json` — emits the full OpenAPI document from the registry.
+- `GET /api/routes` — rewritten to merge `express-list-endpoints` output with the registry, so each row shows summary, tags, side effects, and required permissions. This is what the agent will read.
+- Optional: mount Swagger UI at `/api/docs` for human consumption.
+
+### 6. Runtime validation (bonus)
+
+Because the schemas are Zod, the same definitions can validate incoming request bodies / params via a small middleware — closing the gap between "documented" and "actually enforced".
+
+## What rich metadata unlocks for the agent
+
+With this in place, the agent sees entries like:
+
+```
+POST /api/diagnostics/heap-snapshot
+  Summary: Capture a V8 heap snapshot and stream it to the caller
+  Tags: Diagnostics
+  Permission: settings:write
+  Side effects: briefly pauses the event loop; produces a 50–500 MB file
+  Request: (none)
+  Response: application/octet-stream (.heapsnapshot)
+```
+
+…which lets it answer "how do I debug a memory leak?" correctly instead of guessing.
+
+## Migration plan (when we pick this up)
+
+1. Add `@asteasolutions/zod-to-openapi`, create the registry, define the `describeRoute` wrapper.
+2. Adopt on `server/src/routes/diagnostics.ts` first — smallest surface, clear win for the agent.
+3. Update `server/src/routes/api-routes.ts` to merge registry metadata into `/api/routes`.
+4. Serve `/api/openapi.json` (and optionally Swagger UI).
+5. Migrate remaining routes opportunistically — touch a file, convert its routes. Unmigrated routes keep working.
+
+## Tradeoffs / things to watch
+
+- **Drift**: nothing forces you to call `describeRoute` over `router.get`. A lint rule or a startup check comparing `express-list-endpoints` output against the registry would catch omissions.
+- **Zod version alignment**: `@asteasolutions/zod-to-openapi` needs to match the installed Zod major. Pin accordingly.
+- **Bundle/runtime cost**: negligible on the server; registry is populated at import time.
+- **Schema duplication with `@mini-infra/types`**: shared types currently live in `lib/`. Either move the relevant Zod schemas there (and `z.infer` the TS types), or keep Zod schemas server-side and only share the inferred TS types with the client. The former is cleaner long-term.

--- a/server/src/app-factory.ts
+++ b/server/src/app-factory.ts
@@ -66,6 +66,7 @@ import createImagesRouter from "./routes/images";
 import apiRoutesRoutes from "./routes/api-routes";
 import usersRoutes from "./routes/users";
 import authSettingsRoutes from "./routes/auth-settings";
+import diagnosticsRoutes from "./routes/diagnostics";
 
 type RouteDefinition = {
   id: string;
@@ -132,6 +133,7 @@ function getRouteDefinitions(): RouteDefinition[] {
     { id: "images", path: "/api/images", name: "imagesRoutes", getRouter: createImagesRouter },
     { id: "apiRoutes", path: "/api/routes", name: "apiRoutesRoutes", getRouter: () => apiRoutesRoutes },
     { id: "agent", path: "/api/agent", name: "agentRoutes", getRouter: () => agentRoutes },
+    { id: "diagnostics", path: "/api/diagnostics", name: "diagnosticsRoutes", getRouter: () => diagnosticsRoutes },
   ];
 }
 

--- a/server/src/routes/diagnostics.ts
+++ b/server/src/routes/diagnostics.ts
@@ -1,0 +1,100 @@
+import { Router, RequestHandler } from "express";
+import { createReadStream } from "fs";
+import { stat, unlink } from "fs/promises";
+import v8 from "v8";
+import os from "os";
+import path from "path";
+import { requirePermission } from "../middleware/auth";
+import { appLogger } from "../lib/logger-factory";
+
+const router = Router();
+const logger = appLogger();
+
+// GET /api/diagnostics/memory - current memory usage snapshot
+router.get("/memory", requirePermission("settings:read") as RequestHandler, ((_req, res) => {
+  const mem = process.memoryUsage();
+  const heap = v8.getHeapStatistics();
+  const heapSpaces = v8.getHeapSpaceStatistics();
+
+  res.json({
+    timestamp: new Date().toISOString(),
+    uptimeSeconds: process.uptime(),
+    pid: process.pid,
+    nodeVersion: process.version,
+    process: {
+      rss: mem.rss,
+      heapTotal: mem.heapTotal,
+      heapUsed: mem.heapUsed,
+      external: mem.external,
+      arrayBuffers: mem.arrayBuffers,
+    },
+    heap: {
+      totalHeapSize: heap.total_heap_size,
+      totalHeapSizeExecutable: heap.total_heap_size_executable,
+      totalPhysicalSize: heap.total_physical_size,
+      totalAvailableSize: heap.total_available_size,
+      usedHeapSize: heap.used_heap_size,
+      heapSizeLimit: heap.heap_size_limit,
+      mallocedMemory: heap.malloced_memory,
+      peakMallocedMemory: heap.peak_malloced_memory,
+      numberOfNativeContexts: heap.number_of_native_contexts,
+      numberOfDetachedContexts: heap.number_of_detached_contexts,
+    },
+    heapSpaces: heapSpaces.map((s) => ({
+      name: s.space_name,
+      size: s.space_size,
+      used: s.space_used_size,
+      available: s.space_available_size,
+      physical: s.physical_space_size,
+    })),
+    resourceUsage: process.resourceUsage(),
+  });
+}) as RequestHandler);
+
+// POST /api/diagnostics/heap-snapshot - write a heap snapshot and stream it to the client
+// The file is created in a temp dir, streamed back as a download, then deleted.
+router.post("/heap-snapshot", requirePermission("settings:write") as RequestHandler, (async (_req, res) => {
+  const dir = process.env.HEAP_SNAPSHOT_DIR || os.tmpdir();
+  const filename = `heap-${Date.now()}-${process.pid}.heapsnapshot`;
+  const fullPath = path.join(dir, filename);
+
+  let written: string | undefined;
+  try {
+    const startedAt = Date.now();
+    written = v8.writeHeapSnapshot(fullPath);
+    const writeDurationMs = Date.now() - startedAt;
+    const { size } = await stat(written);
+    logger.info({ path: written, writeDurationMs, size }, "Heap snapshot written, streaming to client");
+
+    res.setHeader("Content-Type", "application/octet-stream");
+    res.setHeader("Content-Disposition", `attachment; filename="${path.basename(written)}"`);
+    res.setHeader("Content-Length", String(size));
+    res.setHeader("X-Heap-Snapshot-Write-Duration-Ms", String(writeDurationMs));
+
+    const stream = createReadStream(written);
+    stream.pipe(res);
+
+    await new Promise<void>((resolve, reject) => {
+      stream.on("end", () => resolve());
+      stream.on("error", reject);
+      res.on("close", () => resolve());
+    });
+  } catch (error) {
+    logger.error({ error }, "Failed to write heap snapshot");
+    if (!res.headersSent) {
+      res.status(500).json({
+        error: error instanceof Error ? error.message : "Failed to write heap snapshot",
+      });
+    } else {
+      res.end();
+    }
+  } finally {
+    if (written) {
+      unlink(written).catch((err) => {
+        logger.warn({ err, path: written }, "Failed to clean up heap snapshot file");
+      });
+    }
+  }
+}) as RequestHandler);
+
+export default router;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,6 +1,9 @@
 console.log("[STARTUP] Starting Mini Infra server...");
 console.log("[STARTUP] Importing app module...");
 import { createServer } from "http";
+import v8 from "v8";
+import os from "os";
+import path from "path";
 import app from "./app";
 console.log("[STARTUP] ✓ App module imported successfully");
 import appConfig from "./lib/config-new";
@@ -589,6 +592,23 @@ startServer()
 
     process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
     process.on("SIGINT", () => gracefulShutdown("SIGINT"));
+
+    // SIGUSR2 triggers a heap snapshot on disk — useful for diagnosing leaks
+    // in a running container without restart. Retrieve via `docker cp`.
+    process.on("SIGUSR2", () => {
+      const dir = process.env.HEAP_SNAPSHOT_DIR || os.tmpdir();
+      const filePath = path.join(dir, `heap-${Date.now()}-${process.pid}.heapsnapshot`);
+      try {
+        const startedAt = Date.now();
+        const written = v8.writeHeapSnapshot(filePath);
+        logger.info(
+          { path: written, durationMs: Date.now() - startedAt },
+          "Heap snapshot written (SIGUSR2)",
+        );
+      } catch (err) {
+        logger.error({ err }, "Failed to write heap snapshot on SIGUSR2");
+      }
+    });
   })
   .catch((error) => {
     // Use console.error to avoid Pino flush timeout on exit


### PR DESCRIPTION
## Summary
- New **System Diagnostics** admin page (`/system-diagnostics`) showing process memory, V8 heap stats, and per-space breakdown, auto-refreshed every 5s.
- Download button captures a V8 heap snapshot and streams it to the browser as a `.heapsnapshot` file — no `docker cp` needed.
- `SIGUSR2` handler in `server.ts` writes a snapshot to disk (`\$HEAP_SNAPSHOT_DIR` or `os.tmpdir()`) as a fallback when the HTTP path is unavailable.

## Endpoints
- `GET /api/diagnostics/memory` — `process.memoryUsage()` + `v8.getHeapStatistics()` + heap space stats (`settings:read`)
- `POST /api/diagnostics/heap-snapshot` — writes a snapshot, streams it back as a file download, deletes the temp file (`settings:write`)

## Test plan
- [ ] Navigate to Admin → System Diagnostics and verify memory/heap cards render and auto-refresh
- [ ] Click "Download heap snapshot" and confirm a `.heapsnapshot` file is downloaded
- [ ] Open the downloaded snapshot in Chrome DevTools → Memory tab
- [ ] `docker kill -s SIGUSR2 <mini-infra-container>` and confirm a snapshot is written and log line appears
- [ ] Verify API permission gating (non-admin API key returns 403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)