### PR TITLE
Always init agent API key before provisioning sidecar

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -202,11 +202,14 @@ const initializeServices = async () => {
       setApiKeyConfigured(true);
       logger.info("Loaded Anthropic API key from database settings");
       console.log("[STARTUP] Loaded Anthropic API key from database settings");
-
-      // Initialize agent API key before provisioning the sidecar,
-      // so MINI_INFRA_API_KEY is available when the container is created.
-      await initializeAgentApiKey();
     }
+
+    // Initialize agent API key before provisioning the sidecar so
+    // MINI_INFRA_API_KEY is available when the container is created.
+    // Runs regardless of Anthropic key — the sidecar still launches and
+    // needs to authenticate against /api/routes even before the user
+    // configures their Anthropic key.
+    await initializeAgentApiKey();
 
     // Provision agent sidecar (if running in Docker and autoStart is enabled)
     console.log("[STARTUP] Checking agent sidecar...");


### PR DESCRIPTION
## Summary
- The agent sidecar was launching with an empty `MINI_INFRA_API_KEY` whenever the Anthropic API key was unconfigured, because `initializeAgentApiKey()` lived inside the `if (anthropicKey)` block in `server.ts`.
- Result: sidecar logs filled with `HTTP 401: Unauthorized` from its startup `GET /api/routes` fetch, exhausting all 5 retries.
- Move `initializeAgentApiKey()` outside that gate so the internal Mini Infra service key is always provisioned before `ensureAgentSidecar()` runs.

## Test plan
- [x] Restart dev container, observe sidecar env now contains a valid `MINI_INFRA_API_KEY=mk_...`
- [x] Sidecar logs show `API reference fetched from server successfully` (no more 401s)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)