### PR TITLE
fix: disable application card buttons while mutation is in-flight

### DIFF
--- a/.claude/skills/test-dev/SKILL.md
+++ b/.claude/skills/test-dev/SKILL.md
@@ -15,8 +15,33 @@ You're running UI tests against a live instance of Mini Infra — a Docker host 
   MINI_INFRA_URL=$(xmllint --xpath 'string(//environment/endpoints/ui)' environment-details.xml)
   ```
 
-  If `environment-details.xml` is absent, the user is on the legacy single-instance flow — fall back to `http://localhost:3005`.
-- **Login**: geoff.rich@gmail.com / Juliette 2010
+  If `environment-details.xml` is absent and you are inside a git worktree (check with `git rev-parse --git-dir`), **stop and tell the user to run `deployment/development/worktree_start.sh` first** — do not fall back to localhost:3005, which would test the wrong instance. Only fall back to `http://localhost:3005` when you are certain you are on the main checkout (not a worktree).
+
+- **Named browser session** — multiple worktrees run concurrently and all share the same playwright-cli daemon. The default session (`default`) is shared, so two worktrees will fight over the same browser. Always derive a session name from the worktree profile and pass `-s=<SESSION>` to every `playwright-cli` command:
+
+  ```bash
+  # Derive once at the top of the test run — use the port number (short, unique per worktree)
+  # Session names must be short alphanumeric strings; hyphens cause socket-path errors.
+  UI_PORT=$(xmllint --xpath 'string(//environment/endpoints/ui)' environment-details.xml 2>/dev/null | grep -oE '[0-9]+$')
+  SESSION="p${UI_PORT:-3005}"
+
+  # Then use it on every playwright-cli call
+  playwright-cli -s="$SESSION" open "$MINI_INFRA_URL"
+  playwright-cli -s="$SESSION" goto "$MINI_INFRA_URL/applications"
+  playwright-cli -s="$SESSION" snapshot
+  playwright-cli -s="$SESSION" click e5
+  # etc.
+  ```
+
+  Note: when using `-s`, element refs (e14, e17…) come from snapshots taken in **that same session** — refs from a different session won't work.
+
+- **Login credentials**: read from `environment-details.xml` — do not hardcode them:
+
+  ```bash
+  ADMIN_EMAIL=$(xmllint --xpath 'string(//environment/admin/email)' environment-details.xml)
+  ADMIN_PASSWORD=$(xmllint --xpath 'string(//environment/admin/password)' environment-details.xml)
+  ```
+
 - **Source code**: available in the current working directory
 
 ---
@@ -41,15 +66,15 @@ Before opening the browser, write out the test cases you intend to run:
 ### Step 3 — Open a browser and log in
 
 ```bash
-playwright-cli open --persistent "$MINI_INFRA_URL"
+playwright-cli -s="$SESSION" open "$MINI_INFRA_URL"
 ```
 
 If redirected to `/login`, fill in credentials and submit:
 
 ```bash
-playwright-cli fill e14 "geoff.rich@gmail.com"
-playwright-cli fill e17 "Juliette 2010"
-playwright-cli click e18
+playwright-cli -s="$SESSION" fill e14 "$ADMIN_EMAIL"
+playwright-cli -s="$SESSION" fill e17 "$ADMIN_PASSWORD"
+playwright-cli -s="$SESSION" click e18
 ```
 
 > If login itself fails, this is a **BLOCKER** — log it and stop.
@@ -57,19 +82,19 @@ playwright-cli click e18
 ### Step 4 — Execute test cases
 
 Work through each planned test case. After each significant interaction:
