### PR TITLE
Per-worktree dev deployment via Colima

### DIFF
--- a/.claude/skills/diagnose-dev/SKILL.md
+++ b/.claude/skills/diagnose-dev/SKILL.md
@@ -9,7 +9,13 @@ You're debugging a running instance of Mini Infra — a Docker host management w
 
 ## Environment
 
-- **App URL**: http://localhost:3005
+- **App URL**: read from `environment-details.xml` at the project root so you're not pinned to a stale port. Grab it once up front and reuse it:
+
+  ```bash
+  MINI_INFRA_URL=$(xmllint --xpath 'string(//environment/endpoints/ui)' environment-details.xml)
+  ```
+
+  If `environment-details.xml` is absent, the user is on the legacy single-instance flow — fall back to `http://localhost:3005`.
 - **Container name**: `mini-infra-dev`
 - **Docker Compose file**: `deployment/development/docker-compose.yaml`
 - **Source code**: available in the current working directory
@@ -125,10 +131,10 @@ Use curl with the API key to query endpoints:
 
 ```bash
 # Health check (no auth needed)
-curl -s http://localhost:3005/health
+curl -s "$MINI_INFRA_URL/health"
 
 # Authenticated requests — add the API key header
-curl -s -H "x-api-key: mk_49181f65c1b91ec453684007f69eaceb7633c5cad706c7c901a2c9f5322c72af" http://localhost:3005/api/containers
+curl -s -H "x-api-key: mk_49181f65c1b91ec453684007f69eaceb7633c5cad706c7c901a2c9f5322c72af" "$MINI_INFRA_URL/api/containers"
 ```
 
 #### Checking container health
@@ -153,7 +159,7 @@ If the issue is visual or involves user interaction, load the Playwright CLI ski
 playwright-cli open --persistent --headed
 
 # Navigate to the app
-playwright-cli goto http://localhost:3005
+playwright-cli goto "$MINI_INFRA_URL"
 
 # Navigate to the affected page, interact with elements, and observe behavior
 # Use snapshots to inspect the DOM state

--- a/.claude/skills/test-dev/SKILL.md
+++ b/.claude/skills/test-dev/SKILL.md
@@ -9,7 +9,13 @@ You're running UI tests against a live instance of Mini Infra — a Docker host 
 
 ## Environment
 
-- **App URL**: http://localhost:3005
+- **App URL**: read from `environment-details.xml` at the project root — each worktree instance uses its own host port. Grab it once up front:
+
+  ```bash
+  MINI_INFRA_URL=$(xmllint --xpath 'string(//environment/endpoints/ui)' environment-details.xml)
+  ```
+
+  If `environment-details.xml` is absent, the user is on the legacy single-instance flow — fall back to `http://localhost:3005`.
 - **Login**: geoff.rich@gmail.com / Juliette 2010
 - **Source code**: available in the current working directory
 
@@ -35,7 +41,7 @@ Before opening the browser, write out the test cases you intend to run:
 ### Step 3 — Open a browser and log in
 
 ```bash
-playwright-cli open --persistent http://localhost:3005
+playwright-cli open --persistent "$MINI_INFRA_URL"
 ```
 
 If redirected to `/login`, fill in credentials and submit:
@@ -127,10 +133,10 @@ Track issues as you find them. Do not wait until the end to log — note each on
 
 ```bash
 # Open browser (headless by default — omit --headed unless you need to watch)
-playwright-cli open --persistent http://localhost:3005
+playwright-cli open --persistent "$MINI_INFRA_URL"
 
 # Navigate (always use full URL — relative paths fail)
-playwright-cli goto http://localhost:3005/some/path
+playwright-cli goto "$MINI_INFRA_URL/some/path"
 
 # Inspect the page (always do this before clicking to find refs)
 playwright-cli snapshot

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ __pycache__/
 *.pyo
 
 scheduled_tasks.lock
+
+# Per-worktree dev environment snapshot written by deployment/development/worktree_start.sh
+environment-details.xml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,26 @@ After the first round of exploration and planning try to do more exploration for
 
 When designing the solution make sure you pick a DRY and well though out solution to reduce duplication and keep the code base maintainable.
 
+## Worktree Development Workflow
+
+For parallel dev work, each git worktree runs its own fully isolated Mini Infra instance on its own Colima VM. This is the default flow — use it instead of fighting over a single dev daemon when you have multiple WIPs in flight.
+
+1. **Spin up.** From the worktree root, run `deployment/development/worktree_start.sh`. This creates (or reuses) a Colima profile named after the worktree directory, allocates stable UI/registry ports from `~/.mini-infra/worktrees.json`, builds + starts the stack, then seeds credentials from `~/.mini-infra/dev.env` so the onboarding wizard is skipped.
+
+2. **Find the URL.** The script writes `environment-details.xml` at the worktree root with the UI URL, Docker host, seeded resource IDs, and connected-service status. Read from it instead of assuming a port (see Browser Automation below for the one-liner).
+
+3. **Edit code normally.** The `server/` / `client/` / `lib/` layout and workspace rules below still apply.
+
+4. **Rebuild after changes.** Re-run `deployment/development/worktree_start.sh`. It's idempotent — profile stays up, image rebuilds, container recreates, seeder skips already-seeded steps.
+
+5. **Test.** Use the `test-dev` or `diagnose-dev` skills; both resolve the URL from `environment-details.xml` automatically.
+
+6. **Tear down.** `colima delete <profile> --data --force` removes the entire VM for that worktree. The profile name is the worktree directory basename (lowercased, sanitised to `[a-z0-9-]`).
+
+Run `git` commands from inside the worktree directory, not the main checkout — mixing shells between the two is the main way commits land on the wrong branch.
+
+See [docs/colima-reference.md](docs/colima-reference.md) for Colima command/config detail and gotchas.
+
 ## Browser Automation & Testing
 
 For browser automation and browser testing tasks, use the Playwright CLI skill defined in `.claude/skills/playwright-cli/SKILL.md`. This skill provides browser interaction capabilities including navigation, form filling, screenshots, and web testing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,14 +14,19 @@ When designing the solution make sure you pick a DRY and well though out solutio
 
 For browser automation and browser testing tasks, use the Playwright CLI skill defined in `.claude/skills/playwright-cli/SKILL.md`. This skill provides browser interaction capabilities including navigation, form filling, screenshots, and web testing.
 
-When opening the site in playwright use `playwright-cli open --persistent` and browse to http://localhost:3005
+When opening the site in playwright, read the current dev UI URL from `environment-details.xml` at the project root rather than hardcoding a port — each worktree instance listens on a different host port:
+
+```bash
+MINI_INFRA_URL=$(xmllint --xpath 'string(//environment/endpoints/ui)' environment-details.xml)
+playwright-cli open --persistent "$MINI_INFRA_URL"
+```
 
 ## Important Instructions
 
-* Always use http://localhost:3005 for all frontend and backend requests as this is a vite server that will proxy through to the backend.
+* Always resolve the frontend/backend URL via `environment-details.xml` (see above) instead of hardcoding a localhost port — Vite proxies client traffic to the backend through whichever port the current worktree instance is bound to.
 * **Always run commands from the project root**. Never `cd` into `client/`, `server/`, or `lib/` subdirectories. Use `-w <workspace>` flags instead (e.g., `npm test -w server`).
 * **Sidecar folders are NOT in the npm workspace**. `update-sidecar/` and `agent-sidecar/` are standalone packages — you must `cd` into them to run npm commands (e.g., `cd agent-sidecar && npm test`), then `cd` back to the project root afterwards.
-* When a change is made for the local dev environment make sure to run `deployment/development/start.sh` to rebuild the underlying containers that support http://localhost:3005
+* When a change is made for the local dev environment rebuild the containers — run `deployment/development/worktree_start.sh` for per-worktree instances (writes the `environment-details.xml`), or the legacy `deployment/development/start.sh` if you're on the single-instance flow.
 
 ## Project Overview
 

--- a/claude-guidance/owasp-zap-guide.md
+++ b/claude-guidance/owasp-zap-guide.md
@@ -127,45 +127,53 @@ docker run --rm -v ${PWD}/zap-reports:/zap/wrk:rw `
 
 ### Testing Localhost Applications
 
