### PR TITLE
Break down RSS beyond the V8 heap + memory region inspector

### DIFF
--- a/API-ROUTES.md
+++ b/API-ROUTES.md
@@ -549,5 +549,7 @@
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/diagnostics/memory` | Current process memory and V8 heap statistics (`settings:read`) |
-| POST | `/api/diagnostics/heap-snapshot` | Write a V8 heap snapshot to disk and return its path (`settings:write`) |
+| GET | `/api/diagnostics/memory` | Current process memory, V8 heap, Linux /proc/self/status, and smaps_rollup (`settings:read`) |
+| GET | `/api/diagnostics/smaps-top` | Top contributors to RSS aggregated from /proc/self/smaps by pathname; supports `?limit=N` (`settings:read`) |
+| GET | `/api/diagnostics/report` | Node.js diagnostic report (process.report) as a downloadable JSON; includes sharedObjects, libuv handles, native stack (`settings:read`) |
+| POST | `/api/diagnostics/heap-snapshot` | Capture a V8 heap snapshot and stream it to the caller; briefly pauses the event loop (`settings:write`) |

--- a/API-ROUTES.md
+++ b/API-ROUTES.md
@@ -551,5 +551,7 @@
 |--------|------|-------------|
 | GET | `/api/diagnostics/memory` | Current process memory, V8 heap, Linux /proc/self/status, and smaps_rollup (`settings:read`) |
 | GET | `/api/diagnostics/smaps-top` | Top contributors to RSS aggregated from /proc/self/smaps by pathname; supports `?limit=N` (`settings:read`) |
+| GET | `/api/diagnostics/smaps-regions` | Individual smaps regions filtered by `?pathname=` and sorted by RSS; supports `?limit=N` (`settings:read`) |
+| POST | `/api/diagnostics/region-peek` | Read a slice of /proc/self/mem and return printable ASCII strings + hex preview; body `{start, length, minLen?, maxStrings?}` (`settings:write`) |
 | GET | `/api/diagnostics/report` | Node.js diagnostic report (process.report) as a downloadable JSON; includes sharedObjects, libuv handles, native stack (`settings:read`) |
 | POST | `/api/diagnostics/heap-snapshot` | Capture a V8 heap snapshot and stream it to the caller; briefly pauses the event loop (`settings:write`) |

--- a/client/src/app/system-diagnostics/page.tsx
+++ b/client/src/app/system-diagnostics/page.tsx
@@ -23,8 +23,10 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   IconAlertCircle,
   IconDownload,
+  IconFileText,
   IconLoader2,
   IconRefresh,
+  IconSearch,
 } from "@tabler/icons-react";
 
 const PROCESS_EXPLANATIONS: Record<string, string> = {
@@ -69,11 +71,120 @@ const HEAP_SPACE_EXPLANATIONS: Record<string, string> = {
   trusted_large_object_space: "Large trusted objects.",
 };
 
+const PROC_STATUS_EXPLANATIONS: Record<string, string> = {
+  "VmRSS": "Resident set — RAM pages currently held by the process. Should match RSS above.",
+  "VmHWM": "High-water mark — peak RSS since the process started.",
+  "RssAnon": "Anonymous RSS — JS heap, native heap (Prisma, etc.), and thread stacks.",
+  "RssFile": "File-backed RSS — shared libraries and mmap'd files currently paged in.",
+  "RssShmem": "Shared-memory RSS (tmpfs / /dev/shm mappings).",
+  "VmData": "Data segment — writable heap + anonymous pages committed to the process.",
+  "VmStk": "Total stack space across all threads.",
+  "VmExe": "Text segment — the node executable's code mapped into memory.",
+  "VmLib": "Shared library code mapped in (libssl, libc, Prisma query engine, etc.).",
+  "VmSize": "Total virtual address space reserved (much larger than RSS; most is unresident).",
+  "VmPeak": "Largest VmSize ever reached by the process.",
+  "VmSwap": "Pages swapped out to disk.",
+  "VmPTE": "Kernel memory used to track this process's page tables.",
+  "Threads": "Number of OS threads the process currently has.",
+};
+
+const SMAPS_ROLLUP_EXPLANATIONS: Record<string, string> = {
+  "RSS": "Same as VmRSS — total resident pages.",
+  "PSS": "Proportional Set Size — your 'fair share' of RAM. Shared pages are divided by the number of processes sharing them.",
+  "PSS Anon": "PSS attributable to anonymous pages (heaps + stacks).",
+  "PSS File": "PSS attributable to file-backed pages (shared libraries, mmap'd files).",
+  "PSS Shmem": "PSS attributable to shared-memory pages.",
+  "Shared Clean":
+    "Pages shared with other processes and unchanged since mapped (e.g. libc code). Cheap — cost is shared.",
+  "Shared Dirty": "Shared writable pages that have been modified (rare outside shmem).",
+  "Private Clean":
+    "Pages private to this process and unchanged since mapped (e.g. your copy of a read-only lib).",
+  "Private Dirty":
+    "Pages private to this process and modified. This is unambiguously your own memory cost.",
+  "Anonymous": "Anonymous pages (not backed by any file) currently in RAM.",
+  "Referenced": "Pages marked as recently accessed by the kernel's page-replacement algorithm.",
+  "Swap": "Pages swapped out to disk.",
+};
+
+const RESOURCE_USAGE_EXPLANATIONS: Record<string, string> = {
+  "Max RSS": "Peak RSS ever reached by the process (from getrusage).",
+  "User CPU": "Total CPU time spent in user-space code.",
+  "System CPU": "Total CPU time spent in kernel-space (syscalls, I/O).",
+  "Minor page faults":
+    "Page faults resolved without disk I/O (page was already in memory or freshly allocated).",
+  "Major page faults":
+    "Page faults that required reading from disk — slow. High numbers suggest swapping or cold mmap'd files.",
+  "Voluntary ctx switches":
+    "Times the process yielded the CPU (waiting on I/O, locks, etc.).",
+  "Involuntary ctx switches":
+    "Times the kernel preempted the process (CPU contention, time slice expired).",
+  "FS reads": "Number of reads from the filesystem performed on behalf of this process.",
+  "FS writes": "Number of writes to the filesystem performed on behalf of this process.",
+  "IPC sent": "Messages sent over IPC channels (Unix signals, pipes).",
+  "IPC received": "Messages received over IPC channels.",
+  "Signals": "Signals received (SIGTERM, SIGUSR1, etc.).",
+  "Swapped out": "Times the process (or pages) were swapped to disk.",
+};
+
+interface ProcStatus {
+  vmPeak: number | null;
+  vmSize: number | null;
+  vmHWM: number | null;
+  vmRSS: number | null;
+  rssAnon: number | null;
+  rssFile: number | null;
+  rssShmem: number | null;
+  vmData: number | null;
+  vmStk: number | null;
+  vmExe: number | null;
+  vmLib: number | null;
+  vmPTE: number | null;
+  vmSwap: number | null;
+  threads: number | null;
+}
+
+interface SmapsRollup {
+  rss: number | null;
+  pss: number | null;
+  pssAnon: number | null;
+  pssFile: number | null;
+  pssShmem: number | null;
+  sharedClean: number | null;
+  sharedDirty: number | null;
+  privateClean: number | null;
+  privateDirty: number | null;
+  referenced: number | null;
+  anonymous: number | null;
+  swap: number | null;
+  swapPss: number | null;
+  locked: number | null;
+}
+
+interface ResourceUsage {
+  userCPUTime: number;
+  systemCPUTime: number;
+  maxRSS: number;
+  sharedMemorySize: number;
+  unsharedDataSize: number;
+  unsharedStackSize: number;
+  minorPageFault: number;
+  majorPageFault: number;
+  swappedOut: number;
+  fsRead: number;
+  fsWrite: number;
+  ipcSent: number;
+  ipcReceived: number;
+  signalsCount: number;
+  voluntaryContextSwitches: number;
+  involuntaryContextSwitches: number;
+}
+
 interface MemoryDiagnostics {
   timestamp: string;
   uptimeSeconds: number;
   pid: number;
   nodeVersion: string;
+  platform: string;
   process: {
     rss: number;
     heapTotal: number;
@@ -100,10 +211,28 @@ interface MemoryDiagnostics {
     available: number;
     physical: number;
   }>;
+  resourceUsage: ResourceUsage;
+  procStatus: ProcStatus | null;
+  smapsRollup: SmapsRollup | null;
 }
 
-function formatBytes(bytes: number): string {
-  if (!Number.isFinite(bytes)) return "—";
+interface SmapsRegionGroup {
+  pathname: string;
+  regions: number;
+  rss: number;
+  pss: number;
+  size: number;
+  privateDirty: number;
+  sharedClean: number;
+}
+
+interface SmapsTopResponse {
+  limit: number;
+  groups: SmapsRegionGroup[];
+}
+
+function formatBytes(bytes: number | null | undefined): string {
+  if (bytes === null || bytes === undefined || !Number.isFinite(bytes)) return "—";
   if (bytes < 1024) return `${bytes} B`;
   const units = ["KB", "MB", "GB", "TB"];
   let value = bytes / 1024;
@@ -126,9 +255,37 @@ function formatUptime(seconds: number): string {
   return `${s}s`;
 }
 
+function formatMicroseconds(us: number): string {
+  const seconds = us / 1_000_000;
+  if (seconds >= 1) return `${seconds.toFixed(2)}s`;
+  return `${(us / 1000).toFixed(1)}ms`;
+}
+
+function formatCount(n: number): string {
+  return n.toLocaleString();
+}
+
+async function downloadFromResponse(res: Response, fallbackName: string) {
+  const disposition = res.headers.get("Content-Disposition") ?? "";
+  const match = /filename="?([^";]+)"?/i.exec(disposition);
+  const filename = match?.[1] ?? fallbackName;
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+  return blob.size;
+}
+
 export default function SystemDiagnosticsPage() {
-  const [downloading, setDownloading] = useState(false);
+  const [downloadingHeap, setDownloadingHeap] = useState(false);
+  const [downloadingReport, setDownloadingReport] = useState(false);
   const [showExplanations, setShowExplanations] = useState(false);
+  const [smapsLoaded, setSmapsLoaded] = useState(false);
 
   const query = useQuery<MemoryDiagnostics>({
     queryKey: ["diagnostics", "memory"],
@@ -140,48 +297,68 @@ export default function SystemDiagnosticsPage() {
     refetchInterval: 5000,
   });
 
+  const smapsQuery = useQuery<SmapsTopResponse>({
+    queryKey: ["diagnostics", "smaps-top"],
+    queryFn: async () => {
+      const res = await fetch("/api/diagnostics/smaps-top?limit=25");
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(text || `Failed to load smaps (${res.status})`);
+      }
+      return res.json();
+    },
+    enabled: smapsLoaded,
+    refetchInterval: smapsLoaded ? 10000 : false,
+  });
+
   const handleDownloadSnapshot = async () => {
-    setDownloading(true);
+    setDownloadingHeap(true);
     const toastId = toast.loading(
       "Capturing heap snapshot — this can take several seconds and temporarily pause the server...",
     );
     try {
-      const res = await fetch("/api/diagnostics/heap-snapshot", {
-        method: "POST",
-      });
+      const res = await fetch("/api/diagnostics/heap-snapshot", { method: "POST" });
       if (!res.ok) {
         const text = await res.text().catch(() => "");
         throw new Error(text || `Snapshot failed (${res.status})`);
       }
-
-      const disposition = res.headers.get("Content-Disposition") ?? "";
-      const match = /filename="?([^";]+)"?/i.exec(disposition);
-      const filename = match?.[1] ?? `heap-${Date.now()}.heapsnapshot`;
-
-      const blob = await res.blob();
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
-      URL.revokeObjectURL(url);
-
-      toast.success(`Heap snapshot downloaded (${formatBytes(blob.size)})`, {
-        id: toastId,
-      });
+      const size = await downloadFromResponse(res, `heap-${Date.now()}.heapsnapshot`);
+      toast.success(`Heap snapshot downloaded (${formatBytes(size)})`, { id: toastId });
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Failed to capture heap snapshot",
         { id: toastId },
       );
     } finally {
-      setDownloading(false);
+      setDownloadingHeap(false);
+    }
+  };
+
+  const handleDownloadReport = async () => {
+    setDownloadingReport(true);
+    const toastId = toast.loading("Generating diagnostic report...");
+    try {
+      const res = await fetch("/api/diagnostics/report");
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(text || `Report failed (${res.status})`);
+      }
+      const size = await downloadFromResponse(res, `diagnostic-report-${Date.now()}.json`);
+      toast.success(`Diagnostic report downloaded (${formatBytes(size)})`, { id: toastId });
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to generate diagnostic report",
+        { id: toastId },
+      );
+    } finally {
+      setDownloadingReport(false);
     }
   };
 
   const data = query.data;
+  const procStatus = data?.procStatus;
+  const smapsRollup = data?.smapsRollup;
+  const resourceUsage = data?.resourceUsage;
 
   return (
     <div className="container mx-auto max-w-5xl space-y-6 py-6">
@@ -189,7 +366,7 @@ export default function SystemDiagnosticsPage() {
         <div>
           <h1 className="text-2xl font-semibold">System Diagnostics</h1>
           <p className="text-sm text-muted-foreground">
-            Server process memory, V8 heap statistics, and heap snapshots.
+            Server process memory, V8 heap statistics, Linux memory maps, and downloadable diagnostic artifacts.
           </p>
         </div>
         <div className="flex items-center gap-4">
@@ -217,11 +394,24 @@ export default function SystemDiagnosticsPage() {
             Refresh
           </Button>
           <Button
+            variant="outline"
+            size="sm"
+            onClick={handleDownloadReport}
+            disabled={downloadingReport}
+          >
+            {downloadingReport ? (
+              <IconLoader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <IconFileText className="h-4 w-4" />
+            )}
+            Download report
+          </Button>
+          <Button
             size="sm"
             onClick={handleDownloadSnapshot}
-            disabled={downloading}
+            disabled={downloadingHeap}
           >
-            {downloading ? (
+            {downloadingHeap ? (
               <IconLoader2 className="h-4 w-4 animate-spin" />
             ) : (
               <IconDownload className="h-4 w-4" />
@@ -248,7 +438,7 @@ export default function SystemDiagnosticsPage() {
             <CardHeader>
               <CardTitle className="text-base">Process</CardTitle>
               <CardDescription>
-                PID {data.pid} · Node {data.nodeVersion} · Uptime{" "}
+                PID {data.pid} · Node {data.nodeVersion} · {data.platform} · Uptime{" "}
                 {formatUptime(data.uptimeSeconds)}
               </CardDescription>
             </CardHeader>
@@ -298,6 +488,239 @@ export default function SystemDiagnosticsPage() {
               </dl>
             </CardContent>
           </Card>
+
+          {procStatus && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Linux Process Memory</CardTitle>
+                <CardDescription>
+                  /proc/self/status — explains where RSS goes beyond the V8 heap.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <dl
+                  className={`grid gap-x-6 gap-y-3 ${
+                    showExplanations
+                      ? "grid-cols-1 md:grid-cols-2"
+                      : "grid-cols-2 md:grid-cols-4"
+                  }`}
+                >
+                  <Stat
+                    label="VmRSS"
+                    value={formatBytes(procStatus.vmRSS)}
+                    description={
+                      showExplanations ? PROC_STATUS_EXPLANATIONS.VmRSS : undefined
+                    }
+                  />
+                  <Stat
+                    label="VmHWM"
+                    value={formatBytes(procStatus.vmHWM)}
+                    description={
+                      showExplanations ? PROC_STATUS_EXPLANATIONS.VmHWM : undefined
+                    }
+                  />
+                  <Stat
+                    label="RssAnon"
+                    value={formatBytes(procStatus.rssAnon)}
+                    description={
+                      showExplanations ? PROC_STATUS_EXPLANATIONS.RssAnon : undefined
+                    }
+                  />
+                  <Stat
+                    label="RssFile"
+                    value={formatBytes(procStatus.rssFile)}
+                    description={
+                      showExplanations ? PROC_STATUS_EXPLANATIONS.RssFile : undefined
+                    }
+                  />
+                  <Stat
+                    label="RssShmem"
+                    value={formatBytes(procStatus.rssShmem)}
+                    description={
+                      showExplanations ? PROC_STATUS_EXPLANATIONS.RssShmem : undefined
+                    }
+                  />
+                  <Stat
+                    label="VmData"
+                    value={formatBytes(procStatus.vmData)}
+                    description={
+                      showExplanations ? PROC_STATUS_EXPLANATIONS.VmData : undefined
+                    }
+                  />
+                  <Stat
+                    label="VmStk"
+                    value={formatBytes(procStatus.vmStk)}
+                    description={
+                      showExplanations ? PROC_STATUS_EXPLANATIONS.VmStk : undefined
+                    }
+                  />
+                  <Stat
+                    label="VmExe"
+                    value={formatBytes(procStatus.vmExe)}
+                    description={
+                      showExplanations ? PROC_STATUS_EXPLANATIONS.VmExe : undefined
+                    }
+                  />
+                  <Stat
+                    label="VmLib"
+                    value={formatBytes(procStatus.vmLib)}
+                    description={
+                      showExplanations ? PROC_STATUS_EXPLANATIONS.VmLib : undefined
+                    }
+                  />
+                  <Stat
+                    label="VmSize"
+                    value={formatBytes(procStatus.vmSize)}
+                    description={
+                      showExplanations ? PROC_STATUS_EXPLANATIONS.VmSize : undefined
+                    }
+                  />
+                  <Stat
+                    label="VmPeak"
+                    value={formatBytes(procStatus.vmPeak)}
+                    description={
+                      showExplanations ? PROC_STATUS_EXPLANATIONS.VmPeak : undefined
+                    }
+                  />
+                  <Stat
+                    label="VmSwap"
+                    value={formatBytes(procStatus.vmSwap)}
+                    description={
+                      showExplanations ? PROC_STATUS_EXPLANATIONS.VmSwap : undefined
+                    }
+                  />
+                  <Stat
+                    label="VmPTE"
+                    value={formatBytes(procStatus.vmPTE)}
+                    description={
+                      showExplanations ? PROC_STATUS_EXPLANATIONS.VmPTE : undefined
+                    }
+                  />
+                  <Stat
+                    label="Threads"
+                    value={procStatus.threads?.toString() ?? "—"}
+                    description={
+                      showExplanations ? PROC_STATUS_EXPLANATIONS.Threads : undefined
+                    }
+                  />
+                </dl>
+              </CardContent>
+            </Card>
+          )}
+
+          {smapsRollup && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Shared vs Private Memory</CardTitle>
+                <CardDescription>
+                  /proc/self/smaps_rollup — your fair share (PSS) vs raw RSS.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <dl
+                  className={`grid gap-x-6 gap-y-3 ${
+                    showExplanations
+                      ? "grid-cols-1 md:grid-cols-2"
+                      : "grid-cols-2 md:grid-cols-4"
+                  }`}
+                >
+                  <Stat
+                    label="RSS"
+                    value={formatBytes(smapsRollup.rss)}
+                    description={
+                      showExplanations ? SMAPS_ROLLUP_EXPLANATIONS.RSS : undefined
+                    }
+                  />
+                  <Stat
+                    label="PSS"
+                    value={formatBytes(smapsRollup.pss)}
+                    description={
+                      showExplanations ? SMAPS_ROLLUP_EXPLANATIONS.PSS : undefined
+                    }
+                  />
+                  <Stat
+                    label="PSS Anon"
+                    value={formatBytes(smapsRollup.pssAnon)}
+                    description={
+                      showExplanations
+                        ? SMAPS_ROLLUP_EXPLANATIONS["PSS Anon"]
+                        : undefined
+                    }
+                  />
+                  <Stat
+                    label="PSS File"
+                    value={formatBytes(smapsRollup.pssFile)}
+                    description={
+                      showExplanations
+                        ? SMAPS_ROLLUP_EXPLANATIONS["PSS File"]
+                        : undefined
+                    }
+                  />
+                  <Stat
+                    label="Private Dirty"
+                    value={formatBytes(smapsRollup.privateDirty)}
+                    description={
+                      showExplanations
+                        ? SMAPS_ROLLUP_EXPLANATIONS["Private Dirty"]
+                        : undefined
+                    }
+                  />
+                  <Stat
+                    label="Private Clean"
+                    value={formatBytes(smapsRollup.privateClean)}
+                    description={
+                      showExplanations
+                        ? SMAPS_ROLLUP_EXPLANATIONS["Private Clean"]
+                        : undefined
+                    }
+                  />
+                  <Stat
+                    label="Shared Clean"
+                    value={formatBytes(smapsRollup.sharedClean)}
+                    description={
+                      showExplanations
+                        ? SMAPS_ROLLUP_EXPLANATIONS["Shared Clean"]
+                        : undefined
+                    }
+                  />
+                  <Stat
+                    label="Shared Dirty"
+                    value={formatBytes(smapsRollup.sharedDirty)}
+                    description={
+                      showExplanations
+                        ? SMAPS_ROLLUP_EXPLANATIONS["Shared Dirty"]
+                        : undefined
+                    }
+                  />
+                  <Stat
+                    label="Anonymous"
+                    value={formatBytes(smapsRollup.anonymous)}
+                    description={
+                      showExplanations
+                        ? SMAPS_ROLLUP_EXPLANATIONS.Anonymous
+                        : undefined
+                    }
+                  />
+                  <Stat
+                    label="Referenced"
+                    value={formatBytes(smapsRollup.referenced)}
+                    description={
+                      showExplanations
+                        ? SMAPS_ROLLUP_EXPLANATIONS.Referenced
+                        : undefined
+                    }
+                  />
+                  <Stat
+                    label="Swap"
+                    value={formatBytes(smapsRollup.swap)}
+                    description={
+                      showExplanations ? SMAPS_ROLLUP_EXPLANATIONS.Swap : undefined
+                    }
+                  />
+                </dl>
+              </CardContent>
+            </Card>
+          )}
 
           <Card>
             <CardHeader>
@@ -420,13 +843,238 @@ export default function SystemDiagnosticsPage() {
             </CardContent>
           </Card>
 
+          {resourceUsage && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Resource Usage</CardTitle>
+                <CardDescription>
+                  getrusage() — cumulative CPU, I/O, faults, and context switches since start.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <dl
+                  className={`grid gap-x-6 gap-y-3 ${
+                    showExplanations
+                      ? "grid-cols-1 md:grid-cols-2"
+                      : "grid-cols-2 md:grid-cols-4"
+                  }`}
+                >
+                  <Stat
+                    label="Max RSS"
+                    value={formatBytes(resourceUsage.maxRSS * 1024)}
+                    description={
+                      showExplanations
+                        ? RESOURCE_USAGE_EXPLANATIONS["Max RSS"]
+                        : undefined
+                    }
+                  />
+                  <Stat
+                    label="User CPU"
+                    value={formatMicroseconds(resourceUsage.userCPUTime)}
+                    description={
+                      showExplanations
+                        ? RESOURCE_USAGE_EXPLANATIONS["User CPU"]
+                        : undefined
+                    }
+                  />
+                  <Stat
+                    label="System CPU"
+                    value={formatMicroseconds(resourceUsage.systemCPUTime)}
+                    description={
+                      showExplanations
+                        ? RESOURCE_USAGE_EXPLANATIONS["System CPU"]
+                        : undefined
+                    }
+                  />
+                  <Stat
+                    label="Minor page faults"
+                    value={formatCount(resourceUsage.minorPageFault)}
+                    description={
+                      showExplanations
+                        ? RESOURCE_USAGE_EXPLANATIONS["Minor page faults"]
+                        : undefined
+                    }
+                  />
+                  <Stat
+                    label="Major page faults"
+                    value={formatCount(resourceUsage.majorPageFault)}
+                    description={
+                      showExplanations
+                        ? RESOURCE_USAGE_EXPLANATIONS["Major page faults"]
+                        : undefined
+                    }
+                  />
+                  <Stat
+                    label="Voluntary ctx switches"
+                    value={formatCount(resourceUsage.voluntaryContextSwitches)}
+                    description={
+                      showExplanations
+                        ? RESOURCE_USAGE_EXPLANATIONS["Voluntary ctx switches"]
+                        : undefined
+                    }
+                  />
+                  <Stat
+                    label="Involuntary ctx switches"
+                    value={formatCount(resourceUsage.involuntaryContextSwitches)}
+                    description={
+                      showExplanations
+                        ? RESOURCE_USAGE_EXPLANATIONS["Involuntary ctx switches"]
+                        : undefined
+                    }
+                  />
+                  <Stat
+                    label="FS reads"
+                    value={formatCount(resourceUsage.fsRead)}
+                    description={
+                      showExplanations
+                        ? RESOURCE_USAGE_EXPLANATIONS["FS reads"]
+                        : undefined
+                    }
+                  />
+                  <Stat
+                    label="FS writes"
+                    value={formatCount(resourceUsage.fsWrite)}
+                    description={
+                      showExplanations
+                        ? RESOURCE_USAGE_EXPLANATIONS["FS writes"]
+                        : undefined
+                    }
+                  />
+                  <Stat
+                    label="IPC sent"
+                    value={formatCount(resourceUsage.ipcSent)}
+                    description={
+                      showExplanations
+                        ? RESOURCE_USAGE_EXPLANATIONS["IPC sent"]
+                        : undefined
+                    }
+                  />
+                  <Stat
+                    label="IPC received"
+                    value={formatCount(resourceUsage.ipcReceived)}
+                    description={
+                      showExplanations
+                        ? RESOURCE_USAGE_EXPLANATIONS["IPC received"]
+                        : undefined
+                    }
+                  />
+                  <Stat
+                    label="Signals"
+                    value={formatCount(resourceUsage.signalsCount)}
+                    description={
+                      showExplanations
+                        ? RESOURCE_USAGE_EXPLANATIONS.Signals
+                        : undefined
+                    }
+                  />
+                </dl>
+              </CardContent>
+            </Card>
+          )}
+
+          <Card>
+            <CardHeader>
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <CardTitle className="text-base">Top Contributors to RSS</CardTitle>
+                  <CardDescription>
+                    /proc/self/smaps aggregated by mapped pathname. Accounts for shared libraries and mmap'd files.
+                  </CardDescription>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    if (!smapsLoaded) setSmapsLoaded(true);
+                    else smapsQuery.refetch();
+                  }}
+                  disabled={smapsQuery.isFetching}
+                >
+                  {smapsQuery.isFetching ? (
+                    <IconLoader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <IconSearch className="h-4 w-4" />
+                  )}
+                  {smapsLoaded ? "Refresh" : "Load"}
+                </Button>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {smapsQuery.isError && (
+                <Alert variant="destructive" className="mb-4">
+                  <IconAlertCircle className="h-4 w-4" />
+                  <AlertDescription>
+                    {smapsQuery.error instanceof Error
+                      ? smapsQuery.error.message
+                      : "Failed to load smaps"}
+                  </AlertDescription>
+                </Alert>
+              )}
+              {!smapsLoaded && !smapsQuery.data && (
+                <p className="py-6 text-center text-sm text-muted-foreground">
+                  Click Load to aggregate /proc/self/smaps by pathname.
+                </p>
+              )}
+              {smapsQuery.data && (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Pathname</TableHead>
+                      <TableHead className="text-right">Regions</TableHead>
+                      <TableHead className="text-right">RSS</TableHead>
+                      <TableHead className="text-right">PSS</TableHead>
+                      <TableHead className="text-right">Private Dirty</TableHead>
+                      <TableHead className="text-right">Size</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {smapsQuery.data.groups.map((g) => (
+                      <TableRow key={g.pathname}>
+                        <TableCell
+                          className="max-w-md truncate font-mono text-xs"
+                          title={g.pathname}
+                        >
+                          {g.pathname}
+                        </TableCell>
+                        <TableCell className="text-right">{g.regions}</TableCell>
+                        <TableCell className="text-right">
+                          {formatBytes(g.rss)}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {formatBytes(g.pss)}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {formatBytes(g.privateDirty)}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {formatBytes(g.size)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+
+          {data.procStatus === null && (
+            <Alert>
+              <IconAlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                /proc/self is unavailable on this platform ({data.platform}) — Linux-only memory
+                maps are hidden. Container-hosted deployments should see the full breakdown.
+              </AlertDescription>
+            </Alert>
+          )}
+
           <Alert>
             <IconAlertCircle className="h-4 w-4" />
             <AlertDescription>
-              Heap snapshots can be large (tens to hundreds of MB) and
-              briefly pause the event loop while they&apos;re written. Load the
-              downloaded <code className="font-mono">.heapsnapshot</code> file
-              in Chrome DevTools → Memory tab to analyse retainers.
+              Heap snapshots can be large (tens to hundreds of MB) and briefly pause the event loop
+              while they&apos;re written. Load the downloaded{" "}
+              <code className="font-mono">.heapsnapshot</code> file in Chrome DevTools → Memory
+              tab to analyse retainers. The diagnostic report is a JSON file listing shared objects,
+              libuv handles, and native stack info.
             </AlertDescription>
           </Alert>
         </>

--- a/client/src/app/system-diagnostics/page.tsx
+++ b/client/src/app/system-diagnostics/page.tsx
@@ -23,6 +23,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   IconAlertCircle,
   IconDownload,
+  IconEye,
   IconFileText,
   IconLoader2,
   IconRefresh,
@@ -231,6 +232,33 @@ interface SmapsTopResponse {
   groups: SmapsRegionGroup[];
 }
 
+interface SmapsRegion {
+  start: string;
+  end: string;
+  perms: string;
+  pathname: string;
+  size: number;
+  rss: number;
+  pss: number;
+  privateDirty: number;
+  sharedClean: number;
+}
+
+interface SmapsRegionsResponse {
+  pathname: string | null;
+  limit: number;
+  regions: SmapsRegion[];
+}
+
+interface PeekResult {
+  address: string;
+  bytesRead: number;
+  truncated: boolean;
+  strings: Array<{ offset: number; text: string }>;
+  hexPreview: string;
+  error?: string;
+}
+
 function formatBytes(bytes: number | null | undefined): string {
   if (bytes === null || bytes === undefined || !Number.isFinite(bytes)) return "—";
   if (bytes < 1024) return `${bytes} B`;
@@ -286,6 +314,9 @@ export default function SystemDiagnosticsPage() {
   const [downloadingReport, setDownloadingReport] = useState(false);
   const [showExplanations, setShowExplanations] = useState(false);
   const [smapsLoaded, setSmapsLoaded] = useState(false);
+  const [inspectPathname, setInspectPathname] = useState("[anon]");
+  const [inspectPeek, setInspectPeek] = useState<PeekResult | null>(null);
+  const [peekingStart, setPeekingStart] = useState<string | null>(null);
 
   const query = useQuery<MemoryDiagnostics>({
     queryKey: ["diagnostics", "memory"],
@@ -310,6 +341,54 @@ export default function SystemDiagnosticsPage() {
     enabled: smapsLoaded,
     refetchInterval: smapsLoaded ? 10000 : false,
   });
+
+  const regionsQuery = useQuery<SmapsRegionsResponse>({
+    queryKey: ["diagnostics", "smaps-regions", inspectPathname],
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/diagnostics/smaps-regions?pathname=${encodeURIComponent(inspectPathname)}&limit=10`,
+      );
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(text || `Failed to load regions (${res.status})`);
+      }
+      return res.json();
+    },
+    enabled: false,
+  });
+
+  const handlePeek = async (region: SmapsRegion) => {
+    if (region.rss === 0) {
+      toast.error("Region has no resident pages — nothing to peek.");
+      return;
+    }
+    setPeekingStart(region.start);
+    setInspectPeek(null);
+    try {
+      const res = await fetch("/api/diagnostics/region-peek", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          start: region.start,
+          length: Math.min(region.rss, 2 * 1024 * 1024),
+          minLen: 8,
+          maxStrings: 200,
+        }),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(text || `Peek failed (${res.status})`);
+      }
+      const data: PeekResult = await res.json();
+      setInspectPeek(data);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to peek region",
+      );
+    } finally {
+      setPeekingStart(null);
+    }
+  };
 
   const handleDownloadSnapshot = async () => {
     setDownloadingHeap(true);
@@ -1057,6 +1136,174 @@ export default function SystemDiagnosticsPage() {
             </CardContent>
           </Card>
 
+          <Card>
+            <CardHeader>
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <CardTitle className="text-base">Inspect Memory Region</CardTitle>
+                  <CardDescription>
+                    Pick a pathname, load its top regions by RSS, then peek one to
+                    extract printable strings from /proc/self/mem. Helpful for
+                    guessing what&apos;s living in an anonymous region (SQL text, JSON
+                    payloads, identifier patterns, etc.).
+                  </CardDescription>
+                </div>
+                <div className="flex gap-2">
+                  <select
+                    className="h-9 rounded-md border bg-background px-2 text-sm"
+                    value={inspectPathname}
+                    onChange={(e) => {
+                      setInspectPathname(e.target.value);
+                      setInspectPeek(null);
+                    }}
+                  >
+                    <option value="[anon]">[anon]</option>
+                    <option value="[heap]">[heap]</option>
+                    <option value="[stack]">[stack]</option>
+                    {smapsQuery.data?.groups
+                      .filter(
+                        (g) =>
+                          !["[anon]", "[heap]", "[stack]"].includes(g.pathname),
+                      )
+                      .map((g) => (
+                        <option key={g.pathname} value={g.pathname}>
+                          {g.pathname}
+                        </option>
+                      ))}
+                  </select>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => regionsQuery.refetch()}
+                    disabled={regionsQuery.isFetching}
+                  >
+                    {regionsQuery.isFetching ? (
+                      <IconLoader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <IconSearch className="h-4 w-4" />
+                    )}
+                    Find regions
+                  </Button>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {regionsQuery.isError && (
+                <Alert variant="destructive">
+                  <IconAlertCircle className="h-4 w-4" />
+                  <AlertDescription>
+                    {regionsQuery.error instanceof Error
+                      ? regionsQuery.error.message
+                      : "Failed to load regions"}
+                  </AlertDescription>
+                </Alert>
+              )}
+
+              {!regionsQuery.data && !regionsQuery.isFetching && (
+                <p className="py-6 text-center text-sm text-muted-foreground">
+                  Pick a pathname (defaults to [anon] — the bulk of your RSS) and
+                  click Find regions.
+                </p>
+              )}
+
+              {regionsQuery.data && (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Address</TableHead>
+                      <TableHead>Perms</TableHead>
+                      <TableHead className="text-right">RSS</TableHead>
+                      <TableHead className="text-right">PSS</TableHead>
+                      <TableHead className="text-right">Size</TableHead>
+                      <TableHead className="text-right">Action</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {regionsQuery.data.regions.map((r) => (
+                      <TableRow key={`${r.start}-${r.end}`}>
+                        <TableCell className="font-mono text-xs">
+                          0x{r.start}
+                        </TableCell>
+                        <TableCell className="font-mono text-xs">
+                          {r.perms}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {formatBytes(r.rss)}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {formatBytes(r.pss)}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {formatBytes(r.size)}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => handlePeek(r)}
+                            disabled={peekingStart === r.start || r.rss === 0}
+                          >
+                            {peekingStart === r.start ? (
+                              <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+                            ) : (
+                              <IconEye className="h-3.5 w-3.5" />
+                            )}
+                            Peek
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+
+              {inspectPeek && (
+                <div className="space-y-2 rounded-md border p-3">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <div className="text-sm font-semibold">
+                      {inspectPeek.address} · {formatBytes(inspectPeek.bytesRead)} read
+                      {inspectPeek.truncated && " (strings truncated)"}
+                    </div>
+                    {inspectPeek.error && (
+                      <span className="text-xs text-destructive">
+                        {inspectPeek.error}
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    {inspectPeek.strings.length} strings (min length 8). Hex
+                    preview of first 256 bytes:
+                  </div>
+                  <pre className="overflow-x-auto rounded bg-muted p-2 font-mono text-xs">
+                    {inspectPeek.hexPreview.match(/.{1,32}/g)?.join("\n") ?? ""}
+                  </pre>
+                  {inspectPeek.strings.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                      No printable ASCII strings of length ≥ 8 found. This region is
+                      likely binary data (V8 internal state, compressed pages,
+                      compiled code, etc.).
+                    </p>
+                  ) : (
+                    <div className="max-h-96 overflow-auto rounded bg-muted p-2">
+                      <table className="w-full text-xs">
+                        <tbody>
+                          {inspectPeek.strings.map((s, i) => (
+                            <tr key={i} className="align-top">
+                              <td className="pr-3 font-mono text-muted-foreground">
+                                +{s.offset.toString(16)}
+                              </td>
+                              <td className="break-all font-mono">{s.text}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
           {data.procStatus === null && (
             <Alert>
               <IconAlertCircle className="h-4 w-4" />
@@ -1074,7 +1321,9 @@ export default function SystemDiagnosticsPage() {
               while they&apos;re written. Load the downloaded{" "}
               <code className="font-mono">.heapsnapshot</code> file in Chrome DevTools → Memory
               tab to analyse retainers. The diagnostic report is a JSON file listing shared objects,
-              libuv handles, and native stack info.
+              libuv handles, and native stack info. The memory-region peek reads raw process memory
+              via /proc/self/mem — treat any returned strings as potentially sensitive (may include
+              query text, tokens, or PII held in caches).
             </AlertDescription>
           </Alert>
         </>

--- a/docs/memory-analysis-2026-04-14.md
+++ b/docs/memory-analysis-2026-04-14.md
@@ -1,0 +1,94 @@
+# Memory Analysis — 2026-04-14
+
+A point-in-time analysis of the Mini Infra server process, using the data exposed by the System Diagnostics page and the `/api/diagnostics/region-peek` endpoint. Intended as a worked example of how to read the page, and as a baseline snapshot to compare future measurements against.
+
+## Sample conditions
+
+- Environment: local Docker dev deployment (Alpine/musl, ARM64)
+- Uptime at sample: 159 s (just past cold-start)
+- Node: v24.13.1
+- Prisma: 7.7.0 with `@prisma/adapter-better-sqlite3` (no Rust query engine — WASM + JS)
+
+## Top-line numbers
+
+| Metric | Value |
+|---|---|
+| RSS | 485 MB |
+| Peak RSS (VmHWM) | 581 MB |
+| VmSize (virtual) | 30.4 GB |
+| RssAnon / RssFile | 417 MB / 69 MB |
+| PSS / RSS | 94% |
+| V8 heap used / total / limit | 126 MB / 204 MB / 2.24 GB |
+| External + ArrayBuffers | 25 MB + 52 MB |
+| Threads | 23 |
+| Detached contexts / Native contexts | 0 / 1 |
+| Major page faults / Swap | 0 / 0 |
+
+## Where every byte is
+
+| Bucket | RSS | % of RSS | Source |
+|---|---:|---:|---|
+| **V8 JS heap** (committed) | 204 MB | 42% | `totalPhysicalSize` — actual heap pages across new/old/large/code/trusted spaces |
+| **V8 JIT code pages** (`rwxp` anon) | ~14 MB | 3% | 3 regions of ARM64 machine code, confirmed via peek |
+| **External + ArrayBuffers** | ~52 MB | 11% | Node Buffers + Prisma WASM linear memory |
+| **node binary mapped** (`/usr/local/bin/node`) | 65 MB | 13% | Text + read-only data |
+| **Shared libraries** (libstdc++, libc, libgcc) | 3 MB | 0.5% | musl + C++ runtime |
+| **Native addons** (better-sqlite3, argon2) | 2 MB | 0.4% | `.node` files mapped |
+| **Remaining `[anon]`** | ~145 MB | 30% | musl allocator retention, native-addon heaps, thread arenas, V8 metadata |
+| **Misc** (`[heap]`, `[stack]`, `[vdso]`, db-shm) | 0.4 MB | — | |
+| **Total** | **485 MB** | | |
+
+### V8's share is bigger than it looks
+
+Once you combine the direct heap with JIT code and the ArrayBuffers V8 owns the backing store for, V8 accounts for **~270 MB (56% of RSS)**:
+
+- 204 MB committed heap (126 MB used + 78 MB reserved headroom)
+- ~14 MB JIT code pages
+- Most of the 52 MB ArrayBuffers (WASM linear memory + Node Buffer pool)
+- Peak `malloced_memory` hit 78 MB during startup (parser/compiler scratch); current is 1.1 MB, but the allocator retains freed pages — those pages show up as anon RSS with no live owner.
+
+## Concrete findings from peeking top `[anon]` regions
+
+Top 15 anonymous regions by RSS account for only ~45 MB of the 415 MB total — the distribution has a long tail of 1574 small-to-medium regions (mostly V8 heap pages at ~512 KB granularity). The largest regions, with a clue from each peek:
+
+| RSS | Perms | Hex preview | First string | What it is |
+|---:|---|---|---|---|
+| 5.2 MB | `rwxp` | `8401600000000000` | (none) | V8 JIT code cache |
+| 5.0 MB | `rwxp` | `0000000000000000` | (none) | V8 JIT code cache (partially zeroed) |
+| 4.7 MB | `rw-p` | — | `AGFzbQEAAAAB…` | **Prisma WASM query engine as base64 JS string** (`\0asm\1\0\0\0` in base64) |
+| 3.9 MB | `rw-p` | `00…00` | (none) | V8 old_space page |
+| 3.7 MB | `rw-p` | `28894cf7aaaa0000` | `H,H(H(H(H(@` | V8 string/handle table internals |
+| 3.5 MB | `rwxp` | `c40004cb5f0004eb` | (none) | V8 JIT code cache |
+| 2–3 MB × many | `rw-p` | `00…00` | (none) | V8 new/old/large-object space pages |
+
+The Prisma WASM source finding is especially illustrative: the WASM binary is ~1.6 MB, but Prisma currently loads it as a base64 string (inflates to ~2.1 MB) and V8 stores JS strings as UTF-16 internally (~4.3 MB), plus allocation overhead — lands at 4.7 MB in a single region. It's held twice in memory: once as this JS string (for the loader), and once as the live `WebAssembly.Memory` linear buffer (counted under ArrayBuffers).
+
+## Health indicators — no leak
+
+| Signal | Value | Verdict |
+|---|---|---|
+| Detached contexts | 0 | Clean |
+| Native contexts | 1 | Clean (multiple = iframe/vm leak) |
+| Major page faults | 0 | No swap pressure |
+| Swap used | 0 B | None |
+| Peak RSS (VmHWM) vs current | 581 → 485 MB | **Went down** 96 MB from peak — healthy post-warmup shrinkage |
+| Peak malloced vs current | 78 MB → 1.1 MB | V8 released internal scratch |
+| PSS / RSS | 94% | Very little is shared (expected for single-process app) |
+| Involuntary ctx switches / total | 218 / 62k | Almost entirely voluntary I/O waits — no CPU contention |
+
+The process grew to 581 MB during startup (JS parsing, compilation, WASM instantiation, Prisma client init) and has since shrunk to 485 MB. That's the exact profile of a healthy warming-up Node app.
+
+## Levers for meaningful RSS reduction (if ever needed)
+
+Ranked by plausibility:
+
+1. **Tune V8 heap** with `--max-semi-space-size=32` and/or `--max-old-space-size=<lower>`. `new_space` is currently 101 MB committed; capping semi-space could save ~30–40 MB steady-state. Low risk, easy to revert.
+2. **Load Prisma WASM as bytes, not base64**. If the `prisma-client` generator exposes an option to embed the module as a `Uint8Array` instead of a base64 string, we save ~5 MB of JS heap. Cosmetic but clean.
+3. **Reduce libuv worker pool** via `UV_THREADPOOL_SIZE` if 4 workers is more than we need. Saves ~5–10 MB of anon pages. Usually not worth the complexity unless profiling shows they sit idle.
+4. **musl allocator tuning** (`mallopt`) is rarely worth the effort; the returns are small and behaviour is fragile.
+
+## Bottom line
+
+The server runs at ~485 MB with no leak signals. V8 owns about 56% of that (heap + JIT + WASM backing store) — matches intuition for a moderately-sized Node.js app with a WASM query engine. The remaining 30% of `[anon]` is the normal long tail: musl allocator pages retained after startup bursts, native-addon heaps (better-sqlite3 page cache, etc.), and thread arenas.
+
+Nothing here is actionable unless we deliberately want to squeeze memory — in which case the V8 heap knobs in §levers are where to start.

--- a/docs/native-heap-profiling.md
+++ b/docs/native-heap-profiling.md
@@ -1,0 +1,101 @@
+# Native Heap Profiling with heaptrack
+
+Status: **proposal, not implemented**. Captures the plan so we can pick it up if/when we suspect a native memory leak.
+
+## Context
+
+The System Diagnostics page already exposes:
+
+- V8 JS heap (used / total / limit / per-space) — covers JavaScript allocations.
+- `process.memoryUsage()` — including External and ArrayBuffers (WASM linear memory, Node buffers).
+- `/proc/self/status` and `/proc/self/smaps_rollup` — total RSS, PSS, private vs shared.
+- Top smaps regions by pathname — attributes shared libraries and the node executable.
+- On-demand strings peek into anonymous regions — peeks bytes to hint at content.
+
+What's still opaque is **where native allocations come from** inside the big `[anon]` bucket. When every allocation is an `mmap(MAP_ANONYMOUS)` or a malloc arena page, the kernel and the JS heap snapshot are both blind to origin. If we ever hit suspicious RSS growth that isn't visible in the JS heap, we need call-site attribution.
+
+## What heaptrack does
+
+[heaptrack](https://github.com/KDE/heaptrack) is a sampling-free tracer that intercepts every `malloc` / `free` / `mmap` / `munmap` (plus new/delete) via `LD_PRELOAD`, records the C++ call stack, and writes a compressed trace. The GUI (`heaptrack_gui`) and CLI (`heaptrack_print`) give you:
+
+- **Peak memory consumption** by call stack (flamegraph)
+- **Memory leaked** (allocations never freed) by call stack
+- **Allocation count hot spots** (often useful for GC pressure)
+- **Temporary allocation** tracking
+- A timeline slider so you can see how the heap grew
+
+Overhead is typically 10–20% CPU and 1–2× memory during recording. Not something you leave on in production — it's a diagnostic mode.
+
+## Running heaptrack in our container
+
+### Installing in the image
+
+The production image is Alpine-based (musl). heaptrack is available:
+
+```dockerfile
+# Dockerfile (opt-in heaptrack stage — do not ship in prod by default)
+RUN apk add --no-cache heaptrack
+```
+
+Keep this behind a build arg (e.g. `ENABLE_HEAPTRACK=1`) so normal builds don't carry the tracer.
+
+### Launching the server under heaptrack
+
+Heaptrack works best when it wraps the process from the start (it hooks allocators via `LD_PRELOAD` before the program loads). Attach-to-running is possible but flaky, so prefer relaunching:
+
+```sh
+# Inside the container:
+heaptrack --output /tmp/heaptrack.node node dist/server.js
+```
+
+This produces `/tmp/heaptrack.node.<pid>.gz`. When the process exits (or you send SIGINT), the trace is finalized and can be downloaded and analysed.
+
+### Analysing the trace
+
+- **GUI:** install `heaptrack` on your dev machine (`brew install kde-mac/kde/kf5-heaptrack` or the Linux package), then `heaptrack_gui heaptrack.node.<pid>.gz`. Best overview — flamegraphs, leak graph, timeline slider.
+- **CLI:** `heaptrack_print heaptrack.node.<pid>.gz | less` for a text summary. Good for CI or quick peeks.
+
+## Integration sketch
+
+If we want to make this a one-click operation from the diagnostics page:
+
+1. **Build**: a separate `Dockerfile.heaptrack` (or an `ENABLE_HEAPTRACK` build arg) that installs heaptrack in the image.
+2. **Env flag**: `MINI_INFRA_HEAPTRACK=1` makes the entrypoint launch the server under `heaptrack` automatically and writes traces to a mounted volume.
+3. **New endpoints**:
+   - `POST /api/diagnostics/heaptrack/start` — starts a new recording (stops any prior one).
+   - `POST /api/diagnostics/heaptrack/stop` — finalises the trace file.
+   - `GET /api/diagnostics/heaptrack/download?id=...` — streams the `.gz`.
+   - All three guarded by `settings:write`.
+4. **UI**: two buttons on the diagnostics page: "Start heap recording" / "Stop & download". A banner at the top of the page notes when recording is active (perf cost reminder).
+
+### Simpler alternative
+
+If wiring start/stop end-to-end is too much, we can just document the manual flow:
+
+```sh
+# 1. rebuild the image with heaptrack baked in (or shell into the running container if it's already there)
+docker exec -it mini-infra-dev sh
+
+# 2. kill the existing server and relaunch under heaptrack
+heaptrack --output /tmp/ht node /app/server/dist/server.js
+
+# 3. hit the affected endpoints for a few minutes
+# 4. SIGINT heaptrack to finalise the trace
+# 5. docker cp the .gz out of the container
+docker cp mini-infra-dev:/tmp/ht.node.<pid>.gz ./
+# 6. open locally in heaptrack_gui
+```
+
+## Tradeoffs
+
+- **Overhead.** 10–20% CPU, 1–2× RSS while recording. Fine for investigation, not for always-on.
+- **Restart requirement.** Heaptrack needs `LD_PRELOAD` at process start; we have to relaunch the server to begin a trace.
+- **Trace size.** A minute of recording against a busy process can produce 50–500 MB of compressed trace. Mount a volume; don't store in-image.
+- **Symbol resolution.** Stacks resolve against the system's shared libraries at analysis time. Keep `-g` / debug symbols in the heaptrack image if you want readable C++ stacks (e.g. for V8 internals).
+- **Alternatives.** If start/stop friction is too high for routine use, `bpftrace` can attach to `mmap`/`munmap` USDTs live without a restart, at the cost of less rich attribution. Good for catching sporadic growth.
+
+## When to reach for this
+
+- `[anon]` RSS is climbing over days and the V8 heap isn't (suggests a native leak — Node buffer pool, addon, or V8 C++ state).
+- `malloced_memory` / `peak_malloced_memory` on the diagnostics page diverge over time.
+- `heaptrack_print` is a 10-minute win vs. spending a day with gdb and a core dump.

--- a/server/src/lib/proc-memory.ts
+++ b/server/src/lib/proc-memory.ts
@@ -1,0 +1,184 @@
+import { readFile } from "fs/promises";
+
+// All sizes returned are in bytes. /proc exposes kB by default; we convert.
+
+export interface ProcStatus {
+  vmPeak: number | null; // peak virtual memory
+  vmSize: number | null; // current virtual memory
+  vmHWM: number | null; // peak resident set size
+  vmRSS: number | null; // current resident set size
+  rssAnon: number | null; // anonymous RSS (heap, stacks)
+  rssFile: number | null; // file-backed RSS (shared libs, mmap'd files)
+  rssShmem: number | null; // shared memory RSS
+  vmData: number | null; // data segment (heap + bss + anon)
+  vmStk: number | null; // stack
+  vmExe: number | null; // text segment (executable code)
+  vmLib: number | null; // shared library code
+  vmPTE: number | null; // page table entries
+  vmSwap: number | null; // swapped-out pages
+  threads: number | null;
+}
+
+export interface SmapsRollup {
+  rss: number | null;
+  pss: number | null;
+  pssAnon: number | null;
+  pssFile: number | null;
+  pssShmem: number | null;
+  sharedClean: number | null;
+  sharedDirty: number | null;
+  privateClean: number | null;
+  privateDirty: number | null;
+  referenced: number | null;
+  anonymous: number | null;
+  swap: number | null;
+  swapPss: number | null;
+  locked: number | null;
+}
+
+export interface SmapsRegionGroup {
+  pathname: string;
+  regions: number;
+  rss: number;
+  pss: number;
+  size: number;
+  privateDirty: number;
+  sharedClean: number;
+}
+
+const kBRegex = /^(\d+)\s*kB$/i;
+
+function parseKbValue(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const m = kBRegex.exec(raw.trim());
+  if (!m) return null;
+  return Number(m[1]) * 1024;
+}
+
+function parseColonKv(content: string): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const line of content.split("\n")) {
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    map.set(line.slice(0, idx).trim(), line.slice(idx + 1).trim());
+  }
+  return map;
+}
+
+export async function readProcStatus(): Promise<ProcStatus | null> {
+  let content: string;
+  try {
+    content = await readFile("/proc/self/status", "utf8");
+  } catch {
+    return null;
+  }
+  const kv = parseColonKv(content);
+  const threadsRaw = kv.get("Threads");
+  return {
+    vmPeak: parseKbValue(kv.get("VmPeak")),
+    vmSize: parseKbValue(kv.get("VmSize")),
+    vmHWM: parseKbValue(kv.get("VmHWM")),
+    vmRSS: parseKbValue(kv.get("VmRSS")),
+    rssAnon: parseKbValue(kv.get("RssAnon")),
+    rssFile: parseKbValue(kv.get("RssFile")),
+    rssShmem: parseKbValue(kv.get("RssShmem")),
+    vmData: parseKbValue(kv.get("VmData")),
+    vmStk: parseKbValue(kv.get("VmStk")),
+    vmExe: parseKbValue(kv.get("VmExe")),
+    vmLib: parseKbValue(kv.get("VmLib")),
+    vmPTE: parseKbValue(kv.get("VmPTE")),
+    vmSwap: parseKbValue(kv.get("VmSwap")),
+    threads: threadsRaw ? Number(threadsRaw) : null,
+  };
+}
+
+export async function readSmapsRollup(): Promise<SmapsRollup | null> {
+  let content: string;
+  try {
+    content = await readFile("/proc/self/smaps_rollup", "utf8");
+  } catch {
+    return null;
+  }
+  const kv = parseColonKv(content);
+  return {
+    rss: parseKbValue(kv.get("Rss")),
+    pss: parseKbValue(kv.get("Pss")),
+    pssAnon: parseKbValue(kv.get("Pss_Anon")),
+    pssFile: parseKbValue(kv.get("Pss_File")),
+    pssShmem: parseKbValue(kv.get("Pss_Shmem")),
+    sharedClean: parseKbValue(kv.get("Shared_Clean")),
+    sharedDirty: parseKbValue(kv.get("Shared_Dirty")),
+    privateClean: parseKbValue(kv.get("Private_Clean")),
+    privateDirty: parseKbValue(kv.get("Private_Dirty")),
+    referenced: parseKbValue(kv.get("Referenced")),
+    anonymous: parseKbValue(kv.get("Anonymous")),
+    swap: parseKbValue(kv.get("Swap")),
+    swapPss: parseKbValue(kv.get("SwapPss")),
+    locked: parseKbValue(kv.get("Locked")),
+  };
+}
+
+// Each region in /proc/self/smaps starts with a header like:
+//   7f0c1234-7f0c5678 r-xp 00000000 08:01 12345  /usr/lib/libssl.so.3
+// ...followed by Size/Rss/Pss/...: N kB lines.
+// Empty pathname = anonymous region. Pseudo-paths like [heap] and [stack] are preserved.
+const REGION_HEADER = /^([0-9a-f]+)-([0-9a-f]+)\s+([rwxsp-]+)\s+\S+\s+\S+\s+\S+(?:\s+(.*))?$/;
+
+export async function readSmapsByPathname(
+  topN = 25,
+): Promise<SmapsRegionGroup[] | null> {
+  let content: string;
+  try {
+    content = await readFile("/proc/self/smaps", "utf8");
+  } catch {
+    return null;
+  }
+
+  const groups = new Map<string, SmapsRegionGroup>();
+  let current: { path: string } | null = null;
+
+  const getOrCreate = (path: string): SmapsRegionGroup => {
+    let g = groups.get(path);
+    if (!g) {
+      g = {
+        pathname: path,
+        regions: 0,
+        rss: 0,
+        pss: 0,
+        size: 0,
+        privateDirty: 0,
+        sharedClean: 0,
+      };
+      groups.set(path, g);
+    }
+    return g;
+  };
+
+  for (const line of content.split("\n")) {
+    const header = REGION_HEADER.exec(line);
+    if (header) {
+      const path = (header[4] || "").trim() || "[anon]";
+      current = { path };
+      getOrCreate(path).regions += 1;
+      continue;
+    }
+    if (!current) continue;
+
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    const value = parseKbValue(line.slice(colonIdx + 1));
+    if (value === null) continue;
+
+    const g = getOrCreate(current.path);
+    if (key === "Rss") g.rss += value;
+    else if (key === "Pss") g.pss += value;
+    else if (key === "Size") g.size += value;
+    else if (key === "Private_Dirty") g.privateDirty += value;
+    else if (key === "Shared_Clean") g.sharedClean += value;
+  }
+
+  return Array.from(groups.values())
+    .sort((a, b) => b.rss - a.rss)
+    .slice(0, topN);
+}

--- a/server/src/lib/proc-memory.ts
+++ b/server/src/lib/proc-memory.ts
@@ -1,4 +1,4 @@
-import { readFile } from "fs/promises";
+import { open, readFile } from "fs/promises";
 
 // All sizes returned are in bytes. /proc exposes kB by default; we convert.
 
@@ -42,6 +42,18 @@ export interface SmapsRegionGroup {
   rss: number;
   pss: number;
   size: number;
+  privateDirty: number;
+  sharedClean: number;
+}
+
+export interface SmapsRegion {
+  start: string; // hex address, no "0x" prefix
+  end: string;
+  perms: string;
+  pathname: string;
+  size: number;
+  rss: number;
+  pss: number;
   privateDirty: number;
   sharedClean: number;
 }
@@ -124,9 +136,7 @@ export async function readSmapsRollup(): Promise<SmapsRollup | null> {
 // Empty pathname = anonymous region. Pseudo-paths like [heap] and [stack] are preserved.
 const REGION_HEADER = /^([0-9a-f]+)-([0-9a-f]+)\s+([rwxsp-]+)\s+\S+\s+\S+\s+\S+(?:\s+(.*))?$/;
 
-export async function readSmapsByPathname(
-  topN = 25,
-): Promise<SmapsRegionGroup[] | null> {
+export async function readSmapsRegions(): Promise<SmapsRegion[] | null> {
   let content: string;
   try {
     content = await readFile("/proc/self/smaps", "utf8");
@@ -134,32 +144,24 @@ export async function readSmapsByPathname(
     return null;
   }
 
-  const groups = new Map<string, SmapsRegionGroup>();
-  let current: { path: string } | null = null;
-
-  const getOrCreate = (path: string): SmapsRegionGroup => {
-    let g = groups.get(path);
-    if (!g) {
-      g = {
-        pathname: path,
-        regions: 0,
-        rss: 0,
-        pss: 0,
-        size: 0,
-        privateDirty: 0,
-        sharedClean: 0,
-      };
-      groups.set(path, g);
-    }
-    return g;
-  };
+  const regions: SmapsRegion[] = [];
+  let current: SmapsRegion | null = null;
 
   for (const line of content.split("\n")) {
     const header = REGION_HEADER.exec(line);
     if (header) {
-      const path = (header[4] || "").trim() || "[anon]";
-      current = { path };
-      getOrCreate(path).regions += 1;
+      current = {
+        start: header[1],
+        end: header[2],
+        perms: header[3],
+        pathname: (header[4] || "").trim() || "[anon]",
+        size: 0,
+        rss: 0,
+        pss: 0,
+        privateDirty: 0,
+        sharedClean: 0,
+      };
+      regions.push(current);
       continue;
     }
     if (!current) continue;
@@ -170,15 +172,130 @@ export async function readSmapsByPathname(
     const value = parseKbValue(line.slice(colonIdx + 1));
     if (value === null) continue;
 
-    const g = getOrCreate(current.path);
-    if (key === "Rss") g.rss += value;
-    else if (key === "Pss") g.pss += value;
-    else if (key === "Size") g.size += value;
-    else if (key === "Private_Dirty") g.privateDirty += value;
-    else if (key === "Shared_Clean") g.sharedClean += value;
+    if (key === "Rss") current.rss = value;
+    else if (key === "Pss") current.pss = value;
+    else if (key === "Size") current.size = value;
+    else if (key === "Private_Dirty") current.privateDirty = value;
+    else if (key === "Shared_Clean") current.sharedClean = value;
+  }
+
+  return regions;
+}
+
+export async function readSmapsByPathname(
+  topN = 25,
+): Promise<SmapsRegionGroup[] | null> {
+  const regions = await readSmapsRegions();
+  if (!regions) return null;
+
+  const groups = new Map<string, SmapsRegionGroup>();
+  for (const r of regions) {
+    let g = groups.get(r.pathname);
+    if (!g) {
+      g = {
+        pathname: r.pathname,
+        regions: 0,
+        rss: 0,
+        pss: 0,
+        size: 0,
+        privateDirty: 0,
+        sharedClean: 0,
+      };
+      groups.set(r.pathname, g);
+    }
+    g.regions += 1;
+    g.rss += r.rss;
+    g.pss += r.pss;
+    g.size += r.size;
+    g.privateDirty += r.privateDirty;
+    g.sharedClean += r.sharedClean;
   }
 
   return Array.from(groups.values())
     .sort((a, b) => b.rss - a.rss)
     .slice(0, topN);
+}
+
+export interface PeekResult {
+  address: string;
+  bytesRead: number;
+  truncated: boolean;
+  strings: Array<{ offset: number; text: string }>;
+  hexPreview: string;
+  error?: string;
+}
+
+const MAX_PEEK_BYTES = 4 * 1024 * 1024; // 4 MiB cap per request
+const MAX_STRINGS = 500;
+const MAX_STRING_LEN = 256;
+
+// Read a chunk of /proc/self/mem and extract printable ASCII strings, similar to strings(1).
+// Requires a Linux host; returns null on non-Linux systems.
+export async function peekMemoryRegion(
+  startHex: string,
+  length: number,
+  options: { minLen?: number; maxStrings?: number } = {},
+): Promise<PeekResult | null> {
+  const minLen = Math.max(1, Math.min(64, options.minLen ?? 8));
+  const maxStrings = Math.max(1, Math.min(MAX_STRINGS, options.maxStrings ?? 200));
+  const readLen = Math.max(1, Math.min(MAX_PEEK_BYTES, length));
+  const start = BigInt("0x" + startHex);
+
+  let fd;
+  try {
+    fd = await open("/proc/self/mem", "r");
+  } catch {
+    return null;
+  }
+
+  const buffer = Buffer.alloc(readLen);
+  let bytesRead = 0;
+  let readError: string | undefined;
+  try {
+    const result = await fd.read(buffer, 0, readLen, start);
+    bytesRead = result.bytesRead;
+  } catch (err) {
+    readError = err instanceof Error ? err.message : String(err);
+  } finally {
+    await fd.close().catch(() => {});
+  }
+
+  const strings: Array<{ offset: number; text: string }> = [];
+  let current = "";
+  let currentStart = -1;
+  for (let i = 0; i < bytesRead; i++) {
+    const b = buffer[i];
+    const printable = (b >= 0x20 && b <= 0x7e) || b === 0x09;
+    if (printable) {
+      if (current.length === 0) currentStart = i;
+      current += String.fromCharCode(b);
+      if (current.length >= MAX_STRING_LEN) {
+        strings.push({ offset: currentStart, text: current });
+        current = "";
+        if (strings.length >= maxStrings) break;
+      }
+    } else {
+      if (current.length >= minLen) {
+        strings.push({ offset: currentStart, text: current });
+        if (strings.length >= maxStrings) break;
+      }
+      current = "";
+    }
+  }
+  if (current.length >= minLen && strings.length < maxStrings) {
+    strings.push({ offset: currentStart, text: current });
+  }
+
+  // First 256 bytes as hex preview, for a glanceable fingerprint of the region.
+  const hexBytes = Math.min(bytesRead, 256);
+  const hexPreview = buffer.subarray(0, hexBytes).toString("hex");
+
+  return {
+    address: "0x" + startHex,
+    bytesRead,
+    truncated: strings.length >= maxStrings,
+    strings,
+    hexPreview,
+    error: readError,
+  };
 }

--- a/server/src/routes/diagnostics.ts
+++ b/server/src/routes/diagnostics.ts
@@ -10,6 +10,8 @@ import {
   readProcStatus,
   readSmapsRollup,
   readSmapsByPathname,
+  readSmapsRegions,
+  peekMemoryRegion,
 } from "../lib/proc-memory";
 
 const router = Router();
@@ -76,6 +78,62 @@ router.get("/smaps-top", requirePermission("settings:read") as RequestHandler, (
     return;
   }
   res.json({ limit, groups });
+}) as RequestHandler);
+
+// GET /api/diagnostics/smaps-regions?pathname=[anon]&limit=N
+// Returns the top-N individual regions matching a pathname (or all pathnames if omitted),
+// sorted by RSS. Used by the UI to pick a specific anonymous region to inspect.
+router.get("/smaps-regions", requirePermission("settings:read") as RequestHandler, (async (req, res) => {
+  const pathname = typeof req.query.pathname === "string" ? req.query.pathname : undefined;
+  const limitParam = Number(req.query.limit);
+  const limit = Number.isFinite(limitParam) && limitParam > 0 ? Math.min(limitParam, 500) : 25;
+
+  const regions = await readSmapsRegions();
+  if (regions === null) {
+    res.status(501).json({ error: "smaps not available on this platform" });
+    return;
+  }
+  const filtered = pathname
+    ? regions.filter((r) => r.pathname === pathname)
+    : regions;
+  const top = filtered.sort((a, b) => b.rss - a.rss).slice(0, limit);
+  res.json({ pathname: pathname ?? null, limit, regions: top });
+}) as RequestHandler);
+
+// POST /api/diagnostics/region-peek - read a slice of /proc/self/mem and extract strings.
+// Inspects process memory contents, so treat as sensitive: gated by settings:write.
+router.post("/region-peek", requirePermission("settings:write") as RequestHandler, (async (req, res) => {
+  const body = (req.body ?? {}) as {
+    start?: string;
+    length?: number;
+    minLen?: number;
+    maxStrings?: number;
+  };
+  if (typeof body.start !== "string" || !/^[0-9a-f]+$/i.test(body.start)) {
+    res.status(400).json({ error: "start must be a hex address string (no 0x prefix)" });
+    return;
+  }
+  const length = Number(body.length);
+  if (!Number.isFinite(length) || length <= 0) {
+    res.status(400).json({ error: "length must be a positive integer" });
+    return;
+  }
+
+  const userId = (req as unknown as { user?: { id?: string } }).user?.id;
+  logger.info(
+    { userId, address: body.start, length, minLen: body.minLen },
+    "region-peek: reading /proc/self/mem",
+  );
+
+  const result = await peekMemoryRegion(body.start.toLowerCase(), length, {
+    minLen: body.minLen,
+    maxStrings: body.maxStrings,
+  });
+  if (result === null) {
+    res.status(501).json({ error: "/proc/self/mem not available on this platform" });
+    return;
+  }
+  res.json(result);
 }) as RequestHandler);
 
 // GET /api/diagnostics/report - Node.js diagnostic report (process.report)

--- a/server/src/routes/diagnostics.ts
+++ b/server/src/routes/diagnostics.ts
@@ -6,21 +6,31 @@ import os from "os";
 import path from "path";
 import { requirePermission } from "../middleware/auth";
 import { appLogger } from "../lib/logger-factory";
+import {
+  readProcStatus,
+  readSmapsRollup,
+  readSmapsByPathname,
+} from "../lib/proc-memory";
 
 const router = Router();
 const logger = appLogger();
 
 // GET /api/diagnostics/memory - current memory usage snapshot
-router.get("/memory", requirePermission("settings:read") as RequestHandler, ((_req, res) => {
+router.get("/memory", requirePermission("settings:read") as RequestHandler, (async (_req, res) => {
   const mem = process.memoryUsage();
   const heap = v8.getHeapStatistics();
   const heapSpaces = v8.getHeapSpaceStatistics();
+  const [procStatus, smapsRollup] = await Promise.all([
+    readProcStatus(),
+    readSmapsRollup(),
+  ]);
 
   res.json({
     timestamp: new Date().toISOString(),
     uptimeSeconds: process.uptime(),
     pid: process.pid,
     nodeVersion: process.version,
+    platform: process.platform,
     process: {
       rss: mem.rss,
       heapTotal: mem.heapTotal,
@@ -48,7 +58,42 @@ router.get("/memory", requirePermission("settings:read") as RequestHandler, ((_r
       physical: s.physical_space_size,
     })),
     resourceUsage: process.resourceUsage(),
+    procStatus,
+    smapsRollup,
   });
+}) as RequestHandler);
+
+// GET /api/diagnostics/smaps-top - aggregate /proc/self/smaps by pathname
+// Returns the top N contributors to RSS. More expensive than /memory because
+// smaps contains every mapped region — fetch on demand, not on every poll.
+router.get("/smaps-top", requirePermission("settings:read") as RequestHandler, (async (req, res) => {
+  const limitParam = Number(req.query.limit);
+  const limit = Number.isFinite(limitParam) && limitParam > 0 ? Math.min(limitParam, 200) : 25;
+
+  const groups = await readSmapsByPathname(limit);
+  if (groups === null) {
+    res.status(501).json({ error: "smaps not available on this platform" });
+    return;
+  }
+  res.json({ limit, groups });
+}) as RequestHandler);
+
+// GET /api/diagnostics/report - Node.js diagnostic report (process.report)
+// Streams a JSON file that includes shared objects, libuv handles, native stack,
+// environment variables, and more — useful for deep post-mortem analysis.
+router.get("/report", requirePermission("settings:read") as RequestHandler, ((_req, res) => {
+  try {
+    const report = process.report.getReport();
+    const filename = `diagnostic-report-${Date.now()}-${process.pid}.json`;
+    res.setHeader("Content-Type", "application/json");
+    res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+    res.send(report);
+  } catch (error) {
+    logger.error({ error }, "Failed to generate diagnostic report");
+    res.status(500).json({
+      error: error instanceof Error ? error.message : "Failed to generate diagnostic report",
+    });
+  }
 }) as RequestHandler);
 
 // POST /api/diagnostics/heap-snapshot - write a heap snapshot and stream it to the client


### PR DESCRIPTION
## Summary

- Extends the System Diagnostics page to show **where the process's memory actually goes**, not just V8's slice of it. Surfaces `/proc/self/status`, `/proc/self/smaps_rollup`, per-pathname smaps aggregation, and `process.resourceUsage()` in new cards.
- Adds an on-demand **"Inspect Memory Region"** card that reads `/proc/self/mem` for a chosen anonymous region and returns printable ASCII strings + a hex preview — useful for identifying what's living in an otherwise opaque `[anon]` region (e.g. we spotted Prisma's WASM query engine held as a base64 JS string this way).
- Adds a "Download report" button that streams `process.report.getReport()` as a JSON artifact next to the existing heap snapshot.
- Captures a **baseline memory analysis** in `docs/memory-analysis-2026-04-14.md` — a worked example of reading the page, confirming no leaks, and ~56% of RSS attributable to V8 (heap + JIT + WASM backing).
- Sketches a **future heaptrack integration** in `docs/native-heap-profiling.md` for real C++ call-stack attribution if we ever suspect a native leak.

## New endpoints

| Method | Path | Purpose |
|---|---|---|
| GET | `/api/diagnostics/smaps-top` | Top pathnames by RSS (aggregated) |
| GET | `/api/diagnostics/smaps-regions` | Top individual regions, filterable by pathname |
| POST | `/api/diagnostics/region-peek` | Read a slice of `/proc/self/mem` and extract strings (guarded by `settings:write`) |
| GET | `/api/diagnostics/report` | `process.report.getReport()` as downloadable JSON |

`GET /api/diagnostics/memory` now also returns `procStatus`, `smapsRollup`, and `platform`. `API-ROUTES.md` is updated so the agent sidecar picks everything up at its next startup.

## Test plan

- [x] Server + client builds pass
- [x] Server and client lint pass (no new warnings)
- [x] Verified every new endpoint returns expected shape from the live container via fetch
- [x] Verified UI end-to-end in Playwright: cards render, Refresh + auto-refetch still work, heap snapshot + diagnostic report download, Find regions + Peek populate a strings table
- [x] Confirmed graceful fallback if `/proc/self` is unavailable (non-container) — the API returns 501 and the UI hides the Linux-only cards

Screenshots: `screenshots/diagnostics-full.png`, `screenshots/diagnostics-peek.png`, `screenshots/diagnostics-explanations-on.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)