### PR TITLE
fix: correct volume/network template naming and fill doc gaps

### DIFF
--- a/docs/stack-definition-reference.md
+++ b/docs/stack-definition-reference.md
@@ -159,6 +159,7 @@ Important note about `dependsOn`:
 | --- | --- | --- | --- |
 | `command` | No | Container command override. | Array of strings. |
 | `entrypoint` | No | Container entrypoint override. | Array of strings. |
+| `capAdd` | No | Linux capabilities to add to the container. | Array of strings, e.g. `["NET_ADMIN"]`. |
 | `user` | No | User the container should run as. | String. |
 | `env` | No | Static environment variables. | Mapping of string keys to string values. |
 | `dynamicEnv` | No | Apply-time env values resolved by Mini Infra. | Mapping of env var name to a supported dynamic source. Keys must not overlap with `env`. |
@@ -294,14 +295,14 @@ Reference note:
 
 Mini Infra resolves templates from a context that includes:
 
-- `stack.name`
-- `stack.projectName`
-- `services.<serviceName>.containerName`
-- `services.<serviceName>.image`
-- `env.<VAR_NAME>`
-- `volumes.<volumeName>`
-- `networks.<networkName>`
-- `params.<paramName>`
+- `stack.name` — the stack's logical name.
+- `stack.projectName` — the Docker project prefix. Resolves to `{envName}-{stackName}` for environment-scoped stacks and `mini-infra-{stackName}` for host-level stacks.
+- `services.<serviceName>.containerName` — the full Docker container name, e.g. `prod-mystack-web`.
+- `services.<serviceName>.image` — the resolved image reference, e.g. `nginx:1.25`.
+- `env.<VAR_NAME>` — static env vars aggregated from `containerConfig.env` across **all services** in definition order. If two services define the same key, the later one wins.
+- `volumes.<volumeName>` — the actual Docker volume name, `{projectName}_{volumeName}`.
+- `networks.<networkName>` — the actual Docker network name, `{projectName}_{networkName}`.
+- `params.<paramName>` — resolved parameter values.
 
 Important limits:
 

--- a/server/src/__tests__/stack-template-engine.test.ts
+++ b/server/src/__tests__/stack-template-engine.test.ts
@@ -55,12 +55,12 @@ describe('resolveTemplate', () => {
   });
 
   it('resolves {{volumes.loki_data}}', () => {
-    expect(resolveTemplate('{{volumes.loki_data}}', ctx)).toBe('prod-monitoring-loki_data');
+    expect(resolveTemplate('{{volumes.loki_data}}', ctx)).toBe('prod-monitoring_loki_data');
   });
 
   it('resolves {{networks.monitoring_network}}', () => {
     expect(resolveTemplate('{{networks.monitoring_network}}', ctx)).toBe(
-      'prod-monitoring-monitoring_network'
+      'prod-monitoring_monitoring_network'
     );
   });
 
@@ -93,8 +93,8 @@ describe('buildTemplateContext', () => {
     expect(ctx.services.grafana.containerName).toBe('prod-monitoring-grafana');
     expect(ctx.env.LOG_LEVEL).toBe('info');
     expect(ctx.env.RETENTION).toBe('30d');
-    expect(ctx.volumes.loki_data).toBe('prod-monitoring-loki_data');
-    expect(ctx.networks.monitoring_network).toBe('prod-monitoring-monitoring_network');
+    expect(ctx.volumes.loki_data).toBe('prod-monitoring_loki_data');
+    expect(ctx.networks.monitoring_network).toBe('prod-monitoring_monitoring_network');
   });
 });
 

--- a/server/src/services/stacks/template-engine.ts
+++ b/server/src/services/stacks/template-engine.ts
@@ -44,12 +44,12 @@ export function buildTemplateContext(
 
   const volumeMap: Record<string, string> = {};
   for (const v of stack.volumes) {
-    volumeMap[v.name] = `${projectName}-${v.name}`;
+    volumeMap[v.name] = `${projectName}_${v.name}`;
   }
 
   const networkMap: Record<string, string> = {};
   for (const n of stack.networks) {
-    networkMap[n.name] = `${projectName}-${n.name}`;
+    networkMap[n.name] = `${projectName}_${n.name}`;
   }
 
   return {


### PR DESCRIPTION
## Summary

- **Bug fix**: `template-engine.ts` was building `volumes.<name>` and `networks.<name>` template context values with a hyphen separator (`projectName-name`), but the reconciler creates the actual Docker objects with an underscore (`projectName_name`). Any stack definition using `{{volumes.x}}` or `{{networks.x}}` in config file content would receive a name that doesn't exist in Docker.
- **Missing field**: `capAdd` (Linux capabilities) was accepted by the schema and passed through to Docker at container create time, but was completely absent from the reference docs.
- **Doc gaps**: Expanded the Templating notes section with `projectName` resolution format, the `env` aggregation behaviour (merged across all services), and the actual resolved values for `volumes.<name>` / `networks.<name>`.

## Changes

| File | Change |
|---|---|
| `server/src/services/stacks/template-engine.ts` | Use `_` separator for volume and network context values |
| `server/src/__tests__/stack-template-engine.test.ts` | Update four assertions to match corrected format |
| `docs/stack-definition-reference.md` | Add `capAdd` row; expand Templating notes |

## Test plan

- [ ] Template engine unit tests pass (`npx -w server vitest run src/__tests__/stack-template-engine.test.ts`) — all 12 green
- [ ] Stack definitions using `{{volumes.x}}` or `{{networks.x}}` in config file content now resolve to names that match the Docker objects the reconciler creates