-When testing applications running on your host machine (e.g., `http://localhost:3005`):
+When testing Mini Infra on your host machine, resolve the current dev URL from `environment-details.xml` at the project root rather than hardcoding a port:
 
 **Linux/Mac:**
 ```bash
+MINI_INFRA_URL=$(xmllint --xpath 'string(//environment/endpoints/ui)' environment-details.xml)
 docker run --rm --network host \
   -v $(pwd)/zap-reports:/zap/wrk:rw \
   -t ghcr.io/zaproxy/zaproxy:stable \
   zap-baseline.py \
-  -t http://localhost:3005
+  -t "$MINI_INFRA_URL"
 ```
 
 **Windows:**
 ```powershell
-# Use host.docker.internal to reach host services
+# Swap localhost for host.docker.internal so the ZAP container can reach the host.
+$port = ([xml](Get-Content environment-details.xml)).environment.endpoints.ui -replace '^http://localhost:', ''
+$target = "http://host.docker.internal:$port"
 docker run --rm -v ${PWD}/zap-reports:/zap/wrk:rw `
   -t ghcr.io/zaproxy/zaproxy:stable `
   zap-baseline.py `
-  -t http://host.docker.internal:3005
+  -t $target
 ```
 
 ### Testing Mini Infra Application
 
-**Development Environment (default port 3005):**
+Resolve the dev URL from `environment-details.xml` at the project root (written by `deployment/development/worktree_start.sh`) instead of hardcoding a port — each worktree instance listens on a different host port.
+
+**Development Environment:**
 ```bash
 # Linux/Mac
+MINI_INFRA_URL=$(xmllint --xpath 'string(//environment/endpoints/ui)' environment-details.xml)
 docker run --rm --network host \
   -v $(pwd)/zap-reports:/zap/wrk:rw \
   -t ghcr.io/zaproxy/zaproxy:stable \
   zap-baseline.py \
-  -t http://localhost:3005 \
+  -t "$MINI_INFRA_URL" \
   -r mini-infra-scan.html
 ```
 
 ```powershell
-# Windows
+# Windows — swap localhost for host.docker.internal so the ZAP container can reach the host
+$port = ([xml](Get-Content environment-details.xml)).environment.endpoints.ui -replace '^http://localhost:', ''
+$target = "http://host.docker.internal:$port"
 docker run --rm -v ${PWD}/zap-reports:/zap/wrk:rw `
   -t ghcr.io/zaproxy/zaproxy:stable `
   zap-baseline.py `
-  -t http://host.docker.internal:3005 `
+  -t $target `
   -r mini-infra-scan.html
 ```
 
@@ -366,7 +374,8 @@ Make sure you're using the correct network configuration:
 Create `quick-scan.sh`:
 ```bash
 #!/bin/bash
-TARGET=${1:-http://localhost:3005}
+# Default target resolves from environment-details.xml; override with $1 if needed.
+TARGET=${1:-$(xmllint --xpath 'string(//environment/endpoints/ui)' environment-details.xml)}
 REPORT_DIR="./zap-reports"
 
 mkdir -p "$REPORT_DIR"
@@ -393,7 +402,12 @@ chmod +x quick-scan.sh
 Create `quick-scan.ps1`:
 ```powershell
 param(
-    [string]$Target = "http://host.docker.internal:3005"
+    # Default: convert localhost URL from environment-details.xml to host.docker.internal
+    # so the ZAP container can reach the host — override with -Target if needed.
+    [string]$Target = $(
+        $port = ([xml](Get-Content environment-details.xml)).environment.endpoints.ui -replace '^http://localhost:', ''
+        "http://host.docker.internal:$port"
+    )
 )
 
 $ReportDir = "./zap-reports"

--- a/deployment/development/README.md
+++ b/deployment/development/README.md
@@ -155,8 +155,10 @@ docker stop mini-infra-dev 2>/dev/null; docker rm mini-infra-dev 2>/dev/null
 # See container status
 docker ps -a --filter 'name=mini-infra'
 
