### PR TITLE
One local + one internet environment; network-type gated stack templates

### DIFF
--- a/client/src/components/environments/environment-card.tsx
+++ b/client/src/components/environments/environment-card.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { Environment, EnvironmentType, EnvironmentNetworkType } from "@mini-infra/types";
+import { Environment, EnvironmentNetworkType } from "@mini-infra/types";
 import { useFormattedDate } from "@/hooks/use-formatted-date";
 import {
   Card,
@@ -27,12 +27,6 @@ export function EnvironmentCard({
 }: EnvironmentCardProps) {
   const { formatDateTime } = useFormattedDate();
 
-  const getTypeColor = (type: EnvironmentType) => {
-    return type === "production"
-      ? "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300"
-      : "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300";
-  };
-
   const getNetworkTypeColor = (networkType: EnvironmentNetworkType) => {
     return networkType === "internet"
       ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300"
@@ -53,12 +47,6 @@ export function EnvironmentCard({
             <CardTitle className="text-lg font-semibold">
               {environment.name}
             </CardTitle>
-            <Badge
-              variant="outline"
-              className={cn("text-xs", getTypeColor(environment.type))}
-            >
-              {environment.type}
-            </Badge>
             <Badge
               variant="outline"
               className={cn("text-xs", getNetworkTypeColor(environment.networkType))}

--- a/client/src/components/environments/environment-create-dialog.tsx
+++ b/client/src/components/environments/environment-create-dialog.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -5,6 +6,7 @@ import {
   CreateEnvironmentRequest,
   ENVIRONMENT_TYPES,
   ENVIRONMENT_NETWORK_TYPES,
+  EnvironmentNetworkType,
 } from "@mini-infra/types";
 import { useCreateEnvironment } from "@/hooks/use-environments";
 import {
@@ -31,6 +33,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
@@ -48,7 +51,7 @@ const createEnvironmentSchema = z.object({
     ),
   description: z.string().optional(),
   type: z.enum(ENVIRONMENT_TYPES),
-  networkType: z.enum(ENVIRONMENT_NETWORK_TYPES).optional(),
+  networkType: z.enum(ENVIRONMENT_NETWORK_TYPES),
 });
 
 type CreateEnvironmentFormData = z.infer<typeof createEnvironmentSchema>;
@@ -56,15 +59,22 @@ type CreateEnvironmentFormData = z.infer<typeof createEnvironmentSchema>;
 interface EnvironmentCreateDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  existingNetworkTypes?: EnvironmentNetworkType[];
   onSuccess?: () => void;
 }
 
 export function EnvironmentCreateDialog({
   open,
   onOpenChange,
+  existingNetworkTypes = [],
   onSuccess,
 }: EnvironmentCreateDialogProps) {
   const createMutation = useCreateEnvironment();
+
+  const localTaken = existingNetworkTypes.includes("local");
+  const internetTaken = existingNetworkTypes.includes("internet");
+  const networkTypeLocked = localTaken || internetTaken;
+  const defaultNetworkType: EnvironmentNetworkType = localTaken ? "internet" : "local";
 
   const form = useForm<CreateEnvironmentFormData>({
     resolver: zodResolver(createEnvironmentSchema),
@@ -72,9 +82,21 @@ export function EnvironmentCreateDialog({
       name: "",
       description: "",
       type: "nonproduction",
-      networkType: "local",
+      networkType: defaultNetworkType,
     },
   });
+
+  // When the dialog opens, realign the networkType default with the latest slot availability.
+  useEffect(() => {
+    if (open) {
+      form.reset({
+        name: "",
+        description: "",
+        type: "nonproduction",
+        networkType: defaultNetworkType,
+      });
+    }
+  }, [open, defaultNetworkType, form]);
 
   const onSubmit = async (data: CreateEnvironmentFormData) => {
     try {
@@ -122,6 +144,53 @@ export function EnvironmentCreateDialog({
                   </p>
                 </div>
               </div>
+
+              {/* Network Type (first) */}
+              <FormField
+                control={form.control}
+                name="networkType"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Network Type</FormLabel>
+                    <FormControl>
+                      <ToggleGroup
+                        type="single"
+                        variant="outline"
+                        value={field.value}
+                        onValueChange={(value) => {
+                          if (!value || networkTypeLocked) return;
+                          field.onChange(value as EnvironmentNetworkType);
+                        }}
+                        disabled={createMutation.isPending}
+                        className="w-full"
+                      >
+                        <ToggleGroupItem
+                          value="local"
+                          disabled={localTaken}
+                          className="flex-1"
+                        >
+                          Local
+                        </ToggleGroupItem>
+                        <ToggleGroupItem
+                          value="internet"
+                          disabled={internetTaken}
+                          className="flex-1"
+                        >
+                          Internet
+                        </ToggleGroupItem>
+                      </ToggleGroup>
+                    </FormControl>
+                    <FormDescription>
+                      {networkTypeLocked
+                        ? `A ${localTaken ? "local" : "internet"} environment already exists. Only one of each network type is allowed.`
+                        : field.value === "internet"
+                          ? "Internet networks use Cloudflare tunnels to route traffic."
+                          : "Local networks require a host IP address."}
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
               {/* Basic Information */}
               <div className="space-y-4">
@@ -174,7 +243,7 @@ export function EnvironmentCreateDialog({
                       <FormLabel>Environment Type</FormLabel>
                       <Select
                         onValueChange={field.onChange}
-                        defaultValue={field.value}
+                        value={field.value}
                         disabled={createMutation.isPending}
                       >
                         <FormControl>
@@ -188,36 +257,7 @@ export function EnvironmentCreateDialog({
                         </SelectContent>
                       </Select>
                       <FormDescription>
-                        Production environments have additional safety measures
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name="networkType"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Network Type</FormLabel>
-                      <Select
-                        onValueChange={field.onChange}
-                        defaultValue={field.value}
-                        disabled={createMutation.isPending}
-                      >
-                        <FormControl>
-                          <SelectTrigger>
-                            <SelectValue placeholder="Select network type" />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          <SelectItem value="local">Local</SelectItem>
-                          <SelectItem value="internet">Internet</SelectItem>
-                        </SelectContent>
-                      </Select>
-                      <FormDescription>
-                        Local networks require a host IP address. Internet networks use Cloudflare tunnels.
+                        Production is a visual indicator only — it has no functional effect.
                       </FormDescription>
                       <FormMessage />
                     </FormItem>

--- a/client/src/components/environments/environment-edit-dialog.tsx
+++ b/client/src/components/environments/environment-edit-dialog.tsx
@@ -190,7 +190,7 @@ export function EnvironmentEditDialog({
                     </SelectContent>
                   </Select>
                   <FormDescription>
-                    Production environments have additional safety measures
+                    Production is a visual indicator only — it has no functional effect.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>

--- a/client/src/components/environments/environment-list.tsx
+++ b/client/src/components/environments/environment-list.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { Environment } from "@mini-infra/types";
-import { useEnvironments, useEnvironmentFilters } from "@/hooks/use-environments";
+import { Environment, EnvironmentNetworkType } from "@mini-infra/types";
+import { useEnvironments } from "@/hooks/use-environments";
 import { EnvironmentCard } from "./environment-card";
 import { EnvironmentCreateDialog } from "./environment-create-dialog";
 import { EnvironmentEditDialog } from "./environment-edit-dialog";
@@ -9,16 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@/components/ui/pagination";
-import { IconPlus, IconRefresh, IconServer, IconAlertCircle } from "@tabler/icons-react";
+import { IconPlus, IconAlertCircle } from "@tabler/icons-react";
 
 interface EnvironmentListProps {
   className?: string;
@@ -30,24 +21,22 @@ export function EnvironmentList({ className }: EnvironmentListProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [selectedEnvironment, setSelectedEnvironment] = useState<Environment | null>(null);
 
-  const { filters, updateFilter } = useEnvironmentFilters();
-
   const {
     data: environmentsData,
     isLoading,
     isError,
     error,
     refetch,
-    isRefetching,
   } = useEnvironments({
-    filters,
-    refetchInterval: 10000, // Refetch every 10 seconds for real-time updates
+    // Always fetch both slots on a single page; there are at most two.
+    filters: { page: 1, limit: 100 },
+    refetchInterval: 10000,
   });
 
   const environments = environmentsData?.environments || [];
-  const totalPages = environmentsData?.totalPages || 0;
-  const hasNextPage = environmentsData?.hasNextPage || false;
-  const hasPreviousPage = environmentsData?.hasPreviousPage || false;
+  const localEnv = environments.find((e) => e.networkType === "local") ?? null;
+  const internetEnv = environments.find((e) => e.networkType === "internet") ?? null;
+  const canCreate = !localEnv || !internetEnv;
 
   const handleEdit = (environment: Environment) => {
     setSelectedEnvironment(environment);
@@ -57,82 +46,6 @@ export function EnvironmentList({ className }: EnvironmentListProps) {
   const handleDelete = (environment: Environment) => {
     setSelectedEnvironment(environment);
     setDeleteDialogOpen(true);
-  };
-
-  const handleRefresh = () => {
-    refetch();
-  };
-
-  const renderPagination = () => {
-    if (totalPages <= 1) return null;
-
-    const generatePageNumbers = () => {
-      const pages = [];
-      const currentPage = filters.page;
-
-      // Always show first page
-      pages.push(1);
-
-      // Add ellipsis if there's a gap
-      if (currentPage > 3) {
-        pages.push('ellipsis-start');
-      }
-
-      // Add pages around current page
-      for (let i = Math.max(2, currentPage - 1); i <= Math.min(totalPages - 1, currentPage + 1); i++) {
-        if (!pages.includes(i)) {
-          pages.push(i);
-        }
-      }
-
-      // Add ellipsis if there's a gap
-      if (currentPage < totalPages - 2) {
-        pages.push('ellipsis-end');
-      }
-
-      // Always show last page if there's more than one page
-      if (totalPages > 1 && !pages.includes(totalPages)) {
-        pages.push(totalPages);
-      }
-
-      return pages;
-    };
-
-    return (
-      <Pagination className="mt-6">
-        <PaginationContent>
-          <PaginationItem>
-            <PaginationPrevious
-              onClick={() => updateFilter("page", filters.page - 1)}
-              className={!hasPreviousPage ? "pointer-events-none opacity-50" : "cursor-pointer"}
-            />
-          </PaginationItem>
-
-          {generatePageNumbers().map((page, index) => (
-            <PaginationItem key={index}>
-              {page === 'ellipsis-start' || page === 'ellipsis-end' ? (
-                <PaginationEllipsis />
-              ) : (
-                <PaginationLink
-                  onClick={() => updateFilter("page", page as number)}
-                  isActive={page === filters.page}
-                  className="cursor-pointer"
-                >
-                  {page}
-                </PaginationLink>
-              )}
-            </PaginationItem>
-          ))}
-
-          <PaginationItem>
-            <PaginationNext
-              onClick={() => updateFilter("page", filters.page + 1)}
-              className={!hasNextPage ? "pointer-events-none opacity-50" : "cursor-pointer"}
-            />
-          </PaginationItem>
-        </PaginationContent>
-      </Pagination>
-    );
   };
 
   if (isError) {
@@ -148,11 +61,15 @@ export function EnvironmentList({ className }: EnvironmentListProps) {
     );
   }
 
+  const existingNetworkTypes: EnvironmentNetworkType[] = [];
+  if (localEnv) existingNetworkTypes.push("local");
+  if (internetEnv) existingNetworkTypes.push("internet");
+
   return (
     <div className={className}>
       {/* Header Actions */}
-      <div className="flex items-center justify-between mb-6">
-        <div className="flex items-center gap-2">
+      {canCreate && (
+        <div className="flex items-center justify-between mb-6">
           <Button
             onClick={() => setCreateDialogOpen(true)}
             className="flex items-center gap-2"
@@ -160,22 +77,13 @@ export function EnvironmentList({ className }: EnvironmentListProps) {
             <IconPlus className="h-4 w-4" />
             Create Environment
           </Button>
-          <Button
-            variant="outline"
-            onClick={handleRefresh}
-            disabled={isRefetching}
-            className="flex items-center gap-2"
-          >
-            <IconRefresh className={`h-4 w-4 ${isRefetching ? "animate-spin" : ""}`} />
-            Refresh
-          </Button>
         </div>
-      </div>
+      )}
 
-      {/* Content */}
+      {/* Content — fixed two-slot layout: Local left, Internet right */}
       {isLoading ? (
         <div className="grid gap-6 md:grid-cols-2">
-          {Array.from({ length: 6 }).map((_, i) => (
+          {Array.from({ length: 2 }).map((_, i) => (
             <Card key={i}>
               <CardContent className="p-6">
                 <div className="space-y-4">
@@ -185,49 +93,39 @@ export function EnvironmentList({ className }: EnvironmentListProps) {
                   </div>
                   <Skeleton className="h-4 w-full" />
                   <Skeleton className="h-4 w-2/3" />
-                  <div className="flex gap-2">
-                    <Skeleton className="h-8 w-16" />
-                    <Skeleton className="h-8 w-16" />
-                  </div>
                 </div>
               </CardContent>
             </Card>
           ))}
         </div>
-      ) : environments.length === 0 ? (
-        <Card>
-          <CardContent className="flex flex-col items-center justify-center py-12">
-            <IconServer className="h-12 w-12 text-muted-foreground mb-4" />
-            <h3 className="text-lg font-semibold mb-2">No Environments Found</h3>
-            <p className="text-muted-foreground text-center mb-4">
-              Get started by creating your first environment.
-            </p>
-            <Button onClick={() => setCreateDialogOpen(true)}>
-              <IconPlus className="h-4 w-4 mr-2" />
-              Create Environment
-            </Button>
-          </CardContent>
-        </Card>
       ) : (
-        <>
-          <div className="grid gap-6 md:grid-cols-2">
-            {environments.map((environment) => (
+        <div className="grid gap-6 md:grid-cols-2">
+          {localEnv && (
+            <div className="md:col-start-1">
               <EnvironmentCard
-                key={environment.id}
-                environment={environment}
+                environment={localEnv}
                 onEdit={handleEdit}
                 onDelete={handleDelete}
               />
-            ))}
-          </div>
-          {renderPagination()}
-        </>
+            </div>
+          )}
+          {internetEnv && (
+            <div className="md:col-start-2">
+              <EnvironmentCard
+                environment={internetEnv}
+                onEdit={handleEdit}
+                onDelete={handleDelete}
+              />
+            </div>
+          )}
+        </div>
       )}
 
       {/* Dialogs */}
       <EnvironmentCreateDialog
         open={createDialogOpen}
         onOpenChange={setCreateDialogOpen}
+        existingNetworkTypes={existingNetworkTypes}
         onSuccess={() => refetch()}
       />
 

--- a/client/src/components/environments/stacks-list.tsx
+++ b/client/src/components/environments/stacks-list.tsx
@@ -77,7 +77,7 @@ export function StacksList({ environmentId, scope, className }: StacksListProps)
   const enableAvailableTemplates = scope !== "host" && !!environmentId;
   const { data: envTemplates } = useStackTemplates(
     enableAvailableTemplates
-      ? { source: "system", scope: "environment" }
+      ? { source: "system", scope: "environment", environmentId }
       : undefined,
   );
   const instantiatedNames = new Set(stacks.map((s) => s.name));

--- a/client/src/hooks/use-stack-templates.ts
+++ b/client/src/hooks/use-stack-templates.ts
@@ -18,6 +18,7 @@ import type {
 export interface StackTemplateFilterParams {
   source?: StackTemplateSource;
   scope?: StackTemplateScope;
+  environmentId?: string;
   includeArchived?: boolean;
   includeLinkedStacks?: boolean;
 }
@@ -30,6 +31,7 @@ async function fetchStackTemplates(
   const url = new URL("/api/stack-templates", window.location.origin);
   if (params?.source) url.searchParams.set("source", params.source);
   if (params?.scope) url.searchParams.set("scope", params.scope);
+  if (params?.environmentId) url.searchParams.set("environmentId", params.environmentId);
   if (params?.includeArchived)
     url.searchParams.set("includeArchived", String(params.includeArchived));
   if (params?.includeLinkedStacks)

--- a/lib/types/stack-templates.ts
+++ b/lib/types/stack-templates.ts
@@ -16,10 +16,11 @@ import type {
   StackResourceInput,
   AdoptedContainerRef,
 } from './stacks';
+import type { EnvironmentNetworkType } from './environments';
 
 // Enum mirrors
 export type StackTemplateSource = 'system' | 'user';
-export const STACK_TEMPLATE_SCOPES = ['host', 'environment'] as const;
+export const STACK_TEMPLATE_SCOPES = ['host', 'environment', 'any'] as const;
 export type StackTemplateScope = typeof STACK_TEMPLATE_SCOPES[number];
 export type StackTemplateVersionStatus = 'draft' | 'published' | 'archived';
 
@@ -32,6 +33,7 @@ export interface StackTemplate {
   description: string | null;
   source: StackTemplateSource;
   scope: StackTemplateScope;
+  networkType: EnvironmentNetworkType | null;
   category: string | null;
   environmentId: string | null;
   isArchived: boolean;
@@ -110,6 +112,7 @@ export interface StackTemplateInfo {
   description: string | null;
   source: StackTemplateSource;
   scope: StackTemplateScope;
+  networkType: EnvironmentNetworkType | null;
   category: string | null;
   environmentId: string | null;
   isArchived: boolean;
@@ -179,6 +182,7 @@ export interface CreateStackTemplateRequest {
   displayName: string;
   description?: string;
   scope: StackTemplateScope;
+  networkType?: EnvironmentNetworkType;
   environmentId?: string;
   deployImmediately?: boolean;
   category?: string;

--- a/server/prisma/migrations/20260415205944_stack_template_network_type_and_any_scope/migration.sql
+++ b/server/prisma/migrations/20260415205944_stack_template_network_type_and_any_scope/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "stack_templates" ADD COLUMN "networkType" TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1040,6 +1040,7 @@ enum StackTemplateSource {
 enum StackTemplateScope {
   host
   environment
+  any
 }
 
 enum StackTemplateVersionStatus {
@@ -1187,7 +1188,8 @@ model StackTemplate {
   displayName      String
   description      String?
   source           StackTemplateSource  // system | user
-  scope            StackTemplateScope   // host | environment
+  scope            StackTemplateScope   // host | environment | any
+  networkType      String?              // 'local' | 'internet' | null (null = compatible with both)
   category         String?
   environmentId    String?
   environment      Environment?         @relation(fields: [environmentId], references: [id])

--- a/server/src/routes/environments.ts
+++ b/server/src/routes/environments.ts
@@ -81,6 +81,18 @@ router.post('/', requirePermission('environments:write'), async (req, res) => {
     const request: CreateEnvironmentRequest = req.body;
     const userId = (req as { user?: { id?: string } }).user?.id;
 
+    const networkType = request.networkType || 'local';
+    const existingWithNetworkType = await prisma.environment.findFirst({
+      where: { networkType },
+      select: { id: true, name: true },
+    });
+    if (existingWithNetworkType) {
+      return res.status(409).json({
+        error: 'Network type already in use',
+        message: `A ${networkType} environment ("${existingWithNetworkType.name}") already exists. Only one ${networkType} environment is allowed.`,
+      });
+    }
+
     const environment = await environmentManager.createEnvironment(request, userId);
 
     logger.debug({

--- a/server/src/routes/stack-templates.ts
+++ b/server/src/routes/stack-templates.ts
@@ -34,11 +34,12 @@ function handleTemplateError(error: unknown, res: Response, fallbackMessage: str
 router.get('/', requirePermission('stacks:read'), async (req, res) => {
   try {
     const service = getTemplateService();
-    const { source, scope, includeArchived, includeLinkedStacks } = req.query;
+    const { source, scope, environmentId, includeArchived, includeLinkedStacks } = req.query;
 
     const templates = await service.listTemplates({
       source: source as StackTemplateSource,
       scope: scope as StackTemplateScope,
+      environmentId: typeof environmentId === 'string' && environmentId.length > 0 ? environmentId : undefined,
       includeArchived: includeArchived === 'true',
       includeLinkedStacks: includeLinkedStacks === 'true',
     });

--- a/server/src/services/stacks/builtin-stack-sync.ts
+++ b/server/src/services/stacks/builtin-stack-sync.ts
@@ -53,6 +53,7 @@ export async function syncBuiltinStacks(prisma: PrismaClient): Promise<void> {
         name: template.name,
         displayName: template.displayName,
         scope: template.scope,
+        networkType: template.networkType ?? null,
         category: template.category,
         builtinVersion: template.builtinVersion,
         definition: template.definition as unknown as StackDefinition,

--- a/server/src/services/stacks/stack-template-service.ts
+++ b/server/src/services/stacks/stack-template-service.ts
@@ -14,6 +14,7 @@ import type {
   StackTemplateScope,
   StackTemplateVersionStatus,
   StackServiceType,
+  EnvironmentNetworkType,
 } from "@mini-infra/types";
 import type {
   StackServiceDefinition,
@@ -31,6 +32,7 @@ export interface UpsertSystemTemplateInput {
   name: string;
   displayName: string;
   scope: StackTemplateScope;
+  networkType?: EnvironmentNetworkType | null;
   category?: string;
   builtinVersion: number;
   definition: StackDefinition;
@@ -88,6 +90,7 @@ interface SerializableTemplate {
   description: string | null;
   source: StackTemplateSource;
   scope: StackTemplateScope;
+  networkType: string | null;
   category: string | null;
   environmentId: string | null;
   isArchived: boolean;
@@ -124,13 +127,31 @@ export class StackTemplateService {
   async listTemplates(opts?: {
     source?: StackTemplateSource;
     scope?: StackTemplateScope;
+    environmentId?: string;
     includeArchived?: boolean;
     includeLinkedStacks?: boolean;
   }): Promise<StackTemplateInfo[]> {
     const where: Prisma.StackTemplateWhereInput = {};
     if (opts?.source) where.source = opts.source;
-    if (opts?.scope) where.scope = opts.scope;
+    if (opts?.scope === "host") {
+      where.scope = { in: ["host", "any"] };
+    } else if (opts?.scope === "environment") {
+      where.scope = { in: ["environment", "any"] };
+    } else if (opts?.scope) {
+      where.scope = opts.scope;
+    }
     if (!opts?.includeArchived) where.isArchived = false;
+
+    // When filtering by environment, hide templates whose networkType doesn't match.
+    if (opts?.environmentId) {
+      const env = await this.prisma.environment.findUnique({
+        where: { id: opts.environmentId },
+        select: { networkType: true },
+      });
+      if (env) {
+        where.OR = [{ networkType: null }, { networkType: env.networkType }];
+      }
+    }
 
     const templates = await this.prisma.stackTemplate.findMany({
       where,
@@ -538,6 +559,7 @@ export class StackTemplateService {
       name,
       displayName,
       scope,
+      networkType,
       category,
       builtinVersion,
       definition,
@@ -581,6 +603,7 @@ export class StackTemplateService {
               displayName,
               description: definition.description ?? null,
               scope,
+              networkType: networkType ?? null,
               category: category ?? null,
             },
           })
@@ -591,6 +614,7 @@ export class StackTemplateService {
               description: definition.description ?? null,
               source: "system",
               scope,
+              networkType: networkType ?? null,
               category: category ?? null,
             },
           });
@@ -737,6 +761,13 @@ export class StackTemplateService {
         select: { networkType: true },
       });
       if (env) {
+        if (template.networkType && template.networkType !== env.networkType) {
+          const article = template.networkType === "internet" ? "an" : "a";
+          throw new TemplateError(
+            `Template "${template.name}" requires ${article} ${template.networkType} environment (target is ${env.networkType})`,
+            400
+          );
+        }
         const ntDefaults = version.networkTypeDefaults as unknown as Record<string, Record<string, StackParameterValue>> | null;
         networkDefaults = ntDefaults?.[env.networkType] ?? {};
       }
@@ -751,7 +782,8 @@ export class StackTemplateService {
     // Build service definitions from template services + config files
     const services = buildServiceDefinitionsFromVersion(version);
 
-    // Validate scope
+    // Validate scope. For `any`-scoped templates the presence of environmentId
+    // determines the effective scope — either direction is allowed.
     if (template.scope === "host" && input.environmentId) {
       throw new TemplateError(
         "Host-scoped template cannot be assigned to an environment",
@@ -925,6 +957,7 @@ export class StackTemplateService {
       description: template.description,
       source: template.source,
       scope: template.scope,
+      networkType: (template.networkType as EnvironmentNetworkType | null) ?? null,
       category: template.category,
       environmentId: template.environmentId ?? null,
       isArchived: template.isArchived,

--- a/server/src/services/stacks/template-file-loader.ts
+++ b/server/src/services/stacks/template-file-loader.ts
@@ -63,7 +63,8 @@ export const templateFileSchema = z.object({
   name: z.string().min(1).max(100).regex(nameRegex),
   displayName: z.string().min(1).max(200),
   builtinVersion: z.number().int().min(1),
-  scope: z.enum(["host", "environment"]),
+  scope: z.enum(["host", "environment", "any"]),
+  networkType: z.enum(["local", "internet"]).optional(),
   category: z.string().max(100).optional(),
   description: z.string().max(500).optional(),
   parameters: z.array(stackParameterDefinitionSchema).optional(),
@@ -91,7 +92,8 @@ export interface LoadedTemplate {
   name: string;
   displayName: string;
   builtinVersion: number;
-  scope: "host" | "environment";
+  scope: "host" | "environment" | "any";
+  networkType?: "local" | "internet";
   category?: string;
   description?: string;
   postInstallActions?: PostInstallAction[];
@@ -240,6 +242,7 @@ export function loadTemplateFromObject(
     displayName: data.displayName,
     builtinVersion: data.builtinVersion,
     scope: data.scope,
+    networkType: data.networkType,
     category: data.category,
     description: data.description,
     postInstallActions: data.postInstallActions,

--- a/server/templates/cloudflare-tunnel/template.json
+++ b/server/templates/cloudflare-tunnel/template.json
@@ -1,8 +1,9 @@
 {
   "name": "cloudflare-tunnel",
   "displayName": "Cloudflare Tunnel",
-  "builtinVersion": 4,
+  "builtinVersion": 5,
   "scope": "environment",
+  "networkType": "internet",
   "category": "infrastructure",
   "description": "Cloudflare tunnel connector for exposing services to the internet via HAProxy",
   "resourceOutputs": [


### PR DESCRIPTION
## Summary
- Restricts environments to a single **local** and a single **internet** instance (UI + server 409; DB unchanged). Fixed two-slot layout replaces pagination; production/nonproduction is now a visual-only label.
- Adds a nullable **`networkType`** to `StackTemplate` so Cloudflare Tunnel (now seeded with `networkType: "internet"`, builtinVersion 4→5) is **hidden** in local environments and **rejected** at instantiation. Route-level guard in `managed-tunnels-routes.ts` kept as belt-and-braces.
- Extends `StackTemplateScope` with **`any`** — templates with this scope appear in both host and environment template lists; effective scope is decided by whether `environmentId` is supplied at instantiation.

## Test plan
- [ ] Fresh DB: onboarding still seeds one local + one internet env.
- [ ] `POST /api/environments` with a second env of the same network type → 409.
- [ ] Environments page: exactly two slots; create button hides once both are filled; create dialog locks the toggle when one network type already exists.
- [ ] Local env detail → "Available templates" list excludes Cloudflare Tunnel.
- [ ] Internet env detail → Cloudflare Tunnel present.
- [ ] `POST /api/stack-templates/:id/instantiate` for cloudflare-tunnel against local env → 400 with "requires an internet environment".
- [ ] Existing stack-template tests still pass (`npx -w server vitest run src/__tests__/stack-template-engine.test.ts src/__tests__/stack-template-environment.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)