### PR TITLE
Skip local DNS self-verify in ACME DNS-01 flow

### DIFF
--- a/server/src/services/tls/acme-client-manager.ts
+++ b/server/src/services/tls/acme-client-manager.ts
@@ -187,12 +187,18 @@ export class AcmeClientManager {
 
       this.logger.info({ domains }, "CSR created, initiating ACME challenge");
 
-      // Request certificate with DNS-01 challenge
+      // Request certificate with DNS-01 challenge.
+      // skipChallengeVerification disables the acme library's local TXT self-check:
+      // our recursive resolver seeing the record has no bearing on whether Let's
+      // Encrypt's own geographically distributed resolvers can see it, and the
+      // self-check often times out on fresh records even when LE validation would
+      // have succeeded.
       const certificate = await this.acmeClient!.auto({
         csr: certCsr,
         domains,
         termsOfServiceAgreed: true,
         challengePriority: ["dns-01"],
+        skipChallengeVerification: true,
 
         challengeCreateFn: async (authz: { identifier: { value: string } }, challenge: { type: string; token: string }, keyAuthorization: string) => {
           this.logger.info(

--- a/server/src/services/tls/dns-challenge-provider.ts
+++ b/server/src/services/tls/dns-challenge-provider.ts
@@ -2,17 +2,19 @@
  * DNS-01 Challenge Provider
  *
  * This service implements DNS-01 challenge for ACME protocol via Cloudflare.
- * It creates and removes TXT records for domain validation and waits for DNS propagation.
+ * It creates and removes TXT records for domain validation.
  */
 
 import { Logger } from "pino";
 import NodeCache from "node-cache";
-import dns from "dns";
-import { promisify } from "util";
 import { getLogger } from "../../lib/logger-factory";
 import { CloudflareService } from "../cloudflare";
 
-const resolveTxt = promisify(dns.resolveTxt);
+// Small delay between TXT creation and telling Let's Encrypt to validate.
+// LE does its own authoritative lookups from multiple resolvers and retries
+// internally, so we don't need to poll — we just give Cloudflare a moment to
+// commit the record before the first LE query hits.
+const POST_CREATE_DELAY_MS = 5000;
 
 /**
  * Service for handling DNS-01 challenges via Cloudflare
@@ -70,9 +72,7 @@ export class DnsChallenge01Provider {
         "DNS-01 challenge TXT record created",
       );
 
-      // Wait for DNS propagation
-      this.logger.info({ domain, recordName }, "Waiting for DNS propagation...");
-      await this.waitForPropagation(recordName, keyAuthorization, 60000);
+      await new Promise((resolve) => setTimeout(resolve, POST_CREATE_DELAY_MS));
 
       this.logger.info({ domain, recordName }, "DNS challenge ready for validation");
     } catch (error) {
@@ -134,72 +134,6 @@ export class DnsChallenge01Provider {
       );
       // Don't throw - cleanup failures shouldn't fail the certificate issuance
     }
-  }
-
-  /**
-   * Wait for DNS propagation
-   *
-   * Polls DNS until the expected TXT record value is found or timeout occurs.
-   *
-   * @param recordName - Full DNS record name (e.g., "_acme-challenge.example.com")
-   * @param expectedValue - Expected TXT record value
-   * @param maxWaitMs - Maximum time to wait in milliseconds (default: 60000)
-   * @returns true if propagation confirmed, false if timeout
-   * @private
-   */
-  private async waitForPropagation(
-    recordName: string,
-    expectedValue: string,
-    maxWaitMs: number = 60000,
-  ): Promise<boolean> {
-    const startTime = Date.now();
-    const interval = 5000; // Check every 5 seconds
-
-    while (Date.now() - startTime < maxWaitMs) {
-      try {
-        const txtRecords = await resolveTxt(recordName);
-        const flatRecords = txtRecords.flat();
-
-        this.logger.debug(
-          { recordName, txtRecords: flatRecords, expectedValue },
-          "DNS lookup result",
-        );
-
-        if (flatRecords.includes(expectedValue)) {
-          const propagationTime = Date.now() - startTime;
-          this.logger.info(
-            { recordName, propagationTimeMs: propagationTime },
-            "DNS propagation confirmed",
-          );
-          return true;
-        }
-
-        this.logger.debug(
-          { recordName, txtRecords: flatRecords },
-          "DNS not yet propagated, waiting...",
-        );
-      } catch (error) {
-        // DNS lookup failures are expected during propagation
-        this.logger.debug(
-          {
-            recordName,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          "DNS lookup failed (expected during propagation)",
-        );
-      }
-
-      // Wait before next check
-      await new Promise((resolve) => setTimeout(resolve, interval));
-    }
-
-    const totalTime = Date.now() - startTime;
-    this.logger.error(
-      { recordName, maxWaitMs, totalTimeMs: totalTime },
-      "DNS propagation timeout",
-    );
-
-    return false;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes failed deployments where ACME DNS-01 certificate issuance bailed out with `queryTxt ENOTFOUND _acme-challenge.<hostname>` even though Cloudflare had the TXT record committed and Let's Encrypt would have validated it successfully.

The flow had **two** redundant local DNS checks:

1. `DnsChallenge01Provider.waitForPropagation()` — polled our container's recursive resolver for 60s, but the return value was ignored so a timeout produced no behaviour anyway.
2. `verifyDnsChallenge` in `@mini-infra/acme` — also queried our local resolver, and **threw `ENOTFOUND`** if the record wasn't yet visible. This is the one that actually aborted deploys.

Neither matters for correctness: Let's Encrypt validates from its own geographically distributed resolvers directly against Cloudflare's authoritative NS — whether our container's recursive resolver has the record cached yet is completely irrelevant. If LE can't see the record, it retries on its own.

### Changes

- Pass `skipChallengeVerification: true` to the acme client's `auto()` call — disables the library's local self-check.
- Replace `waitForPropagation()` polling (60s max) with a 5s fixed delay — enough time for Cloudflare to commit the record before LE's first validation query lands, without burning minutes on resolver-cache theatre.
- Delete the unused `waitForPropagation` helper and its `dns`/`promisify` imports.

### Verified end-to-end

Redeployed the same stack that failed before (`sdfsfsdfsdf.blinglabs.tech`):

- TXT record created → 5s delay → LE validates → certificate issued in ~10s
- Stack reconciled, container deployed, HAProxy backend added — all green

## Test plan

- [ ] Deploy a StatelessWeb app on a local environment and confirm the cert issues successfully on first try
- [ ] Redeploy with an existing cert (covers renewal path — no change expected, but worth confirming)
- [ ] Verify logs show the new "DNS challenge ready for validation" appearing ~5s after "DNS-01 challenge TXT record created", with no `waitForPropagation`/`DNS propagation timeout` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)