-# Query the update result via API
-curl -s -H 'x-api-key: <KEY>' http://localhost:3005/api/self-update/status | python3 -m json.tool
+# Query the update result via API — resolve the URL from the generated
+# environment-details.xml rather than hardcoding the port.
+MINI_INFRA_URL=$(xmllint --xpath 'string(//environment/endpoints/ui)' environment-details.xml)
+curl -s -H 'x-api-key: <KEY>' "$MINI_INFRA_URL/api/self-update/status" | python3 -m json.tool
 ```
 
 ## When to Use This vs Regular Development

--- a/deployment/development/dev.env.example
+++ b/deployment/development/dev.env.example
@@ -1,0 +1,37 @@
+# Mini Infra Worktree Seeder — Credentials & Defaults
+#
+# Copy this file to ~/.mini-infra/dev.env and fill in real values. The
+# worktree_seed.sh script sources this file to drive the API during first-run
+# setup. Keep the real file out of git; the example template is the only one
+# committed.
+#
+#   cp deployment/development/dev.env.example ~/.mini-infra/dev.env
+#   chmod 600 ~/.mini-infra/dev.env
+#
+# All values are plaintext as far as Mini Infra is concerned (it encrypts
+# sensitive fields before persisting), but this file itself is on your local
+# disk — protect it accordingly.
+
+# ---- Admin user (required) ------------------------------------------------
+ADMIN_EMAIL=admin@example.test
+ADMIN_DISPLAY_NAME=Admin
+# Min 8 chars, at least one letter and one number.
+ADMIN_PASSWORD=changeme123
+
+# ---- Local environment name (optional) ------------------------------------
+# LOCAL_ENV_NAME=local
+
+# ---- Azure Blob Storage (optional; seeder skips if blank) -----------------
+# Must include DefaultEndpointsProtocol=, AccountName=, AccountKey=
+# Wrap the value in single quotes — the connection string contains ; which bash
+# would otherwise treat as a statement separator when sourcing this file.
+# AZURE_STORAGE_CONNECTION_STRING='DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...;EndpointSuffix=core.windows.net'
+
+# ---- Cloudflare (optional; seeder skips if either is blank) ---------------
+# API token needs Zone:DNS:Edit on the zones you manage.
+# CLOUDFLARE_API_TOKEN=
+# CLOUDFLARE_ACCOUNT_ID=
+
+# ---- GitHub (optional; seeder skips if blank) -----------------------------
+# Classic PAT or fine-grained token with repo read access for your use case.
+# GITHUB_TOKEN=

--- a/deployment/development/docker-compose.worktree.yaml
+++ b/deployment/development/docker-compose.worktree.yaml
@@ -1,0 +1,59 @@
+# Parameterized compose file for running one Mini Infra instance per worktree.
+# Driven by worktree_start.sh, which sets COMPOSE_PROJECT_NAME, DOCKER_HOST (to
+# a per-worktree Colima socket), and the ${UI_PORT}/${REGISTRY_PORT}/${DOCKER_SOCK}
+# variables below. Container, network, and volume namespacing is handled by
+# COMPOSE_PROJECT_NAME — no resources here are hardcoded to a single instance.
+
+services:
+  registry:
+    image: registry:2
+    restart: unless-stopped
+    ports:
+      - "${REGISTRY_PORT}:5000"
+    volumes:
+      - registry:/var/lib/registry
+
+  mini-infra:
+    build:
+      context: ../../
+      dockerfile: Dockerfile
+      args:
+        AGENT_SIDECAR_IMAGE_TAG: ${AGENT_SIDECAR_IMAGE_TAG}
+    user: root
+    restart: unless-stopped
+    depends_on:
+      registry:
+        condition: service_started
+    ports:
+      - "${UI_PORT}:5005"
+    volumes:
+      # /var/run/docker.sock inside the Colima VM is the per-profile daemon
+      # socket — this path is VM-local, not host-local, so no DOCKER_SOCK
+      # variable is needed.
+      - /var/run/docker.sock:/var/run/docker.sock
+      - data:/app/data
+      - logs:/app/server/logs
+    environment:
+      - LOG_LEVEL=debug
+      - ALLOW_INSECURE=true
+      - ENABLE_DEV_API_KEY_ENDPOINT=true
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "require('http').get('http://localhost:5000/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})",
+        ]
+      interval: 10s
+      timeout: 3s
+      start_period: 40s
+      retries: 10
+
+volumes:
+  data:
+    driver: local
+  logs:
+    driver: local
+  registry:
+    driver: local

--- a/deployment/development/worktree_seed.sh
+++ b/deployment/development/worktree_seed.sh
@@ -1,0 +1,512 @@
+#!/bin/bash
+# Mini Infra Worktree Seeder
+#
+# Drives the running app via its REST API to skip onboarding:
+#   1. Create the first admin user via POST /auth/setup
+#   2. Exchange admin credentials for a full-admin API key via
+#      POST /api/dev/issue-api-key (requires ENABLE_DEV_API_KEY_ENDPOINT=true)
+#   3. Complete the setup wizard (docker host) via POST /auth/setup/complete
+#   4. Upsert Azure / Cloudflare / GitHub credentials from ~/.mini-infra/dev.env
+#   5. Create a local environment
+#   6. Instantiate the built-in HAProxy stack template into the local env
+#   7. Mark onboarding complete
+#
+# Each step is idempotent-ish: already-configured state is logged and skipped,
+# but the script doesn't go out of its way to back out partial state — if a
+# step fails mid-way, fix the env file and re-run.
+#
+# Invoked by worktree_start.sh once the app is healthy. Expects UI_PORT and
+# DEV_ENV_FILE to be set in the environment.
+
+set -e
+
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+info()  { echo -e "${CYAN}▸ $1${NC}"; }
+ok()    { echo -e "${GREEN}✓ $1${NC}"; }
+skip()  { echo -e "${YELLOW}• $1${NC}"; }
+fail()  { echo -e "${RED}✗ $1${NC}"; }
+
+: "${UI_PORT:?UI_PORT must be set}"
+: "${DEV_ENV_FILE:?DEV_ENV_FILE must be set}"
+
+if [ ! -f "$DEV_ENV_FILE" ]; then
+    fail "Env file not found: $DEV_ENV_FILE"
+    exit 1
+fi
+
+# shellcheck disable=SC1090
+set -a; source "$DEV_ENV_FILE"; set +a
+
+: "${ADMIN_EMAIL:?ADMIN_EMAIL must be set in dev.env}"
+: "${ADMIN_PASSWORD:?ADMIN_PASSWORD must be set in dev.env}"
+: "${ADMIN_DISPLAY_NAME:=Admin}"
+
+BASE_URL="http://localhost:$UI_PORT"
+
+# Single response-body buffer shared across api() calls. We can't create it
+# inside api() because $(api ...) runs in a subshell and any variable set
+# there would be lost.
+RESP_FILE="$(mktemp)"
+trap 'rm -f "$RESP_FILE"' EXIT
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+# Prints the HTTP status to stdout; writes the response body to $RESP_FILE.
+api() {
+    local method="$1" path="$2" body="${3-}"
+    : > "$RESP_FILE"
+    local curl_args=(-sS -o "$RESP_FILE" -w "%{http_code}" -X "$method" \
+        -H "Content-Type: application/json" "${BASE_URL}${path}")
+    if [ -n "${API_KEY:-}" ]; then
+        curl_args+=(-H "Authorization: Bearer ${API_KEY}")
+    fi
+    if [ -n "$body" ]; then
+        curl_args+=(-d "$body")
+    fi
+    curl "${curl_args[@]}"
+}
+
+json_escape() { python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().rstrip("\n")))'; }
+
+# ---------------------------------------------------------------------------
+# 1. Create admin user (idempotent: /auth/setup returns 403 if already done)
+# ---------------------------------------------------------------------------
+info "Checking setup status"
+status=$(api GET /auth/setup-status)
+if [ "$status" != "200" ]; then
+    fail "setup-status returned $status: $(cat "$RESP_FILE")"
+    exit 1
+fi
+setup_complete=$(python3 -c "import json,sys; print(json.load(open('$RESP_FILE')).get('setupComplete', False))")
+has_users=$(python3 -c "import json,sys; print(json.load(open('$RESP_FILE')).get('hasUsers', False))")
+
+if [ "$has_users" = "True" ]; then
+    skip "Admin user already exists"
+else
+    info "Creating admin user $ADMIN_EMAIL"
+    body=$(python3 -c "
+import json, os
+print(json.dumps({
+    'email': os.environ['ADMIN_EMAIL'],
+    'displayName': os.environ['ADMIN_DISPLAY_NAME'],
+    'password': os.environ['ADMIN_PASSWORD'],
+}))")
+    status=$(api POST /auth/setup "$body")
+    if [ "$status" != "201" ]; then
+        fail "POST /auth/setup returned $status: $(cat "$RESP_FILE")"
+        exit 1
+    fi
+    ok "Admin user created"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Issue a full-admin API key
+# ---------------------------------------------------------------------------
+info "Issuing dev API key"
+body=$(python3 -c "
+import json, os
+print(json.dumps({
+    'email': os.environ['ADMIN_EMAIL'],
+    'password': os.environ['ADMIN_PASSWORD'],
+    'name': 'worktree-seeder',
+}))")
+status=$(api POST /api/dev/issue-api-key "$body")
+if [ "$status" != "201" ]; then
+    fail "issue-api-key returned $status: $(cat "$RESP_FILE")"
+    fail "Is ENABLE_DEV_API_KEY_ENDPOINT=true set on the container?"
+    exit 1
+fi
+API_KEY=$(python3 -c "import json; print(json.load(open('$RESP_FILE'))['apiKey'])")
+export API_KEY
+ok "API key obtained"
+
+# ---------------------------------------------------------------------------
+# 3. Complete setup wizard (docker host)
+# ---------------------------------------------------------------------------
+if [ "$setup_complete" = "True" ]; then
+    skip "Setup wizard already completed"
+else
+    info "Completing setup wizard"
+    # /var/run/docker.sock inside the container is bind-mounted to the Colima
+    # profile's socket on the host. That's the only docker socket the container
+    # can reach, so it's the correct value to save here.
+    body='{"dockerHost":"unix:///var/run/docker.sock"}'
+    status=$(api POST /auth/setup/complete "$body")
+    if [ "$status" != "200" ] && [ "$status" != "201" ]; then
+        fail "setup/complete returned $status: $(cat "$RESP_FILE")"
+        exit 1
+    fi
+    ok "Setup wizard completed"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Service credentials (best-effort: missing env vars skip the step)
+# ---------------------------------------------------------------------------
+if [ -n "${AZURE_STORAGE_CONNECTION_STRING:-}" ]; then
+    info "Configuring Azure Storage"
+    body=$(python3 -c "
+import json, os
+print(json.dumps({'connectionString': os.environ['AZURE_STORAGE_CONNECTION_STRING']}))")
+    status=$(api PUT /api/settings/azure "$body")
+    if [ "$status" = "200" ] || [ "$status" = "201" ]; then
+        ok "Azure configured"
+    else
+        fail "Azure PUT returned $status: $(cat "$RESP_FILE")"
+    fi
+else
+    skip "AZURE_STORAGE_CONNECTION_STRING not set — skipping"
+fi
+
+if [ -n "${CLOUDFLARE_API_TOKEN:-}" ] && [ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
+    info "Configuring Cloudflare"
+    body=$(python3 -c "
+import json, os
+print(json.dumps({
+    'api_token': os.environ['CLOUDFLARE_API_TOKEN'],
+    'account_id': os.environ['CLOUDFLARE_ACCOUNT_ID'],
+}))")
+    status=$(api POST /api/settings/cloudflare "$body")
+    if [ "$status" = "200" ] || [ "$status" = "201" ]; then
+        ok "Cloudflare configured"
+    else
+        fail "Cloudflare POST returned $status: $(cat "$RESP_FILE")"
+    fi
+else
+    skip "CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID not set — skipping"
+fi
+
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+    info "Configuring GitHub"
+    body=$(python3 -c "
+import json, os
+print(json.dumps({'token': os.environ['GITHUB_TOKEN']}))")
+    status=$(api PUT /api/settings/github "$body")
+    if [ "$status" = "200" ] || [ "$status" = "201" ]; then
+        ok "GitHub configured"
+    else
+        # GitHub settings route shape may differ — surface the response so the
+        # user can adjust the payload without guessing.
+        skip "GitHub PUT returned $status (likely a payload-shape mismatch): $(cat "$RESP_FILE")"
+    fi
+else
+    skip "GITHUB_TOKEN not set — skipping"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Create the local environment
+# ---------------------------------------------------------------------------
+info "Creating local environment"
+ENV_NAME="${LOCAL_ENV_NAME:-local}"
+status=$(api GET "/api/environments")
+LOCAL_ENV_ID=""
+if [ "$status" = "200" ]; then
+    LOCAL_ENV_ID=$(python3 -c "
+import json, sys
+envs = json.load(open('$RESP_FILE'))
+if isinstance(envs, dict):
+    envs = envs.get('data') or envs.get('environments') or []
+for e in envs:
+    if e.get('networkType') == 'local':
+        print(e.get('id', ''))
+        break
+")
+fi
+
+if [ -n "$LOCAL_ENV_ID" ]; then
+    skip "Local environment already exists (id=$LOCAL_ENV_ID)"
+else
+    body=$(python3 -c "
+import json, os
+print(json.dumps({
+    'name': os.environ.get('LOCAL_ENV_NAME', 'local'),
+    'description': 'Dev local environment (seeded)',
+    'type': 'nonproduction',
+    'networkType': 'local',
+}))")
+    status=$(api POST /api/environments "$body")
+    if [ "$status" != "201" ]; then
+        fail "POST /api/environments returned $status: $(cat "$RESP_FILE")"
+        exit 1
+    fi
+    LOCAL_ENV_ID=$(python3 -c "import json; print(json.load(open('$RESP_FILE')).get('id',''))")
+    ok "Local environment created (id=$LOCAL_ENV_ID)"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Ensure HAProxy stack exists in the local env, then apply it.
+# Re-runs are idempotent: we look up an existing haproxy-local stack by name
+# before instantiating a fresh one. The /:templateId/instantiate endpoint does
+# not dedupe on its own.
+# ---------------------------------------------------------------------------
+STACK_NAME="haproxy-local"
+
+info "Looking for existing $STACK_NAME stack in local env"
+HAPROXY_STACK_ID=""
+status=$(api GET "/api/stacks?environmentId=$LOCAL_ENV_ID")
+if [ "$status" = "200" ]; then
+    HAPROXY_STACK_ID=$(STACK_NAME="$STACK_NAME" RESP_FILE="$RESP_FILE" python3 -c "
+import json, os
+d = json.load(open(os.environ['RESP_FILE']))
+stacks = d.get('data') if isinstance(d, dict) else d
+for s in stacks or []:
+    if s.get('name') == os.environ['STACK_NAME']:
+        print(s.get('id', ''))
+        break
+")
+fi
+
+if [ -n "$HAPROXY_STACK_ID" ]; then
+    skip "HAProxy stack already exists (id=$HAPROXY_STACK_ID)"
+else
+    info "Locating HAProxy stack template"
+    status=$(api GET "/api/stack-templates")
+    HAPROXY_TPL_ID=""
+    if [ "$status" = "200" ]; then
+        HAPROXY_TPL_ID=$(RESP_FILE="$RESP_FILE" python3 -c "
+import json, os
+d = json.load(open(os.environ['RESP_FILE']))
+items = d if isinstance(d, list) else (d.get('data') or d.get('templates') or [])
+for t in items:
+    if 'haproxy' in (t.get('name') or '').lower():
+        print(t.get('id', ''))
+        break
+")
+    fi
+
+    if [ -z "$HAPROXY_TPL_ID" ]; then
+        skip "HAProxy template not found — skipping HAProxy setup"
+    else
+        body=$(STACK_NAME="$STACK_NAME" LOCAL_ENV_ID="$LOCAL_ENV_ID" python3 -c "
+import json, os
+print(json.dumps({
+    'environmentId': os.environ['LOCAL_ENV_ID'],
+    'name': os.environ['STACK_NAME'],
+}))")
+        status=$(api POST "/api/stack-templates/$HAPROXY_TPL_ID/instantiate" "$body")
+        if [ "$status" != "201" ]; then
+            fail "HAProxy instantiate returned $status: $(cat "$RESP_FILE")"
+        else
+            HAPROXY_STACK_ID=$(RESP_FILE="$RESP_FILE" python3 -c "
+import json, os
+d = json.load(open(os.environ['RESP_FILE']))
+s = d.get('data') if isinstance(d, dict) else d
+print((s or {}).get('id', ''))
+")
+            ok "HAProxy stack created (id=$HAPROXY_STACK_ID)"
+        fi
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Apply the HAProxy stack so containers are actually running.
+# Apply is fire-and-forget; we poll status until Synced/Error or timeout.
+# ---------------------------------------------------------------------------
+if [ -n "$HAPROXY_STACK_ID" ]; then
+    # Snapshot both status and lastAppliedAt pre-apply. The status field may
+    # still read "error" (or whatever) from a prior run until the reconciler
+    # finishes this one, so we use lastAppliedAt as the authoritative
+    # "reconciler completed a new run" signal.
+    current_status=""
+    prev_last_applied=""
+    status=$(api GET "/api/stacks/$HAPROXY_STACK_ID")
+    if [ "$status" = "200" ]; then
+        current_status=$(RESP_FILE="$RESP_FILE" python3 -c "
+import json, os
+d = json.load(open(os.environ['RESP_FILE']))
+s = (d.get('data') if isinstance(d, dict) else d) or {}
+print(s.get('status','') or '')
+")
+        prev_last_applied=$(RESP_FILE="$RESP_FILE" python3 -c "
+import json, os
+d = json.load(open(os.environ['RESP_FILE']))
+s = (d.get('data') if isinstance(d, dict) else d) or {}
+print(s.get('lastAppliedAt','') or '')
+")
+    fi
+
+    current_lower=$(echo "$current_status" | tr '[:upper:]' '[:lower:]')
+    if [ "$current_lower" = "synced" ]; then
+        skip "HAProxy stack is already Synced — skipping apply"
+    else
+        info "Applying HAProxy stack (current status: ${current_status:-unknown})"
+        status=$(api POST "/api/stacks/$HAPROXY_STACK_ID/apply" "{}")
+        if [ "$status" != "200" ] && [ "$status" != "202" ]; then
+            fail "Apply returned $status: $(cat "$RESP_FILE")"
+        else
+            info "Apply started — polling for completion (timeout 120s)"
+            polled_status=""
+            for i in $(seq 1 40); do
+                sleep 3
+                status=$(api GET "/api/stacks/$HAPROXY_STACK_ID")
+                if [ "$status" != "200" ]; then
+                    continue
+                fi
+                polled_status=$(RESP_FILE="$RESP_FILE" python3 -c "
+import json, os
+d = json.load(open(os.environ['RESP_FILE']))
+s = (d.get('data') if isinstance(d, dict) else d) or {}
+print(s.get('status','') or '')
+")
+                polled_last_applied=$(RESP_FILE="$RESP_FILE" python3 -c "
+import json, os
+d = json.load(open(os.environ['RESP_FILE']))
+s = (d.get('data') if isinstance(d, dict) else d) or {}
+print(s.get('lastAppliedAt','') or '')
+")
+                # Only treat a terminal status as meaningful once lastAppliedAt
+                # has advanced — otherwise we'd accept the pre-apply value.
+                if [ "$polled_last_applied" = "$prev_last_applied" ]; then
+                    continue
+                fi
+                polled_lower=$(echo "$polled_status" | tr '[:upper:]' '[:lower:]')
+                case "$polled_lower" in
+                    synced)
+                        ok "HAProxy stack is Synced"
+                        break
+                        ;;
+                    error)
+                        fail "HAProxy stack apply failed (status=error)"
+                        break
+                        ;;
+                esac
+                if [ "$i" -eq 40 ]; then
+                    skip "Timed out waiting for HAProxy to sync (last status: ${polled_status:-unknown})"
+                fi
+            done
+        fi
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Mark onboarding complete
+# ---------------------------------------------------------------------------
+info "Marking onboarding complete"
+status=$(api POST /api/onboarding/complete "{}")
+if [ "$status" = "200" ] || [ "$status" = "201" ] || [ "$status" = "204" ]; then
+    ok "Onboarding marked complete"
+else
+    skip "onboarding/complete returned $status (may already be complete): $(cat "$RESP_FILE")"
+fi
+
+# ---------------------------------------------------------------------------
+# 8. Emit environment-details.xml at the project root.
+# Only written when DETAILS_FILE is provided (by worktree_start.sh). Captures
+# the current state of the worktree instance so follow-up tooling — or a human
+# — can see everything in one place without going hunting across shells.
+# ---------------------------------------------------------------------------
+if [ -n "${DETAILS_FILE:-}" ]; then
+    info "Writing $DETAILS_FILE"
+    # Collect fresh state from the API so whatever the seeder skipped or
+    # couldn't change is still reflected accurately.
+    status=$(api GET "/api/environments")
+    envs_json="${RESP_FILE}.envs"; cp "$RESP_FILE" "$envs_json"
+    status=$(api GET "/api/stacks?environmentId=$LOCAL_ENV_ID")
+    stacks_json="${RESP_FILE}.stacks"; cp "$RESP_FILE" "$stacks_json"
+
+    DETAILS_FILE="$DETAILS_FILE" \
+    PROFILE="${PROFILE:-}" \
+    PROJECT_ROOT="${PROJECT_ROOT:-}" \
+    UI_PORT="$UI_PORT" \
+    REGISTRY_PORT="${REGISTRY_PORT:-}" \
+    DOCKER_HOST="${DOCKER_HOST:-}" \
+    COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-}" \
+    AGENT_SIDECAR_IMAGE_TAG="${AGENT_SIDECAR_IMAGE_TAG:-}" \
+    ADMIN_EMAIL="$ADMIN_EMAIL" \
+    LOCAL_ENV_ID="$LOCAL_ENV_ID" \
+    ENVS_JSON="$envs_json" \
+    STACKS_JSON="$stacks_json" \
+    AZURE_SET="$([ -n "${AZURE_STORAGE_CONNECTION_STRING:-}" ] && echo true || echo false)" \
+    CLOUDFLARE_SET="$([ -n "${CLOUDFLARE_API_TOKEN:-}" ] && [ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ] && echo true || echo false)" \
+    GITHUB_SET="$([ -n "${GITHUB_TOKEN:-}" ] && echo true || echo false)" \
+    python3 - <<'PY'
+import json, os
+from datetime import datetime, timezone
+from xml.sax.saxutils import escape
+
+def t(v):
+    return escape(v or '')
+
+def load(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+envs = load(os.environ['ENVS_JSON']) or []
+if isinstance(envs, dict):
+    envs = envs.get('data') or envs.get('environments') or []
+local_env = next((e for e in envs if e.get('id') == os.environ['LOCAL_ENV_ID']), None)
+
+stacks_raw = load(os.environ['STACKS_JSON']) or []
+if isinstance(stacks_raw, dict):
+    stacks_raw = stacks_raw.get('data') or []
+
+stacks_xml = []
+for s in stacks_raw:
+    stacks_xml.append(
+        '    <stack>\n'
+        f'      <id>{t(s.get("id"))}</id>\n'
+        f'      <name>{t(s.get("name"))}</name>\n'
+        f'      <status>{t(s.get("status"))}</status>\n'
+        f'      <lastAppliedAt>{t(s.get("lastAppliedAt"))}</lastAppliedAt>\n'
+        '    </stack>'
+    )
+stacks_block = '\n'.join(stacks_xml) if stacks_xml else ''
+
+local_env_block = ''
+if local_env:
+    local_env_block = (
+        '  <localEnvironment>\n'
+        f'    <id>{t(local_env.get("id"))}</id>\n'
+        f'    <name>{t(local_env.get("name"))}</name>\n'
+        f'    <type>{t(local_env.get("type"))}</type>\n'
+        f'    <networkType>{t(local_env.get("networkType"))}</networkType>\n'
+        '  </localEnvironment>'
+    )
+
+xml = f"""<?xml version="1.0" encoding="UTF-8"?>
+<environment>
+  <generated>{datetime.now(timezone.utc).isoformat(timespec='seconds')}</generated>
+  <seeded>true</seeded>
+  <worktree>
+    <profile>{t(os.environ['PROFILE'])}</profile>
+    <path>{t(os.environ['PROJECT_ROOT'])}</path>
+    <dockerHost>{t(os.environ['DOCKER_HOST'])}</dockerHost>
+    <composeProject>{t(os.environ['COMPOSE_PROJECT_NAME'])}</composeProject>
+  </worktree>
+  <endpoints>
+    <ui>http://localhost:{t(os.environ['UI_PORT'])}</ui>
+    <registry>localhost:{t(os.environ['REGISTRY_PORT'])}</registry>
+  </endpoints>
+  <images>
+    <agentSidecar>{t(os.environ['AGENT_SIDECAR_IMAGE_TAG'])}</agentSidecar>
+  </images>
+  <admin>
+    <email>{t(os.environ['ADMIN_EMAIL'])}</email>
+  </admin>
+  <connectedServices>
+    <azure configured="{os.environ['AZURE_SET']}"/>
+    <cloudflare configured="{os.environ['CLOUDFLARE_SET']}"/>
+    <github configured="{os.environ['GITHUB_SET']}"/>
+  </connectedServices>
+{local_env_block}
+  <stacks>
+{stacks_block}
+  </stacks>
+</environment>
+"""
+with open(os.environ['DETAILS_FILE'], 'w') as f:
+    f.write(xml)
+PY
+    rm -f "$envs_json" "$stacks_json"
+    ok "Wrote $DETAILS_FILE"
+fi
+
+echo ""
+ok "Seeder finished"

--- a/deployment/development/worktree_start.sh
+++ b/deployment/development/worktree_start.sh
@@ -1,0 +1,327 @@
+#!/bin/bash
+# Mini Infra Per-Worktree Development Startup (Bash)
+#
+# Runs one fully isolated Mini Infra instance per worktree by giving each a
+# dedicated Colima VM (its own Docker daemon) and a namespaced Compose project.
+# Ports are allocated from ~/.mini-infra/worktrees.json so re-runs are stable.
+#
+# Usage: ./worktree_start.sh [--profile <name>] [--reset] [--skip-seed]
+#
+# After the app is healthy, the script runs worktree_seed.sh to POST /setup,
+# issue an admin API key, and seed service configs + a local environment +
+# HAProxy from values in ~/.mini-infra/dev.env.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR/../.."
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.worktree.yaml"
+SEED_SCRIPT="$SCRIPT_DIR/worktree_seed.sh"
+
+# ---------------------------------------------------------------------------
+# Config / defaults
+# ---------------------------------------------------------------------------
+MINI_INFRA_HOME="${MINI_INFRA_HOME:-$HOME/.mini-infra}"
+REGISTRY_FILE="$MINI_INFRA_HOME/worktrees.json"
+DEV_ENV_FILE="$MINI_INFRA_HOME/dev.env"
+
+UI_PORT_MIN=3100
+UI_PORT_MAX=3199
+REGISTRY_PORT_MIN=5100
+REGISTRY_PORT_MAX=5199
+
+COLIMA_CPUS=2
+COLIMA_MEMORY=8
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+log_info()  { echo -e "${CYAN}$1${NC}"; }
+log_ok()    { echo -e "${GREEN}$1${NC}"; }
+log_warn()  { echo -e "${YELLOW}$1${NC}"; }
+log_error() { echo -e "${RED}$1${NC}"; }
+
+# Minimal environment-details.xml used when the seeder doesn't run (skip-seed
+# or missing dev.env). The seeder itself writes a richer version including the
+# local environment / stack IDs / connected-service status.
+write_minimal_environment_details() {
+    local target="$1"
+    PROFILE="$PROFILE" \
+    PROJECT_ROOT="$PROJECT_ROOT" \
+    UI_PORT="$UI_PORT" \
+    REGISTRY_PORT="$REGISTRY_PORT" \
+    DOCKER_HOST="$DOCKER_HOST" \
+    DOCKER_SOCK_PATH="$DOCKER_SOCK_PATH" \
+    COMPOSE_PROJECT_NAME="$COMPOSE_PROJECT_NAME" \
+    AGENT_SIDECAR_IMAGE_TAG="$AGENT_SIDECAR_IMAGE_TAG" \
+    TARGET="$target" \
+    python3 - <<'PY'
+import os
+from datetime import datetime, timezone
+from xml.sax.saxutils import escape
+
+def t(v):
+    return escape(v or '')
+
+xml = f"""<?xml version="1.0" encoding="UTF-8"?>
+<environment>
+  <generated>{datetime.now(timezone.utc).isoformat(timespec='seconds')}</generated>
+  <seeded>false</seeded>
+  <worktree>
+    <profile>{t(os.environ['PROFILE'])}</profile>
+    <path>{t(os.environ['PROJECT_ROOT'])}</path>
+    <dockerHost>{t(os.environ['DOCKER_HOST'])}</dockerHost>
+    <dockerSocket>{t(os.environ.get('DOCKER_SOCK_PATH',''))}</dockerSocket>
+    <composeProject>{t(os.environ['COMPOSE_PROJECT_NAME'])}</composeProject>
+  </worktree>
+  <endpoints>
+    <ui>http://localhost:{t(os.environ['UI_PORT'])}</ui>
+    <registry>localhost:{t(os.environ['REGISTRY_PORT'])}</registry>
+  </endpoints>
+  <images>
+    <agentSidecar>{t(os.environ['AGENT_SIDECAR_IMAGE_TAG'])}</agentSidecar>
+  </images>
+</environment>
+"""
+with open(os.environ['TARGET'], 'w') as f:
+    f.write(xml)
+print(f"Wrote {os.environ['TARGET']}")
+PY
+}
+
+# ---------------------------------------------------------------------------
+# Parse args
+# ---------------------------------------------------------------------------
+PROFILE=""
+RESET=false
+SKIP_SEED=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --profile) PROFILE="$2"; shift 2 ;;
+        --reset) RESET=true; shift ;;
+        --skip-seed) SKIP_SEED=true; shift ;;
+        -h|--help)
+            sed -n '2,12p' "$0"
+            exit 0
+            ;;
+        *) log_error "Unknown arg: $1"; exit 1 ;;
+    esac
+done
+
+# Derive profile name from the worktree directory basename if not passed
+if [ -z "$PROFILE" ]; then
+    WORKTREE_DIR="$(cd "$PROJECT_ROOT" && pwd)"
+    PROFILE="$(basename "$WORKTREE_DIR")"
+fi
+# Colima profile names must match [a-z0-9-]+; normalize liberally.
+PROFILE="$(echo "$PROFILE" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9-' '-' | sed 's/--*/-/g; s/^-//; s/-$//')"
+if [ -z "$PROFILE" ]; then
+    log_error "Could not derive a valid profile name"
+    exit 1
+fi
+log_info "Worktree profile: $PROFILE"
+
+# ---------------------------------------------------------------------------
+# Prerequisites
+# ---------------------------------------------------------------------------
+if ! command -v colima >/dev/null 2>&1; then
+    log_error "colima is not installed. Install with: brew install colima"
+    exit 1
+fi
+if ! command -v docker >/dev/null 2>&1; then
+    log_error "docker CLI is not installed. Install with: brew install docker"
+    exit 1
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    log_error "python3 is required for port allocation"
+    exit 1
+fi
+
+mkdir -p "$MINI_INFRA_HOME"
+[ -f "$REGISTRY_FILE" ] || echo '{"worktrees": {}}' > "$REGISTRY_FILE"
+
+# ---------------------------------------------------------------------------
+# Allocate ports (deterministic: same worktree always gets same ports)
+# ---------------------------------------------------------------------------
+PORTS_JSON=$(python3 - <<PY
+import json, sys
+reg_path = "$REGISTRY_FILE"
+profile = "$PROFILE"
+ui_min, ui_max = $UI_PORT_MIN, $UI_PORT_MAX
+reg_min, reg_max = $REGISTRY_PORT_MIN, $REGISTRY_PORT_MAX
+
+with open(reg_path) as f:
+    reg = json.load(f)
+wt = reg.setdefault("worktrees", {})
+
+if profile in wt:
+    entry = wt[profile]
+else:
+    used_ui = {w.get("ui_port") for w in wt.values()}
+    used_reg = {w.get("registry_port") for w in wt.values()}
+    ui = next((p for p in range(ui_min, ui_max + 1) if p not in used_ui), None)
+    rg = next((p for p in range(reg_min, reg_max + 1) if p not in used_reg), None)
+    if ui is None or rg is None:
+        print("NO_PORTS", file=sys.stderr)
+        sys.exit(1)
+    entry = {"ui_port": ui, "registry_port": rg, "profile": profile}
+    wt[profile] = entry
+    with open(reg_path, "w") as f:
+        json.dump(reg, f, indent=2, sort_keys=True)
+
+print(f"{entry['ui_port']} {entry['registry_port']}")
+PY
+)
+UI_PORT=$(echo "$PORTS_JSON" | awk '{print $1}')
+REGISTRY_PORT=$(echo "$PORTS_JSON" | awk '{print $2}')
+if [ -z "$UI_PORT" ] || [ -z "$REGISTRY_PORT" ]; then
+    log_error "Port allocation failed. Check $REGISTRY_FILE."
+    exit 1
+fi
+log_info "Ports: UI=$UI_PORT, registry=$REGISTRY_PORT"
+
+# ---------------------------------------------------------------------------
+# Ensure Colima profile is running
+# ---------------------------------------------------------------------------
+COLIMA_STATUS=$(colima status "$PROFILE" 2>&1 || true)
+if ! echo "$COLIMA_STATUS" | grep -q "Running"; then
+    log_info "Starting Colima profile '$PROFILE' (vz, ${COLIMA_CPUS} CPU, ${COLIMA_MEMORY}G RAM)..."
+    # vz + virtiofs are substantially faster on Apple Silicon; fall back to qemu
+    # if vz fails (Intel, older macOS).
+    colima start "$PROFILE" \
+        --cpu "$COLIMA_CPUS" \
+        --memory "$COLIMA_MEMORY" \
+        --vm-type vz \
+        --mount-type virtiofs \
+        2>/dev/null || colima start "$PROFILE" \
+            --cpu "$COLIMA_CPUS" \
+            --memory "$COLIMA_MEMORY"
+    log_ok "Colima profile '$PROFILE' started"
+else
+    log_info "Colima profile '$PROFILE' already running"
+fi
+
+DOCKER_SOCK_PATH="$HOME/.colima/$PROFILE/docker.sock"
+if [ ! -S "$DOCKER_SOCK_PATH" ]; then
+    log_error "Expected Colima socket not found at $DOCKER_SOCK_PATH"
+    exit 1
+fi
+
+export DOCKER_HOST="unix://$DOCKER_SOCK_PATH"
+export COMPOSE_PROJECT_NAME="mini-infra-$PROFILE"
+export UI_PORT
+export REGISTRY_PORT
+export AGENT_SIDECAR_IMAGE_TAG="localhost:$REGISTRY_PORT/mini-infra-agent-sidecar:latest"
+export PROJECT_ROOT
+export PROFILE
+
+# ---------------------------------------------------------------------------
+# Handle --reset: tear down containers and volumes for this profile
+# ---------------------------------------------------------------------------
+if [ "$RESET" = true ]; then
+    log_warn "⚠  WARNING: This will destroy ALL data for profile '$PROFILE' including:"
+    echo "  - The database (users, settings, configuration)"
+    echo "  - All log files"
+    echo "  - Registry images"
+    echo ""
+    read -r -p "Are you sure? [y/N] " confirm
+    if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+        echo "Aborted."
+        exit 0
+    fi
+    log_info "Stopping containers and removing volumes for $COMPOSE_PROJECT_NAME..."
+    docker compose -f "$COMPOSE_FILE" down -v || true
+    log_ok "Reset complete. Rebuilding..."
+    echo ""
+fi
+
+# ---------------------------------------------------------------------------
+# Bring up the registry first so we have somewhere to push the sidecar image
+# ---------------------------------------------------------------------------
+log_info "Ensuring local Docker registry is running..."
+docker compose -f "$COMPOSE_FILE" up -d registry
+
+for i in $(seq 1 15); do
+    if curl -sf "http://localhost:$REGISTRY_PORT/v2/" >/dev/null 2>&1; then
+        break
+    fi
+    if [ "$i" -eq 15 ]; then
+        log_error "Local registry failed to become ready on port $REGISTRY_PORT"
+        exit 1
+    fi
+    sleep 1
+done
+log_ok "Local registry is ready at localhost:$REGISTRY_PORT"
+
+# ---------------------------------------------------------------------------
+# Pre-pull images the stack reconciler needs as ephemeral helpers. Fresh
+# Colima daemons don't have these cached, and stack apply creates containers
+# directly (no auto-pull), so the first apply of HAProxy etc. fails without
+# this step.
+# ---------------------------------------------------------------------------
+log_info "Pre-pulling alpine:latest (used by stack reconciler for ephemeral helpers)..."
+docker pull alpine:latest >/dev/null && log_ok "alpine:latest ready"
+
+# ---------------------------------------------------------------------------
+# Build + push the agent sidecar image
+# ---------------------------------------------------------------------------
+log_info "Building agent sidecar image..."
+docker build -t "$AGENT_SIDECAR_IMAGE_TAG" \
+    -f "$PROJECT_ROOT/agent-sidecar/Dockerfile" "$PROJECT_ROOT"
+
+log_info "Pushing agent sidecar image to $AGENT_SIDECAR_IMAGE_TAG..."
+docker push "$AGENT_SIDECAR_IMAGE_TAG"
+log_ok "Agent sidecar image pushed"
+
+# ---------------------------------------------------------------------------
+# Build + start the full stack
+# ---------------------------------------------------------------------------
+log_info "Building and starting Mini Infra (project=$COMPOSE_PROJECT_NAME)..."
+docker compose -f "$COMPOSE_FILE" up -d --build
+
+# ---------------------------------------------------------------------------
+# Wait for health, then seed
+# ---------------------------------------------------------------------------
+log_info "Waiting for Mini Infra to become healthy on port $UI_PORT..."
+for i in $(seq 1 60); do
+    if curl -sf "http://localhost:$UI_PORT/health" >/dev/null 2>&1; then
+        break
+    fi
+    if [ "$i" -eq 60 ]; then
+        log_error "Mini Infra did not become healthy within 60s"
+        docker compose -f "$COMPOSE_FILE" logs --tail=100 mini-infra || true
+        exit 1
+    fi
+    sleep 1
+done
+log_ok "Mini Infra is healthy"
+
+DETAILS_FILE="$PROJECT_ROOT/environment-details.xml"
+
+if [ "$SKIP_SEED" = true ]; then
+    log_warn "Skipping seed step (--skip-seed)"
+    write_minimal_environment_details "$DETAILS_FILE"
+elif [ ! -f "$DEV_ENV_FILE" ]; then
+    log_warn "Skipping seed step — $DEV_ENV_FILE not found"
+    log_warn "Copy $SCRIPT_DIR/dev.env.example to $DEV_ENV_FILE and fill in values."
+    write_minimal_environment_details "$DETAILS_FILE"
+else
+    log_info "Running seeder..."
+    UI_PORT="$UI_PORT" DEV_ENV_FILE="$DEV_ENV_FILE" DETAILS_FILE="$DETAILS_FILE" bash "$SEED_SCRIPT"
+fi
+
+echo ""
+log_ok "Mini Infra dev instance for '$PROFILE' is up"
+echo ""
+echo "  URL:         http://localhost:$UI_PORT"
+echo "  Registry:    localhost:$REGISTRY_PORT"
+echo "  DOCKER_HOST: $DOCKER_HOST"
+echo ""
+echo "  Logs:   DOCKER_HOST=$DOCKER_HOST docker compose -f $COMPOSE_FILE -p $COMPOSE_PROJECT_NAME logs -f"
+echo "  Stop:   DOCKER_HOST=$DOCKER_HOST docker compose -f $COMPOSE_FILE -p $COMPOSE_PROJECT_NAME down"
+echo "  Nuke:   $0 --reset --profile $PROFILE"
+echo ""

--- a/docs/colima-reference.md
+++ b/docs/colima-reference.md
@@ -1,0 +1,192 @@
+# Colima Reference
+
+Reference notes for using Colima to run multiple isolated Docker daemons on macOS — one per Mini Infra worktree.
+
+Source: <https://colima.run/docs/> and <https://github.com/abiosoft/colima>
+
+## What Colima Is
+
+Colima is a CLI-only container runtime for macOS and Linux. It runs a Linux VM (via Lima) and exposes a Docker daemon from inside that VM. Each profile is an independent VM with its own Docker daemon, socket, containers, images, and volumes.
+
+Key properties for our use case:
+
+- Multiple concurrent profiles are supported — each is a fully isolated Docker host.
+- Each profile creates its own Docker context (`colima`, `colima-<profile>`).
+- ~400 MB RAM idle per profile.
+- Free, open source, CLI-only (no GUI).
+
+## Installation
+
+```bash
+brew install colima docker
+```
+
+Alternatives: MacPorts (`sudo port install colima`), Nix, Mise, or raw binary from GitHub releases.
+
+Docker CLI is not bundled — install it separately (above) or reuse the one from Docker Desktop.
+
+## VM Defaults
+
+- CPUs: 2
+- Memory: 2 GiB
+- Disk: 100 GiB
+- Runtime: `docker`
+- VM type: `qemu` (default) or `vz` (newer, faster, Rosetta 2 support on Apple Silicon, macOS 13+)
+
+## Core Commands
+
+```bash
+colima start [profile] [flags]     # create/start a profile VM
+colima stop [profile]              # halt without data loss
+colima restart [profile]
+colima delete [profile]            # remove VM, preserve images/volumes
+colima delete [profile] --data     # full teardown
+colima list                        # show all profiles + status
+colima status [profile]            # show socket path, runtime, arch, etc.
+colima ssh [profile] -- <cmd>      # shell into the VM
+colima template                    # print YAML template
+colima version
+```
+
+## Profiles — The Important Bit
+
+### Creating a profile
+
+Three equivalent ways:
+
+```bash
+colima start dev --cpus 4 --memory 8
+colima start --profile dev --cpus 4 --memory 8
+COLIMA_PROFILE=dev colima start --cpus 4 --memory 8
+```
+
+Profile selection priority: `--profile` flag > positional arg > `COLIMA_PROFILE` env var > `default`.
+
+### Storage layout
+
+- Config: `~/.colima/<profile>/colima.yaml`
+- Docker socket: `~/.colima/<profile>/docker.sock`
+- Base dir override: `COLIMA_HOME` env var (default `~/.colima`)
+
+### Targeting a specific profile from Docker
+
+Two options:
+
+**Docker context** (auto-created per profile):
+
+```bash
+docker context ls                  # lists colima, colima-dev, etc.
+docker context use colima-dev
+docker compose up                  # now targets the dev profile
+```
+
+**DOCKER_HOST env var** (takes precedence over context, good for scripts):
+
+```bash
+export DOCKER_HOST="unix://$HOME/.colima/dev/docker.sock"
+docker compose up                  # targets the dev profile
+```
+
+For our `start.sh`, `DOCKER_HOST` is the cleaner choice — it makes the target explicit in the script without mutating the user's active context.
+
+## Configuration File (colima.yaml)
+
+Per-profile config at `~/.colima/<profile>/colima.yaml`. CLI flags override YAML. Common options:
+
+```yaml
+cpu: 4
+memory: 8
+disk: 100
+vmType: vz                # qemu | vz | krunkit
+rosetta: true             # requires vz on Apple Silicon
+runtime: docker           # docker | containerd | incus
+mountType: virtiofs       # sshfs | 9p | virtiofs (virtiofs requires vz)
+mounts:
+  - location: ~
+    writable: true
+network:
+  address: true           # reachable IP (slower startup)
+docker:
+  insecure-registries:
+    - localhost:5051
+```
+
+### Immutable after create
+
+These require `colima delete` + restart to change:
+
+- `arch`
+- `runtime`
+- `vmType`
+- `mountType`
+
+## Mount Gotcha
+
+Bind mounts from paths **outside** `/Users/$USER` silently mount as empty inside containers. To expose extra paths, add them under `mounts:` in `colima.yaml` and restart the profile.
+
+For Mini Infra this matters because `start.sh` lives inside a worktree path (e.g. `~/Repos/mini-infra/.claude/worktrees/...`) — as long as that's under `/Users/$USER`, bind mounts work by default.
+
+## Docker Socket — Bind Mount for Mini Infra
+
+Our `docker-compose.yaml` does:
+
+```yaml
+volumes:
+  - /var/run/docker.sock:/var/run/docker.sock
+```
+
+With Colima, the host-side path is **not** `/var/run/docker.sock`. It's `~/.colima/<profile>/docker.sock`. Either:
+
+1. **Change the compose mount to honour a variable** (preferred):
+
+   ```yaml
+   - ${DOCKER_SOCK:-/var/run/docker.sock}:/var/run/docker.sock
+   ```
+
+   Then export `DOCKER_SOCK=$HOME/.colima/<profile>/docker.sock` in `start.sh`.
+
+2. **Symlink** `/var/run/docker.sock` to the Colima socket (breaks multi-profile, not recommended):
+
+   ```bash
+   sudo ln -sf $HOME/.colima/<profile>/docker.sock /var/run/docker.sock
+   ```
+
+## Concurrent Profiles
+
+Multiple profiles can run simultaneously — each is a separate VM. Cost: ~400 MB + some CPU per active profile.
+
+```bash
+colima start wt-alpha
+colima start wt-beta
+colima list
+# NAME         STATUS    ARCH      CPUS    MEMORY    DISK    RUNTIME   ADDRESS
+# wt-alpha     Running   aarch64   4       8GiB      100GiB  docker    …
+# wt-beta      Running   aarch64   4       8GiB      100GiB  docker    …
+```
+
+## Known Gotchas
+
+- macOS sleep/restart can leave a profile in a "broken" state → `colima stop --force <profile>` then `colima start <profile>`.
+- Network-address mode (`--network-address`) slows startup and needs root — leave off unless a container genuinely needs a reachable IP from the host.
+- Rosetta (`vmType: vz` + `rosetta: true`) speeds up x86_64 emulation on Apple Silicon but requires macOS 13+.
+
+## Useful Recipes
+
+### Tear down a worktree's profile completely
+
+```bash
+colima delete <profile> --data --force
+```
+
+### Inspect what's inside a profile's VM
+
+```bash
+colima ssh <profile> -- docker ps
+```
+
+### Point one shell at one profile for ad-hoc work
+
+```bash
+export DOCKER_HOST="unix://$HOME/.colima/<profile>/docker.sock"
+docker ps
+```

--- a/server/src/app-factory.ts
+++ b/server/src/app-factory.ts
@@ -73,13 +73,14 @@ import authSettingsRoutes from "./routes/auth-settings";
 import diagnosticsRoutes from "./routes/diagnostics";
 import onboardingRoutes from "./routes/onboarding";
 import openapiRoutes from "./routes/openapi";
+import devApiKeyRoutes from "./routes/dev-api-key";
 import { listRouteMeta } from "./lib/openapi-registry";
 
 type RouteDefinition = {
   id: string;
   path: string;
   name: string;
-  getRouter: () => Router;
+  getRouter: () => Router | undefined;
 };
 
 export type CreateAppOptions = {
@@ -175,6 +176,18 @@ function getRouteDefinitions(): RouteDefinition[] {
     { id: "agent", path: "/api/agent", name: "agentRoutes", getRouter: () => agentRoutes },
     { id: "diagnostics", path: "/api/diagnostics", name: "diagnosticsRoutes", getRouter: () => diagnosticsRoutes },
     { id: "onboarding", path: "/api/onboarding", name: "onboardingRoutes", getRouter: () => onboardingRoutes },
+    // Dev-only: exchange admin credentials for a full-admin API key. Only
+    // registered when ENABLE_DEV_API_KEY_ENDPOINT=true — otherwise getRouter
+    // returns undefined and the route is skipped.
+    {
+      id: "devApiKey",
+      path: "/api/dev",
+      name: "devApiKeyRoutes",
+      getRouter: () =>
+        process.env.ENABLE_DEV_API_KEY_ENDPOINT === "true"
+          ? devApiKeyRoutes
+          : undefined,
+    },
   ];
 }
 

--- a/server/src/routes/dev-api-key.ts
+++ b/server/src/routes/dev-api-key.ts
@@ -1,0 +1,63 @@
+import { Router, Request, Response, RequestHandler } from "express";
+import { getLogger } from "../lib/logger-factory";
+import prisma from "../lib/prisma";
+import { verifyPassword } from "../lib/password-service";
+import { createApiKey } from "../lib/api-key-service";
+
+const logger = getLogger("auth", "dev-api-key-route");
+const router = Router();
+
+// Gated by ENABLE_DEV_API_KEY_ENDPOINT at registration time. Exchanges admin
+// email + password for a full-admin API key. Intended for dev/seed tooling
+// that needs to drive the API before a UI session exists.
+router.post("/issue-api-key", (async (req: Request, res: Response) => {
+  const { email, password, name } = req.body as {
+    email?: string;
+    password?: string;
+    name?: string;
+  };
+
+  if (!email || !password) {
+    return res.status(400).json({ error: "Email and password are required" });
+  }
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: { email: email.toLowerCase().trim() },
+    });
+
+    if (!user || !user.passwordHash) {
+      logger.warn({ email }, "dev issue-api-key: user not found or no password");
+      return res.status(401).json({ error: "Invalid credentials" });
+    }
+
+    const ok = await verifyPassword(user.passwordHash, password);
+    if (!ok) {
+      logger.warn({ userId: user.id }, "dev issue-api-key: bad password");
+      return res.status(401).json({ error: "Invalid credentials" });
+    }
+
+    const keyName =
+      name?.trim() ||
+      `dev-seed ${new Date().toISOString().replace(/[:.]/g, "-")}`;
+
+    // permissions: null => full access (see parsePermissions in api-key-service.ts)
+    const apiKey = await createApiKey(user.id, { name: keyName });
+
+    logger.info(
+      { userId: user.id, keyId: apiKey.id, keyName },
+      "Dev API key issued",
+    );
+
+    return res.status(201).json({
+      apiKey: apiKey.key,
+      keyId: apiKey.id,
+      userId: user.id,
+    });
+  } catch (error) {
+    logger.error({ error }, "Failed to issue dev API key");
+    return res.status(500).json({ error: "Failed to issue API key" });
+  }
+}) as RequestHandler);
+
+export default router;

--- a/server/src/routes/onboarding.ts
+++ b/server/src/routes/onboarding.ts
@@ -2,9 +2,9 @@ import { Router, Request, Response } from "express";
 import prisma from "../lib/prisma";
 import { getLogger } from "../lib/logger-factory";
 import { requirePermission } from "../middleware/auth";
+import { getAuthenticatedUser } from "../lib/auth-middleware";
 import { UserPreferencesService } from "../services/user-preferences";
 import { TlsConfigService } from "../services/tls/tls-config";
-import type { JWTUser } from "@mini-infra/types";
 
 const logger = getLogger("http", "onboarding");
 const router = Router();
@@ -54,7 +54,9 @@ router.post(
   "/complete",
   requirePermission("settings:write"),
   async (req: Request, res: Response) => {
-    const user = req.user as JWTUser | undefined;
+    // Use the unified helper so API-key auth (where req.user isn't
+    // populated by the JWT middleware) works the same as a session.
+    const user = getAuthenticatedUser(req);
     if (!user?.id) {
       return res
         .status(401)


### PR DESCRIPTION
## Summary

Lets each git worktree run its own fully isolated Mini Infra instance on its own Colima VM, so parallel WIP doesn't fight over a single Docker daemon.

- **New `deployment/development/worktree_start.sh`** provisions a dedicated Colima profile per worktree (named after the worktree dir), allocates stable UI/registry ports from `~/.mini-infra/worktrees.json`, pre-pulls `alpine:latest` (used by the stack reconciler for ephemeral config-volume writers), builds + runs the app, then kicks off the seeder.
- **New `deployment/development/worktree_seed.sh`** drives the REST API to skip onboarding: creates the admin user via `POST /auth/setup`, swaps admin creds for a full-admin API key, wires up Docker/Azure/Cloudflare/GitHub from `~/.mini-infra/dev.env`, creates a `local` environment, and applies the built-in HAProxy stack with poll-until-Synced (using `lastAppliedAt` as the signal so stale `error` status from a prior run doesn't trigger a false negative).
- **New `deployment/development/docker-compose.worktree.yaml`** parameterises everything (`COMPOSE_PROJECT_NAME`, ports, agent-sidecar tag) so resources don't collide across worktrees. The legacy `start.sh` + `docker-compose.yaml` single-instance flow is untouched.
- **Server:** new `POST /api/dev/issue-api-key` route (gated by `ENABLE_DEV_API_KEY_ENDPOINT=true` — registration is conditional, so the handler isn't exposed in prod). `/api/onboarding/complete` now resolves the caller via `getAuthenticatedUser()` so API-key auth works the same as a session.
- **`environment-details.xml`** is written at the worktree root on every run, containing the profile name, UI/registry URLs, seeded env/stack IDs, and connected-service status. Docs and skills (`CLAUDE.md`, `diagnose-dev`, `test-dev`, deployment `README.md`, OWASP ZAP guide) now resolve the dev URL from this XML via xmllint rather than hardcoding `http://localhost:3005`.
- **Docs:** `CLAUDE.md` gains a "Worktree Development Workflow" section (spin up → URL → edit → rebuild → test → teardown), and `docs/colima-reference.md` captures Colima profile/socket/mount behaviour relevant to this setup.

