### PR TITLE
Plans: host OpenBao inside Mini Infra as a managed SecretsVault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ screenshots/
 __pycache__/
 *.pyc
 *.pyo
+
+scheduled_tasks.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ When opening the site in playwright use `playwright-cli open --persistent` and b
 * Always use http://localhost:3005 for all frontend and backend requests as this is a vite server that will proxy through to the backend.
 * **Always run commands from the project root**. Never `cd` into `client/`, `server/`, or `lib/` subdirectories. Use `-w <workspace>` flags instead (e.g., `npm test -w server`).
 * **Sidecar folders are NOT in the npm workspace**. `update-sidecar/` and `agent-sidecar/` are standalone packages — you must `cd` into them to run npm commands (e.g., `cd agent-sidecar && npm test`), then `cd` back to the project root afterwards.
-* NOTE: NEVER run `docker-compose` as it no longer exists, instead run `docker compose`
+* When a change is made for the local dev environment make sure to run `deployment/development/start.sh` to rebuild the underlying containers that support http://localhost:3005
 
 ## Project Overview
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -69,6 +69,15 @@ Give Mini Infra a way to reach operators proactively, starting simple and buildi
   - "All clear" heartbeat option so operators know the watchdog itself is alive.
   - Persist findings and actions taken so the UI has a history of what the agent noticed and said.
 
+## Secrets Management (SecretsVault)
+
+Host OpenBao as a managed service inside Mini Infra, mint short-lived AppRole credentials for deployed stacks at apply time, and manage Vault policies as HCL files. Mini Infra itself does not depend on Vault.
+
+- **Main design** — [secrets-vault-plan.md](secrets-vault-plan.md): OpenBao stack template, operator-passphrase-gated unseal, HCL policy resource with draft/publish, per-deploy wrapped secret_id injection into stack containers.
+- **Implementation plan** — [secrets-vault-implementation.md](secrets-vault-implementation.md): phase-by-phase build plan with file paths, schema changes, and the systems each phase touches.
+- **Deferred: Vault UI SSO** — [vault-oidc-plan.md](vault-oidc-plan.md): JWT auth method MVP so operators open the Vault UI already authenticated as themselves, with a later path to a full OIDC provider or external IdP passthrough.
+- **Deferred: Volume backups** — [volume-azure-backup-plan.md](volume-azure-backup-plan.md): generalises the Postgres-to-Azure backup pattern to arbitrary Docker volumes (covers backup of the Vault data volume).
+
 ## Cloudflare Improvements
 
 Expand the Cloudflare integration beyond DNS and basic tunnel wiring so internet-exposed applications can be protected with minimal effort.

