### PR TITLE
Fix stack plan 500 when TLS/Azure unconfigured

### DIFF
--- a/client/src/components/stacks/StackPlanView.tsx
+++ b/client/src/components/stacks/StackPlanView.tsx
@@ -292,6 +292,35 @@ export const StackPlanView = React.memo(function StackPlanView({
   // Error state
   if (error) {
     const isDockerUnavailable = error.message.includes("Docker is unavailable");
+    const errWithMeta = error as Error & {
+      code?: string;
+      missing?: Array<{ resource: string; settings: string[]; settingsUrl: string; reason: string }>;
+    };
+    const isMissingConfig = errWithMeta.code === "MISSING_CONFIGURATION" && Array.isArray(errWithMeta.missing);
+
+    if (isMissingConfig) {
+      return (
+        <Alert variant="destructive" className={className}>
+          <IconAlertTriangle className="h-4 w-4" />
+          <AlertTitle>Configuration required</AlertTitle>
+          <AlertDescription className="space-y-2">
+            <p>This stack has external-resource requirements that aren&apos;t configured yet.</p>
+            <ul className="list-disc pl-5 space-y-1">
+              {errWithMeta.missing!.map((m) => (
+                <li key={m.resource}>
+                  <span className="font-medium">{m.reason}</span>{" "}
+                  <span>Configure: {m.settings.join(", ")}.</span>{" "}
+                  <a href={m.settingsUrl} className="underline">
+                    Open settings
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </AlertDescription>
+        </Alert>
+      );
+    }
+
     return (
       <Alert variant="destructive" className={className}>
         <IconAlertTriangle className="h-4 w-4" />

--- a/client/src/hooks/use-stacks.ts
+++ b/client/src/hooks/use-stacks.ts
@@ -102,7 +102,17 @@ async function fetchStackPlan(
     if (response.status === 503) {
       throw new Error("Docker is unavailable");
     }
-    throw new Error(`Failed to fetch stack plan: ${response.statusText}`);
+    const body = await response.json().catch(() => null);
+    const message = body?.message || `Failed to fetch stack plan: ${response.statusText}`;
+    const err = new Error(message) as Error & {
+      status?: number;
+      code?: string;
+      missing?: unknown;
+    };
+    err.status = response.status;
+    err.code = body?.code;
+    err.missing = body?.missing;
+    throw err;
   }
 
   const data: StackPlanResponse = await response.json();

--- a/server/src/routes/stacks/stacks-validation-routes.ts
+++ b/server/src/routes/stacks/stacks-validation-routes.ts
@@ -6,6 +6,7 @@ import { DockerExecutorService } from '../../services/docker-executor';
 import { StackReconciler } from '../../services/stacks/stack-reconciler';
 import { createResourceReconciler } from '../../services/stacks/resource-reconciler-factory';
 import { findEmptyStackParameters } from '../../services/stacks/parameter-validation';
+import { checkStackConfigurationRequirements } from '../../services/stacks/stack-config-requirements';
 import type { StackValidationResult } from '@mini-infra/types';
 
 const router = Router();
@@ -22,6 +23,16 @@ router.get(
     });
     if (!exists) {
       return res.status(404).json({ success: false, message: 'Stack not found' });
+    }
+
+    const missingConfig = await checkStackConfigurationRequirements(prisma, stackId);
+    if (missingConfig) {
+      return res.status(422).json({
+        success: false,
+        code: missingConfig.code,
+        message: missingConfig.message,
+        missing: missingConfig.missing,
+      });
     }
 
     const dockerExecutor = new DockerExecutorService();

--- a/server/src/services/stacks/resource-reconciler-factory.ts
+++ b/server/src/services/stacks/resource-reconciler-factory.ts
@@ -17,20 +17,24 @@ import { DockerExecutorService } from '../docker-executor';
  * Initializes TLS lifecycle manager (ACME client, Azure storage, DNS challenge provider)
  * along with Cloudflare DNS and HAProxy certificate deployer services.
  *
- * If Azure storage is not configured, TLS methods on the returned reconciler
- * throw a descriptive error when invoked.
+ * Construction never throws on missing configuration. If Azure storage or the
+ * certificate container setting is not configured, the returned reconciler's
+ * TLS methods throw a descriptive error only when invoked. Callers that
+ * require TLS should preflight with `checkStackConfigurationRequirements()`.
  */
 export async function createResourceReconciler(): Promise<StackResourceReconciler> {
   const tlsConfig = new TlsConfigService(prisma);
   const azureConfig = new AzureStorageService(prisma);
 
-  const containerName = await tlsConfig.getCertificateContainerName();
   const connectionString = await azureConfig.getConnectionString();
+  const containerName = connectionString
+    ? await tlsConfig.getCertificateContainerNameOrNull()
+    : null;
 
   let certLifecycleManager: CertificateLifecycleManager | undefined;
   const cloudflareConfig = new CloudflareService(prisma);
 
-  if (connectionString) {
+  if (connectionString && containerName) {
     const certificateStore = new AzureStorageCertificateStore(connectionString, containerName);
     const acmeClient = new AcmeClientManager(tlsConfig, certificateStore);
     const dnsChallenge = new DnsChallenge01Provider(cloudflareConfig);

--- a/server/src/services/stacks/stack-config-requirements.ts
+++ b/server/src/services/stacks/stack-config-requirements.ts
@@ -1,0 +1,107 @@
+import type { PrismaClient } from '../../generated/prisma/client';
+import type {
+  StackTlsCertificate,
+  StackDnsRecord,
+  StackTunnelIngress,
+} from '@mini-infra/types';
+import { TlsConfigService } from '../tls/tls-config';
+import { AzureStorageService } from '../azure-storage-service';
+import { CloudflareService } from '../cloudflare/cloudflare-service';
+
+export interface MissingRequirement {
+  resource: 'tls' | 'dns' | 'tunnel';
+  settings: string[];
+  settingsUrl: string;
+  reason: string;
+}
+
+export interface StackConfigurationRequirementError {
+  code: 'MISSING_CONFIGURATION';
+  message: string;
+  missing: MissingRequirement[];
+}
+
+/**
+ * Check whether a stack's resource declarations (TLS certificates, DNS
+ * records, tunnel ingress) can be satisfied by the currently configured
+ * integrations. Returns null if the stack has no external-resource needs
+ * or all needs are met; returns a structured error otherwise.
+ *
+ * Fetches the stack's resource arrays and the relevant connectivity settings
+ * (Azure Storage, TLS container, Cloudflare API token) in parallel.
+ */
+export async function checkStackConfigurationRequirements(
+  prisma: PrismaClient,
+  stackId: string,
+): Promise<StackConfigurationRequirementError | null> {
+  const stack = await prisma.stack.findUnique({
+    where: { id: stackId },
+    select: { tlsCertificates: true, dnsRecords: true, tunnelIngress: true },
+  });
+  if (!stack) return null;
+
+  const tls = (stack.tlsCertificates as unknown as StackTlsCertificate[]) ?? [];
+  const dns = (stack.dnsRecords as unknown as StackDnsRecord[]) ?? [];
+  const tunnels = (stack.tunnelIngress as unknown as StackTunnelIngress[]) ?? [];
+
+  if (tls.length === 0 && dns.length === 0 && tunnels.length === 0) {
+    return null;
+  }
+
+  const tlsConfig = new TlsConfigService(prisma);
+  const azureConfig = new AzureStorageService(prisma);
+  const cloudflareConfig = new CloudflareService(prisma);
+
+  const [azureConnectionString, certContainer, cloudflareToken] = await Promise.all([
+    azureConfig.getConnectionString(),
+    tlsConfig.getCertificateContainerNameOrNull(),
+    cloudflareConfig.getApiToken(),
+  ]);
+
+  const missing: MissingRequirement[] = [];
+
+  if (tls.length > 0) {
+    const tlsGaps: string[] = [];
+    if (!azureConnectionString) tlsGaps.push('Azure Storage connection string');
+    if (!certContainer) tlsGaps.push('TLS certificate storage container');
+    if (!cloudflareToken) tlsGaps.push('Cloudflare API token (required for DNS-01 challenge)');
+    if (tlsGaps.length > 0) {
+      missing.push({
+        resource: 'tls',
+        settings: tlsGaps,
+        settingsUrl: '/connectivity-azure',
+        reason: `This stack provisions ${tls.length} TLS certificate${tls.length === 1 ? '' : 's'}.`,
+      });
+    }
+  }
+
+  if (dns.length > 0 && !cloudflareToken) {
+    missing.push({
+      resource: 'dns',
+      settings: ['Cloudflare API token'],
+      settingsUrl: '/connectivity-cloudflare',
+      reason: `This stack manages ${dns.length} DNS record${dns.length === 1 ? '' : 's'}.`,
+    });
+  }
+
+  if (tunnels.length > 0 && !cloudflareToken) {
+    missing.push({
+      resource: 'tunnel',
+      settings: ['Cloudflare API token'],
+      settingsUrl: '/connectivity-cloudflare',
+      reason: `This stack configures ${tunnels.length} tunnel ingress rule${tunnels.length === 1 ? '' : 's'}.`,
+    });
+  }
+
+  if (missing.length === 0) return null;
+
+  const summary = missing
+    .map((m) => `${m.reason} Configure: ${m.settings.join(', ')}.`)
+    .join(' ');
+
+  return {
+    code: 'MISSING_CONFIGURATION',
+    message: `This stack has external-resource requirements that aren't configured. ${summary}`,
+    missing,
+  };
+}

--- a/server/src/services/tls/tls-config.ts
+++ b/server/src/services/tls/tls-config.ts
@@ -230,6 +230,15 @@ export class TlsConfigService extends ConfigurationService {
   }
 
   /**
+   * Get certificate storage container name without throwing.
+   * Use this when the caller needs to handle the unconfigured case
+   * (e.g. building services that don't always require TLS).
+   */
+  async getCertificateContainerNameOrNull(): Promise<string | null> {
+    return this.get(TLS_SETTINGS_KEYS.CERTIFICATE_BLOB_CONTAINER);
+  }
+
+  /**
    * Get ACME account configuration
    * @returns ACME account configuration
    */


### PR DESCRIPTION
## Summary

- On a fresh install (no Azure/TLS config), opening **any** stack on the Host page returned `500 Internal Server Error` from `GET /api/stacks/:id/plan` with *"Certificate storage container not configured"* — even for the DataPlane network stack which has zero TLS/DNS/tunnel resources.
- Root cause: `resource-reconciler-factory.ts` called `TlsConfigService.getCertificateContainerName()` (which throws) unconditionally, before the existing `if (connectionString)` guard for Azure.
- Fix 1 — **factory tolerance**: only fetch the certificate container name when Azure storage is actually configured, matching the factory's documented intent that TLS methods throw on *invocation*, not *construction*. Added a non-throwing `getCertificateContainerNameOrNull()` variant for this case.
- Fix 2 — **preflight validation**: new `checkStackConfigurationRequirements()` inspects a stack's `tlsCertificates` / `dnsRecords` / `tunnelIngress` arrays and, if the stack genuinely needs integrations that aren't configured, returns a structured 422 with a specific list of missing settings and the settings page to fix each one.
- Fix 3 — **client rendering**: `use-stacks.ts` now parses the server's JSON error body on non-2xx responses (previously fell back to `statusText`). `StackPlanView` renders the structured `MISSING_CONFIGURATION` response as a "Configuration required" alert with direct links (`/connectivity-azure`, `/connectivity-cloudflare`) instead of a generic 500.

## Test plan

- [x] Open DataPlane Network stack on `/host` — now shows "Stack is in sync" (was: 500 Plan Error)
- [x] Server + client TypeScript builds pass
- [ ] Verify that a stack with TLS certificates on an unconfigured instance shows the new "Configuration required" alert with settings links
- [ ] Verify apply path still fails fast with the stubbed cert manager error when TLS is needed but unconfigured (belt-and-braces — preflight should catch it first, but the runtime stub is the safety net)
- [ ] Verify destroy path unaffected (already catches reconciler errors non-fatally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)