## Why

Mini Infra manages the Docker host it runs on (HAProxy, environment networks, TLS certs, managed containers). Two instances on the same daemon fight over shared state, so "run multiple dev instances" is only safe with per-instance Docker daemons. Colima profiles give you that cheaply on macOS.

## Test plan

- [x] `npm run build:lib && npm run build -w server` — clean
- [x] Fresh Colima profile + compose up + seed from scratch end-to-end
- [x] Re-running the seeder (idempotent: admin / setup / local env / HAProxy stack all short-circuit)
- [x] HAProxy stack applies, polls to Synced, `haproxytech/haproxy-alpine` container running + healthy
- [x] Browser smoke via playwright-cli — login, dashboard (Docker/Azure/Cloudflare all "Connected"), environments, containers list, stack detail
- [x] `environment-details.xml` written with correct profile/URL/resource IDs
- [ ] Second worktree concurrently (not tested in this branch — design covers it but hasn't been shaken out with two profiles at once)

## Reviewer notes

- The stack reconciler uses ephemeral `alpine:latest` containers via `createContainer` (no auto-pull) — that's why `worktree_start.sh` pre-pulls. A longer-term fix would be to have [stack-container-manager.ts:91](server/src/services/stacks/stack-container-manager.ts:91) pull before creating; flagged as separate cleanup.
- `environment-details.xml` is gitignored.
- The dev-only endpoint is registered conditionally (returns `undefined` from `getRouter` when the env var isn't set) so prod containers without `ENABLE_DEV_API_KEY_ENDPOINT=true` have no route at `/api/dev/issue-api-key` at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)