### PR TITLE
Env-scoped system templates on-demand, not pre-seeded

### DIFF
--- a/client/src/components/environments/stacks-list.tsx
+++ b/client/src/components/environments/stacks-list.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
+import { toast } from "sonner";
 import { useStacks } from "@/hooks/use-stacks";
-import type { StackInfo, StackStatus } from "@mini-infra/types";
+import { useStackTemplates, useInstantiateTemplate } from "@/hooks/use-stack-templates";
+import type { StackInfo, StackStatus, StackTemplateInfo } from "@mini-infra/types";
 import { StackPlanView } from "@/components/stacks";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -13,6 +15,7 @@ import {
   IconChevronDown,
   IconChevronUp,
   IconAlertCircle,
+  IconPlus,
 } from "@tabler/icons-react";
 import { useFormattedDate } from "@/hooks/use-formatted-date";
 
@@ -68,6 +71,40 @@ export function StacksList({ environmentId, scope, className }: StacksListProps)
   const stacks: StackInfo[] = (stacksData?.data ?? []).filter((s) =>
     scope === "host" ? s.environmentId === null : s.environmentId !== null
   );
+
+  // For environment-scoped views, list system templates that haven't been
+  // instantiated in this environment yet. Host-scope view doesn't need this.
+  const enableAvailableTemplates = scope !== "host" && !!environmentId;
+  const { data: envTemplates } = useStackTemplates(
+    enableAvailableTemplates
+      ? { source: "system", scope: "environment" }
+      : undefined,
+  );
+  const instantiatedNames = new Set(stacks.map((s) => s.name));
+  const availableTemplates: StackTemplateInfo[] = enableAvailableTemplates
+    ? (envTemplates ?? []).filter(
+        (t) => !t.isArchived && !instantiatedNames.has(t.name),
+      )
+    : [];
+
+  const instantiate = useInstantiateTemplate();
+  const handleInstantiate = (template: StackTemplateInfo) => {
+    if (!environmentId) return;
+    instantiate.mutate(
+      { templateId: template.id, environmentId },
+      {
+        onSuccess: () => {
+          toast.success(`Added ${template.displayName} to environment`);
+          refetch();
+        },
+        onError: (err) => {
+          toast.error(
+            `Failed to add template: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        },
+      },
+    );
+  };
 
   const toggleExpanded = (stackId: string) => {
     setExpandedStackId((prev) => (prev === stackId ? null : stackId));
@@ -128,7 +165,7 @@ export function StacksList({ environmentId, scope, className }: StacksListProps)
                 </div>
               ))}
             </div>
-          ) : stacks.length === 0 ? (
+          ) : stacks.length === 0 && availableTemplates.length === 0 ? (
             <div className="text-center py-8">
               <IconStack2 className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
               <h3 className="text-lg font-semibold mb-2">No Stacks</h3>
@@ -208,6 +245,40 @@ export function StacksList({ environmentId, scope, className }: StacksListProps)
                   </div>
                 );
               })}
+
+              {availableTemplates.length > 0 && (
+                <div className="mt-2 pt-4 border-t">
+                  <p className="text-sm font-medium text-muted-foreground mb-3">
+                    Available templates for this environment
+                  </p>
+                  <div className="grid gap-2">
+                    {availableTemplates.map((t) => (
+                      <div
+                        key={t.id}
+                        className="flex items-center justify-between rounded-md border p-3"
+                      >
+                        <div className="min-w-0">
+                          <div className="font-medium truncate">{t.displayName}</div>
+                          {t.description && (
+                            <div className="text-sm text-muted-foreground truncate">
+                              {t.description}
+                            </div>
+                          )}
+                        </div>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => handleInstantiate(t)}
+                          disabled={instantiate.isPending}
+                        >
+                          <IconPlus className="h-4 w-4" />
+                          Add
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
           )}
         </CardContent>

--- a/client/src/hooks/use-stack-templates.ts
+++ b/client/src/hooks/use-stack-templates.ts
@@ -316,13 +316,19 @@ export function useInstantiateTemplate() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (args: { templateId: string; name?: string; parameterValues?: Record<string, unknown> }) => {
+    mutationFn: async (args: {
+      templateId: string;
+      name?: string;
+      environmentId?: string;
+      parameterValues?: Record<string, unknown>;
+    }) => {
       const response = await fetch(`/api/stack-templates/${args.templateId}/instantiate`, {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: args.name,
+          environmentId: args.environmentId,
           parameterValues: args.parameterValues,
         }),
       });

--- a/server/src/__tests__/environment-manager.test.ts
+++ b/server/src/__tests__/environment-manager.test.ts
@@ -29,9 +29,6 @@ vi.mock('../services/stacks/stack-routing-manager', () => ({
 vi.mock('../services/haproxy', () => ({
   HAProxyFrontendManager: vi.fn(),
 }));
-vi.mock('../services/stacks/seed', () => ({
-  seedStacksForEnvironment: vi.fn().mockResolvedValue(undefined),
-}));
 
 const MockDockerExecutorService = DockerExecutorService as MockedClass<typeof DockerExecutorService>;
 

--- a/server/src/services/environment/environment-manager.ts
+++ b/server/src/services/environment/environment-manager.ts
@@ -11,7 +11,6 @@ import {
 import { DockerExecutorService } from '../docker-executor';
 import { getLogger } from '../../lib/logger-factory';
 import { UserEventService } from '../user-events';
-import { seedStacksForEnvironment } from '../stacks/seed';
 
 export class EnvironmentManager {
   private static instance: EnvironmentManager;
@@ -66,11 +65,6 @@ export class EnvironmentManager {
         },
       });
       await this.userEventService.appendLogs(userEvent.id, `[${new Date().toISOString()}] Environment record created (ID: ${environmentData.id})`);
-
-      // Seed stacks for the new environment (stacks create their own infra resources on apply)
-      await this.userEventService.appendLogs(userEvent.id, `[${new Date().toISOString()}] Seeding stacks for environment...`);
-      await seedStacksForEnvironment(this.prisma, environmentData.id);
-      await this.userEventService.appendLogs(userEvent.id, `[${new Date().toISOString()}] Stack seeding complete`);
 
       // Fetch the complete environment with relations
       const environment = await this.getEnvironmentById(environmentData.id);

--- a/server/src/services/stacks/builtin-stack-sync.ts
+++ b/server/src/services/stacks/builtin-stack-sync.ts
@@ -44,97 +44,10 @@ export async function syncBuiltinStacks(prisma: PrismaClient): Promise<void> {
     return;
   }
 
-  // 1. Sync host-scoped templates (template rows only — stacks are created on user deploy)
-  const hostTemplates = templates.filter((t) => t.scope === "host");
-  for (const template of hostTemplates) {
-    try {
-      await templateService.upsertSystemTemplate({
-        name: template.name,
-        displayName: template.displayName,
-        scope: template.scope,
-        category: template.category,
-        builtinVersion: template.builtinVersion,
-        definition: template.definition as unknown as StackDefinition,
-        configFiles: template.configFiles,
-      });
-    } catch (error) {
-      log.error(
-        { error, stackName: template.name },
-        "Failed to sync host-scoped system template"
-      );
-    }
-  }
-
-  // 2. Sync environment-scoped templates (per environment)
-  const envTemplates = templates.filter((t) => t.scope === "environment");
-  if (envTemplates.length > 0) {
-    const environments = await prisma.environment.findMany({
-      select: { id: true, networkType: true },
-    });
-
-    log.info(
-      { environmentCount: environments.length },
-      "Syncing environment-scoped system templates"
-    );
-
-    for (const env of environments) {
-      for (const template of envTemplates) {
-        try {
-          const { templateId } = await templateService.upsertSystemTemplate({
-            name: template.name,
-            displayName: template.displayName,
-            scope: template.scope,
-            category: template.category,
-            builtinVersion: template.builtinVersion,
-            definition: template.definition as unknown as StackDefinition,
-            configFiles: template.configFiles,
-          });
-          await syncStackFromTemplate(prisma, templateId, template, env.id, log, env.networkType);
-        } catch (error) {
-          log.error(
-            { error, stackName: template.name, environmentId: env.id },
-            "Failed to sync environment-scoped system template"
-          );
-        }
-      }
-    }
-  }
-
-  // 3. Clean up orphaned stacks from old sync logic
-  await cleanupOrphanedStacks(prisma, templates, log);
-
-  // 4. Backfill InfraResource records from existing EnvironmentNetwork data
-  await migrateEnvironmentNetworksToInfraResources(prisma, log);
-
-  log.info("Built-in stack sync complete");
-}
-
-export async function syncBuiltinStacksForEnvironment(
-  prisma: PrismaClient,
-  environmentId: string
-): Promise<void> {
-  const log = getLogger("stacks", "builtin-stack-sync").child({
-    operation: "builtin-stack-sync",
-    environmentId,
-  });
-  const templateService = new StackTemplateService(prisma);
-
-  let templates: LoadedTemplate[];
-  try {
-    templates = discoverTemplates(TEMPLATES_DIR);
-  } catch (error) {
-    log.error({ error }, "Failed to discover template files");
-    return;
-  }
-
-  const environment = await prisma.environment.findUnique({
-    where: { id: environmentId },
-    select: { networkType: true },
-  });
-  const networkType = environment?.networkType ?? "local";
-
-  const envTemplates = templates.filter((t) => t.scope === "environment");
-  for (const template of envTemplates) {
+  // 1. Upsert all system template rows (host + environment scoped) so the catalog
+  // reflects every built-in template regardless of whether any environments exist yet.
+  const templateByName = new Map<string, { id: string; template: LoadedTemplate }>();
+  for (const template of templates) {
     try {
       const { templateId } = await templateService.upsertSystemTemplate({
         name: template.name,
@@ -145,26 +58,70 @@ export async function syncBuiltinStacksForEnvironment(
         definition: template.definition as unknown as StackDefinition,
         configFiles: template.configFiles,
       });
-      await syncStackFromTemplate(prisma, templateId, template, environmentId, log, networkType);
+      templateByName.set(template.name, { id: templateId, template });
     } catch (error) {
       log.error(
-        { error, stackName: template.name },
+        { error, stackName: template.name, scope: template.scope },
         "Failed to sync system template"
+      );
+    }
+  }
+
+  // 2. Upgrade existing stacks that were instantiated from a system template
+  // when the template version on disk has advanced. Stacks are never created
+  // here — that happens on explicit user action (template instantiation).
+  await upgradeExistingStacksForTemplates(prisma, templateByName, log);
+
+  // 3. Backfill InfraResource records from existing EnvironmentNetwork data
+  await migrateEnvironmentNetworksToInfraResources(prisma, log);
+
+  log.info("Built-in stack sync complete");
+}
+
+async function upgradeExistingStacksForTemplates(
+  prisma: PrismaClient,
+  templateByName: Map<string, { id: string; template: LoadedTemplate }>,
+  log: ReturnType<typeof getLogger>
+): Promise<void> {
+  const builtinStacks = await prisma.stack.findMany({
+    where: { builtinVersion: { not: null } },
+    select: { id: true, name: true, environmentId: true },
+  });
+
+  for (const s of builtinStacks) {
+    const entry = templateByName.get(s.name);
+    if (!entry) continue;
+
+    let networkType = "local";
+    if (s.environmentId) {
+      const env = await prisma.environment.findUnique({
+        where: { id: s.environmentId },
+        select: { networkType: true },
+      });
+      networkType = env?.networkType ?? "local";
+    }
+
+    try {
+      await upgradeStackFromTemplate(prisma, entry.id, entry.template, s.id, log, networkType);
+    } catch (error) {
+      log.error(
+        { error, stackName: s.name, environmentId: s.environmentId },
+        "Failed to upgrade built-in stack from template"
       );
     }
   }
 }
 
 /**
- * Sync a Stack row from a loaded template. Creates the stack if it doesn't exist,
- * updates it if the template version has advanced, and backfills templateId
- * on existing stacks that don't have it set yet.
+ * Upgrade an existing Stack row if the template version on disk has advanced,
+ * and apply environment-driven parameter overrides to non-running stacks.
+ * Never creates a stack — creation is user-initiated via template instantiation.
  */
-async function syncStackFromTemplate(
+async function upgradeStackFromTemplate(
   prisma: PrismaClient,
   templateId: string,
   template: LoadedTemplate,
-  environmentId: string | null,
+  stackId: string,
   log: ReturnType<typeof getLogger>,
   networkType: string = "local"
 ): Promise<void> {
@@ -172,51 +129,8 @@ async function syncStackFromTemplate(
   const networkTypeDefaults = definition.networkTypeDefaults ?? {};
   const parameterOverrides = networkTypeDefaults[networkType] ?? {};
 
-  const existing = await prisma.stack.findFirst({
-    where: { name: template.name, environmentId },
-  });
-
-  // No DB record → create
-  if (!existing) {
-    log.info({ stackName: template.name }, "Creating built-in stack from template");
-    const paramDefs = (definition.parameters ?? []) as StackParameterDefinition[];
-    const defaultValues = mergeParameterValues(paramDefs, parameterOverrides);
-
-    const serviceCreates: Prisma.StackServiceCreateWithoutStackInput[] =
-      (definition.services as StackServiceDefinition[]).map(toServiceCreateInput) as unknown as Prisma.StackServiceCreateWithoutStackInput[];
-
-    await prisma.stack.create({
-      data: {
-        name: definition.name,
-        description: definition.description ?? null,
-        environmentId,
-        version: 1,
-        status: "undeployed",
-        builtinVersion: template.builtinVersion,
-        templateId,
-        templateVersion: template.builtinVersion,
-        parameters: paramDefs.length > 0 ? (paramDefs as unknown as Prisma.InputJsonValue) : undefined,
-        parameterValues: Object.keys(defaultValues).length > 0 ? (defaultValues as unknown as Prisma.InputJsonValue) : undefined,
-        resourceOutputs: definition.resourceOutputs ? (definition.resourceOutputs as unknown as Prisma.InputJsonValue) : undefined,
-        resourceInputs: definition.resourceInputs ? (definition.resourceInputs as unknown as Prisma.InputJsonValue) : undefined,
-        networks: definition.networks as unknown as Prisma.InputJsonValue,
-        volumes: definition.volumes as unknown as Prisma.InputJsonValue,
-        services: {
-          create: serviceCreates,
-        },
-      },
-    });
-    return;
-  }
-
-  // builtinVersion is null → user-created stack with same name, skip
-  if (existing.builtinVersion === null) {
-    log.debug(
-      { stackName: template.name },
-      "Skipping user-created stack with built-in name"
-    );
-    return;
-  }
+  const existing = await prisma.stack.findUnique({ where: { id: stackId } });
+  if (!existing || existing.builtinVersion === null) return;
 
   // Backfill templateId if not set (migration from pre-template stacks)
   if (!existing.templateId) {
@@ -254,23 +168,16 @@ async function syncStackFromTemplate(
     }
   }
 
-  // DB version matches → no-op
-  if (existing.builtinVersion >= template.builtinVersion) {
-    log.debug(
-      { stackName: template.name, version: existing.builtinVersion },
-      "Built-in stack is up to date"
-    );
-    return;
-  }
+  // DB version matches — no upgrade needed
+  if (existing.builtinVersion >= template.builtinVersion) return;
 
-  // Template version is newer → update
   log.info(
     {
       stackName: template.name,
       oldVersion: existing.builtinVersion,
       newVersion: template.builtinVersion,
     },
-    "Updating built-in stack definition"
+    "Upgrading built-in stack to newer template version"
   );
 
   const paramDefs = (definition.parameters ?? []) as StackParameterDefinition[];
@@ -306,60 +213,6 @@ async function syncStackFromTemplate(
       },
     });
   });
-}
-
-async function cleanupOrphanedStacks(
-  prisma: PrismaClient,
-  templates: LoadedTemplate[],
-  log: ReturnType<typeof getLogger>
-): Promise<void> {
-  // Clean up orphaned per-environment monitoring stacks (from old sync logic)
-  const orphanedMonitoring = await prisma.stack.findMany({
-    where: {
-      name: "monitoring",
-      environmentId: { not: null },
-      builtinVersion: { not: null },
-      status: "undeployed",
-    },
-    select: { id: true },
-  });
-
-  if (orphanedMonitoring.length > 0) {
-    log.info(
-      { count: orphanedMonitoring.length },
-      "Cleaning up orphaned per-environment monitoring stacks"
-    );
-    for (const s of orphanedMonitoring) {
-      await prisma.stack.delete({ where: { id: s.id } });
-    }
-  }
-
-  // Clean up orphaned host-level stacks for environment-scoped templates
-  const envScopedNames = templates
-    .filter((t) => t.scope === "environment")
-    .map((t) => t.name);
-
-  if (envScopedNames.length > 0) {
-    const orphanedHostLevel = await prisma.stack.findMany({
-      where: {
-        name: { in: envScopedNames },
-        environmentId: null,
-        builtinVersion: { not: null },
-        status: "undeployed",
-      },
-      select: { id: true, name: true },
-    });
-
-    if (orphanedHostLevel.length > 0) {
-      log.info(
-        { count: orphanedHostLevel.length, stacks: orphanedHostLevel.map((s) => s.name) },
-        "Cleaning up orphaned host-level stacks for environment-scoped templates"
-      );
-      for (const s of orphanedHostLevel) {
-        await prisma.stack.delete({ where: { id: s.id } });
-      }
-    }
-  }
 }
 
 /**

--- a/server/src/services/stacks/seed.ts
+++ b/server/src/services/stacks/seed.ts
@@ -1,9 +1,0 @@
-import { PrismaClient } from "../../generated/prisma/client";
-import { syncBuiltinStacksForEnvironment } from "./builtin-stack-sync";
-
-export async function seedStacksForEnvironment(
-  prisma: PrismaClient,
-  environmentId: string
-): Promise<void> {
-  await syncBuiltinStacksForEnvironment(prisma, environmentId);
-}


### PR DESCRIPTION
## Summary

Fix two related issues with how built-in environment-scoped stack templates (haproxy, cloudflare-tunnel, postgres) are surfaced and instantiated.

- **Bug fix**: env-scoped system templates now appear in `/stack-templates` on a fresh install even when no environments exist (previously their template rows were only upserted inside the per-environment loop).
- **Refactor**: stop pre-seeding a `Stack` row per `(environment × env-scoped template)`. Creating an environment no longer auto-creates undeployed placeholder stacks. The environment detail page now lists available env-scoped templates with an "Add" button that calls the existing instantiate endpoint, so a Stack row only exists when the user asks for one.
- Existing template-version upgrade logic still runs at startup for stacks that have already been instantiated.

## Test plan
- [x] `/stack-templates` shows all 5 system templates on a fresh install with zero environments
- [x] Creating a new environment results in 0 pre-seeded stacks
- [x] Environment detail page shows "Available templates" section with Add buttons for env-scoped system templates not yet instantiated
- [x] Clicking Add creates the stack as `undeployed` and removes it from the available list
- [x] All 1221 server tests pass
- [x] Server + client builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)