### PR TITLE
Seed backup + TLS defaults on onboarding completion

### DIFF
--- a/API-ROUTES.md
+++ b/API-ROUTES.md
@@ -149,6 +149,12 @@
 | POST | `/api/settings/github-app/agent/token` | Generate agent token via GitHub App |
 | POST | `/api/settings/github-app/agent/revoke` | Revoke agent token |
 
+### Onboarding (`/api/onboarding`)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/onboarding/complete` | Mark onboarding complete and seed backup/TLS defaults |
+
 ### Self-Backup Settings (`/api/settings/self-backup`)
 
 | Method | Path | Description |

--- a/client/src/hooks/use-onboarding.ts
+++ b/client/src/hooks/use-onboarding.ts
@@ -1,9 +1,5 @@
-import { useQueryClient } from "@tanstack/react-query";
-import {
-  useSystemSettings,
-  useCreateSystemSetting,
-  useUpdateSystemSetting,
-} from "@/hooks/use-settings";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useSystemSettings } from "@/hooks/use-settings";
 
 const ONBOARDING_FILTER = {
   category: "system" as const,
@@ -23,37 +19,37 @@ export function useOnboardingStatus() {
   return { onboardingComplete, isLoading };
 }
 
+async function completeOnboardingRequest(): Promise<void> {
+  const response = await fetch("/api/onboarding/complete", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to complete onboarding: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  if (!data.success) {
+    throw new Error(data.error || "Failed to complete onboarding");
+  }
+}
+
 export function useCompleteOnboarding() {
   const queryClient = useQueryClient();
-  const { data } = useSystemSettings({
-    filters: ONBOARDING_FILTER,
-    limit: 1,
+
+  const mutation = useMutation({
+    mutationFn: completeOnboardingRequest,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["systemSettings", ONBOARDING_FILTER],
+      });
+      queryClient.invalidateQueries({ queryKey: ["systemSettings"] });
+      queryClient.invalidateQueries({ queryKey: ["selfBackupConfig"] });
+      queryClient.invalidateQueries({ queryKey: ["tlsSettings"] });
+    },
   });
-  const createSetting = useCreateSystemSetting();
-  const updateSetting = useUpdateSystemSetting();
 
-  const existing = data?.data?.[0];
-
-  const complete = async () => {
-    if (existing) {
-      await updateSetting.mutateAsync({
-        id: existing.id,
-        setting: { value: "true" },
-      });
-    } else {
-      await createSetting.mutateAsync({
-        category: "system",
-        key: "onboarding_complete",
-        value: "true",
-        isEncrypted: false,
-      });
-    }
-    queryClient.invalidateQueries({
-      queryKey: ["systemSettings", ONBOARDING_FILTER],
-    });
-  };
-
-  const isPending = createSetting.isPending || updateSetting.isPending;
-
-  return { complete, isPending };
+  return { complete: mutation.mutateAsync, isPending: mutation.isPending };
 }

--- a/server/src/app-factory.ts
+++ b/server/src/app-factory.ts
@@ -70,6 +70,7 @@ import apiRoutesRoutes from "./routes/api-routes";
 import usersRoutes from "./routes/users";
 import authSettingsRoutes from "./routes/auth-settings";
 import diagnosticsRoutes from "./routes/diagnostics";
+import onboardingRoutes from "./routes/onboarding";
 
 type RouteDefinition = {
   id: string;
@@ -136,6 +137,7 @@ function getRouteDefinitions(): RouteDefinition[] {
     { id: "apiRoutes", path: "/api/routes", name: "apiRoutesRoutes", getRouter: () => apiRoutesRoutes },
     { id: "agent", path: "/api/agent", name: "agentRoutes", getRouter: () => agentRoutes },
     { id: "diagnostics", path: "/api/diagnostics", name: "diagnosticsRoutes", getRouter: () => diagnosticsRoutes },
+    { id: "onboarding", path: "/api/onboarding", name: "onboardingRoutes", getRouter: () => onboardingRoutes },
   ];
 }
 

--- a/server/src/routes/onboarding.ts
+++ b/server/src/routes/onboarding.ts
@@ -1,0 +1,179 @@
+import { Router, Request, Response } from "express";
+import prisma from "../lib/prisma";
+import { getLogger } from "../lib/logger-factory";
+import { requirePermission } from "../middleware/auth";
+import { UserPreferencesService } from "../services/user-preferences";
+import { TlsConfigService } from "../services/tls/tls-config";
+import type { JWTUser } from "@mini-infra/types";
+
+const logger = getLogger("http", "onboarding");
+const router = Router();
+
+const SELF_BACKUP_DEFAULT_CRON = "0 2 * * *";
+const ACME_DEFAULT_PROVIDER = "letsencrypt";
+const ACME_DEFAULT_RENEWAL_DAYS = "30";
+const TLS_DEFAULT_RENEWAL_CHECK_CRON = "0 2 * * *";
+
+async function upsertSelfBackupDefault(
+  key: string,
+  value: string,
+  userId: string,
+): Promise<boolean> {
+  const existing = await prisma.systemSettings.findUnique({
+    where: { category_key: { category: "self-backup", key } },
+  });
+  if (existing && existing.value) {
+    return false;
+  }
+  await prisma.systemSettings.upsert({
+    where: { category_key: { category: "self-backup", key } },
+    create: {
+      category: "self-backup",
+      key,
+      value,
+      isEncrypted: false,
+      isActive: true,
+      createdBy: userId,
+      updatedBy: userId,
+    },
+    update: {
+      value,
+      updatedBy: userId,
+      updatedAt: new Date(),
+    },
+  });
+  return true;
+}
+
+/**
+ * POST /complete — finalise onboarding, marking it complete and seeding
+ * sensible defaults for backups and TLS/ACME based on the user's profile.
+ * Existing values are preserved so this is safe to call on re-entry.
+ */
+router.post(
+  "/complete",
+  requirePermission("settings:write"),
+  async (req: Request, res: Response) => {
+    const user = req.user as JWTUser | undefined;
+    if (!user?.id) {
+      return res
+        .status(401)
+        .json({ success: false, error: "User not authenticated" });
+    }
+    const userId = user.id;
+    const userEmail = user.email;
+
+    try {
+      const preferences =
+        await UserPreferencesService.getUserPreferences(userId);
+      const userTimezone = preferences.timezone || "UTC";
+
+      await prisma.systemSettings.upsert({
+        where: {
+          category_key: { category: "system", key: "onboarding_complete" },
+        },
+        create: {
+          category: "system",
+          key: "onboarding_complete",
+          value: "true",
+          isEncrypted: false,
+          isActive: true,
+          createdBy: userId,
+          updatedBy: userId,
+        },
+        update: {
+          value: "true",
+          isActive: true,
+          updatedBy: userId,
+          updatedAt: new Date(),
+        },
+      });
+
+      const backupCronSeeded = await upsertSelfBackupDefault(
+        "cron_schedule",
+        SELF_BACKUP_DEFAULT_CRON,
+        userId,
+      );
+      const backupTimezoneSeeded = await upsertSelfBackupDefault(
+        "timezone",
+        userTimezone,
+        userId,
+      );
+
+      const tlsConfig = new TlsConfigService(prisma);
+      const existingAcmeEmail = await tlsConfig.get("default_acme_email");
+      const existingAcmeProvider = await tlsConfig.get("default_acme_provider");
+      const existingRenewalDays = await tlsConfig.get(
+        "renewal_days_before_expiry",
+      );
+      const existingRenewalCheckCron = await tlsConfig.get(
+        "renewal_check_cron",
+      );
+
+      let acmeEmailSeeded = false;
+      let acmeProviderSeeded = false;
+      let renewalDaysSeeded = false;
+      let renewalCheckCronSeeded = false;
+
+      if (!existingAcmeEmail && userEmail) {
+        await tlsConfig.set("default_acme_email", userEmail, userId);
+        acmeEmailSeeded = true;
+      }
+      if (!existingAcmeProvider) {
+        await tlsConfig.set(
+          "default_acme_provider",
+          ACME_DEFAULT_PROVIDER,
+          userId,
+        );
+        acmeProviderSeeded = true;
+      }
+      if (!existingRenewalDays) {
+        await tlsConfig.set(
+          "renewal_days_before_expiry",
+          ACME_DEFAULT_RENEWAL_DAYS,
+          userId,
+        );
+        renewalDaysSeeded = true;
+      }
+      if (!existingRenewalCheckCron) {
+        await tlsConfig.set(
+          "renewal_check_cron",
+          TLS_DEFAULT_RENEWAL_CHECK_CRON,
+          userId,
+        );
+        renewalCheckCronSeeded = true;
+      }
+
+      logger.info(
+        {
+          userId,
+          seeded: {
+            backupCron: backupCronSeeded,
+            backupTimezone: backupTimezoneSeeded,
+            acmeEmail: acmeEmailSeeded,
+            acmeProvider: acmeProviderSeeded,
+            renewalDays: renewalDaysSeeded,
+            renewalCheckCron: renewalCheckCronSeeded,
+          },
+          userTimezone,
+        },
+        "Onboarding completed and defaults seeded",
+      );
+
+      res.json({ success: true });
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logger.error(
+        { userId, error: errorMessage },
+        "Failed to complete onboarding",
+      );
+      res.status(500).json({
+        success: false,
+        error: "Failed to complete onboarding",
+      });
+    }
+  },
+);
+
+export default router;


### PR DESCRIPTION
## Summary
- New `POST /api/onboarding/complete` endpoint that marks onboarding complete and seeds backup + TLS defaults in one hop
- Backup cron set to `0 2 * * *` (2am daily) in the user's own timezone preference
- ACME seeded to Let's Encrypt production with the user's email and a 30-day renewal window
- Only seeds values that aren't already set, so re-running onboarding never clobbers an operator's manual config
- Frontend `useCompleteOnboarding` hook rewired to the new endpoint (API surface unchanged for `WelcomeDashboard` and `DashboardPage`)

Addresses the roadmap's "Onboarding flow" item for Time/locale and TLS/ACME defaults (docs/roadmap.md).

## Test plan
- [ ] `npm run build:server` passes
- [ ] `npm run build -w client` passes
- [ ] Fresh instance: complete the onboarding flow, then confirm `/api/settings/self-backup` returns cron `0 2 * * *` and the user's timezone
- [ ] Fresh instance: confirm TLS settings show ACME email = signed-in user's email, provider = `letsencrypt`, renewal days = 30
- [ ] Pre-configured instance: set a custom backup cron and ACME email, complete onboarding, confirm neither value was overwritten
- [ ] Skip button on the Welcome dashboard still completes onboarding and seeds the same defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)