### PR TITLE
Improve worktree dev seeder: logging, connectivity checks, API key in env details

### DIFF
--- a/.claude/skills/diagnose-dev/SKILL.md
+++ b/.claude/skills/diagnose-dev/SKILL.md
@@ -20,7 +20,7 @@ You're debugging a running instance of Mini Infra — a Docker host management w
 - **Docker Compose file**: `deployment/development/docker-compose.yaml`
 - **Source code**: available in the current working directory
 
-Ask the user for an API key as this will change often.
+Read the API key from `environment-details.xml` at the project root (`//admin/apiKey`). If the file is absent or the element is empty, ask the user for the key.
 
 ## Diagnosis Workflow
 
@@ -133,8 +133,9 @@ Use curl with the API key to query endpoints:
 # Health check (no auth needed)
 curl -s "$MINI_INFRA_URL/health"
 
-# Authenticated requests — add the API key header
-curl -s -H "x-api-key: mk_49181f65c1b91ec453684007f69eaceb7633c5cad706c7c901a2c9f5322c72af" "$MINI_INFRA_URL/api/containers"
+# Authenticated requests — read the API key from environment-details.xml
+API_KEY=$(xmllint --xpath 'string(//admin/apiKey)' environment-details.xml)
+curl -s -H "x-api-key: $API_KEY" "$MINI_INFRA_URL/api/containers"
 ```
 
 #### Checking container health

--- a/deployment/development/worktree_cleanup.plist
+++ b/deployment/development/worktree_cleanup.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.mini-infra.worktree-cleanup</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>REPO_ROOT/deployment/development/worktree_cleanup.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>REPO_ROOT</string>
+
+    <!-- Run once an hour -->
+    <key>StartInterval</key>
+    <integer>3600</integer>
+
+    <key>StandardOutPath</key>
+    <string>MINI_INFRA_HOME/worktree-cleanup.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>MINI_INFRA_HOME/worktree-cleanup.log</string>
+
+    <!-- Only run when the user is logged in -->
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/deployment/development/worktree_cleanup.sh
+++ b/deployment/development/worktree_cleanup.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+# Mini Infra Worktree Cleanup
+#
+# Runs from the main repo checkout (not a worktree). Scans all git worktrees,
+# checks via GitHub CLI whether each branch's PR has been merged, and for
+# merged ones:
+#   1. Deletes the Colima VM
+#   2. Removes the git worktree
+#   3. Removes the port registry entry from ~/.mini-infra/worktrees.json
+#
+# Usage: ./worktree_cleanup.sh [--dry-run] [--repo <owner/repo>]
+#
+# Options:
+#   --dry-run   Show what would be cleaned up without making any changes
+#   --repo      GitHub repo (default: auto-detected from git remote)
+#
+# Designed to be run as a launchd agent (see worktree_cleanup.plist).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+MINI_INFRA_HOME="${MINI_INFRA_HOME:-$HOME/.mini-infra}"
+REGISTRY_FILE="$MINI_INFRA_HOME/worktrees.json"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+YELLOW='\033[0;33m'
+GRAY='\033[0;90m'
+NC='\033[0m'
+
+ts()      { date '+%H:%M:%S'; }
+log_info()  { echo -e "${CYAN}[$(ts)] $1${NC}"; }
+log_ok()    { echo -e "${GREEN}[$(ts)] ✓ $1${NC}"; }
+log_warn()  { echo -e "${YELLOW}[$(ts)] ⚠ $1${NC}"; }
+log_skip()  { echo -e "${GRAY}[$(ts)] · $1${NC}"; }
+log_error() { echo -e "${RED}[$(ts)] ✗ $1${NC}"; }
+
+# ---------------------------------------------------------------------------
+# Parse args
+# ---------------------------------------------------------------------------
+DRY_RUN=false
+REPO=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) DRY_RUN=true; shift ;;
+        --repo) REPO="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,14p' "$0"
+            exit 0
+            ;;
+        *) log_error "Unknown arg: $1"; exit 1 ;;
+    esac
+done
+
+if [ "$DRY_RUN" = true ]; then
+    log_warn "DRY RUN — no changes will be made"
+fi
+
+# ---------------------------------------------------------------------------
+# Prerequisites
+# ---------------------------------------------------------------------------
+if ! command -v gh >/dev/null 2>&1; then
+    log_error "gh CLI is not installed. Install with: brew install gh"
+    exit 1
+fi
+if ! command -v colima >/dev/null 2>&1; then
+    log_error "colima is not installed. Install with: brew install colima"
+    exit 1
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    log_error "python3 is required for registry updates"
+    exit 1
+fi
+
+# Auto-detect repo from remote if not passed
+if [ -z "$REPO" ]; then
+    REPO=$(cd "$REPO_ROOT" && gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
+    if [ -z "$REPO" ]; then
+        log_error "Could not detect GitHub repo. Pass --repo <owner/repo>"
+        exit 1
+    fi
+fi
+log_info "Repo: $REPO"
+
+# Ensure we're running from the main checkout, not inside a worktree
+MAIN_WORKTREE=$(cd "$REPO_ROOT" && git worktree list --porcelain | awk '/^worktree / && !seen { print $2; seen=1 }')
+if [ "$REPO_ROOT" != "$MAIN_WORKTREE" ]; then
+    log_error "Must be run from the main checkout ($MAIN_WORKTREE), not a worktree ($REPO_ROOT)"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Derive the Colima profile name from a worktree directory basename.
+# Mirrors the normalisation in worktree_start.sh.
+# ---------------------------------------------------------------------------
+colima_profile() {
+    echo "$1" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9-' '-' | sed 's/--*/-/g; s/^-//; s/-$//'
+}
+
+# ---------------------------------------------------------------------------
+# Remove a profile from the port registry (best-effort, non-fatal)
+# ---------------------------------------------------------------------------
+remove_from_registry() {
+    local profile="$1"
+    if [ ! -f "$REGISTRY_FILE" ]; then return; fi
+    python3 - "$REGISTRY_FILE" "$profile" <<'PY'
+import json, sys
+
+reg_path, profile = sys.argv[1], sys.argv[2]
+try:
+    with open(reg_path) as f:
+        reg = json.load(f)
+    wt = reg.get("worktrees", {})
+    if profile in wt:
+        del wt[profile]
+        reg["worktrees"] = wt
+        with open(reg_path, "w") as f:
+            json.dump(reg, f, indent=2, sort_keys=True)
+        print(f"Removed '{profile}' from registry")
+    else:
+        print(f"'{profile}' not in registry (already clean)")
+except Exception as e:
+    print(f"Registry update skipped: {e}", file=sys.stderr)
+PY
+}
+
+# ---------------------------------------------------------------------------
+# Main loop — iterate over non-main worktrees
+# ---------------------------------------------------------------------------
+log_info "Scanning worktrees in $REPO_ROOT..."
+
+cleaned=0
+skipped=0
+
+while IFS= read -r line; do
+    # Parse porcelain output into (path, branch) pairs
+    if [[ "$line" =~ ^worktree\ (.+)$ ]]; then
+        wt_path="${BASH_REMATCH[1]}"
+        wt_branch=""
+        wt_detached=false
+    elif [[ "$line" =~ ^branch\ refs/heads/(.+)$ ]]; then
+        wt_branch="${BASH_REMATCH[1]}"
+    elif [[ "$line" == "detached" ]]; then
+        wt_detached=true
+    elif [ -z "$line" ]; then
+        # Blank line = end of a stanza — process it
+        [ -z "$wt_path" ] && continue
+
+        # Skip the main checkout
+        if [ "$wt_path" = "$MAIN_WORKTREE" ]; then
+            log_skip "Skipping main checkout"
+            wt_path=""
+            continue
+        fi
+
+        wt_name="$(basename "$wt_path")"
+        profile="$(colima_profile "$wt_name")"
+
+        if [ "$wt_detached" = true ] || [ -z "$wt_branch" ]; then
+            log_skip "$wt_name — detached HEAD, skipping"
+            ((skipped++)) || true
+            wt_path=""
+            continue
+        fi
+
+        log_info "Checking $wt_name (branch: $wt_branch)"
+
+        # Age check — skip worktrees younger than 24 hours
+        wt_age_hours=$(python3 -c "
+import os, time
+try:
+    mtime = os.path.getmtime('$wt_path')
+    print(int((time.time() - mtime) / 3600))
+except Exception:
+    print(0)
+")
+        if [ "${wt_age_hours:-0}" -lt 24 ]; then
+            log_skip "$wt_name — only ${wt_age_hours}h old (< 24h), skipping"
+            ((skipped++)) || true
+            wt_path=""
+            continue
+        fi
+
+        # Query GitHub for PR state
+        pr_state=$(gh pr view "$wt_branch" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo "NOT_FOUND")
+
+        if [ "$pr_state" != "MERGED" ]; then
+            log_skip "$wt_name — PR state: ${pr_state:-unknown}, skipping"
+            ((skipped++)) || true
+            wt_path=""
+            continue
+        fi
+
+        log_ok "$wt_name — PR merged, folder ${wt_age_hours}h old — cleaning up"
+
+        if [ "$DRY_RUN" = true ]; then
+            echo "  [dry-run] colima delete $profile --force"
+            echo "  [dry-run] git worktree remove --force $wt_path  (${wt_age_hours}h old)"
+            echo "  [dry-run] remove '$profile' from $REGISTRY_FILE"
+            ((cleaned++)) || true
+            wt_path=""
+            continue
+        fi
+
+        # 1. Delete Colima VM (non-fatal — may not exist if never started)
+        if colima status "$profile" >/dev/null 2>&1; then
+            log_info "Deleting Colima VM: $profile"
+            colima delete "$profile" --force 2>/dev/null && log_ok "Colima VM deleted" || log_warn "Colima delete returned non-zero (continuing)"
+        else
+            log_skip "No Colima VM for $profile"
+        fi
+
+        # 2. Remove git worktree
+        log_info "Removing git worktree: $wt_path"
+        cd "$REPO_ROOT" && git worktree remove --force "$wt_path" && log_ok "Worktree removed" || log_warn "git worktree remove returned non-zero (continuing)"
+
+        # 3. Clean up port registry
+        remove_from_registry "$profile"
+
+        ((cleaned++)) || true
+        wt_path=""
+    fi
+done < <(cd "$REPO_ROOT" && git worktree list --porcelain && echo "")
+
+cd "$REPO_ROOT" && git worktree prune 2>/dev/null || true
+
+echo ""
+log_info "Done — cleaned: $cleaned, skipped: $skipped"

--- a/deployment/development/worktree_cleanup.sh
+++ b/deployment/development/worktree_cleanup.sh
@@ -178,8 +178,8 @@ try:
 except Exception:
     print(0)
 ")
-        if [ "${wt_age_hours:-0}" -lt 24 ]; then
-            log_skip "$wt_name — only ${wt_age_hours}h old (< 24h), skipping"
+        if [ "${wt_age_hours:-0}" -lt 2 ]; then
+            log_skip "$wt_name — only ${wt_age_hours}h old (< 2h), skipping"
             ((skipped++)) || true
             wt_path=""
             continue

--- a/deployment/development/worktree_cleanup_install.sh
+++ b/deployment/development/worktree_cleanup_install.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Install (or uninstall) the worktree cleanup launchd agent.
+#
+# Usage:
+#   ./worktree_cleanup_install.sh           # install
+#   ./worktree_cleanup_install.sh --remove  # uninstall
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MINI_INFRA_HOME="${MINI_INFRA_HOME:-$HOME/.mini-infra}"
+
+PLIST_LABEL="com.mini-infra.worktree-cleanup"
+PLIST_SRC="$SCRIPT_DIR/worktree_cleanup.plist"
+PLIST_DST="$HOME/Library/LaunchAgents/$PLIST_LABEL.plist"
+
+if [ "${1:-}" = "--remove" ]; then
+    echo "Unloading and removing worktree cleanup agent..."
+    launchctl unload "$PLIST_DST" 2>/dev/null || true
+    rm -f "$PLIST_DST"
+    echo "Done."
+    exit 0
+fi
+
+mkdir -p "$MINI_INFRA_HOME"
+mkdir -p "$HOME/Library/LaunchAgents"
+
+# Expand REPO_ROOT and MINI_INFRA_HOME placeholders in the plist template
+sed \
+    -e "s|REPO_ROOT|$REPO_ROOT|g" \
+    -e "s|MINI_INFRA_HOME|$MINI_INFRA_HOME|g" \
+    "$PLIST_SRC" > "$PLIST_DST"
+
+chmod +x "$SCRIPT_DIR/worktree_cleanup.sh"
+
+# Reload (unload first in case it's already loaded)
+launchctl unload "$PLIST_DST" 2>/dev/null || true
+launchctl load "$PLIST_DST"
+
+echo "Worktree cleanup agent installed and loaded."
+echo "  Runs every hour."
+echo "  Logs: $MINI_INFRA_HOME/worktree-cleanup.log"
+echo "  Dry run: $SCRIPT_DIR/worktree_cleanup.sh --dry-run"
+echo "  Uninstall: $0 --remove"

--- a/deployment/development/worktree_seed.sh
+++ b/deployment/development/worktree_seed.sh
@@ -25,11 +25,14 @@ GREEN='\033[0;32m'
 CYAN='\033[0;36m'
 YELLOW='\033[0;33m'
 RED='\033[0;31m'
+GRAY='\033[0;90m'
 NC='\033[0m'
-info()  { echo -e "${CYAN}▸ $1${NC}"; }
-ok()    { echo -e "${GREEN}✓ $1${NC}"; }
-skip()  { echo -e "${YELLOW}• $1${NC}"; }
-fail()  { echo -e "${RED}✗ $1${NC}"; }
+ts()    { date '+%H:%M:%S'; }
+info()  { echo -e "${CYAN}[$(ts)] ▸ $1${NC}"; }
+ok()    { echo -e "${GREEN}[$(ts)] ✓ $1${NC}"; }
+skip()  { echo -e "${YELLOW}[$(ts)] • $1${NC}"; }
+fail()  { echo -e "${RED}[$(ts)] ✗ $1${NC}"; }
+debug() { [ "${SEED_DEBUG:-0}" = "1" ] && echo -e "${GRAY}[$(ts)] DBG $1${NC}" || true; }
 
 : "${UI_PORT:?UI_PORT must be set}"
 : "${DEV_ENV_FILE:?DEV_ENV_FILE must be set}"
@@ -48,19 +51,21 @@ set -a; source "$DEV_ENV_FILE"; set +a
 
 BASE_URL="http://localhost:$UI_PORT"
 
-# Single response-body buffer shared across api() calls. We can't create it
-# inside api() because $(api ...) runs in a subshell and any variable set
-# there would be lost.
+# Shared buffers for API call response body and curl stderr.
+# Can't be created inside api() because $(...) runs in a subshell.
 RESP_FILE="$(mktemp)"
-trap 'rm -f "$RESP_FILE"' EXIT
+CURL_ERR_FILE="$(mktemp)"
+trap 'rm -f "$RESP_FILE" "$CURL_ERR_FILE"' EXIT
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 # Prints the HTTP status to stdout; writes the response body to $RESP_FILE.
+# On curl network failure (status "000"), RESP_FILE contains the curl error.
 api() {
     local method="$1" path="$2" body="${3-}"
     : > "$RESP_FILE"
+    : > "$CURL_ERR_FILE"
     local curl_args=(-sS -o "$RESP_FILE" -w "%{http_code}" -X "$method" \
         -H "Content-Type: application/json" "${BASE_URL}${path}")
     if [ -n "${API_KEY:-}" ]; then
@@ -69,9 +74,34 @@ api() {
     if [ -n "$body" ]; then
         curl_args+=(-d "$body")
     fi
-    # || true so a curl network error (e.g. exit 52) doesn't trip set -e and
-    # abort the whole script. Callers check $status; "000" signals a curl failure.
-    curl "${curl_args[@]}" || echo "000"
+    debug "$method ${BASE_URL}${path}"
+    local http_code
+    http_code=$(curl "${curl_args[@]}" 2>"$CURL_ERR_FILE") || true
+    if [ -z "$http_code" ]; then
+        # curl network failure — stash its stderr in RESP_FILE so callers surface it
+        cat "$CURL_ERR_FILE" > "$RESP_FILE"
+        debug "curl failed: $(cat "$CURL_ERR_FILE")"
+        echo "000"
+        return
+    fi
+    debug "→ $http_code"
+    echo "$http_code"
+}
+
+# Polls GET /health until the app responds 200 or timeout expires.
+wait_for_healthy() {
+    local max="${1:-30}" label="${2:-app}"
+    info "Waiting for $label to become healthy (up to ${max}s)..."
+    for i in $(seq 1 "$max"); do
+        if curl -sf "$BASE_URL/health" >/dev/null 2>&1; then
+            ok "$label is healthy"
+            return 0
+        fi
+        debug "health check attempt $i/$max failed"
+        sleep 1
+    done
+    fail "$label did not become healthy within ${max}s"
+    return 1
 }
 
 json_escape() { python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().rstrip("\n")))'; }
@@ -145,6 +175,9 @@ else
         exit 1
     fi
     ok "Setup wizard completed"
+    # The server restarts after setup/complete to apply Docker host config.
+    # Wait for it to recover before continuing or subsequent API calls will fail.
+    wait_for_healthy 30 "app after setup"
 fi
 
 # ---------------------------------------------------------------------------
@@ -237,6 +270,13 @@ print(json.dumps({'connectionString': os.environ['AZURE_STORAGE_CONNECTION_STRIN
     status=$(api PUT /api/settings/azure "$body")
     if [ "$status" = "200" ] || [ "$status" = "201" ]; then
         ok "Azure configured"
+        info "Validating Azure connectivity"
+        status=$(api POST /api/settings/validate/azure "{}")
+        if [ "$status" = "200" ] || [ "$status" = "201" ]; then
+            ok "Azure connectivity verified"
+        else
+            skip "Azure validation returned $status (non-fatal): $(cat "$RESP_FILE")"
+        fi
     else
         fail "Azure PUT returned $status: $(cat "$RESP_FILE")"
     fi
@@ -255,6 +295,13 @@ print(json.dumps({
     status=$(api POST /api/settings/cloudflare "$body")
     if [ "$status" = "200" ] || [ "$status" = "201" ]; then
         ok "Cloudflare configured"
+        info "Validating Cloudflare connectivity"
+        status=$(api POST /api/settings/validate/cloudflare "{}")
+        if [ "$status" = "200" ] || [ "$status" = "201" ]; then
+            ok "Cloudflare connectivity verified"
+        else
+            skip "Cloudflare validation returned $status (non-fatal): $(cat "$RESP_FILE")"
+        fi
     else
         fail "Cloudflare POST returned $status: $(cat "$RESP_FILE")"
     fi
@@ -270,6 +317,13 @@ print(json.dumps({'token': os.environ['GITHUB_TOKEN']}))")
     status=$(api PUT /api/settings/github "$body")
     if [ "$status" = "200" ] || [ "$status" = "201" ]; then
         ok "GitHub configured"
+        info "Validating GitHub connectivity"
+        status=$(api POST /api/settings/validate/github-app "{}")
+        if [ "$status" = "200" ] || [ "$status" = "201" ]; then
+            ok "GitHub connectivity verified"
+        else
+            skip "GitHub validation returned $status (non-fatal): $(cat "$RESP_FILE")"
+        fi
     else
         # GitHub settings route shape may differ — surface the response so the
         # user can adjust the payload without guessing.
@@ -499,6 +553,7 @@ if [ -n "${DETAILS_FILE:-}" ]; then
     COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-}" \
     AGENT_SIDECAR_IMAGE_TAG="${AGENT_SIDECAR_IMAGE_TAG:-}" \
     ADMIN_EMAIL="$ADMIN_EMAIL" \
+    API_KEY="${API_KEY:-}" \
     LOCAL_ENV_ID="$LOCAL_ENV_ID" \
     ENVS_JSON="$envs_json" \
     STACKS_JSON="$stacks_json" \
@@ -572,6 +627,7 @@ xml = f"""<?xml version="1.0" encoding="UTF-8"?>
   <admin>
     <email>{t(os.environ['ADMIN_EMAIL'])}</email>
     <password>{t(os.environ['ADMIN_PASSWORD'])}</password>
+    <apiKey>{t(os.environ['API_KEY'])}</apiKey>
   </admin>
   <connectedServices>
     <azure configured="{os.environ['AZURE_SET']}"/>

--- a/deployment/development/worktree_start.sh
+++ b/deployment/development/worktree_start.sh
@@ -39,10 +39,11 @@ CYAN='\033[0;36m'
 YELLOW='\033[0;33m'
 NC='\033[0m'
 
-log_info()  { echo -e "${CYAN}$1${NC}"; }
-log_ok()    { echo -e "${GREEN}$1${NC}"; }
-log_warn()  { echo -e "${YELLOW}$1${NC}"; }
-log_error() { echo -e "${RED}$1${NC}"; }
+ts() { date '+%H:%M:%S'; }
+log_info()  { echo -e "${CYAN}[$(ts)] $1${NC}"; }
+log_ok()    { echo -e "${GREEN}[$(ts)] $1${NC}"; }
+log_warn()  { echo -e "${YELLOW}[$(ts)] $1${NC}"; }
+log_error() { echo -e "${RED}[$(ts)] $1${NC}"; }
 
 # Minimal environment-details.xml used when the seeder doesn't run (skip-seed
 # or missing dev.env). The seeder itself writes a richer version including the
@@ -250,7 +251,8 @@ for i in $(seq 1 15); do
         break
     fi
     if [ "$i" -eq 15 ]; then
-        log_error "Local registry failed to become ready on port $REGISTRY_PORT"
+        log_error "Local registry failed to become ready on port $REGISTRY_PORT after 15s"
+        docker compose -f "$COMPOSE_FILE" logs --tail=30 registry || true
         exit 1
     fi
     sleep 1
@@ -293,9 +295,11 @@ for i in $(seq 1 60); do
     fi
     if [ "$i" -eq 60 ]; then
         log_error "Mini Infra did not become healthy within 60s"
+        log_error "Last 100 lines of container logs:"
         docker compose -f "$COMPOSE_FILE" logs --tail=100 mini-infra || true
         exit 1
     fi
+    [ $((i % 10)) -eq 0 ] && log_info "Still waiting... (${i}s elapsed)"
     sleep 1
 done
 log_ok "Mini Infra is healthy"


### PR DESCRIPTION
## Summary

- **Timestamps on all log lines** in `worktree_start.sh` and `worktree_seed.sh` (`[HH:MM:SS]` prefix) so it's easy to see how long each step takes
- **Curl error capture** — `api()` now captures curl stderr; on a network failure (status `000`) the actual curl error message surfaces in the log instead of a blank `: `
- **`wait_for_healthy()` after `setup/complete`** — fixes a bug where the server restarts after the setup wizard is completed, causing the Azure/Cloudflare seed calls to fail with connection-reset errors
- **Immediate connectivity validation** — after saving Azure, Cloudflare, and GitHub credentials, the seeder now calls `POST /api/settings/validate/:service` which writes a `ConnectivityStatus` record immediately, so connected services show as connected right away rather than waiting up to 5 minutes for the scheduler
- **API key in `environment-details.xml`** — the seeder API key is now written to `//admin/apiKey` so tooling can read it without prompting
- **`diagnose-dev` SKILL.md updated** — reads the API key from `environment-details.xml` via `xmllint` instead of asking the user
- **`SEED_DEBUG=1` mode** — enables per-request/response debug output for troubleshooting seed issues
- **Registry wait loop** — on timeout, now dumps the last 30 lines of registry container logs
- **App health wait loop** — prints progress every 10 seconds and dumps container logs on timeout

## Root cause fixed

After `POST /auth/setup/complete` the server restarts to apply the Docker host config. The seeder previously had no wait, so the Docker host IP, Azure, Cloudflare, and local environment seed calls all hit a recovering server and failed silently (curl exit 52/7 → status `000` with no error message shown).

## Test plan

- [ ] Wipe Colima VM and run `worktree_start.sh` from scratch — all seed steps should succeed including Azure and Cloudflare connectivity
- [ ] Check `environment-details.xml` contains `<apiKey>` under `<admin>`
- [ ] Verify Connected Services page shows Azure and Cloudflare as connected immediately after startup
- [ ] Run with `SEED_DEBUG=1` to verify debug output appears
