### PR TITLE
Rework New Application UI as progressive-disclosure flow

### DIFF
--- a/client/src/app/applications/new/components/basics-step.tsx
+++ b/client/src/app/applications/new/components/basics-step.tsx
@@ -1,0 +1,108 @@
+import { useEffect } from "react";
+import { useFormContext } from "react-hook-form";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { Environment } from "@mini-infra/types";
+import type { CreateApplicationFormData } from "@/lib/application-schemas";
+
+interface Props {
+  environments: Environment[];
+  isLoading: boolean;
+}
+
+export function BasicsStep({ environments, isLoading }: Props) {
+  const form = useFormContext<CreateApplicationFormData>();
+  const currentEnvId = form.watch("environmentId");
+
+  useEffect(() => {
+    if (!isLoading && environments.length === 1 && !currentEnvId) {
+      form.setValue("environmentId", environments[0].id, {
+        shouldValidate: true,
+      });
+    }
+  }, [isLoading, environments, currentEnvId, form]);
+
+  const hasSingleEnv = environments.length === 1;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Application</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <FormField
+            control={form.control}
+            name="displayName"
+            render={({ field }) => (
+              <FormItem data-tour="new-app-display-name-input">
+                <FormLabel>Name</FormLabel>
+                <FormControl>
+                  <Input placeholder="My Application" autoFocus {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="environmentId"
+            render={({ field }) => (
+              <FormItem data-tour="new-app-environment-select">
+                <FormLabel>Environment</FormLabel>
+                <Select
+                  onValueChange={field.onChange}
+                  value={field.value ?? ""}
+                  disabled={hasSingleEnv || isLoading}
+                >
+                  <FormControl>
+                    <SelectTrigger className="w-full">
+                      <SelectValue
+                        placeholder={
+                          isLoading
+                            ? "Loading environments..."
+                            : "Select an environment"
+                        }
+                      />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {environments.map((env) => (
+                      <SelectItem key={env.id} value={env.id}>
+                        {env.name}
+                        <span className="ml-2 text-xs text-muted-foreground">
+                          ({env.networkType})
+                        </span>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/app/applications/new/components/configuration-step.tsx
+++ b/client/src/app/applications/new/components/configuration-step.tsx
@@ -1,0 +1,536 @@
+import { useState } from "react";
+import { useFormContext, useFieldArray } from "react-hook-form";
+import {
+  IconPlus,
+  IconTrash,
+  IconFileImport,
+} from "@tabler/icons-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { CreateApplicationFormData } from "@/lib/application-schemas";
+import { PasteEnvDialog } from "./paste-env-dialog";
+
+export function ConfigurationStep() {
+  const form = useFormContext<CreateApplicationFormData>();
+
+  const portsArray = useFieldArray({ control: form.control, name: "ports" });
+  const envArray = useFieldArray({ control: form.control, name: "envVars" });
+  const volumesArray = useFieldArray({
+    control: form.control,
+    name: "volumeMounts",
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Configuration</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Tabs defaultValue="env" className="w-full">
+          <TabsList className="grid w-full grid-cols-5">
+            <TabsTrigger value="env">Env vars</TabsTrigger>
+            <TabsTrigger value="volumes">Volumes</TabsTrigger>
+            <TabsTrigger value="health">Health check</TabsTrigger>
+            <TabsTrigger value="ports">Ports</TabsTrigger>
+            <TabsTrigger value="advanced">Advanced</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="env" className="mt-4 space-y-3">
+            <EnvVarsTab
+              fields={envArray.fields}
+              append={envArray.append}
+              remove={envArray.remove}
+            />
+          </TabsContent>
+
+          <TabsContent value="volumes" className="mt-4 space-y-3">
+            <VolumesTab
+              fields={volumesArray.fields}
+              append={volumesArray.append}
+              remove={volumesArray.remove}
+            />
+          </TabsContent>
+
+          <TabsContent value="health" className="mt-4 space-y-4">
+            <HealthCheckTab />
+          </TabsContent>
+
+          <TabsContent value="ports" className="mt-4 space-y-3">
+            <PortsTab
+              fields={portsArray.fields}
+              append={portsArray.append}
+              remove={portsArray.remove}
+            />
+          </TabsContent>
+
+          <TabsContent value="advanced" className="mt-4 space-y-4">
+            <AdvancedTab />
+          </TabsContent>
+        </Tabs>
+      </CardContent>
+    </Card>
+  );
+}
+
+type PortsArray = ReturnType<
+  typeof useFieldArray<CreateApplicationFormData, "ports">
+>;
+function PortsTab({
+  fields,
+  append,
+  remove,
+}: Pick<PortsArray, "fields" | "append" | "remove">) {
+  const form = useFormContext<CreateApplicationFormData>();
+
+  return (
+    <>
+      <p className="text-sm text-muted-foreground">
+        By default, no ports are exposed on the host. Internal container ports
+        are still reachable from other services in the same environment
+        (including HAProxy). Only add a mapping if you need direct host access.
+      </p>
+      {fields.map((field, index) => (
+        <div key={field.id} className="flex items-end gap-2">
+          <FormField
+            control={form.control}
+            name={`ports.${index}.hostPort`}
+            render={({ field }) => (
+              <FormItem className="flex-1">
+                {index === 0 && <FormLabel>Host port</FormLabel>}
+                <FormControl>
+                  <Input
+                    type="number"
+                    placeholder="8080"
+                    value={field.value || ""}
+                    onChange={(e) =>
+                      field.onChange(
+                        e.target.value ? Number(e.target.value) : 0,
+                      )
+                    }
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name={`ports.${index}.containerPort`}
+            render={({ field }) => (
+              <FormItem className="flex-1">
+                {index === 0 && <FormLabel>Container port</FormLabel>}
+                <FormControl>
+                  <Input
+                    type="number"
+                    placeholder="80"
+                    value={field.value || ""}
+                    onChange={(e) =>
+                      field.onChange(
+                        e.target.value ? Number(e.target.value) : 0,
+                      )
+                    }
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name={`ports.${index}.protocol`}
+            render={({ field }) => (
+              <FormItem className="w-24">
+                {index === 0 && <FormLabel>Protocol</FormLabel>}
+                <Select onValueChange={field.onChange} value={field.value}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="tcp">TCP</SelectItem>
+                    <SelectItem value="udp">UDP</SelectItem>
+                  </SelectContent>
+                </Select>
+              </FormItem>
+            )}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={() => remove(index)}
+          >
+            <IconTrash className="h-4 w-4" />
+          </Button>
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() =>
+          append({ hostPort: 0, containerPort: 0, protocol: "tcp" })
+        }
+      >
+        <IconPlus className="mr-1 h-4 w-4" />
+        Add port
+      </Button>
+    </>
+  );
+}
+
+type EnvArray = ReturnType<
+  typeof useFieldArray<CreateApplicationFormData, "envVars">
+>;
+function EnvVarsTab({
+  fields,
+  append,
+  remove,
+}: Pick<EnvArray, "fields" | "append" | "remove">) {
+  const form = useFormContext<CreateApplicationFormData>();
+  const [pasteOpen, setPasteOpen] = useState(false);
+
+  const handlePaste = (entries: { key: string; value: string }[]) => {
+    const current = form.getValues("envVars");
+    const byKey = new Map(current.map((e) => [e.key, e.value]));
+    for (const entry of entries) {
+      byKey.set(entry.key, entry.value);
+    }
+    const merged = Array.from(byKey, ([key, value]) => ({ key, value }));
+    form.setValue("envVars", merged, { shouldDirty: true });
+  };
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          {fields.length === 0
+            ? "No environment variables configured."
+            : `${fields.length} variable${fields.length === 1 ? "" : "s"}.`}
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => setPasteOpen(true)}
+        >
+          <IconFileImport className="mr-1 h-4 w-4" />
+          Paste .env
+        </Button>
+      </div>
+
+      {fields.map((field, index) => (
+        <div key={field.id} className="flex items-end gap-2">
+          <FormField
+            control={form.control}
+            name={`envVars.${index}.key`}
+            render={({ field }) => (
+              <FormItem className="flex-1">
+                {index === 0 && <FormLabel>Key</FormLabel>}
+                <FormControl>
+                  <Input placeholder="ENV_VAR" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name={`envVars.${index}.value`}
+            render={({ field }) => (
+              <FormItem className="flex-1">
+                {index === 0 && <FormLabel>Value</FormLabel>}
+                <FormControl>
+                  <Input placeholder="value" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={() => remove(index)}
+          >
+            <IconTrash className="h-4 w-4" />
+          </Button>
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => append({ key: "", value: "" })}
+      >
+        <IconPlus className="mr-1 h-4 w-4" />
+        Add variable
+      </Button>
+
+      <PasteEnvDialog
+        open={pasteOpen}
+        onOpenChange={setPasteOpen}
+        onApply={handlePaste}
+      />
+    </>
+  );
+}
+
+type VolumesArray = ReturnType<
+  typeof useFieldArray<CreateApplicationFormData, "volumeMounts">
+>;
+function VolumesTab({
+  fields,
+  append,
+  remove,
+}: Pick<VolumesArray, "fields" | "append" | "remove">) {
+  const form = useFormContext<CreateApplicationFormData>();
+
+  return (
+    <>
+      {fields.length === 0 && (
+        <p className="text-sm text-muted-foreground">No volumes mounted.</p>
+      )}
+      {fields.map((field, index) => (
+        <div key={field.id} className="flex items-end gap-2">
+          <FormField
+            control={form.control}
+            name={`volumeMounts.${index}.name`}
+            render={({ field }) => (
+              <FormItem className="flex-1">
+                {index === 0 && <FormLabel>Volume name</FormLabel>}
+                <FormControl>
+                  <Input placeholder="data-volume" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name={`volumeMounts.${index}.mountPath`}
+            render={({ field }) => (
+              <FormItem className="flex-1">
+                {index === 0 && <FormLabel>Mount path</FormLabel>}
+                <FormControl>
+                  <Input placeholder="/data" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={() => remove(index)}
+          >
+            <IconTrash className="h-4 w-4" />
+          </Button>
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => append({ name: "", mountPath: "" })}
+      >
+        <IconPlus className="mr-1 h-4 w-4" />
+        Add volume
+      </Button>
+    </>
+  );
+}
+
+function HealthCheckTab() {
+  const form = useFormContext<CreateApplicationFormData>();
+  const enabled = form.watch("enableHealthCheck");
+
+  return (
+    <>
+      <FormField
+        control={form.control}
+        name="enableHealthCheck"
+        render={({ field }) => (
+          <FormItem className="flex items-center gap-3">
+            <FormControl>
+              <Switch checked={field.value} onCheckedChange={field.onChange} />
+            </FormControl>
+            <FormLabel className="!mt-0">Enable health check</FormLabel>
+          </FormItem>
+        )}
+      />
+
+      {enabled && (
+        <>
+          <FormField
+            control={form.control}
+            name="healthCheck.test"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Command</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="curl -f http://localhost/ || exit 1"
+                    {...field}
+                  />
+                </FormControl>
+                <FormDescription>
+                  Shell command that exits 0 when healthy.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div className="grid grid-cols-2 gap-4">
+            <FormField
+              control={form.control}
+              name="healthCheck.interval"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Interval (seconds)</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      value={field.value || ""}
+                      onChange={(e) =>
+                        field.onChange(
+                          e.target.value ? Number(e.target.value) : 0,
+                        )
+                      }
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="healthCheck.timeout"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Timeout (seconds)</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      value={field.value || ""}
+                      onChange={(e) =>
+                        field.onChange(
+                          e.target.value ? Number(e.target.value) : 0,
+                        )
+                      }
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <FormField
+              control={form.control}
+              name="healthCheck.retries"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Retries</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      value={field.value || ""}
+                      onChange={(e) =>
+                        field.onChange(
+                          e.target.value ? Number(e.target.value) : 0,
+                        )
+                      }
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="healthCheck.startPeriod"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Start period (seconds)</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      value={field.value ?? ""}
+                      onChange={(e) =>
+                        field.onChange(
+                          e.target.value ? Number(e.target.value) : 0,
+                        )
+                      }
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </>
+      )}
+    </>
+  );
+}
+
+function AdvancedTab() {
+  const form = useFormContext<CreateApplicationFormData>();
+
+  return (
+    <FormField
+      control={form.control}
+      name="restartPolicy"
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>Restart policy</FormLabel>
+          <Select onValueChange={field.onChange} value={field.value}>
+            <FormControl>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              <SelectItem value="no">No</SelectItem>
+              <SelectItem value="always">Always</SelectItem>
+              <SelectItem value="unless-stopped">Unless stopped</SelectItem>
+              <SelectItem value="on-failure">On failure</SelectItem>
+            </SelectContent>
+          </Select>
+          <FormDescription>
+            What Docker should do if the container exits.
+          </FormDescription>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}

--- a/client/src/app/applications/new/components/image-step.tsx
+++ b/client/src/app/applications/new/components/image-step.tsx
@@ -1,0 +1,247 @@
+import { useState } from "react";
+import { useFormContext } from "react-hook-form";
+import { Link } from "react-router-dom";
+import {
+  IconAlertCircle,
+  IconCheck,
+  IconExternalLink,
+  IconLoader2,
+} from "@tabler/icons-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  useDetectImagePorts,
+  type ImageValidationResult,
+} from "@/hooks/use-detect-image-ports";
+import type { CreateApplicationFormData } from "@/lib/application-schemas";
+
+type RegistryChoice = "docker.io" | "ghcr.io" | "other";
+
+interface Props {
+  onValidated: (payload: { image: string; ports: number[] }) => void;
+  onReset: () => void;
+  validated: boolean;
+}
+
+function assembleImage(
+  registry: RegistryChoice,
+  customRegistry: string,
+  containerName: string,
+): string {
+  const name = containerName.trim();
+  if (registry === "docker.io") return name;
+  if (registry === "ghcr.io") return `ghcr.io/${name}`;
+  const host = customRegistry.trim().replace(/\/+$/, "");
+  return host ? `${host}/${name}` : name;
+}
+
+export function ImageStep({ onValidated, onReset, validated }: Props) {
+  const form = useFormContext<CreateApplicationFormData>();
+  const detect = useDetectImagePorts();
+
+  const [registry, setRegistry] = useState<RegistryChoice>("docker.io");
+  const [customRegistry, setCustomRegistry] = useState("");
+  const [containerName, setContainerName] = useState("");
+  const [result, setResult] = useState<ImageValidationResult | null>(null);
+
+  const tag = form.watch("dockerTag");
+
+  const canValidate =
+    containerName.trim().length > 0 &&
+    tag.trim().length > 0 &&
+    (registry !== "other" || customRegistry.trim().length > 0) &&
+    !detect.isPending;
+
+  const resetValidation = () => {
+    setResult(null);
+    if (validated) onReset();
+  };
+
+  const handleValidate = async () => {
+    const fullImage = assembleImage(registry, customRegistry, containerName);
+    const validation = await detect.mutateAsync({
+      image: fullImage,
+      tag: tag.trim(),
+    });
+    setResult(validation);
+
+    if (validation.status === "success") {
+      form.setValue("dockerImage", fullImage, { shouldValidate: true });
+      onValidated({ image: fullImage, ports: validation.ports });
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Container image</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-[200px_1fr]">
+          <div className="space-y-2">
+            <Label>Registry</Label>
+            <Select
+              value={registry}
+              onValueChange={(v) => {
+                setRegistry(v as RegistryChoice);
+                resetValidation();
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="docker.io">docker.io</SelectItem>
+                <SelectItem value="ghcr.io">ghcr.io</SelectItem>
+                <SelectItem value="other">Other…</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {registry === "other" && (
+            <div className="space-y-2">
+              <Label>Registry host</Label>
+              <Input
+                placeholder="quay.io"
+                value={customRegistry}
+                onChange={(e) => {
+                  setCustomRegistry(e.target.value);
+                  resetValidation();
+                }}
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-[1fr_200px]">
+          <div className="space-y-2">
+            <Label>Container name</Label>
+            <Input
+              placeholder={
+                registry === "docker.io"
+                  ? "nginx or library/nginx"
+                  : "owner/repo"
+              }
+              value={containerName}
+              onChange={(e) => {
+                setContainerName(e.target.value);
+                resetValidation();
+              }}
+              data-tour="new-app-docker-image-input"
+            />
+          </div>
+
+          <FormField
+            control={form.control}
+            name="dockerTag"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Tag</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="latest"
+                    {...field}
+                    onChange={(e) => {
+                      field.onChange(e);
+                      resetValidation();
+                    }}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <Button
+          type="button"
+          variant={validated ? "outline" : "default"}
+          onClick={handleValidate}
+          disabled={!canValidate}
+        >
+          {detect.isPending && (
+            <IconLoader2 className="mr-2 h-4 w-4 animate-spin" />
+          )}
+          {validated ? "Re-validate" : "Validate"}
+        </Button>
+
+        {result && <ResultDisplay result={result} />}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ResultDisplay({ result }: { result: ImageValidationResult }) {
+  if (result.status === "success") {
+    return (
+      <div className="flex items-start gap-3 rounded-md border border-emerald-500/50 bg-emerald-500/10 p-3 text-sm">
+        <IconCheck className="mt-0.5 h-5 w-5 shrink-0 text-emerald-600" />
+        <div className="text-emerald-900 dark:text-emerald-100">
+          <p className="font-medium">Image verified</p>
+          <p className="mt-1">
+            {result.ports.length === 0
+              ? "No exposed ports detected in this image. You can configure ports manually below."
+              : result.ports.length === 1
+                ? `Detected exposed port: ${result.ports[0]}.`
+                : `Detected exposed ports: ${result.ports.join(", ")}.`}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (result.status === "auth-required") {
+    return (
+      <div className="flex items-start gap-3 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+        <IconAlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
+        <div>
+          <p className="font-medium">Authentication required</p>
+          <p className="mt-1 text-destructive/80">
+            This registry requires credentials we don&apos;t have. Add a credential
+            and try again.
+          </p>
+          <Link
+            to="/settings/registry-credentials"
+            className="mt-2 inline-flex items-center gap-1 underline"
+          >
+            Manage registry credentials
+            <IconExternalLink className="h-3 w-3" />
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-start gap-3 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+      <IconAlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
+      <div>
+        <p className="font-medium">
+          {result.status === "not-found" ? "Image not found" : "Validation failed"}
+        </p>
+        <p className="mt-1 text-destructive/80">{result.message}</p>
+      </div>
+    </div>
+  );
+}

--- a/client/src/app/applications/new/components/paste-env-dialog.tsx
+++ b/client/src/app/applications/new/components/paste-env-dialog.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { parseDotenv } from "@/lib/parse-dotenv";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onApply: (entries: { key: string; value: string }[]) => void;
+}
+
+export function PasteEnvDialog({ open, onOpenChange, onApply }: Props) {
+  const [text, setText] = useState("");
+
+  const handleApply = () => {
+    const entries = parseDotenv(text);
+    onApply(entries);
+    setText("");
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) setText("");
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Paste .env</DialogTitle>
+          <DialogDescription>
+            Paste the contents of a <code>.env</code> file. Lines like{" "}
+            <code>KEY=value</code> are parsed. Comments and blank lines are
+            skipped. Duplicate keys overwrite existing values.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder={"# database\nDB_HOST=localhost\nDB_PORT=5432\n\n# api\nAPI_KEY=\"secret\""}
+          className="min-h-[220px] font-mono text-sm"
+          autoFocus
+        />
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleApply}
+            disabled={text.trim().length === 0}
+          >
+            Apply
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/app/applications/new/components/routing-step.tsx
+++ b/client/src/app/applications/new/components/routing-step.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
+import { Link } from "react-router-dom";
+import { IconAlertTriangle, IconExternalLink } from "@tabler/icons-react";
 import {
   Card,
   CardContent,
@@ -24,6 +26,10 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useDnsZones } from "@/hooks/use-dns";
+import {
+  useCloudflareConnectivity,
+  useCloudflareSettings,
+} from "@/hooks/use-cloudflare-settings";
 import type { CreateApplicationFormData } from "@/lib/application-schemas";
 
 interface Props {
@@ -51,6 +57,16 @@ export function RoutingStep({ networkType, detectedPorts }: Props) {
   const { data: zonesData, isLoading: zonesLoading } = useDnsZones();
   const zones = zonesData?.data?.zones ?? [];
 
+  const { data: cfSettings } = useCloudflareSettings();
+  const { data: cfConnectivity } = useCloudflareConnectivity();
+  const cfConfigured = cfSettings?.data?.isConfigured ?? false;
+  const cfConnected = cfConnectivity?.data?.status === "connected";
+  const cfWarning = !cfConfigured
+    ? "Cloudflare is not configured. DNS integration requires Cloudflare to create records and manage zones."
+    : !cfConnected
+      ? "Cloudflare is configured but not reachable. DNS zones shown below may be stale, and deployment may fail to provision DNS records."
+      : null;
+
   const [subdomain, setSubdomain] = useState(() => kebabCase(displayName));
   const [zoneName, setZoneName] = useState<string>("");
 
@@ -77,6 +93,23 @@ export function RoutingStep({ networkType, detectedPorts }: Props) {
         <CardTitle>Routing</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
+        {cfWarning && (
+          <div className="flex items-start gap-3 rounded-md border border-amber-500/50 bg-amber-500/10 p-3 text-sm text-amber-900 dark:text-amber-100">
+            <IconAlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-600" />
+            <div>
+              <p className="font-medium">Cloudflare connection issue</p>
+              <p className="mt-1 opacity-90">{cfWarning}</p>
+              <Link
+                to="/connectivity/cloudflare"
+                className="mt-2 inline-flex items-center gap-1 underline"
+              >
+                Configure Cloudflare
+                <IconExternalLink className="h-3 w-3" />
+              </Link>
+            </div>
+          </div>
+        )}
+
         <div className="space-y-2">
           <Label>Hostname</Label>
           <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-center">

--- a/client/src/app/applications/new/components/routing-step.tsx
+++ b/client/src/app/applications/new/components/routing-step.tsx
@@ -61,26 +61,38 @@ export function RoutingStep({ networkType, detectedPorts }: Props) {
   const { data: zonesData, isLoading: zonesLoading } = useDnsZones();
   const zones = zonesData?.data?.zones ?? [];
 
-  const { data: cfSettings } = useCloudflareSettings();
-  const { data: cfConnectivity } = useCloudflareConnectivity();
+  const { data: cfSettings, isLoading: cfSettingsLoading } =
+    useCloudflareSettings();
+  const { data: cfConnectivity, isLoading: cfConnLoading } =
+    useCloudflareConnectivity();
   const cfConfigured = cfSettings?.data?.isConfigured ?? false;
-  const cfConnected = cfConnectivity?.data?.status === "connected";
-  const cfWarning = !cfConfigured
-    ? "Cloudflare is not configured. DNS integration requires Cloudflare to create records and manage zones."
-    : !cfConnected
-      ? "Cloudflare is configured but not reachable. DNS zones shown below may be stale, and deployment may fail to provision DNS records."
-      : null;
+  const cfConnected = cfConnectivity?.status === "connected";
+  const cfLoading = cfSettingsLoading || cfConnLoading;
+  const cfNeedsTunnel = networkType === "internet";
+  const cfWarning = cfLoading
+    ? null
+    : !cfConfigured
+      ? cfNeedsTunnel
+        ? "Cloudflare is not configured. Internet applications require Cloudflare to provision tunnel ingress and DNS records."
+        : "Cloudflare is not configured. DNS integration requires Cloudflare to create records and manage zones."
+      : !cfConnected
+        ? cfNeedsTunnel
+          ? "Cloudflare is configured but not reachable. DNS zones shown below may be stale, and deployment may fail to provision tunnel ingress or DNS records."
+          : "Cloudflare is configured but not reachable. DNS zones shown below may be stale, and deployment may fail to provision DNS records."
+        : null;
 
-  const { data: azSettings } = useAzureSettings({
+  const { data: azSettings, isLoading: azSettingsLoading } = useAzureSettings({
     enabled: networkType === "local",
   });
-  const { data: azConnectivity } = useAzureConnectivityStatus({
-    enabled: networkType === "local",
-  });
+  const { data: azConnectivity, isLoading: azConnLoading } =
+    useAzureConnectivityStatus({
+      enabled: networkType === "local",
+    });
   const azConfigured = azSettings?.data?.connectionConfigured ?? false;
   const azConnected = azConnectivity?.status === "connected";
+  const azLoading = azSettingsLoading || azConnLoading;
   const azWarning =
-    networkType === "local"
+    networkType === "local" && !azLoading
       ? !azConfigured
         ? "Azure Storage is not configured. Local applications use Let's Encrypt certificates, which are stored in Azure Blob Storage. Without it, TLS provisioning will fail on deploy."
         : !azConnected

--- a/client/src/app/applications/new/components/routing-step.tsx
+++ b/client/src/app/applications/new/components/routing-step.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useState } from "react";
+import { useFormContext } from "react-hook-form";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useDnsZones } from "@/hooks/use-dns";
+import type { CreateApplicationFormData } from "@/lib/application-schemas";
+
+interface Props {
+  networkType?: "local" | "internet";
+  detectedPorts: number[];
+}
+
+function kebabCase(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function buildHostname(subdomain: string, zone: string): string {
+  const sub = subdomain.trim().replace(/^\.+|\.+$/g, "");
+  if (!zone) return sub;
+  if (!sub) return zone;
+  return `${sub}.${zone}`;
+}
+
+export function RoutingStep({ networkType, detectedPorts }: Props) {
+  const form = useFormContext<CreateApplicationFormData>();
+  const displayName = form.watch("displayName");
+  const { data: zonesData, isLoading: zonesLoading } = useDnsZones();
+  const zones = zonesData?.data?.zones ?? [];
+
+  const [subdomain, setSubdomain] = useState(() => kebabCase(displayName));
+  const [zoneName, setZoneName] = useState<string>("");
+
+  // Seed zone when zones load
+  useEffect(() => {
+    if (!zoneName && zones.length > 0) {
+      setZoneName(zones[0].name);
+    }
+  }, [zones, zoneName]);
+
+  // Keep hidden form field in sync with subdomain + zone
+  useEffect(() => {
+    form.setValue("routing.hostname", buildHostname(subdomain, zoneName), {
+      shouldValidate: true,
+    });
+  }, [subdomain, zoneName, form]);
+
+  const showPortSelect = detectedPorts.length >= 2;
+  const fullHostname = buildHostname(subdomain, zoneName);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Routing</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label>Hostname</Label>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-center">
+            <Input
+              placeholder="app"
+              value={subdomain}
+              onChange={(e) => setSubdomain(e.target.value)}
+            />
+            <span className="text-muted-foreground text-center">.</span>
+            <Select
+              value={zoneName}
+              onValueChange={setZoneName}
+              disabled={zonesLoading || zones.length === 0}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue
+                  placeholder={
+                    zonesLoading
+                      ? "Loading zones..."
+                      : zones.length === 0
+                        ? "No DNS zones"
+                        : "Select a zone"
+                  }
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {zones.map((zone) => (
+                  <SelectItem key={zone.id} value={zone.name}>
+                    {zone.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <p className="text-muted-foreground text-sm">
+            {fullHostname
+              ? `Full hostname: ${fullHostname}`
+              : "Enter a subdomain and choose a zone."}
+          </p>
+          {/* Hidden form field drives validation + submission */}
+          <FormField
+            control={form.control}
+            name="routing.hostname"
+            render={() => (
+              <FormItem>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <FormField
+          control={form.control}
+          name="routing.listeningPort"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Listening port</FormLabel>
+              <FormControl>
+                {showPortSelect ? (
+                  <Select
+                    value={String(field.value)}
+                    onValueChange={(val) => field.onChange(Number(val))}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {detectedPorts.map((port) => (
+                        <SelectItem key={port} value={String(port)}>
+                          {port}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ) : (
+                  <Input
+                    type="number"
+                    placeholder="80"
+                    value={field.value || ""}
+                    onChange={(e) =>
+                      field.onChange(
+                        e.target.value ? Number(e.target.value) : 0,
+                      )
+                    }
+                  />
+                )}
+              </FormControl>
+              <FormDescription>
+                The port your application listens on inside the container.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {networkType && (
+          <div className="rounded-md bg-muted p-3 text-sm text-muted-foreground">
+            {networkType === "local" &&
+              "A TLS certificate and DNS record will be automatically created for this hostname."}
+            {networkType === "internet" &&
+              "A Cloudflare tunnel ingress will be automatically created for this hostname."}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/app/applications/new/components/routing-step.tsx
+++ b/client/src/app/applications/new/components/routing-step.tsx
@@ -30,6 +30,10 @@ import {
   useCloudflareConnectivity,
   useCloudflareSettings,
 } from "@/hooks/use-cloudflare-settings";
+import {
+  useAzureSettings,
+  useAzureConnectivityStatus,
+} from "@/hooks/use-azure-settings";
 import type { CreateApplicationFormData } from "@/lib/application-schemas";
 
 interface Props {
@@ -65,6 +69,23 @@ export function RoutingStep({ networkType, detectedPorts }: Props) {
     ? "Cloudflare is not configured. DNS integration requires Cloudflare to create records and manage zones."
     : !cfConnected
       ? "Cloudflare is configured but not reachable. DNS zones shown below may be stale, and deployment may fail to provision DNS records."
+      : null;
+
+  const { data: azSettings } = useAzureSettings({
+    enabled: networkType === "local",
+  });
+  const { data: azConnectivity } = useAzureConnectivityStatus({
+    enabled: networkType === "local",
+  });
+  const azConfigured = azSettings?.data?.connectionConfigured ?? false;
+  const azConnected = azConnectivity?.status === "connected";
+  const azWarning =
+    networkType === "local"
+      ? !azConfigured
+        ? "Azure Storage is not configured. Local applications use Let's Encrypt certificates, which are stored in Azure Blob Storage. Without it, TLS provisioning will fail on deploy."
+        : !azConnected
+          ? "Azure Storage is configured but not reachable. TLS certificate provisioning may fail on deploy."
+          : null
       : null;
 
   const [subdomain, setSubdomain] = useState(() => kebabCase(displayName));
@@ -104,6 +125,23 @@ export function RoutingStep({ networkType, detectedPorts }: Props) {
                 className="mt-2 inline-flex items-center gap-1 underline"
               >
                 Configure Cloudflare
+                <IconExternalLink className="h-3 w-3" />
+              </Link>
+            </div>
+          </div>
+        )}
+
+        {azWarning && (
+          <div className="flex items-start gap-3 rounded-md border border-amber-500/50 bg-amber-500/10 p-3 text-sm text-amber-900 dark:text-amber-100">
+            <IconAlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-600" />
+            <div>
+              <p className="font-medium">Azure Storage connection issue</p>
+              <p className="mt-1 opacity-90">{azWarning}</p>
+              <Link
+                to="/connectivity-azure"
+                className="mt-2 inline-flex items-center gap-1 underline"
+              >
+                Configure Azure Storage
                 <IconExternalLink className="h-3 w-3" />
               </Link>
             </div>

--- a/client/src/app/applications/new/components/service-type-step.tsx
+++ b/client/src/app/applications/new/components/service-type-step.tsx
@@ -1,0 +1,101 @@
+import { useFormContext } from "react-hook-form";
+import { IconAlertTriangle, IconServer, IconWorld } from "@tabler/icons-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import type { StackServiceType } from "@mini-infra/types";
+import type { CreateApplicationFormData } from "@/lib/application-schemas";
+
+interface Props {
+  showHaproxyWarning: boolean;
+}
+
+const OPTIONS: Array<{
+  value: StackServiceType;
+  label: string;
+  description: string;
+  icon: typeof IconWorld;
+}> = [
+  {
+    value: "StatelessWeb",
+    label: "Stateless web app",
+    description: "Web server or API. Routed by HAProxy with zero-downtime deploys.",
+    icon: IconWorld,
+  },
+  {
+    value: "Stateful",
+    label: "Stateful service",
+    description: "Database, cache, or other persistent service. Stop/start replacement.",
+    icon: IconServer,
+  },
+];
+
+export function ServiceTypeStep({ showHaproxyWarning }: Props) {
+  const form = useFormContext<CreateApplicationFormData>();
+  const value = form.watch("serviceType");
+
+  const setType = (next: StackServiceType) => {
+    form.setValue("serviceType", next, { shouldValidate: true });
+    form.setValue("serviceName", next === "StatelessWeb" ? "web" : "stateful", {
+      shouldValidate: true,
+    });
+    form.setValue("enableRouting", next === "StatelessWeb", {
+      shouldValidate: true,
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Service type</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {OPTIONS.map((opt) => {
+            const Icon = opt.icon;
+            const selected = value === opt.value;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setType(opt.value)}
+                className={cn(
+                  "flex flex-col items-start gap-2 rounded-lg border p-4 text-left transition-colors",
+                  selected
+                    ? "border-primary bg-primary/5"
+                    : "border-border hover:border-primary/50",
+                )}
+              >
+                <div className="flex items-center gap-2">
+                  <Icon className="h-4 w-4" />
+                  <span className="font-medium">{opt.label}</span>
+                </div>
+                <span className="text-sm text-muted-foreground">
+                  {opt.description}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        {showHaproxyWarning && (
+          <div className="flex items-start gap-3 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+            <IconAlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
+            <div>
+              <p className="font-medium">HAProxy stack required</p>
+              <p className="mt-1 text-destructive/80">
+                Stateless web applications require a deployed HAProxy stack with
+                an applications network in this environment. Deploy an HAProxy
+                stack in the environment&apos;s infrastructure first.
+              </p>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/app/applications/new/page.tsx
+++ b/client/src/app/applications/new/page.tsx
@@ -1,55 +1,32 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useForm, useFieldArray } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { IconArrowLeft, IconLoader2 } from "@tabler/icons-react";
 import {
-  IconAlertTriangle,
-  IconArrowLeft,
-  IconLoader2,
-  IconPlus,
-  IconTrash,
-} from "@tabler/icons-react";
-import { useCreateApplication } from "@/hooks/use-applications";
+  useCreateApplication,
+  useUserStacks,
+} from "@/hooks/use-applications";
 import { useEnvironments } from "@/hooks/use-environments";
 import { useStacks } from "@/hooks/use-stacks";
-import { useDetectImagePorts } from "@/hooks/use-detect-image-ports";
 import { useTaskTracker } from "@/hooks/use-task-tracker";
 import { Channel } from "@mini-infra/types";
-import type { StackResourceOutput } from "@mini-infra/types";
+import type { StackResourceOutput, StackServiceType } from "@mini-infra/types";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { Form, FormControl, FormField, FormItem, FormLabel } from "@/components/ui/form";
 import { Switch } from "@/components/ui/switch";
-import type { StackServiceType } from "@mini-infra/types";
 import {
   createApplicationFormSchema,
   createApplicationDefaults,
   type CreateApplicationFormData,
 } from "@/lib/application-schemas";
+
+import { BasicsStep } from "./components/basics-step";
+import { ServiceTypeStep } from "./components/service-type-step";
+import { ImageStep } from "./components/image-step";
+import { ConfigurationStep } from "./components/configuration-step";
+import { RoutingStep } from "./components/routing-step";
 
 export default function NewApplicationPage() {
   const navigate = useNavigate();
@@ -61,41 +38,22 @@ export default function NewApplicationPage() {
     defaultValues: createApplicationDefaults,
   });
 
-  const {
-    fields: portFields,
-    append: appendPort,
-    remove: removePort,
-  } = useFieldArray({ control: form.control, name: "ports" });
-
-  const {
-    fields: envFields,
-    append: appendEnv,
-    remove: removeEnv,
-  } = useFieldArray({ control: form.control, name: "envVars" });
-
-  const {
-    fields: volumeFields,
-    append: appendVolume,
-    remove: removeVolume,
-  } = useFieldArray({ control: form.control, name: "volumeMounts" });
-
-  const { data: envData } = useEnvironments();
+  const { data: envData, isLoading: environmentsLoading } = useEnvironments();
   const environments = envData?.environments ?? [];
 
-  const detectPorts = useDetectImagePorts();
+  const [imageValidated, setImageValidated] = useState(false);
   const [detectedPorts, setDetectedPorts] = useState<number[]>([]);
-  const [useCustomPort, setUseCustomPort] = useState(false);
 
   const selectedEnvId = form.watch("environmentId");
+  const displayName = form.watch("displayName");
   const serviceType = form.watch("serviceType");
-  const enableRouting = form.watch("enableRouting");
-  const enableHealthCheck = form.watch("enableHealthCheck");
+  const deployImmediately = form.watch("deployImmediately");
 
   const selectedEnvironment = environments.find((e) => e.id === selectedEnvId);
   const networkType = selectedEnvironment?.networkType;
 
-  // Check if HAProxy stack with applications network exists in the selected environment
   const { data: stacksData } = useStacks(selectedEnvId);
+  const { data: userStacksData } = useUserStacks();
   const hasHaproxyApplicationsNetwork = (stacksData?.data ?? []).some(
     (stack) =>
       stack.status === "synced" &&
@@ -103,65 +61,88 @@ export default function NewApplicationPage() {
         (o) => o.type === "docker-network" && o.purpose === "applications",
       ),
   );
+
   const showHaproxyWarning =
-    serviceType === "StatelessWeb" && selectedEnvId && !hasHaproxyApplicationsNetwork;
+    serviceType === "StatelessWeb" &&
+    !!selectedEnvId &&
+    !hasHaproxyApplicationsNetwork;
 
-  const setFormValue = form.setValue;
+  // Progression gates
+  const hasBasics =
+    Boolean(selectedEnvId) && displayName.trim().length > 0;
+  const hasServiceType =
+    hasBasics &&
+    Boolean(serviceType) &&
+    (serviceType !== "StatelessWeb" || hasHaproxyApplicationsNetwork);
+  const canShowConfig = hasServiceType && imageValidated;
+  const canShowRouting = canShowConfig && serviceType === "StatelessWeb";
+  const canShowCreate =
+    canShowConfig && (serviceType !== "StatelessWeb" || canShowRouting);
 
-  useEffect(() => {
-    if (!selectedEnvId || !serviceType) return;
-    setFormValue("enableRouting", serviceType === "StatelessWeb");
-  }, [selectedEnvId, serviceType, setFormValue]);
+  const handleImageValidated = ({
+    image,
+    ports,
+  }: {
+    image: string;
+    ports: number[];
+  }) => {
+    setImageValidated(true);
+    setDetectedPorts(ports);
 
-  const handleDetectPorts = async () => {
-    const image = form.getValues("dockerImage");
-    const tag = form.getValues("dockerTag");
-    if (!image || !tag) return;
-
-    try {
-      const ports = await detectPorts.mutateAsync({ image, tag });
-      setDetectedPorts(ports);
-      setUseCustomPort(false);
-      if (ports.length >= 1) {
-        form.setValue("routing.listeningPort", ports[0], { shouldDirty: true, shouldValidate: true });
-      } else {
-        toast.info("No exposed ports found in this image");
-      }
-    } catch {
-      toast.error("Couldn't detect ports — you can set the port manually");
+    // For routing: default listeningPort to the first detected port
+    if (ports.length >= 1) {
+      form.setValue("routing.listeningPort", ports[0], {
+        shouldValidate: true,
+      });
     }
+
+    // Make sure dockerImage is set (ImageStep already does this, but belt & braces)
+    form.setValue("dockerImage", image, { shouldValidate: true });
   };
 
-  const dockerImage = form.watch("dockerImage");
-  const dockerTag = form.watch("dockerTag");
-
-  useEffect(() => {
+  const handleImageReset = () => {
+    setImageValidated(false);
     setDetectedPorts([]);
-    setUseCustomPort(false);
-  }, [dockerImage, dockerTag]);
+  };
 
   const onSubmit = async (data: CreateApplicationFormData) => {
-    // Prevent creation of StatelessWeb apps without HAProxy
-    if (data.serviceType === "StatelessWeb" && !hasHaproxyApplicationsNetwork) {
+    if (
+      data.serviceType === "StatelessWeb" &&
+      !hasHaproxyApplicationsNetwork
+    ) {
       toast.error(
-        "This environment does not have a deployed HAProxy stack with an applications network. Deploy an HAProxy stack first before creating a stateless web application.",
+        "This environment does not have a deployed HAProxy stack with an applications network.",
       );
       return;
     }
 
-    // Build the template name from display name
+    // Hostname uniqueness check — against existing stack service routing
+    if (data.enableRouting && data.routing?.hostname) {
+      const desired = data.routing.hostname.trim().toLowerCase();
+      const takenBy = (userStacksData?.data ?? []).find((stack) =>
+        (stack.services ?? []).some(
+          (svc) =>
+            svc.routing?.hostname?.trim().toLowerCase() === desired,
+        ),
+      );
+      if (takenBy) {
+        toast.error(
+          `Hostname "${data.routing.hostname}" is already used by "${takenBy.name}".`,
+        );
+        return;
+      }
+    }
+
     const templateName = data.displayName
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, "-")
       .replace(/^-|-$/g, "");
 
-    // Build env vars as Record
     const env: Record<string, string> = {};
     for (const e of data.envVars) {
       if (e.key) env[e.key] = e.value;
     }
 
-    // Build volumes and mounts
     const volumes = data.volumeMounts.map((v) => ({ name: v.name }));
     const mounts = data.volumeMounts.map((v) => ({
       source: v.name,
@@ -169,14 +150,12 @@ export default function NewApplicationPage() {
       type: "volume" as const,
     }));
 
-    // Build ports
     const ports = data.ports.map((p) => ({
       containerPort: p.containerPort,
       hostPort: p.hostPort,
       protocol: p.protocol,
     }));
 
-    // Build healthcheck
     const healthcheck =
       data.enableHealthCheck && data.healthCheck
         ? {
@@ -188,14 +167,16 @@ export default function NewApplicationPage() {
           }
         : undefined;
 
-    // Build routing — auto-derive resources from environment network type
     const routing =
       data.enableRouting && data.routing
         ? {
             hostname: data.routing.hostname,
             listeningPort: data.routing.listeningPort,
             ...(networkType === "local"
-              ? { tlsCertificate: data.routing.hostname, dnsRecord: data.routing.hostname }
+              ? {
+                  tlsCertificate: data.routing.hostname,
+                  dnsRecord: data.routing.hostname,
+                }
               : {}),
             ...(networkType === "internet"
               ? { tunnelIngress: data.routing.hostname }
@@ -203,7 +184,6 @@ export default function NewApplicationPage() {
           }
         : undefined;
 
-    // StatelessWeb apps depend on the HAProxy applications network
     const resourceInputs =
       data.serviceType === "StatelessWeb"
         ? [{ type: "docker-network", purpose: "applications" }]
@@ -213,7 +193,6 @@ export default function NewApplicationPage() {
       await createApplication.mutateAsync({
         name: templateName,
         displayName: data.displayName,
-        description: data.description || undefined,
         scope: "environment",
         environmentId: data.environmentId,
         deployImmediately: data.deployImmediately,
@@ -249,7 +228,7 @@ export default function NewApplicationPage() {
       });
       navigate("/applications");
     } catch {
-      // Error handled by the mutation hook via toast
+      // Error handled by mutation hook via toast
     }
   };
 
@@ -262,759 +241,65 @@ export default function NewApplicationPage() {
           onClick={() => navigate("/applications")}
           className="mb-4"
         >
-          <IconArrowLeft className="h-4 w-4 mr-1" />
+          <IconArrowLeft className="mr-1 h-4 w-4" />
           Back to Applications
         </Button>
 
         <h1 className="text-3xl font-bold">New Application</h1>
-        <p className="text-muted-foreground mt-1">
-          Define a new application template with its services, ports, and
-          configuration.
+        <p className="mt-1 text-muted-foreground">
+          Deploy a container as a managed application.
         </p>
       </div>
 
-      <div className="px-4 lg:px-6 max-w-3xl">
+      <div className="max-w-3xl px-4 lg:px-6">
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-            {/* Basic Info */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Basic Information</CardTitle>
-                <CardDescription>
-                  Name and describe your application.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <FormField
-                  control={form.control}
-                  name="displayName"
-                  render={({ field }) => (
-                    <FormItem data-tour="new-app-display-name-input">
-                      <FormLabel>Application Name</FormLabel>
-                      <FormControl>
-                        <Input placeholder="My Application" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <BasicsStep
+              environments={environments}
+              isLoading={environmentsLoading}
+            />
 
-                <FormField
-                  control={form.control}
-                  name="description"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Description</FormLabel>
-                      <FormControl>
-                        <Textarea
-                          placeholder="Optional description..."
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </CardContent>
-            </Card>
-
-            {/* Service Configuration */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Service Configuration</CardTitle>
-                <CardDescription>
-                  Define the Docker service for this application.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <FormField
-                  control={form.control}
-                  name="serviceName"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Service Name</FormLabel>
-                      <FormControl>
-                        <Input placeholder="my-service" {...field} />
-                      </FormControl>
-                      <FormDescription>
-                        Used as the container name prefix. Lowercase, hyphens
-                        allowed.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name="serviceType"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Service Type</FormLabel>
-                      <Select
-                        onValueChange={field.onChange}
-                        defaultValue={field.value}
-                      >
-                        <FormControl>
-                          <SelectTrigger>
-                            <SelectValue placeholder="Select type" />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          <SelectItem value="Stateful">
-                            Stateful (database, cache, etc.)
-                          </SelectItem>
-                          <SelectItem value="StatelessWeb">
-                            Stateless Web (web server, API, etc.)
-                          </SelectItem>
-                        </SelectContent>
-                      </Select>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name="environmentId"
-                  render={({ field }) => (
-                    <FormItem data-tour="new-app-environment-select">
-                      <FormLabel>Environment</FormLabel>
-                      <Select onValueChange={field.onChange} value={field.value ?? ""}>
-                        <FormControl>
-                          <SelectTrigger>
-                            <SelectValue placeholder="Select an environment" />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {environments.map((env) => (
-                            <SelectItem key={env.id} value={env.id}>
-                              {env.name}
-                              <span className="ml-2 text-xs text-muted-foreground">
-                                ({env.networkType})
-                              </span>
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                {showHaproxyWarning && (
-                  <div className="flex items-start gap-3 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
-                    <IconAlertTriangle className="h-5 w-5 mt-0.5 shrink-0" />
-                    <div>
-                      <p className="font-medium">HAProxy stack required</p>
-                      <p className="mt-1 text-destructive/80">
-                        Stateless web applications require a deployed HAProxy stack with an
-                        applications network in this environment. Go to the environment&apos;s
-                        infrastructure stacks and deploy an HAProxy load balancer first.
-                      </p>
-                    </div>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-
-            {serviceType && selectedEnvId && (
-              <>
-                {/* Docker Image & Container Config */}
-                <Card>
-                  <CardHeader>
-                    <CardTitle>Container Configuration</CardTitle>
-                    <CardDescription>
-                      Configure the Docker image and container settings.
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent className="space-y-4">
-                    <div className="grid grid-cols-2 gap-4">
-                      <FormField
-                        control={form.control}
-                        name="dockerImage"
-                        render={({ field }) => (
-                          <FormItem data-tour="new-app-docker-image-input">
-                            <FormLabel>Docker Image</FormLabel>
-                            <FormControl>
-                              <Input placeholder="nginx" {...field} />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-
-                      <FormField
-                        control={form.control}
-                        name="dockerTag"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Tag</FormLabel>
-                            <FormControl>
-                              <Input placeholder="latest" {...field} />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                    </div>
-
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      disabled={!form.watch("dockerImage") || !form.watch("dockerTag") || detectPorts.isPending}
-                      onClick={handleDetectPorts}
-                    >
-                      {detectPorts.isPending ? (
-                        <IconLoader2 className="h-4 w-4 mr-1 animate-spin" />
-                      ) : null}
-                      Detect Ports
-                    </Button>
-
-                    <FormField
-                      control={form.control}
-                      name="restartPolicy"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>Restart Policy</FormLabel>
-                          <Select
-                            onValueChange={field.onChange}
-                            defaultValue={field.value}
-                          >
-                            <FormControl>
-                              <SelectTrigger>
-                                <SelectValue />
-                              </SelectTrigger>
-                            </FormControl>
-                            <SelectContent>
-                              <SelectItem value="no">No</SelectItem>
-                              <SelectItem value="always">Always</SelectItem>
-                              <SelectItem value="unless-stopped">
-                                Unless Stopped
-                              </SelectItem>
-                              <SelectItem value="on-failure">On Failure</SelectItem>
-                            </SelectContent>
-                          </Select>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                  </CardContent>
-                </Card>
-
-            {/* Health Check */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Health Check</CardTitle>
-                <CardDescription>
-                  Configure a Docker health check for the container.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <FormField
-                  control={form.control}
-                  name="enableHealthCheck"
-                  render={({ field }) => (
-                    <FormItem className="flex items-center gap-3">
-                      <FormControl>
-                        <Switch
-                          checked={field.value}
-                          onCheckedChange={field.onChange}
-                        />
-                      </FormControl>
-                      <FormLabel className="!mt-0">Enable Health Check</FormLabel>
-                    </FormItem>
-                  )}
-                />
-
-                {enableHealthCheck && (
-                  <>
-                    <FormField
-                      control={form.control}
-                      name="healthCheck.test"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>Command</FormLabel>
-                          <FormControl>
-                            <Input
-                              placeholder="curl -f http://localhost/ || exit 1"
-                              {...field}
-                            />
-                          </FormControl>
-                          <FormDescription>
-                            Shell command to test container health. Should exit 0 for healthy.
-                          </FormDescription>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-
-                    <div className="grid grid-cols-2 gap-4">
-                      <FormField
-                        control={form.control}
-                        name="healthCheck.interval"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Interval (seconds)</FormLabel>
-                            <FormControl>
-                              <Input
-                                type="number"
-                                value={field.value || ""}
-                                onChange={(e) =>
-                                  field.onChange(
-                                    e.target.value ? Number(e.target.value) : 0,
-                                  )
-                                }
-                              />
-                            </FormControl>
-                            <FormDescription>
-                              Time between health checks.
-                            </FormDescription>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-
-                      <FormField
-                        control={form.control}
-                        name="healthCheck.timeout"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Timeout (seconds)</FormLabel>
-                            <FormControl>
-                              <Input
-                                type="number"
-                                value={field.value || ""}
-                                onChange={(e) =>
-                                  field.onChange(
-                                    e.target.value ? Number(e.target.value) : 0,
-                                  )
-                                }
-                              />
-                            </FormControl>
-                            <FormDescription>
-                              Max time for a single check.
-                            </FormDescription>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                    </div>
-
-                    <div className="grid grid-cols-2 gap-4">
-                      <FormField
-                        control={form.control}
-                        name="healthCheck.retries"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Retries</FormLabel>
-                            <FormControl>
-                              <Input
-                                type="number"
-                                value={field.value || ""}
-                                onChange={(e) =>
-                                  field.onChange(
-                                    e.target.value ? Number(e.target.value) : 0,
-                                  )
-                                }
-                              />
-                            </FormControl>
-                            <FormDescription>
-                              Consecutive failures before unhealthy.
-                            </FormDescription>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-
-                      <FormField
-                        control={form.control}
-                        name="healthCheck.startPeriod"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Start Period (seconds)</FormLabel>
-                            <FormControl>
-                              <Input
-                                type="number"
-                                value={field.value ?? ""}
-                                onChange={(e) =>
-                                  field.onChange(
-                                    e.target.value ? Number(e.target.value) : 0,
-                                  )
-                                }
-                              />
-                            </FormControl>
-                            <FormDescription>
-                              Grace period before checks count.
-                            </FormDescription>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                    </div>
-                  </>
-                )}
-              </CardContent>
-            </Card>
-
-            {/* Port Mappings */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Port Mappings</CardTitle>
-                <CardDescription>
-                  Map container ports to host ports.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                {portFields.map((field, index) => (
-                  <div key={field.id} className="flex items-end gap-2">
-                    <FormField
-                      control={form.control}
-                      name={`ports.${index}.hostPort`}
-                      render={({ field }) => (
-                        <FormItem className="flex-1">
-                          {index === 0 && <FormLabel>Host Port</FormLabel>}
-                          <FormControl>
-                            <Input
-                              type="number"
-                              placeholder="8080"
-                              value={field.value || ""}
-                              onChange={(e) =>
-                                field.onChange(
-                                  e.target.value
-                                    ? Number(e.target.value)
-                                    : 0,
-                                )
-                              }
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                    <FormField
-                      control={form.control}
-                      name={`ports.${index}.containerPort`}
-                      render={({ field }) => (
-                        <FormItem className="flex-1">
-                          {index === 0 && (
-                            <FormLabel>Container Port</FormLabel>
-                          )}
-                          <FormControl>
-                            <Input
-                              type="number"
-                              placeholder="80"
-                              value={field.value || ""}
-                              onChange={(e) =>
-                                field.onChange(
-                                  e.target.value
-                                    ? Number(e.target.value)
-                                    : 0,
-                                )
-                              }
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                    <FormField
-                      control={form.control}
-                      name={`ports.${index}.protocol`}
-                      render={({ field }) => (
-                        <FormItem className="w-24">
-                          {index === 0 && <FormLabel>Protocol</FormLabel>}
-                          <Select
-                            onValueChange={field.onChange}
-                            defaultValue={field.value}
-                          >
-                            <FormControl>
-                              <SelectTrigger>
-                                <SelectValue />
-                              </SelectTrigger>
-                            </FormControl>
-                            <SelectContent>
-                              <SelectItem value="tcp">TCP</SelectItem>
-                              <SelectItem value="udp">UDP</SelectItem>
-                            </SelectContent>
-                          </Select>
-                        </FormItem>
-                      )}
-                    />
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => removePort(index)}
-                    >
-                      <IconTrash className="h-4 w-4" />
-                    </Button>
-                  </div>
-                ))}
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() =>
-                    appendPort({
-                      hostPort: 0,
-                      containerPort: 0,
-                      protocol: "tcp",
-                    })
-                  }
-                >
-                  <IconPlus className="h-4 w-4 mr-1" />
-                  Add Port
-                </Button>
-              </CardContent>
-            </Card>
-
-            {/* Environment Variables */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Environment Variables</CardTitle>
-                <CardDescription>
-                  Set environment variables for the container.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                {envFields.map((field, index) => (
-                  <div key={field.id} className="flex items-end gap-2">
-                    <FormField
-                      control={form.control}
-                      name={`envVars.${index}.key`}
-                      render={({ field }) => (
-                        <FormItem className="flex-1">
-                          {index === 0 && <FormLabel>Key</FormLabel>}
-                          <FormControl>
-                            <Input placeholder="ENV_VAR" {...field} />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                    <FormField
-                      control={form.control}
-                      name={`envVars.${index}.value`}
-                      render={({ field }) => (
-                        <FormItem className="flex-1">
-                          {index === 0 && <FormLabel>Value</FormLabel>}
-                          <FormControl>
-                            <Input placeholder="value" {...field} />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => removeEnv(index)}
-                    >
-                      <IconTrash className="h-4 w-4" />
-                    </Button>
-                  </div>
-                ))}
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => appendEnv({ key: "", value: "" })}
-                >
-                  <IconPlus className="h-4 w-4 mr-1" />
-                  Add Variable
-                </Button>
-              </CardContent>
-            </Card>
-
-            {/* Volumes */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Volumes</CardTitle>
-                <CardDescription>
-                  Mount named volumes into the container.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                {volumeFields.map((field, index) => (
-                  <div key={field.id} className="flex items-end gap-2">
-                    <FormField
-                      control={form.control}
-                      name={`volumeMounts.${index}.name`}
-                      render={({ field }) => (
-                        <FormItem className="flex-1">
-                          {index === 0 && <FormLabel>Volume Name</FormLabel>}
-                          <FormControl>
-                            <Input placeholder="data-volume" {...field} />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                    <FormField
-                      control={form.control}
-                      name={`volumeMounts.${index}.mountPath`}
-                      render={({ field }) => (
-                        <FormItem className="flex-1">
-                          {index === 0 && <FormLabel>Mount Path</FormLabel>}
-                          <FormControl>
-                            <Input placeholder="/data" {...field} />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => removeVolume(index)}
-                    >
-                      <IconTrash className="h-4 w-4" />
-                    </Button>
-                  </div>
-                ))}
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => appendVolume({ name: "", mountPath: "" })}
-                >
-                  <IconPlus className="h-4 w-4 mr-1" />
-                  Add Volume
-                </Button>
-              </CardContent>
-            </Card>
-
-            {/* Routing (for StatelessWeb) */}
-            {serviceType === "StatelessWeb" && (
-              <Card>
-                <CardHeader>
-                  <CardTitle>Routing</CardTitle>
-                  <CardDescription>
-                    Configure HTTP routing via HAProxy for this web service.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <FormField
-                    control={form.control}
-                    name="enableRouting"
-                    render={({ field }) => (
-                      <FormItem className="flex items-center gap-3">
-                        <FormControl>
-                          <Switch
-                            checked={field.value}
-                            onCheckedChange={field.onChange}
-                          />
-                        </FormControl>
-                        <FormLabel className="!mt-0">Enable Routing</FormLabel>
-                      </FormItem>
-                    )}
-                  />
-
-                  {enableRouting && (
-                    <>
-                      <FormField
-                        control={form.control}
-                        name="routing.hostname"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Hostname</FormLabel>
-                            <FormControl>
-                              <Input
-                                placeholder="app.example.com"
-                                {...field}
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-
-                      <FormField
-                        control={form.control}
-                        name="routing.listeningPort"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Listening Port</FormLabel>
-                            <FormControl>
-                              {detectedPorts.length >= 2 && !useCustomPort ? (
-                                <Select
-                                  value={String(field.value)}
-                                  onValueChange={(val) => {
-                                    if (val === "custom") {
-                                      setUseCustomPort(true);
-                                    } else {
-                                      field.onChange(Number(val));
-                                    }
-                                  }}
-                                >
-                                  <SelectTrigger>
-                                    <SelectValue />
-                                  </SelectTrigger>
-                                  <SelectContent>
-                                    {detectedPorts.map((port) => (
-                                      <SelectItem key={port} value={String(port)}>
-                                        {port}
-                                      </SelectItem>
-                                    ))}
-                                    <SelectItem value="custom">Custom...</SelectItem>
-                                  </SelectContent>
-                                </Select>
-                              ) : (
-                                <Input
-                                  type="number"
-                                  placeholder="80"
-                                  value={field.value || ""}
-                                  onChange={(e) =>
-                                    field.onChange(
-                                      e.target.value
-                                        ? Number(e.target.value)
-                                        : 0,
-                                    )
-                                  }
-                                />
-                              )}
-                            </FormControl>
-                            <FormDescription>
-                              The port your application listens on inside the
-                              container.
-                            </FormDescription>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-
-                      {networkType && (
-                        <div className="text-sm text-muted-foreground p-3 bg-muted rounded-md">
-                          {networkType === "local" &&
-                            "A TLS certificate and DNS record will be automatically created for this hostname."}
-                          {networkType === "internet" &&
-                            "A Cloudflare tunnel ingress will be automatically created for this hostname."}
-                        </div>
-                      )}
-                    </>
-                  )}
-                </CardContent>
-              </Card>
+            {hasBasics && (
+              <ServiceTypeStep showHaproxyWarning={showHaproxyWarning} />
             )}
-                {/* Deploy Immediately */}
+
+            {hasServiceType && (
+              <ImageStep
+                onValidated={handleImageValidated}
+                onReset={handleImageReset}
+                validated={imageValidated}
+              />
+            )}
+
+            {canShowConfig && <ConfigurationStep />}
+
+            {canShowRouting && (
+              <RoutingStep
+                networkType={networkType}
+                detectedPorts={detectedPorts}
+              />
+            )}
+
+            {canShowCreate && (
+              <div className="space-y-4">
                 <FormField
                   control={form.control}
                   name="deployImmediately"
                   render={({ field }) => (
                     <FormItem className="flex items-center gap-2">
                       <FormControl>
-                        <Switch checked={field.value} onCheckedChange={field.onChange} />
+                        <Switch
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
                       </FormControl>
-                      <FormLabel className="!mt-0">Deploy immediately after creation</FormLabel>
+                      <FormLabel className="!mt-0">
+                        Deploy immediately after creation
+                      </FormLabel>
                     </FormItem>
                   )}
                 />
 
-                {/* Submit */}
                 <div className="flex gap-3">
                   <Button
                     type="button"
@@ -1025,16 +310,16 @@ export default function NewApplicationPage() {
                   </Button>
                   <Button
                     type="submit"
-                    disabled={createApplication.isPending || !!showHaproxyWarning}
+                    disabled={createApplication.isPending}
                     data-tour="new-app-create-button"
                   >
                     {createApplication.isPending && (
-                      <IconLoader2 className="h-4 w-4 mr-2 animate-spin" />
+                      <IconLoader2 className="mr-2 h-4 w-4 animate-spin" />
                     )}
-                    {form.watch("deployImmediately") ? "Create & Deploy" : "Create Application"}
+                    {deployImmediately ? "Create & Deploy" : "Create Application"}
                   </Button>
                 </div>
-              </>
+              </div>
             )}
           </form>
         </Form>

--- a/client/src/app/connectivity/cloudflare/page.tsx
+++ b/client/src/app/connectivity/cloudflare/page.tsx
@@ -302,8 +302,8 @@ export default function CloudflareSettingsPage() {
                               </div>
                             </FormControl>
                             <FormDescription>
-                              Your Cloudflare API token with Zone:Read,
-                              Tunnel:Read, and Tunnel:Edit permissions.
+                              Your Cloudflare API token with Cloudflare
+                              Tunnel:Edit, Zone:Read, and DNS:Edit permissions.
                               Create one at{" "}
                               <a
                                 href="https://dash.cloudflare.com/profile/api-tokens"

--- a/client/src/hooks/use-cloudflare-settings.ts
+++ b/client/src/hooks/use-cloudflare-settings.ts
@@ -2,7 +2,6 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
   CloudflareSettingResponse,
   CreateCloudflareSettingRequest,
-  ConnectivityStatusResponse,
   CloudflareTunnelListResponse,
   CloudflareTunnelConfigResponse,
   CloudflareAddHostnameRequest,
@@ -12,6 +11,18 @@ import type {
 } from "@mini-infra/types";
 import { Channel, ServerEvent } from "@mini-infra/types";
 import { useSocket, useSocketChannel, useSocketEvent } from "./use-socket";
+
+// The /api/connectivity/cloudflare endpoint returns the latest status as a
+// flat object (not the wrapped `{ success, data }` shape used elsewhere).
+export interface CloudflareConnectivityStatus {
+  id: string;
+  service: string;
+  status: "connected" | "failed" | "timeout" | "unreachable";
+  message: string | null;
+  metadata: Record<string, unknown> | null;
+  checkedAt: string;
+  responseTime: number | null;
+}
 
 // Hook for retrieving current Cloudflare settings
 export function useCloudflareSettings() {
@@ -125,7 +136,7 @@ export function useCloudflareConnectivity() {
     },
   );
 
-  return useQuery<ConnectivityStatusResponse>({
+  return useQuery<CloudflareConnectivityStatus>({
     queryKey: ["cloudflare-connectivity"],
     queryFn: async () => {
       const response = await fetch("/api/connectivity/cloudflare", {

--- a/client/src/hooks/use-detect-image-ports.ts
+++ b/client/src/hooks/use-detect-image-ports.ts
@@ -11,7 +11,16 @@ interface DetectPortsResponse {
   error?: string;
 }
 
-async function detectImagePorts({ image, tag }: DetectPortsParams): Promise<number[]> {
+export type ImageValidationResult =
+  | { status: "success"; ports: number[] }
+  | { status: "not-found"; message: string }
+  | { status: "auth-required"; message: string }
+  | { status: "error"; message: string };
+
+async function validateImage({
+  image,
+  tag,
+}: DetectPortsParams): Promise<ImageValidationResult> {
   const url = new URL("/api/images/inspect-ports", window.location.origin);
   url.searchParams.set("image", image);
   url.searchParams.set("tag", tag);
@@ -20,17 +29,33 @@ async function detectImagePorts({ image, tag }: DetectPortsParams): Promise<numb
     credentials: "include",
   });
 
-  const data: DetectPortsResponse = await res.json();
-
-  if (!res.ok || !data.success) {
-    throw new Error(data.error ?? "Failed to detect ports");
+  let data: DetectPortsResponse;
+  try {
+    data = await res.json();
+  } catch {
+    return {
+      status: "error",
+      message: `Unexpected response (${res.status})`,
+    };
   }
 
-  return data.ports;
+  if (res.ok && data.success) {
+    return { status: "success", ports: data.ports };
+  }
+
+  const message = data.error ?? `Failed to inspect image (${res.status})`;
+
+  if (res.status === 404) {
+    return { status: "not-found", message };
+  }
+  if (res.status === 502 && /authentication/i.test(message)) {
+    return { status: "auth-required", message };
+  }
+  return { status: "error", message };
 }
 
 export function useDetectImagePorts() {
   return useMutation({
-    mutationFn: detectImagePorts,
+    mutationFn: validateImage,
   });
 }

--- a/client/src/lib/application-schemas.ts
+++ b/client/src/lib/application-schemas.ts
@@ -51,7 +51,6 @@ export const serviceNameSchema = z
 
 export const createApplicationFormSchema = z.object({
   displayName: z.string().min(1, "Application name is required").max(100),
-  description: z.string().max(500).optional(),
   serviceName: serviceNameSchema,
   serviceType: z.enum(STACK_SERVICE_TYPES),
   environmentId: z.string().min(1, "Environment is required"),
@@ -74,8 +73,7 @@ export type CreateApplicationFormData = z.infer<
 
 export const createApplicationDefaults: CreateApplicationFormData = {
   displayName: "",
-  description: "",
-  serviceName: "",
+  serviceName: "web",
   serviceType: "StatelessWeb",
   environmentId: "",
   dockerImage: "",
@@ -83,7 +81,7 @@ export const createApplicationDefaults: CreateApplicationFormData = {
   ports: [],
   envVars: [],
   volumeMounts: [],
-  enableRouting: false,
+  enableRouting: true,
   routing: { hostname: "", listeningPort: 8080 },
   restartPolicy: "unless-stopped",
   enableHealthCheck: false,

--- a/client/src/lib/parse-dotenv.ts
+++ b/client/src/lib/parse-dotenv.ts
@@ -1,0 +1,50 @@
+export interface DotenvEntry {
+  key: string;
+  value: string;
+}
+
+const LINE_RE =
+  /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/;
+
+function unquote(raw: string): string {
+  if (raw.length >= 2) {
+    const first = raw[0];
+    const last = raw[raw.length - 1];
+    if (first === '"' && last === '"') {
+      return raw
+        .slice(1, -1)
+        .replace(/\\n/g, "\n")
+        .replace(/\\r/g, "\r")
+        .replace(/\\t/g, "\t")
+        .replace(/\\"/g, '"')
+        .replace(/\\\\/g, "\\");
+    }
+    if (first === "'" && last === "'") {
+      return raw.slice(1, -1);
+    }
+  }
+  return raw;
+}
+
+export function parseDotenv(text: string): DotenvEntry[] {
+  const seen = new Map<string, string>();
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "" || line.startsWith("#")) continue;
+
+    const match = LINE_RE.exec(line);
+    if (!match) continue;
+
+    const [, key, rawValue] = match;
+    // Strip inline comments only when value is not quoted
+    let value = rawValue;
+    if (value && value[0] !== '"' && value[0] !== "'") {
+      const hashIdx = value.indexOf(" #");
+      if (hashIdx >= 0) value = value.slice(0, hashIdx).trim();
+    }
+    seen.set(key, unquote(value));
+  }
+
+  return Array.from(seen, ([key, value]) => ({ key, value }));
+}

--- a/client/src/user-docs/connectivity/health-monitoring.md
+++ b/client/src/user-docs/connectivity/health-monitoring.md
@@ -69,7 +69,7 @@ Configure Cloudflare API access for tunnel monitoring and DNS management.
 
 | Field | Description |
 |-------|-------------|
-| **API Token** | Cloudflare API token with Zone:Read and Tunnel:Read permissions |
+| **API Token** | Cloudflare API token with Cloudflare Tunnel:Edit, Zone:Read, and DNS:Edit permissions |
 | **Account ID** | Your 32-character Cloudflare Account ID |
 
 Generate an API token at `https://dash.cloudflare.com/profile/api-tokens`. Find your Account ID in the URL when logged into the Cloudflare dashboard.

--- a/client/src/user-docs/tunnels/troubleshooting.md
+++ b/client/src/user-docs/tunnels/troubleshooting.md
@@ -19,7 +19,7 @@ tags:
 
 **What to check:** Go to [Connected Services → Cloudflare](/connectivity-cloudflare). Check whether the connection is validated and healthy.
 
-**Fix:** Enter a valid Cloudflare API token with `Zone:Read` and `Tunnel:Read` permissions, plus your Account ID. Click **Validate & Save**.
+**Fix:** Enter a valid Cloudflare API token with `Cloudflare Tunnel:Edit`, `Zone:Read`, and `DNS:Edit` permissions, plus your Account ID. Click **Validate & Save**.
 
 ---
 
@@ -58,6 +58,6 @@ tags:
 
 **What to check:** In the error message on the connectivity page, look for specific details about which permission is missing.
 
-**Fix:** Generate a new API token in the Cloudflare dashboard with `Zone:Read` and `Tunnel:Read` permissions. Verify your Account ID from the Cloudflare URL: `https://dash.cloudflare.com/[account-id]/home`.
+**Fix:** Generate a new API token in the Cloudflare dashboard with `Cloudflare Tunnel:Edit`, `Zone:Read`, and `DNS:Edit` permissions. Verify your Account ID from the Cloudflare URL: `https://dash.cloudflare.com/[account-id]/home`.
 
 ---

--- a/server/src/services/__tests__/cloudflare-config.test.ts
+++ b/server/src/services/__tests__/cloudflare-config.test.ts
@@ -20,6 +20,11 @@ const { mockCloudflare } = vi.hoisted(() => ({
         list: vi.fn(),
       },
     },
+    dns: {
+      records: {
+        list: vi.fn(),
+      },
+    },
   },
 }));
 
@@ -148,13 +153,19 @@ describe("CloudflareService", () => {
 
       // Mock successful zone list
       mockCloudflare.zones.list.mockResolvedValue({
-        result: [{ name: "example.com" }, { name: "example.org" }],
+        result: [
+          { id: "zone-1", name: "example.com" },
+          { id: "zone-2", name: "example.org" },
+        ],
       });
 
       // Mock successful tunnel list
       mockCloudflare.zeroTrust.tunnels.list.mockResolvedValue({
         result: [{ name: "web-tunnel", deleted_at: null }],
       });
+
+      // Mock successful DNS records list (for DNS:Edit probe)
+      mockCloudflare.dns.records.list.mockResolvedValue({ result: [] });
 
       mockPrisma.connectivityStatus.create = vi.fn().mockResolvedValue({});
 
@@ -227,7 +238,7 @@ describe("CloudflareService", () => {
 
       // Mock successful zone list
       mockCloudflare.zones.list.mockResolvedValue({
-        result: [{ name: "example.com" }],
+        result: [{ id: "zone-1", name: "example.com" }],
       });
 
       // Mock tunnel list failure (missing permission)
@@ -235,12 +246,38 @@ describe("CloudflareService", () => {
         new Error("Forbidden"),
       );
 
+      // DNS probe succeeds so only the tunnel scope is flagged
+      mockCloudflare.dns.records.list.mockResolvedValue({ result: [] });
+
       mockPrisma.connectivityStatus.create = vi.fn().mockResolvedValue({});
 
       const result = await cloudflareConfigService.validate();
 
       expect(result.isValid).toBe(false);
-      expect(result.message).toContain("Tunnel:Read");
+      expect(result.message).toContain("Cloudflare Tunnel:Edit");
+      expect(result.errorCode).toBe("MISSING_PERMISSIONS");
+    });
+
+    it("should fail validation when DNS record access is denied", async () => {
+      mockPrisma.systemSettings.findUnique = vi
+        .fn()
+        .mockResolvedValueOnce({ value: "valid-api-token-123" })
+        .mockResolvedValueOnce({ value: "account-456" });
+
+      mockCloudflare.zones.list.mockResolvedValue({
+        result: [{ id: "zone-1", name: "example.com" }],
+      });
+      mockCloudflare.zeroTrust.tunnels.list.mockResolvedValue({
+        result: [{ name: "web-tunnel", deleted_at: null }],
+      });
+      mockCloudflare.dns.records.list.mockRejectedValue(new Error("Forbidden"));
+
+      mockPrisma.connectivityStatus.create = vi.fn().mockResolvedValue({});
+
+      const result = await cloudflareConfigService.validate();
+
+      expect(result.isValid).toBe(false);
+      expect(result.message).toContain("DNS:Edit");
       expect(result.errorCode).toBe("MISSING_PERMISSIONS");
     });
 
@@ -265,7 +302,7 @@ describe("CloudflareService", () => {
 
       expect(result.isValid).toBe(false);
       expect(result.message).toContain("Zone:Read");
-      expect(result.message).toContain("Tunnel:Read");
+      expect(result.message).toContain("Cloudflare Tunnel:Edit");
       expect(result.errorCode).toBe("MISSING_PERMISSIONS");
     });
 

--- a/server/src/services/cloudflare/cloudflare-service.ts
+++ b/server/src/services/cloudflare/cloudflare-service.ts
@@ -309,6 +309,7 @@ export class CloudflareService extends ConfigurationService {
       const cf = new Cloudflare({ apiToken });
       const metadata: Record<string, unknown> = {};
       const missingPermissions: string[] = [];
+      let firstZoneId: string | undefined;
 
       // Zone:Read — missing scopes are captured rather than thrown so we
       // can report exactly which permissions are absent.
@@ -321,6 +322,7 @@ export class CloudflareService extends ConfigurationService {
         const zones = zonesResponse.result || [];
         metadata.zoneCount = zones.length;
         metadata.zones = zones.slice(0, 10).map((z: Zone) => z.name);
+        firstZoneId = zones[0]?.id;
       } catch (zoneError) {
         if (this.isPermissionError(zoneError)) {
           missingPermissions.push("Zone:Read");
@@ -339,7 +341,9 @@ export class CloudflareService extends ConfigurationService {
         }
       }
 
-      // Tunnel:Read
+      // Cloudflare Tunnel:Edit — listing tunnels requires at minimum Read,
+      // but the app creates managed tunnels and requires Edit. If the probe
+      // fails with a permission error, Edit is definitely absent.
       try {
         const tunnelsResponse = await this.runner.withTimeout(
           cf.zeroTrust.tunnels.list({ account_id: accountId }),
@@ -354,7 +358,7 @@ export class CloudflareService extends ConfigurationService {
           .map((t: TunnelListResponse) => t.name);
       } catch (tunnelError) {
         if (this.isPermissionError(tunnelError)) {
-          missingPermissions.push("Tunnel:Read");
+          missingPermissions.push("Cloudflare Tunnel:Edit");
           getLogger("integrations", "cloudflare-service").warn(
             {
               accountId,
@@ -363,10 +367,42 @@ export class CloudflareService extends ConfigurationService {
                   ? tunnelError.message
                   : "Unknown error",
             },
-            "Cloudflare token lacks Tunnel:Read permission",
+            "Cloudflare token lacks Cloudflare Tunnel:Edit permission",
           );
         } else {
           throw tunnelError;
+        }
+      }
+
+      // DNS:Edit — probe by listing records on the first accessible zone.
+      // Listing technically only requires Read, but DNS:Edit is a superset
+      // and the app needs Edit to create/update records for app routing.
+      // If no zones are accessible we can't probe here; the Zone:Read
+      // failure above will have been captured.
+      if (firstZoneId) {
+        try {
+          await this.runner.withTimeout(
+            cf.dns.records.list({ zone_id: firstZoneId }),
+            "dns record list",
+            CLOUDFLARE_TIMEOUT_MS,
+          );
+        } catch (dnsError) {
+          if (this.isPermissionError(dnsError)) {
+            missingPermissions.push("DNS:Edit");
+            getLogger("integrations", "cloudflare-service").warn(
+              {
+                accountId,
+                zoneId: firstZoneId,
+                error:
+                  dnsError instanceof Error
+                    ? dnsError.message
+                    : "Unknown error",
+              },
+              "Cloudflare token lacks DNS:Edit permission",
+            );
+          } else {
+            throw dnsError;
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

- Rewrites the New Application page as a step-by-step progressive-disclosure flow split into focused subcomponents (`BasicsStep`, `ServiceTypeStep`, `ImageStep`, `ConfigurationStep`, `RoutingStep`), shrinking the monolithic page from ~959 to ~330 lines.
- Adds connectivity warnings on the Routing step for Cloudflare and Azure Storage so users see config issues before deploy rather than at failure time. Wording is tailored to the selected network type (local vs internet) and warnings are gated on query loading state to avoid false-positive flashes.
- Tightens Cloudflare API token validation and aligns the connectivity docs and token-permission advice with the actual required `DNS:Edit` scope.
- Misc: extracts `.env` paste handling into `parse-dotenv.ts` + `PasteEnvDialog`, refines image-port detection.

## Test plan

- [x] Build the client (`npm run build -w client`) — passes
- [x] Reproduced the original Cloudflare warning bug in dev (Cloudflare reachable, warning still firing) and confirmed it no longer appears after the fix
- [x] Verified the Azure warning still appears correctly when Azure is genuinely disconnected
- [ ] Manual sanity walk through the full New Application flow end-to-end with a real deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)