--- a/docs/secrets-vault-implementation.md
+++ b/docs/secrets-vault-implementation.md
@@ -1,0 +1,406 @@
+# SecretsVault — Implementation Plan
+
+Concrete implementation plan for [secrets-vault-plan.md](secrets-vault-plan.md). Organised so each phase can land as its own PR. File paths are relative to the repo root.
+
+> This plan has been revised following a sceptical review. Key changes from the first draft:
+> - Phase 1 (template-only) was merged into Phase 2 — a deployed-but-unbootstrapped OpenBao leaves the operator in a half-state.
+> - Networking reuses the existing `resourceOutputs` / `joinResourceNetworks` idiom instead of inventing `mini-infra-vault-net`.
+> - AES-GCM is a shared `server/src/lib/crypto.ts` utility with a versioned format, not tucked inside the passphrase service.
+> - Env injection happens in the plan-computer / reconciler layer with explicit "dynamic field" marking, not in `stack-container-manager.ts` — otherwise `definition-hash` and `lastAppliedSnapshot` break.
+> - `VaultState` uses `cuid()` + a `kind` unique constraint, not a magic `id: "singleton"`.
+> - Human operator access to the Vault UI for MVP is explicitly designed (was hand-waved).
+> - Wrapping TTL is 300s (was 60s) and minted *after* image pull to avoid a correctness bug.
+
+## Systems we're interacting with
+
+| System | Role | Touchpoint |
+|---|---|---|
+| OpenBao | The managed vault itself | HTTP API (`/v1/*`) |
+| Mini Infra server | Orchestrates OpenBao + exposes management UI | New services, routes, prisma models |
+| Mini Infra client | Management UI | New pages under `client/src/app/vault/` |
+| Stack templates | Ship OpenBao as a system template | New `server/templates/vault/` |
+| Stack plan-computer + reconciler | Inject AppRole wrapped secret_ids at apply time | New dynamic-env mechanism in `stack-plan-computer.ts` / `stack-resource-reconciler.ts` |
+| InfraResource model | Exposes the Vault docker network for bindings to join | Reuses `resourceOutputs` + `joinResourceNetworks` (postgres pattern) |
+| HAProxy | Exposes Vault UI via existing routing | New StatelessWeb service on the Vault stack |
+| Task tracker | Surfaces bootstrap / unseal / apply progress | New registry entries |
+| Socket.IO | Real-time progress events | New `Channel.VAULT` |
+| Prisma | Persists Vault state, policies, AppRoles, bindings | New models + migration |
+
+## Prework — decisions to lock in before Phase 1
+
+These are **pre-phase** choices that affect scope. Settle them in small design-only tickets.
+
+### P0. Pick an HCL editor
+
+There is **no Monaco or CodeMirror in the client today** (confirmed — no `monaco-editor` / `@monaco-editor/react` / `codemirror` in `client/package.json`). Phase 3's HCL editor requires adding one. Options:
+
+- **`@monaco-editor/react`** — full IDE feel, built-in diff view, but a ~2 MB bundle hit and dark-theme integration work. No off-the-shelf HCL language package; we'd hand-roll a Monarch tokenizer (small, maybe 80 lines).
+- **`react-simple-code-editor` + `prismjs` with the existing `prism-hcl` grammar** — tiny bundle (~30 KB), basic highlighting, no diff view. We'd build diff via side-by-side `<pre>` blocks or `diff2html`.
+- **Textarea with server-side validation only** — cheapest, ugliest. Probably not worth shipping.
+
+**Recommendation**: start with option 2 (Prism) — ship Phase 3 smaller; upgrade to Monaco later if operators complain.
+
+### P1. AES-GCM format + KDF parameters
+
+First real symmetric crypto in the repo — confirmed no existing helper (the RegistryCredential `password` field is labelled "Encrypted" in schema and `server/CLAUDE.md` but the service at `server/src/services/registry-credential.ts` stores the raw value; this is a pre-existing issue flagged separately below).
+
+Specify once, reuse:
+
+- **Cipher**: AES-256-GCM via `crypto.createCipheriv`.
+- **On-disk format (bytes)**: `version(1) | nonce(12) | ciphertext(N) | tag(16)`. Version byte = `0x01` so we can rotate schemes later.
+- **KDF**: Argon2id via the existing `argon2` package (already in `server/src/lib/password-service.ts`). Parameters: `memoryCost: 65536 KiB` (64 MB), `timeCost: 3`, `parallelism: 4`. Salt: 16 random bytes, persisted alongside the wrapped state so the same passphrase derives the same key across restarts.
+- **Wrapping-key zeroisation**: stored in a `Buffer` that gets overwritten via `buf.fill(0)` on `lock()`.
+- Implemented once in `server/src/lib/crypto.ts` — `encrypt(key, plaintext)`, `decrypt(key, ciphertext)`. Not in the passphrase service.
+
+### P2. Human operator access to the Vault UI for MVP
+
+OIDC is deferred to [vault-oidc-plan.md](vault-oidc-plan.md), and Phase 2 rotates the root token immediately after bootstrap. So how does a human log into the Vault UI?
+
+**Decision for MVP**: Phase 2 creates a `mini-infra-operator` userpass user with a randomly generated password, stored encrypted in `VaultState` like any other credential. Operator is shown the password once at bootstrap completion (same screen as the unseal keys). Rotation via the Vault UI banner: "Change password". This keeps human access working without OIDC and without leaking the root token.
+
+### P3. `mini-infra-admin` regeneration
+
+If `VaultState.encryptedAdminSecretId` is ever lost (DB restore, disaster recovery), Mini Infra can still re-authenticate using the unseal keys → re-init path *as long as unseal keys survive*. The recovery route (Phase 5) handles this. Do not rely on root token persistence.
+
+## Files worth pulling into context
+
+Before touching anything, read these.
+
+**Patterns to mirror**
+- `server/templates/postgres/template.json` — reference system stack template. Note the `resourceOutputs: [{ type: "docker-network", purpose: "database", joinSelf: true }]` pattern and how consumers set `joinResourceNetworks: ["database"]` — this is the mechanism we use for Vault-to-app connectivity, not a bespoke external network.
+- `server/src/services/stacks/post-install-actions/register-postgres-server.ts` — post-install action pattern.
+- `server/src/services/stacks/builtin-stack-sync.ts` — how templates are upserted on boot.
+- `server/src/services/stacks/stack-plan-computer.ts` + `stack-resource-reconciler.ts` + `stack-reconciler.ts` — **where env injection must happen** (not `stack-container-manager.ts`, which is too late in the flow).
+- `server/src/services/stacks/template-engine.ts` — where parameter interpolation into env maps lives; this is the surface where "dynamic env" markers get resolved.
+- `server/src/services/stacks/definition-hash.ts` — hashing of the stack definition for drift detection. Anything apply-time dynamic **must be excluded** here.
+- `server/src/services/stacks/stack-applied-snapshot.ts` — last-applied snapshot. Same exclusion rule.
+- `server/src/services/tls/certificate-lifecycle-manager.ts` — reference long-running multi-step operation with step callbacks.
+- `server/src/services/configuration-factory.ts` — factory for new config categories. Current supported set is `"docker", "cloudflare", "azure", "tls"` (not `postgres`; `server/CLAUDE.md` is outdated on this point).
+- `server/src/services/azure-storage-service.ts` — reference `IConfigurationService` implementation.
+- `server/src/lib/password-service.ts` — Argon2id already available; KDF parameters go in `crypto.ts` per P1.
+- `server/src/lib/connectivity-scheduler.ts` — pattern for the auto-unseal health watcher.
+
+**Reference from slackbot-agent-sdk**
+- `/Users/geoff/Repos/slackbot-agent-sdk/environment/vault/bootstrap.ts` — Vault init, unseal, auth-method enable, policy + AppRole create, KV seed.
+- `/Users/geoff/Repos/slackbot-agent-sdk/environment/up.ts` — auto-unseal, wrapped secret_id mint, env injection.
+- `/Users/geoff/Repos/slackbot-agent-sdk/environment/vault/*.hcl` — shape of AppRole / user-self-service policies.
+
+**Types + schema touchpoints**
+- `server/prisma/schema.prisma` — Stack, StackTemplate, InfraResource, RegistryCredential models.
+- `lib/types/socket-events.ts` — where `Channel.VAULT` and `VAULT_*` events go. Pin step event shape to `{ step: OperationStep, completedCount: number, totalSteps: number }` to match TLS / sidecar / self-update.
+- `lib/types/stack-templates.ts`, `lib/types/stacks.ts` — extension point for `StackVaultBinding`.
+- `lib/types/settings.ts` — add `'vault'` to `SettingsCategory`.
+- `lib/types/permissions.ts` — new `vault:*` scopes.
+- `client/src/lib/task-type-registry.ts` — where new task types are declared.
+- `client/CLAUDE.md` + `server/CLAUDE.md` — patterns we're required to follow.
+
+## Phase breakdown
+
+Each phase ends on a shippable PR.
+
+---
+
+### Phase 1 — Vault stack + bootstrap + operator passphrase
+
+Was two phases in the original plan. Merged because OpenBao without `sys/init` is functionally useless (health returns 501, no auth methods enabled) and a "half-deployed" state has no honest UI story. This is the heavy phase; subsequent ones are smaller.
+
+#### Template
+
+- `server/templates/vault/template.json` — openbao image, single service, volume `openbao_data`, host-scoped, no parameters for MVP. Based on `slackbot-agent-sdk/environment/compose.vault.yml`. **Adds** `resourceOutputs: [{ type: "docker-network", purpose: "vault", joinSelf: true }]` so the Mini Infra server container joins the network and consumer stacks can attach via `joinResourceNetworks: ["vault"]`.
+- `server/templates/vault/README.md` — operator notes.
+
+#### Crypto + passphrase
+
+- `server/src/lib/crypto.ts` (new) — shared AES-GCM utilities per P1. `encrypt(key: Buffer, plaintext: Buffer): Buffer`, `decrypt(key: Buffer, ciphertext: Buffer): Buffer`, plus `deriveKey(passphrase: string, salt: Buffer): Promise<Buffer>` using Argon2id. Versioned byte format.
+- `server/src/lib/operator-passphrase-service.ts` (new) — singleton service with an explicit state machine:
+  - States: `uninitialised` (no salt stored), `locked` (salt stored, key not derived), `unlocked` (key in memory), `failed-N` (after N wrong attempts; backoff or lockout).
+  - `setPassphrase(passphrase)` — used during bootstrap; generates salt, derives key, moves to `unlocked`.
+  - `unlock(passphrase)` — post-bootstrap; derives key with stored salt, verifies by decrypting a known-value probe (stored alongside salt), moves to `unlocked`.
+  - `lock()` — zeroises the key buffer, moves to `locked`.
+  - `wrap` / `unwrap` — delegates to `crypto.ts` with the in-memory key.
+  - `OPERATOR_PASSPHRASE` env var unlocks at boot if set.
+  - Emits `VAULT_PASSPHRASE_UNLOCKED` / `_LOCKED` socket events so the UI reacts immediately.
+
+#### Vault client + orchestration
+
+- `server/src/services/vault/vault-http-client.ts` — thin wrapper around OpenBao's HTTP API (`/v1/*`). Modelled on `BaoClient` in `bootstrap.ts`. Circuit breaker like `github-service.ts`.
+- `server/src/services/vault/vault-state-service.ts` — reads/writes the encrypted `VaultState` row; all mutations pass through `operatorPassphraseService.wrap/unwrap`.
+- `server/src/services/vault/vault-admin-service.ts` — orchestrator; methods `bootstrap(onStep)`, `unseal(onStep)`, `rotateRootToken()`, `isReady()`. Step callbacks emit to `Channel.VAULT`. Bootstrap:
+  1. Init (3 shares, threshold 2). Wrap + persist unseal keys and root token.
+  2. Unseal with 2 shares.
+  3. Enable `approle/` and `userpass/` auth methods; enable `kv/` v2 at `secret/`.
+  4. Write the `mini-infra-admin` policy; create the AppRole; read role_id, mint a non-wrapping secret_id, persist both wrapped.
+  5. Create the `mini-infra-operator` userpass user with a random password (per P2); persist encrypted.
+  6. Rotate the root token; switch client auth to the admin AppRole for all subsequent operations.
+  7. Emit `VAULT_BOOTSTRAP_COMPLETED` with the one-time-viewable credentials blob.
+- `server/src/services/vault/vault-config-service.ts` — `IConfigurationService` for `address`, `stackId`, `bootstrappedAt`. `validate()` probes `/v1/sys/health`.
+- Extend `server/src/services/configuration-factory.ts` — register `vault` category.
+
+#### Auto-unseal watcher
+
+- `server/src/services/vault/vault-health-watcher.ts` — periodic seal-status poll (pattern from `connectivity-scheduler.ts`). On `sealed && passphrase.isUnlocked()` → call `vaultAdminService.unseal()`. Emits `VAULT_STATUS_CHANGED` on transitions.
+
+#### Routes
+
+- `server/src/routes/vault/bootstrap.ts` — `POST /api/vault/bootstrap`.
+- `server/src/routes/vault/unseal.ts` — `POST /api/vault/unseal`.
+- `server/src/routes/vault/passphrase.ts` — `POST /api/vault/passphrase/unlock`, `POST /api/vault/passphrase/lock`, `POST /api/vault/passphrase/change`.
+- `server/src/routes/vault/status.ts` — `GET /api/vault/status` (seal, init, passphrase unlocked, reachable).
+- `server/src/routes/vault/index.ts` — mounts the above. Gated behind the `VAULT_ENABLED` flag (see Rollout).
+
+#### Schema
+
+```prisma
+model VaultState {
+  id                          String   @id @default(cuid())
+  kind                        String   @unique  // "primary" for MVP; enables multi-vault later
+  stackId                     String?
+  address                     String?
+  initialised                 Boolean  @default(false)
+  initialisedAt               DateTime?
+  bootstrappedAt              DateTime?
+  passphraseSalt              Bytes?
+  passphraseProbe             Bytes?    // known-value encrypted by the derived key; used to verify passphrase on unlock
+  encryptedUnsealKeys         Bytes?
+  encryptedRootToken          Bytes?
+  encryptedAdminRoleId        Bytes?
+  encryptedAdminSecretId      Bytes?
+  encryptedAdminSecretIdAt    DateTime?
+  encryptedOperatorPassword   Bytes?    // for the userpass mini-infra-operator user (P2)
+  createdAt                   DateTime @default(now())
+  updatedAt                   DateTime @updatedAt
+}
+```
+
+`kind` unique + `cuid()` id preserves singleton-for-now behaviour while allowing multi-vault later without a migration. Upsert by `kind: "primary"` on bootstrap.
+
+#### Types + events
+
+- `lib/types/vault.ts` — `VaultStatus`, `VaultBootstrapResult`, event payload types. Step shape matches the existing `OperationStep` convention.
+- `lib/types/socket-events.ts` — add to `STATIC_SOCKET_CHANNELS`: `"vault"`. Add `Channel.VAULT`. Events: `VAULT_BOOTSTRAP_STARTED / _STEP / _COMPLETED`, `VAULT_UNSEAL_STARTED / _COMPLETED`, `VAULT_STATUS_CHANGED`, `VAULT_PASSPHRASE_UNLOCKED / _LOCKED`.
+
+#### Client
+
+- `client/src/app/vault/page.tsx` — overview: stack status, health, seal status, passphrase-locked banner, Bootstrap / Unlock / Unseal CTAs.
+- `client/src/app/vault/components/VaultStatusCard.tsx` — status badges.
+- `client/src/app/vault/components/BootstrapDialog.tsx` — wizard with passphrase entry → progress via `useOperationProgress(Channel.VAULT, ...)`.
+- `client/src/app/vault/components/PassphraseUnlockDialog.tsx` — shown when locked.
+- `client/src/app/vault/components/BootstrapCompletePage.tsx` — one-time view of unseal keys + root token + operator password. "I've saved these" confirmation required before navigation.
+
+#### Task tracker
+
+- `client/src/lib/task-type-registry.ts` — `vault-bootstrap`, `vault-unseal`.
+
+#### Permissions
+
+- `lib/types/permissions.ts` — new scopes `vault:read`, `vault:write`, `vault:admin`. Wire into presets.
+
+#### Tests
+
+- `server/src/lib/__tests__/crypto.test.ts` — AES-GCM round-trips, version-byte handling, tamper detection, KDF determinism.
+- `server/src/lib/__tests__/operator-passphrase-service.test.ts` — state machine transitions, wrong-passphrase lockout, zeroisation.
+- `server/src/services/vault/__tests__/vault-http-client.test.ts` — mocked fetch, error mapping, circuit breaker.
+- `server/src/services/vault/__tests__/vault-admin-service.test.ts` — bootstrap happy path + failure paths against a mocked Vault.
+- `server/src/services/vault/__tests__/vault-health-watcher.test.ts` — auto-unseal on seal detection, no-op when locked.
+- Integration test (optional, gated): real OpenBao in a docker container for bootstrap e2e.
+
+#### Phase 1 exit criteria
+
+- Operator deploys the vault stack, enters a passphrase, runs bootstrap, end state is: running unsealed Vault, `VaultState` encrypted in DB, `mini-infra-admin` AppRole active, `mini-infra-operator` userpass user can log into the Vault UI.
+- Vault container restart → auto-unseal fires without operator intervention (while passphrase unlocked).
+- Mini Infra restart → Vault stays sealed until operator unlocks passphrase via UI; rest of platform keeps running.
+- **Backup restore test passes**: take a self-backup, destroy `VaultState`, restore from backup, re-unlock passphrase, confirm Vault is operable again. This is an exit gate, not a best-effort check.
+
+---
+
+### Phase 2 — HCL policies + AppRoles as first-class resources
+
+CRUD + apply-to-Vault for policies and AppRoles. Still no stack binding.
+
+#### Schema
+
+```prisma
+model VaultPolicy {
+  id                String   @id @default(cuid())
+  name              String   @unique
+  displayName       String
+  description       String?
+  draftHclBody      String?
+  publishedHclBody  String?
+  publishedVersion  Int      @default(0)
+  publishedAt       DateTime?
+  lastAppliedAt     DateTime?
+  isSystem          Boolean  @default(false)
+  createdById       String?
+  updatedById       String?
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  appRoles          VaultAppRole[]
+}
+
+model VaultAppRole {
+  id                String       @id @default(cuid())
+  name              String       @unique
+  policyId          String
+  policy            VaultPolicy  @relation(fields: [policyId], references: [id], onDelete: Restrict)
+  secretIdNumUses   Int          @default(1)
+  secretIdTtl       String       @default("0")
+  tokenTtl          String?
+  tokenMaxTtl       String?
+  tokenPeriod       String?
+  cachedRoleId      String?      // captured after apply; nullable until reconciled
+  lastAppliedAt     DateTime?
+  createdById       String?
+  createdAt         DateTime     @default(now())
+  updatedAt         DateTime     @updatedAt
+}
+```
+
+Real FK with `onDelete: Restrict` so deleting a policy in use is a loud failure, not a silent dangling reference.
+
+#### Services
+
+- `server/src/services/vault/vault-policy-service.ts` — CRUD + `publish(id)` → `PUT sys/policies/acl/<name>`, bumps `publishedVersion`, sets `lastAppliedAt`.
+- `server/src/services/vault/vault-approle-service.ts` — CRUD + `apply(id)` writes the role to Vault; reads role_id and stores in `cachedRoleId`.
+
+#### Routes
+
+- `server/src/routes/vault/policies.ts` — REST CRUD.
+- `server/src/routes/vault/approles.ts` — REST CRUD + `POST /:id/apply`.
+
+#### Client
+
+- `client/src/app/vault/policies/page.tsx` — list + create.
+- `client/src/app/vault/policies/[id]/page.tsx` — HCL editor per P0 decision (Prism + `react-simple-code-editor` assumed). Side-by-side diff between draft and published via `diff2html` or similar.
+- `client/src/app/vault/roles/` — form-based AppRole editor.
+
+#### Seed data
+
+- `server/src/services/vault/vault-seed.ts` (new, **not** inside `builtin-stack-sync.ts` which is stack-template-specific) — on server boot, upsert:
+  - `mini-infra-admin` policy row (content mirroring what Phase 1 bootstrap wrote to Vault), `isSystem: true`.
+  - `user-self-service` policy template, `isSystem: true`, unapplied.
+  - Example read-only and kv-user-namespaced policies, `isSystem: true`, unapplied.
+- Called from `app-factory.ts` alongside `syncBuiltinStacks()`.
+
+#### Events
+
+- `ServerEvent.VAULT_POLICY_APPLIED`, `ServerEvent.VAULT_APPROLE_APPLIED`.
+
+#### Phase 2 exit criteria
+
+Operator writes an HCL policy in-app, publishes it to Vault, defines an AppRole referencing it, sees `cachedRoleId` populated. Deleting a policy in use returns a clear "cannot delete: referenced by AppRoles x, y, z" error.
+
+---
+
+### Phase 3 — Stack ↔ Vault binding + wrapped secret_id injection
+
+The payoff. This phase is where the existing stack pipeline meets Vault. It's more invasive than Phases 1–2 because we're introducing the concept of **apply-time dynamic env vars** to the stack definition.
+
+#### Schema
+
+```prisma
+model Stack {
+  // existing fields...
+  vaultAppRoleId      String?
+  vaultAppRole        VaultAppRole?  @relation(fields: [vaultAppRoleId], references: [id], onDelete: SetNull)
+  vaultFailClosed     Boolean        @default(true)
+}
+```
+
+Real relation instead of `Json?` — we want FK integrity, and there's exactly one binding field. Promote to a join table later if stacks grow multiple bindings.
+
+#### The dynamic-env mechanism (cross-cutting)
+
+`stack-container-manager.ts` is the **wrong seam** — env vars there bypass `definition-hash` and `lastAppliedSnapshot`, so re-applies won't re-mint secret_ids (a functional bug) and drift detection gets confused (a correctness bug).
+
+Instead:
+
+- Extend the stack-service env model with a `dynamic` marker: `Record<string, string | { dynamic: true; source: 'vault-role-id' | 'vault-wrapped-secret-id' | 'vault-addr' }>`.
+- `template-engine.ts` passes dynamic markers through untouched during parameter interpolation.
+- `definition-hash.ts` and `stack-applied-snapshot.ts` **exclude** dynamic-marked values from their hash / snapshot so the stack is never "drifted" because the wrapping token changed.
+- `stack-plan-computer.ts` resolves dynamic markers at plan time **after** any image pull step has completed, calling a new `VaultCredentialInjector` to mint a wrapped secret_id.
+- `stack-resource-reconciler.ts` / `stack-reconciler.ts` pass the resolved env to the container-creation step through the normal channel.
+
+This is the biggest design risk in the project. Before writing code, do a spike: add a single dynamic-marked env to one test service and verify that (a) subsequent re-applies re-resolve it, (b) drift detection stays stable, (c) applied-snapshot round-trips cleanly.
+
+#### VaultCredentialInjector
+
+- `server/src/services/vault/vault-credential-injector.ts` — given a stack's `vaultAppRoleId`, returns `{ VAULT_ADDR, VAULT_ROLE_ID, VAULT_WRAPPED_SECRET_ID }` or null.
+- Wrapping TTL: **300s** (was 60s in the original plan; too tight given cold image pull + boot). Still short-lived, still one-shot.
+- Mint *after* `pullImageWithAutoAuth()` completes, not before. The plan-computer orchestrates this.
+- Fail-closed nuance:
+  - `vaultFailClosed: true` + Vault unreachable + stack has never been applied successfully → **fail**.
+  - `vaultFailClosed: true` + Vault unreachable + stack has a valid `lastAppliedSnapshot` with the same AppRole → **proceed with `VAULT_ROLE_ID` only, skip wrapping**. The app's responsibility to handle an absent wrap by retrying against Vault once it's reachable. This preserves the design promise ("Mini Infra keeps running when Vault is sealed") — platform redeploys don't block on Vault.
+  - `vaultFailClosed: false` → always proceed with whatever's available.
+
+#### Docker networking — **not** a new external network
+
+Phase 1's template already declared `resourceOutputs: [{ type: "docker-network", purpose: "vault", joinSelf: true }]`. Bound stacks declare `joinResourceNetworks: ["vault"]` in their container config. The existing `stack-infra-resource-manager.ts` handles the attach/detach lifecycle — no new infrastructure code needed.
+
+Verify during the spike: a container on two bridge networks (environment + vault) resolves `mini-infra-vault` short-name reliably. If not, fall back to the Vault container's IP via `docker inspect` or expose the Vault address as a fully-qualified name (e.g. `mini-infra-vault.<vault-network>`). This is the correctness question called out in the review.
+
+#### Routes
+
+- `server/src/routes/stacks/stacks-update-route.ts` — accept `vaultAppRoleId` + `vaultFailClosed` in the patch payload; validate that the AppRole exists.
+- `server/src/routes/vault/bindings.ts` — `GET /api/vault/approles/:id/stacks` — "which stacks use this AppRole?" for the role detail page.
+
+#### Client
+
+- Stack / Application edit UI: new "Vault Integration" section with AppRole dropdown and the fail-closed toggle.
+- Application card: Vault icon badge when bound.
+- `server/templates/hello-vault/template.json` — reference sample that unwraps at boot, logs in via AppRole, reads a KV secret, and echoes it. End-to-end demo.
+
+#### Phase 3 exit criteria
+
+- Deploy hello-vault with a binding; container comes up, unwraps, reads a secret. End-to-end proof.
+- Re-apply the same stack without changes → new wrapping token is minted each time; `definition-hash` stays stable; drift is not reported.
+- Seal Vault after deploy → the already-running app keeps working until its AppRole token expires; a re-apply with the same AppRole succeeds and injects role_id without wrap (the fail-closed nuance); a brand-new stack deploy with a binding fails with a clear error.
+
+---
+
+### Phase 4 — Vault UI exposure via HAProxy + recovery flow
+
+Polish + operational readiness.
+
+#### Files
+
+- Add a `StatelessWeb` service to `server/templates/vault/template.json` routed via HAProxy with a route like `vault.{host}`. Toggle via a template parameter; off means UI-only-on-docker-network. ACME cert issuance is free via the existing flow.
+- `server/src/routes/vault/recover.ts` — `POST /api/vault/recover` lets an operator paste unseal keys + root token if `VaultState` is lost (e.g. backup restore before Phase 1). Re-wraps with current passphrase. Emits a loud audit event.
+- `client/src/app/vault/recover/page.tsx` — admin-only, gated by a double confirmation.
+
+#### Observability
+
+- Log every vault admin op via `userEventService.create()`. Not a full audit log — OpenBao has its own — but a trail of *what Mini Infra did* to Vault.
+
+#### Phase 4 exit criteria
+
+Operator can enable Vault UI via HAProxy with a TLS cert, browse it over the LAN, log in as `mini-infra-operator`. Recovery flow works in a DR drill: wipe `VaultState`, paste the one-time unseal keys from Phase 1, re-enter passphrase, Mini Infra re-seeds its state and regains admin access.
+
+---
+
+## Rollout ordering & feature flag
+
+- `VAULT_ENABLED` env var read at boot. Until Phase 3, all Vault routes return 404 and the nav entry is hidden.
+- Prisma models ship early. Empty tables are harmless; they're tracked in migrations and covered by self-backup automatically.
+- Flag is removed when Phase 4 ships.
+
+## Adjacent issue surfaced by this work (flagged, not fixed here)
+
+The schema labels `RegistryCredential.password`, `PostgresDatabase.connectionString`, `PostgresServer.connectionString`, and `ManagedDatabaseUser.passwordHash` as "Encrypted" in comments, and `server/CLAUDE.md` claims AES encryption via the API key secret. In reality, there is no cipher code — these fields are stored in plaintext. This is not within scope for SecretsVault but the new `server/src/lib/crypto.ts` utility makes a retrofit trivial. Worth a standalone ticket.
+
+## Risks & open questions to resolve during build
+
+- **Short-name DNS resolution on multi-network containers** — tested during the Phase 3 spike. Fallback: bake the Vault address via `docker inspect` when attaching.
+- **HCL editor polish** — Prism-based editor is functional but plain. If operators write lots of HCL, revisit Monaco.
+- **Wrapping TTL under slow pulls** — 300s is generous for normal operation but could be tight on very slow registries. Observable: if any app ever fails to unwrap due to TTL, bump to 600s.
+- **Passphrase rotation** — requires re-wrapping all `VaultState.encrypted*` fields. Implement as part of Phase 4's recovery route or a dedicated settings page; needs explicit testing around partial-rewrap failures.
+- **Self-backup coverage** — covered by the Phase 1 restore-test exit criterion.
+
+## Don't forget
+
+- Update `CLAUDE.md` (project) with a short note about Vault being available and never on the critical path of Mini Infra itself.
+- Update `server/CLAUDE.md` with conventions for `VaultHttpClient`, `VaultAdminService`, `VaultCredentialInjector` (mirror the pattern established for Docker/Azure/GitHub services). Also correct the outdated claim that `postgres` is a supported `ConfigurationServiceFactory` category.
+- Update `docs/roadmap.md` status as phases ship.
+- `scripts/generate-ui-manifest.mjs` auto-picks-up `data-tour` attributes — add them to every new Vault page so the agent sidecar can highlight them.
+- Run the `api-change-check` skill before each phase's PR.