-- Take a snapshot (`playwright-cli snapshot`) to inspect DOM state and get element refs
+- Take a snapshot (`playwright-cli -s="$SESSION" snapshot`) to inspect DOM state and get element refs
 - Take a screenshot if you want to capture visual state
 
 **Async data caveat**: Pages that fetch data via React Query render empty first, then populate. After navigation or an action that triggers a data fetch, wait for a specific element that signals the content has loaded before snapshotting:
 
 ```bash
-playwright-cli run-code "async page => { await page.waitForSelector('.card', { timeout: 5000 }); }"
+playwright-cli -s="$SESSION" run-code "async page => { await page.waitForSelector('.card', { timeout: 5000 }); }"
 ```
 
 To find the right selector, take a snapshot after the data loads (or take a screenshot), identify an element in the loaded content, then use its class or text. Example — waiting for a server card to appear:
 
 ```bash
-playwright-cli run-code "async page => { await page.waitForSelector('text=healthy', { timeout: 5000 }); }"
+playwright-cli -s="$SESSION" run-code "async page => { await page.waitForSelector('text=healthy', { timeout: 5000 }); }"
 ```
 
 > **Avoid `waitForLoadState('networkidle')`** in SPAs — React apps make ongoing background requests so the network never fully settles, which causes hangs and timeouts.
@@ -132,30 +157,34 @@ Track issues as you find them. Do not wait until the end to log — note each on
 ## Playwright Tips
 
 ```bash
-# Open browser (headless by default — omit --headed unless you need to watch)
-playwright-cli open --persistent "$MINI_INFRA_URL"
+# Derive session name once (at the top of your test run)
+UI_PORT=$(xmllint --xpath 'string(//environment/endpoints/ui)' environment-details.xml 2>/dev/null | grep -oE '[0-9]+$')
+SESSION="p${UI_PORT:-3005}"
+
+# Open browser (use named session to avoid clashes with other worktrees)
+playwright-cli -s="$SESSION" open "$MINI_INFRA_URL"
 
 # Navigate (always use full URL — relative paths fail)
-playwright-cli goto "$MINI_INFRA_URL/some/path"
+playwright-cli -s="$SESSION" goto "$MINI_INFRA_URL/some/path"
 
 # Inspect the page (always do this before clicking to find refs)
-playwright-cli snapshot
+playwright-cli -s="$SESSION" snapshot
 
 # Interact
-playwright-cli click e5
-playwright-cli fill e7 "some value"
-playwright-cli press Enter
-playwright-cli select e9 "option-value"
+playwright-cli -s="$SESSION" click e5
+playwright-cli -s="$SESSION" fill e7 "some value"
+playwright-cli -s="$SESSION" press Enter
+playwright-cli -s="$SESSION" select e9 "option-value"
 
 # Verify
-playwright-cli eval "document.title"
-playwright-cli eval "el => el.textContent" e5
+playwright-cli -s="$SESSION" eval "document.title"
+playwright-cli -s="$SESSION" eval "el => el.textContent" e5
 
 # Capture state (always save screenshots to the screenshots/ folder in the project root)
-playwright-cli screenshot --filename=screenshots/issue-1.png
+playwright-cli -s="$SESSION" screenshot --filename=screenshots/issue-1.png
 
 # Close when done
-playwright-cli close
+playwright-cli -s="$SESSION" close
 ```
 
 ---
@@ -175,6 +204,6 @@ playwright-cli close
 ## Notes
 
 - Keep the browser session open throughout the test run — reuse it for all test cases.
-- If the app is unresponsive or broken beyond recovery, `playwright-cli close` and report a BLOCKER.
+- If the app is unresponsive or broken beyond recovery, `playwright-cli -s="$SESSION" close` and report a BLOCKER.
 - Screenshots are useful evidence for BLOCKER and MAJOR issues — attach them to the report. Always save screenshots to `screenshots/` in the project root (e.g. `screenshots/issue-1.png`).
 - Source code is available if you need to check what behaviour is intended (`client/src/pages/`, `client/src/components/`).

--- a/client/src/app/applications/application-card.tsx
+++ b/client/src/app/applications/application-card.tsx
@@ -99,10 +99,6 @@ export function ApplicationCard({
   const currentTag = primaryService?.dockerTag ?? "";
   const [tagDraft, setTagDraft] = useState(currentTag);
 
-  // Don't show the flipped face while the stack is churning — the busy overlay
-  // takes precedence. Derived rather than an effect to avoid cascading renders.
-  const effectivelyFlipped = flipped && !isBusy;
-
   const openUpdateForm = () => {
     setTagDraft(currentTag);
     setFlipped(true);
@@ -111,6 +107,14 @@ export function ApplicationCard({
 
   const { registerTask } = useTaskTracker();
   const deployUpdate = useDeployApplicationUpdate();
+
+  // Cover the gap between deployUpdate resolving and the socket "pending" event
+  // arriving — keep the card locked until one or the other is true.
+  const effectivelyBusy = isBusy || deployUpdate.isPending;
+
+  // Don't show the flipped face while the stack is churning — the busy overlay
+  // takes precedence. Derived rather than an effect to avoid cascading renders.
+  const effectivelyFlipped = flipped && !effectivelyBusy;
 
   const trimmedTag = tagDraft.trim();
   const tagChanged = trimmedTag !== currentTag;
@@ -146,14 +150,14 @@ export function ApplicationCard({
         className={cn(
           "grid transition-transform duration-500 [transform-style:preserve-3d]",
           effectivelyFlipped && "[transform:rotateY(180deg)]",
-          isBusy && "opacity-60 pointer-events-none",
+          effectivelyBusy && "opacity-60 pointer-events-none",
         )}
       >
         {/* FRONT */}
         <Card
           className={cn(
             "group flex flex-col transition-shadow [grid-area:1/1] [backface-visibility:hidden]",
-            !isBusy && "hover:shadow-md",
+            !effectivelyBusy && "hover:shadow-md",
           )}
         >
           <CardHeader className="pb-2">

--- a/deployment/development/dev.env.example
+++ b/deployment/development/dev.env.example
@@ -32,6 +32,13 @@ ADMIN_PASSWORD=changeme123
 # CLOUDFLARE_API_TOKEN=
 # CLOUDFLARE_ACCOUNT_ID=
 
+# ---- Docker host IP (optional; seeder auto-detects if blank) ---------------
+# IP address of the Docker host machine, used as the DNS A-record target when
+# deploying applications with public hostnames. The seeder auto-detects your
+# primary LAN IP via a UDP socket probe — set this explicitly if auto-detect
+# picks the wrong interface (e.g. VPN, multiple NICs).
+# DOCKER_HOST_IP=192.168.1.100
+
 # ---- GitHub (optional; seeder skips if blank) -----------------------------
 # Classic PAT or fine-grained token with repo read access for your use case.
 # GITHUB_TOKEN=

--- a/deployment/development/worktree_seed.sh
+++ b/deployment/development/worktree_seed.sh
@@ -6,6 +6,7 @@
 #   2. Exchange admin credentials for a full-admin API key via
 #      POST /api/dev/issue-api-key (requires ENABLE_DEV_API_KEY_ENDPOINT=true)
 #   3. Complete the setup wizard (docker host) via POST /auth/setup/complete
+#   3b. Upsert docker_host_ip system setting (needed for application DNS records)
 #   4. Upsert Azure / Cloudflare / GitHub credentials from ~/.mini-infra/dev.env
 #   5. Create a local environment
 #   6. Instantiate the built-in HAProxy stack template into the local env
@@ -68,7 +69,9 @@ api() {
     if [ -n "$body" ]; then
         curl_args+=(-d "$body")
     fi
-    curl "${curl_args[@]}"
+    # || true so a curl network error (e.g. exit 52) doesn't trip set -e and
+    # abort the whole script. Callers check $status; "000" signals a curl failure.
+    curl "${curl_args[@]}" || echo "000"
 }
 
 json_escape() { python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().rstrip("\n")))'; }
@@ -142,6 +145,85 @@ else
         exit 1
     fi
     ok "Setup wizard completed"
+fi
+
+# ---------------------------------------------------------------------------
+# 3b. Set Docker host IP (always runs — idempotent upsert via settings API).
+# Used as the DNS A-record target when deploying stateless web apps. Required
+# for POST /api/stack-templates/:id/instantiate to succeed.
+# ---------------------------------------------------------------------------
+info "Setting Docker host IP"
+# Prefer explicit value from dev.env; fall back to auto-detecting the primary
+# outbound interface IP via a UDP probe (never actually sends a packet).
+if [ -z "${DOCKER_HOST_IP:-}" ]; then
+    DOCKER_HOST_IP=$(python3 -c "
+import socket
+try:
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(('8.8.8.8', 80))
+    print(s.getsockname()[0])
+    s.close()
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+fi
+
+if [ -z "$DOCKER_HOST_IP" ]; then
+    skip "Could not detect Docker host IP — set DOCKER_HOST_IP in dev.env to enable application DNS records"
+else
+    # Check whether the setting already exists (filter by category + key + isActive).
+    status=$(api GET "/api/settings?category=system&key=docker_host_ip&isActive=true")
+    existing_setting_id=""
+    existing_value=""
+    if [ "$status" = "200" ]; then
+        existing_setting_id=$(RESP_FILE="$RESP_FILE" python3 -c "
+import json, os
+d = json.load(open(os.environ['RESP_FILE']))
+items = d.get('data') if isinstance(d, dict) else d
+for s in (items or []):
+    if s.get('category') == 'system' and s.get('key') == 'docker_host_ip':
+        print(s.get('id', ''))
+        break
+" 2>/dev/null || echo "")
+        existing_value=$(RESP_FILE="$RESP_FILE" python3 -c "
+import json, os
+d = json.load(open(os.environ['RESP_FILE']))
+items = d.get('data') if isinstance(d, dict) else d
+for s in (items or []):
+    if s.get('category') == 'system' and s.get('key') == 'docker_host_ip':
+        print(s.get('value', ''))
+        break
+" 2>/dev/null || echo "")
+    fi
+
+    if [ -n "$existing_setting_id" ] && [ "$existing_value" = "$DOCKER_HOST_IP" ]; then
+        skip "Docker host IP already set ($DOCKER_HOST_IP)"
+    elif [ -n "$existing_setting_id" ]; then
+        body=$(DOCKER_HOST_IP="$DOCKER_HOST_IP" python3 -c "
+import json, os
+print(json.dumps({'value': os.environ['DOCKER_HOST_IP']}))")
+        status=$(api PUT "/api/settings/$existing_setting_id" "$body")
+        if [ "$status" = "200" ]; then
+            ok "Docker host IP updated ($DOCKER_HOST_IP)"
+        else
+            skip "Docker host IP update returned $status (non-fatal): $(cat "$RESP_FILE")"
+        fi
+    else
+        body=$(DOCKER_HOST_IP="$DOCKER_HOST_IP" python3 -c "
+import json, os
+print(json.dumps({
+    'category': 'system',
+    'key': 'docker_host_ip',
+    'value': os.environ['DOCKER_HOST_IP'],
+    'isEncrypted': False,
+}))")
+        status=$(api POST "/api/settings" "$body")
+        if [ "$status" = "201" ] || [ "$status" = "200" ]; then
+            ok "Docker host IP set ($DOCKER_HOST_IP)"
+        else
+            skip "Docker host IP create returned $status (non-fatal): $(cat "$RESP_FILE")"
+        fi
+    fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -489,6 +571,7 @@ xml = f"""<?xml version="1.0" encoding="UTF-8"?>
   </images>
   <admin>
     <email>{t(os.environ['ADMIN_EMAIL'])}</email>
+    <password>{t(os.environ['ADMIN_PASSWORD'])}</password>
   </admin>
   <connectedServices>
     <azure configured="{os.environ['AZURE_SET']}"/>


### PR DESCRIPTION
## Summary

- Adds `effectivelyBusy = isBusy || deployUpdate.isPending` to `ApplicationCard` to close the timing gap between the mutation resolving and the socket "pending" event arriving — keeping Update/Stop non-interactive and the card dimmed for the full busy window
- Seeds `docker_host_ip` system setting in `worktree_seed.sh` via an idempotent upsert (auto-detects host IP via UDP probe) — this setting is required for `POST /api/stack-templates/:id/instantiate` to create DNS A records when deploying stateless web apps
- Adds admin password to `environment-details.xml` output
- Updates `test-dev` skill to use named playwright-cli sessions (`-s=p<PORT>`) and read credentials from `environment-details.xml` instead of hardcoding them

## Test plan

- [x] Navigated to `/applications`, clicked Update on nginx-test card
- [x] Changed tag and clicked Deploy — card immediately flipped back to front face with `opacity-60 pointer-events-none` applied (visible dimming, Update/Stop non-interactive) while `deployUpdate.isPending = true`
- [x] After deployment settled (error status), card returned to fully interactive state with no busy classes
- [x] Screenshots captured: spinner mid-flip, front-busy state, DOM-busy state, resolved state

🤖 Generated with [Claude Code](https://claude.com/claude-code)