--- a/docs/secrets-vault-plan.md
+++ b/docs/secrets-vault-plan.md
@@ -1,0 +1,157 @@
+# SecretsVault — OpenBao as a managed service
+
+Mini Infra hosts OpenBao the same way a cloud platform hosts a managed secrets service. Applications deployed through Mini Infra log in via short-lived AppRole credentials minted at deploy time; operators manage Vault policies as HCL files stored in Mini Infra. Mini Infra itself **does not** depend on Vault — it writes to Vault but never reads its own secrets from it, so a sealed or broken Vault does not break the platform.
+
+Inspired by the two-stage bootstrap/up pattern in `slackbot-agent-sdk/environment/` ([`bootstrap.ts`](https://github.com/geoff-rich/slackbot-agent-sdk/blob/main/environment/vault/bootstrap.ts), [`up.ts`](https://github.com/geoff-rich/slackbot-agent-sdk/blob/main/environment/up.ts)), generalised and absorbed into Mini Infra's existing Stack + Configuration machinery.
+
+## Related documents
+
+- [secrets-vault-implementation.md](secrets-vault-implementation.md) — concrete, phase-by-phase implementation plan with file paths, schema changes, and services to add.
+
+## Out of scope (tracked separately)
+
+- OIDC / JWT federation so operators can open the Vault UI as themselves — see [vault-oidc-plan.md](vault-oidc-plan.md).
+- Docker volume → Azure Blob backups (useful for backing up the vault's data volume) — see [volume-azure-backup-plan.md](volume-azure-backup-plan.md).
+
+MVP uses OpenBao's built-in userpass/root/AppRole flows. Operators log into the Vault UI with credentials minted by Mini Infra (short-lived, userpass-backed). OIDC lands later.
+
+## Concepts & data model
+
+### New resources
+
+- **SecretsVault** — a singleton record representing the managed OpenBao instance. Fields: `status` (Uninitialised / Sealed / Unsealed / Error), `address`, `stackId` (→ the underlying Stack), `initialisedAt`, `lastUnsealedAt`. One per Mini Infra install (for now).
+- **VaultState** — encrypted persistent state: unseal key shares (wrapped), root token (rotated after bootstrap), mini-infra admin AppRole role_id/secret_id. Separate table so the row can be excluded from routine backups with different retention rules.
+- **VaultPolicy** — `{ name, hclBody, publishedVersion, draftVersion, publishedAt }`. Versioned with draft/publish semantics mirroring `StackTemplate`.
+- **VaultAppRole** — `{ name, policyName, secretIdNumUses, tokenPeriod, tokenTtl, tokenMaxTtl }`. Configuration for an AppRole; Mini Infra reconciles these against Vault on change.
+- **StackVaultBinding** — extension to `Stack` (or `Application`): `{ appRoleName, injectAs: 'env' | 'file' }`. Opt-in. When set, the stack apply flow injects a wrapped secret_id for that AppRole at deploy time.
+
+### Concepts reused
+
+- Stack + Stack Template — the OpenBao service itself is a system stack template.
+- `ConfigurationServiceFactory` — new `vault` category exposing status + address.
+- Task tracker — bootstrap, unseal, policy apply, role apply all use the existing long-running-op pattern.
+- Socket.IO channels — new `Channel.VAULT` with `VAULT_BOOTSTRAP_*`, `VAULT_UNSEAL_*`, `VAULT_POLICY_APPLIED`, `VAULT_ROLE_APPLIED` events.
+
+## Operator passphrase — the unseal story
+
+Mini Infra must not auto-unseal Vault with secrets it can decrypt unattended; that would defeat Shamir. Instead:
+
+- On Mini Infra boot, prompt the operator once for a **passphrase** (CLI prompt, env var, or one-time UI entry that stays in memory only).
+- The passphrase derives (Argon2id) a key-wrapping key. Unseal shares and the mini-infra-admin secret_id are stored in `VaultState` **wrapped by that key** — cannot be decrypted without the passphrase.
+- With the passphrase in memory, Mini Infra auto-unseals on Vault restart, rotates credentials, and mints secret_ids transparently.
+- Without it (e.g. fresh Mini Infra restart), Vault stays sealed; the UI shows a banner "Operator passphrase required to unseal Vault" with a one-time input. Mini Infra **keeps running** — only Vault-dependent features degrade.
+- Passphrase never touches disk, never leaves the server process. Changing it re-wraps the state.
+
+Tradeoffs vs pure auto-unseal: operator must re-enter the passphrase after Mini Infra restarts. That's the cost of not making Mini Infra a single point of compromise.
+
+## Bootstrap flow (first-time setup)
+
+Equivalent of `bootstrap.ts`. Runs once when the operator deploys the SecretsVault stack.
+
+1. Deploy the OpenBao stack via the normal stack apply pipeline (system template).
+2. Wait for `/v1/sys/health` to respond.
+3. Call `sys/init` with `secret_shares: 3, secret_threshold: 2`. Capture unseal keys + root token.
+4. Wrap unseal keys + root token with the operator passphrase's key-wrapping key. Persist to `VaultState`.
+5. Unseal using 2 of 3 shares.
+6. Enable auth methods: `approle/`, `userpass/`.
+7. Enable `kv/` v2 at `secret/`.
+8. Write the built-in `mini-infra-admin` policy and create a matching AppRole. Capture its role_id + secret_id, wrap with the operator key, persist.
+9. Rotate the root token (generate a new one, revoke the original). From now on Mini Infra uses the admin AppRole for all Vault operations; root only regenerated via a manual rotation ceremony.
+10. Emit `VAULT_BOOTSTRAP_COMPLETED`. Show the operator a one-time banner: "Download unseal keys" — the operator gets a copy in case Mini Infra state is lost.
+
+All of this is a single long-running op tracked via the task tracker, step by step.
+
+## HCL policy management
+
+No permissions UI — the HCL *is* the interface. Follows the Stack Template draft/publish pattern.
+
+- **List page** — all policies with publish status + last-applied-to-Vault timestamp.
+- **Editor** — Monaco with HCL syntax highlighting (existing Monaco setup in the client; add HCL mode). Shows diff between draft and published.
+- **Publish action** — validates HCL locally (basic lint), writes to Vault via `PUT sys/policies/acl/<name>`, marks version as published.
+- **Delete action** — removes from Vault + DB; warns if any AppRole references it.
+- **Import** — seed canonical policies (analogue of `slack-gateway-secrets.hcl`, `user-self-service.hcl` etc.) as system policies on first boot. Operators can copy/edit them.
+
+AppRoles are managed the same way: small form with policy picker + TTL fields, or paste raw JSON for the role definition. Reconciled against Vault on change.
+
+## Per-deploy secret_id injection (the `up.ts` equivalent)
+
+This is where the feature earns its keep. Slots into the existing stack apply pipeline.
+
+When a stack has a `StackVaultBinding`, the apply executor:
+
+1. Reads `role_id` from Vault (`GET auth/approle/role/<name>/role-id`) — cached per-role, durable.
+2. Mints a **response-wrapped** secret_id via `POST auth/approle/role/<name>/secret-id` with header `X-Vault-Wrap-TTL: 60s`.
+3. Injects two env vars into every container in the stack:
+   - `VAULT_ADDR` = the internal Vault address (e.g. `http://navi-vault:8200`)
+   - `VAULT_ROLE_ID` = role_id
+   - `VAULT_WRAPPED_SECRET_ID` = wrapping token (60s TTL)
+4. Containers unwrap at boot via `sys/wrapping/unwrap`, then log in via `auth/approle/login`. After that they renew periodically based on the policy.
+
+Wrapped secret_ids never land in logs, env files, or long-lived config — they're minted per deploy and die 60s after the apply. A failed apply leaves nothing behind.
+
+## Networking — who reaches Vault and how
+
+Three audiences, three paths. Mini Infra already owns HAProxy, ACME-issued TLS, and Cloudflare tunnels — lean on those rather than inventing new exposure patterns.
+
+### 1. Container-to-container (apps on the host)
+
+Dedicated external Docker network: `mini-infra-vault-net`. The Vault stack declares it as its primary network (external, so the lifecycle is independent of the Vault stack).
+
+Any stack with a `StackVaultBinding` is automatically attached to `mini-infra-vault-net` at apply time, alongside its normal environment network. Those containers reach Vault at `http://mini-infra-vault:8200`. Stacks without a binding never touch the network and cannot see Vault.
+
+No TLS inside this overlay — the wrapped-secret_id handshake already protects the credential exchange, and everything is on the same Docker host. Adding internal TLS is a bigger lift than it's worth for MVP.
+
+### 2. Users on the local network / LAN
+
+Vault UI is exposed as a first-class application in HAProxy. Reuse the `StatelessWeb` service type with a Shared frontend route (e.g. `vault.<local-domain>`). TLS terminates at HAProxy using the existing ACME cert machinery — no special case. Vault's own auth (userpass for MVP, OIDC later per [vault-oidc-plan.md](vault-oidc-plan.md)) handles identity.
+
+This is identical to how any other internal app is published — Vault is just an app that happens to be system-managed.
+
+### 3. Remote users (optional)
+
+If the install has an internet-type environment with a Cloudflare tunnel, an operator can opt in to a tunnel route pointing at the HAProxy frontend above. Inherits all the existing tunnel plumbing. Recommended to gate behind Cloudflare Access when enabled. Off by default — most single-host installs won't need it.
+
+### Mini Infra → Vault (server-side admin calls)
+
+Two viable options:
+- **Put the Mini Infra server container on `mini-infra-vault-net`** — cleanest. Same address as apps use (`http://mini-infra-vault:8200`). Slightly increases Mini Infra's attack surface (it now sits on the Vault network).
+- **Bind `127.0.0.1:8200` on the Vault container** — for installs where Mini Infra runs on the host, not in Docker, or where the operator wants Mini Infra off the Vault network. Host-local only, not user-facing.
+
+Pick the Docker-network option as the default; expose `127.0.0.1:8200` only when explicitly toggled.
+
+### Explicitly rejected
+
+- **Host port binding as the primary path** — duplicates HAProxy's job, doesn't scale past a single laptop, and forces operators to think about firewall rules Mini Infra could handle for them.
+- **Tailscale sidecar** (the slackbot-agent-sdk pattern) — introduces a non-native dependency and duplicates what HAProxy + Cloudflare tunnels already provide. Operators who want tailnet access can still run their own tailnet sidecar out-of-band.
+- **Per-environment Vault reverse proxies** — deferred. Single shared network is enough for one Docker host. The schema doesn't preclude it later.
+
+### Tradeoffs
+
+- **Shared Vault network** — any compromised app container on `mini-infra-vault-net` can at least reach the Vault API. It still needs a valid token, AppRole policies are strict, and Vault's audit log catches misuse. Kubernetes-style network policies would be stricter; out of scope.
+- **HAProxy as the Vault UI fronting** — if HAProxy is down, the UI is down. HAProxy is already platform-critical, so not a new failure mode. Operators can still hit the API directly on the Vault network if they need break-glass access.
+
+## Mini Infra's own Vault usage
+
+Deliberately minimal in MVP:
+- Mini Infra uses the admin AppRole only for policy management, role management, and secret_id minting.
+- Mini Infra does **not** store its own operational secrets in Vault (API keys, registry creds, Azure connection strings continue to use the existing encrypted-at-rest DB pattern). This keeps the platform bootable when Vault is sealed, broken, or mid-upgrade.
+- Later: optional migration path where platform secrets can be sourced from Vault, but always with a local-DB fallback.
+
+## Build plan — rough phases
+
+1. **OpenBao stack template** — system template + one-click deploy via existing stack machinery. UI shows Vault status on a new "Secrets" page.
+2. **Bootstrap flow** — init + unseal + root rotation + admin AppRole, wrapped by operator passphrase. Task-tracker integration.
+3. **Policy CRUD + HCL editor** — list, edit, publish, delete. Monaco HCL mode.
+4. **AppRole CRUD** — small form, reconciled against Vault on change.
+5. **Stack Vault binding** — schema field + apply-time secret_id injection. Ship one reference app template (e.g. a "Hello Vault" container) that unwraps and reads a secret.
+6. **Auto-unseal on Vault restart** — Mini Infra health-checks Vault and unseals when sealed, provided the operator passphrase is in memory.
+7. **Recovery flows** — operator-initiated root rotation; "paste unseal keys" flow for disaster recovery when `VaultState` is lost.
+
+## Risks & open questions
+
+- **Operator UX for the passphrase** — how prominent is the banner when Vault is sealed? Should Mini Infra prompt at login if the passphrase isn't cached? Needs a small design pass.
+- **Multiple Vaults per install** — today we assume one. Environments might want isolation. Deferred; the schema allows it without rework if the `SecretsVault` row grows an `environmentId`.
+- **Policy linting** — local HCL validation is nice-to-have; worst case we surface Vault's error on publish.
+- **Backup of `VaultState`** — must be part of Mini Infra's own DB backup. The *vault data volume* backup is covered by the separate volume-backup plan.
+- **Sidecar pattern for AppRole** — apps that can't be modified to unwrap at boot need a helper. Possible future: an optional `vault-agent` sidecar in the Stack definition that unwraps + renders templates into a shared volume. Out of scope for MVP.
+- **Audit logging** — OpenBao has its own audit log; expose it in the Mini Infra UI? Probably later, once the core flows are solid.

--- a/docs/vault-oidc-plan.md
+++ b/docs/vault-oidc-plan.md
@@ -1,0 +1,43 @@
+# Vault Auth — OIDC / JWT federation (deferred)
+
+Deferred from the main SecretsVault design. The Vault feature ships first using OpenBao's built-in userpass/token flows and the root/AppRole tokens minted by mini-infra. This plan covers bringing mini-infra's user identity into Vault so operators can open the Vault UI already logged in as themselves.
+
+## Goal
+
+When a mini-infra user clicks "Open Vault UI", they land in OpenBao authenticated as themselves with a short-lived token bound to a policy derived from their mini-infra role.
+
+## Staged approach
+
+### Stage 1 — Vault JWT auth method (MVP)
+
+Smallest path to federated identity. No full OIDC provider required.
+
+- Mini-infra exposes `/.well-known/jwks.json` serving the public half of a signing key (RS256 or EdDSA). Key generated at boot, rotated on a schedule, stored encrypted alongside other platform secrets.
+- New endpoint `POST /api/vault/login` mints a short-lived signed JWT for the current session:
+  - `sub` = mini-infra user id
+  - `email` = user email
+  - `groups` = mini-infra roles (admin / editor / reader)
+  - `aud` = `"mini-infra-vault"`
+  - `exp` = now + 60s
+- OpenBao configured once (during vault bootstrap) with the JWT auth method pointing at mini-infra's JWKS URL. One Vault role per mini-infra role group, each bound to a matching policy.
+- UI: "Open Vault UI" button → calls `/api/vault/login` → POSTs the JWT to Vault's `/v1/auth/jwt/login` → stores the returned client token in the Vault UI's local storage → opens the UI.
+
+### Stage 2 — Full OIDC provider (later)
+
+Only if external consumers need to federate against mini-infra. Adds:
+- Discovery document at `/.well-known/openid-configuration`
+- Authorization code flow (`/authorize`, `/token`)
+- Consent screen
+- Client registration (DB-backed)
+
+Meaningful scope — at least a 1–2 week job on top of stage 1. Defer until a second consumer exists.
+
+### Stage 3 — External IdP passthrough (optional)
+
+For teams that already have an IdP (Google / GitHub / Entra). Configure OpenBao's OIDC auth method directly against the external IdP and skip mini-infra entirely for the identity leg. Mini-infra stores the IdP config via the existing `ConfigurationServiceFactory` pattern.
+
+## Open questions
+
+- Role mapping — flat (mini-infra admin → vault admin) or configurable (admins can edit role-to-policy mapping in UI)?
+- JWKS key rotation cadence — 30 days with 60-day retention of the previous key?
+- Does "Open Vault UI" deep-link through Cloudflare tunnel, or is Vault's UI only reachable on the local network?

--- a/docs/volume-azure-backup-plan.md
+++ b/docs/volume-azure-backup-plan.md
@@ -1,0 +1,39 @@
+# Docker volume backups to Azure Blob (deferred)
+
+A standalone feature, separate from SecretsVault. Mini-infra already has the PostgreSQL + Azure backup pattern; this generalises it to arbitrary Docker volumes.
+
+## Goal
+
+Operators can pick any Docker volume managed by mini-infra, schedule recurring encrypted backups to Azure Blob, and restore from a previous snapshot on demand.
+
+## Shape
+
+- New resource: `VolumeBackupPolicy` — `{ volumeName, schedule (cron), retention, enabled, encryption }`.
+- Reuse `AzureStorageService` (already wired for PG backups).
+- Reuse the backup executor pattern (`server/src/services/backup/` + `restore-executor/`) — probably a new `VolumeBackupExecutor` that follows the same shape as `PostgresBackupExecutor`.
+
+## Implementation sketch
+
+1. **Backup**: spin a transient container (e.g. `alpine:3`) that mounts the target volume read-only, tars + compresses contents, streams to stdout. Pipe into `AzureStorageService.uploadStream()` with server-side encryption enabled. Chunked upload for large volumes.
+2. **Restore**: reverse flow — download blob, stream into a transient container that mounts the target volume RW and extracts. Warn if the volume is currently attached to a running container (require explicit override / stop first).
+3. **Scheduling**: reuse the existing cron scheduler used by PG backups.
+4. **Progress tracking**: new `VOLUME_BACKUP_*` Socket.IO events + task type registry entry, same pattern as existing long-running ops.
+
+## Considerations
+
+- **Volume-in-use safety**: for stateful services, a live tar is racy. Option to quiesce — stop container → snapshot → restart. Note this in the UI.
+- **Size limits**: some volumes will be large. Stream to blob rather than staging on disk; monitor free space.
+- **Encryption at rest**: Azure blob server-side encryption by default; add optional client-side encryption with a key derived from the operator passphrase (same passphrase pattern as SecretsVault unseal).
+- **Retention**: mirror `PostgresBackup` retention policy — keep N most recent or T days.
+- **Restore target**: restoring into a different volume name (clone) is useful for debugging — worth supporting from day one.
+
+## UI
+
+- New "Backups" tab on the volume detail page, showing policy + recent backups.
+- List view on the Volumes page: status badge for "backed up" / "no policy".
+- Restore dialog with blast-radius warning when the volume is attached.
+
+## Dependencies
+
+- Azure storage already configured (existing `ConfigurationServiceFactory` support).
+- No dependency on SecretsVault.


### PR DESCRIPTION
## Summary

Docs-only ideation PR. Adds four design documents for a potential new feature — hosting OpenBao inside Mini Infra as a managed secrets service — and cross-links them from the roadmap. No code changes.

The feature would let Mini Infra orchestrate an OpenBao deployment (bootstrap, unseal, policy and AppRole management) and inject wrapped short-lived AppRole secret_ids into deployed stacks at apply time, so applications log in to Vault without long-lived creds. Inspired by the working two-stage pattern in `slackbot-agent-sdk/environment/{bootstrap.ts, up.ts}`, generalised and absorbed into Mini Infra's existing Stack + Configuration machinery. **Mini Infra itself stays independent of Vault** — the platform keeps running when Vault is sealed.

## What's in the PR

- `docs/secrets-vault-plan.md` — architectural design. Covers operator-passphrase-gated unseal, HCL policies as first-class versioned resources, per-deploy wrapped secret_id injection, and networking for three audiences (apps, LAN users, remote users) via the existing HAProxy + Cloudflare tunnel machinery.
- `docs/secrets-vault-implementation.md` — phase-by-phase build plan with file paths, schema changes, and systems touched. Revised after a sceptical review pass: phases 1+2 collapsed (OpenBao without bootstrap is a half-state), env injection moved to the plan-computer layer so `definition-hash` and `lastAppliedSnapshot` stay stable, networking reuses the existing `resourceOutputs` / `joinResourceNetworks` idiom, shared AES-GCM crypto utility with versioned on-disk format, explicit human UI access story for MVP, wrapping TTL bumped to 300s and minted after image pull.
- `docs/vault-oidc-plan.md` — deferred scope for Vault UI SSO: JWT auth method MVP → full OIDC provider → external IdP passthrough.
- `docs/volume-azure-backup-plan.md` — deferred scope: generalise the Postgres-to-Azure backup pattern to arbitrary Docker volumes (covers backup of the Vault data volume).
- `docs/roadmap.md` — new Secrets Management section linking the three plans.

## Notes for reviewers

- The review pass surfaced an adjacent issue flagged in the implementation plan: `RegistryCredential.password`, `PostgresDatabase.connectionString`, and other fields labelled "Encrypted" in `schema.prisma` + `server/CLAUDE.md` are actually stored in plaintext — there is no cipher code. Out of scope for this PR; worth a standalone ticket. The new `server/src/lib/crypto.ts` utility proposed in the implementation plan would make a retrofit trivial.
- The implementation plan calls out `server/CLAUDE.md` claiming `postgres` is a supported `ConfigurationServiceFactory` category. It isn't (`configuration-factory.ts` lists `docker / cloudflare / azure / tls`). Not fixed in this PR.
- Nothing here is committed to — the plans can be trimmed, re-scoped, or shelved before any code lands.

## Test plan

- [ ] Read the design and confirm the platform non-dependency on Vault is acceptable
- [ ] Review the operator-passphrase tradeoff vs full auto-unseal
- [ ] Review the dynamic-env mechanism in `stack-plan-computer.ts` proposed in implementation Phase 3 — this is called out as the biggest design risk
- [ ] Confirm the HCL editor recommendation (Prism + `react-simple-code-editor`) vs adding Monaco

🤖 Generated with [Claude Code](https://claude.com/claude-code)