### PR TITLE
feat: Vault UX improvements — lock confirmation, operator credentials, download, network restore

### DIFF
--- a/client/src/app/vault/components/BootstrapDialog.tsx
+++ b/client/src/app/vault/components/BootstrapDialog.tsx
@@ -11,7 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { IconAlertCircle, IconCheck } from "@tabler/icons-react";
+import { IconAlertCircle, IconCheck, IconDownload } from "@tabler/icons-react";
 import { useBootstrapVault } from "@/hooks/use-vault";
 import { Channel, ServerEvent } from "@mini-infra/types";
 import type { VaultBootstrapResult } from "@mini-infra/types";
@@ -199,10 +199,15 @@ export function BootstrapDialog({
               </Button>
             </>
           )}
-          {phase === "complete" && (
-            <Button onClick={() => onOpenChange(false)}>
-              <IconCheck className="h-4 w-4 mr-2" /> I've saved these
-            </Button>
+          {phase === "complete" && result && (
+            <>
+              <Button variant="outline" onClick={() => downloadCredentials(result)}>
+                <IconDownload className="h-4 w-4 mr-2" /> Download
+              </Button>
+              <Button onClick={() => onOpenChange(false)}>
+                <IconCheck className="h-4 w-4 mr-2" /> I've saved these
+              </Button>
+            </>
           )}
           {phase === "failed" && (
             <Button variant="outline" onClick={() => onOpenChange(false)}>
@@ -213,6 +218,32 @@ export function BootstrapDialog({
       </DialogContent>
     </Dialog>
   );
+}
+
+function downloadCredentials(result: VaultBootstrapResult) {
+  const lines = [
+    "=== Vault Bootstrap Credentials ===",
+    `Generated: ${new Date().toISOString()}`,
+    "",
+    "IMPORTANT: Store this file securely and delete it when no longer needed.",
+    "",
+    "--- Unseal Keys (2 of 3 required to unseal) ---",
+    ...result.unsealKeys.map((k, i) => `Key ${i + 1}: ${k}`),
+    "",
+    "--- Root Token (revoked after bootstrap — kept for record-keeping) ---",
+    result.rootToken,
+    "",
+    "--- Operator Credentials (Vault UI userpass login) ---",
+    `Username: ${result.operatorUsername}`,
+    `Password: ${result.operatorPassword}`,
+  ];
+  const blob = new Blob([lines.join("\n")], { type: "text/plain" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "vault-credentials.txt";
+  a.click();
+  URL.revokeObjectURL(url);
 }
 
 function BootstrapComplete({ result }: { result: VaultBootstrapResult }) {

--- a/client/src/app/vault/page.tsx
+++ b/client/src/app/vault/page.tsx
@@ -6,10 +6,13 @@ import {
   IconAlertCircle,
   IconCheck,
   IconRefresh,
+  IconCopy,
+  IconKey,
 } from "@tabler/icons-react";
 import {
   useVaultStatus,
   useLockPassphrase,
+  useOperatorCredentials,
 } from "@/hooks/use-vault";
 import { Button } from "@/components/ui/button";
 import {
@@ -22,6 +25,19 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { BootstrapDialog } from "./components/BootstrapDialog";
 import { PassphraseUnlockDialog } from "./components/PassphraseUnlockDialog";
 import { UnsealDialog } from "./components/UnsealDialog";
@@ -127,14 +143,58 @@ export default function VaultPage() {
                 </Button>
               )}
               {!notBootstrapped && !locked && (
-                <Button
-                  variant="outline"
-                  onClick={() => lockMutation.mutate()}
-                  data-tour="vault-lock"
-                >
-                  <IconLock className="h-4 w-4 mr-2" />
-                  Lock Passphrase
-                </Button>
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button
+                      variant="destructive"
+                      data-tour="vault-lock"
+                    >
+                      <IconLock className="h-4 w-4 mr-2" />
+                      Lock Passphrase
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Lock the operator passphrase?</AlertDialogTitle>
+                      <AlertDialogDescription asChild>
+                        <div className="flex flex-col gap-2 text-sm text-muted-foreground">
+                          <p>
+                            Locking removes the passphrase from memory. This has the following effects:
+                          </p>
+                          <ul className="list-disc pl-5 space-y-1">
+                            <li>
+                              <b>Auto-unseal stops.</b> If Vault restarts or is
+                              manually sealed, Mini Infra cannot unseal it until
+                              you unlock the passphrase again.
+                            </li>
+                            <li>
+                              <b>Operator credentials become unreadable.</b> The
+                              stored password can no longer be decrypted until
+                              unlocked.
+                            </li>
+                            <li>
+                              The currently active admin token continues working
+                              until it expires (1 hour).
+                            </li>
+                          </ul>
+                          <p>
+                            You will need to re-enter the passphrase to resume
+                            normal operation.
+                          </p>
+                        </div>
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={() => lockMutation.mutate()}
+                        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                      >
+                        Lock Passphrase
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
               )}
               {sealed && (
                 <Button
@@ -148,6 +208,10 @@ export default function VaultPage() {
             </div>
           </CardContent>
         </Card>
+
+        {status?.initialised && !locked && (
+          <OperatorCredentialsCard />
+        )}
 
         <Card>
           <CardHeader>
@@ -183,6 +247,88 @@ export default function VaultPage() {
       />
       <UnsealDialog open={unsealOpen} onOpenChange={setUnsealOpen} />
     </div>
+  );
+}
+
+function OperatorCredentialsCard() {
+  const [revealed, setRevealed] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const { data, isFetching, refetch, error } = useOperatorCredentials();
+
+  const handleReveal = async () => {
+    await refetch();
+    setRevealed(true);
+  };
+
+  const handleCopy = async () => {
+    if (data?.password) {
+      await navigator.clipboard.writeText(data.password);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <IconKey className="h-5 w-5 text-muted-foreground" />
+          <div>
+            <CardTitle>Operator Credentials</CardTitle>
+            <CardDescription>
+              Userpass credentials for logging into the Vault UI as{" "}
+              <code>mini-infra-operator</code>
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <Label className="text-xs text-muted-foreground">Username</Label>
+          <p className="font-mono text-sm">mini-infra-operator</p>
+        </div>
+        <div className="flex flex-col gap-2">
+          <Label className="text-xs text-muted-foreground">Password</Label>
+          {!revealed ? (
+            <Button
+              variant="outline"
+              size="sm"
+              className="self-start"
+              onClick={handleReveal}
+              disabled={isFetching}
+            >
+              {isFetching ? "Loading…" : "Reveal password"}
+            </Button>
+          ) : (
+            <div className="flex gap-2 max-w-sm">
+              <Input
+                type="password"
+                value={data?.password ?? ""}
+                readOnly
+                className="font-mono"
+              />
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={handleCopy}
+                title="Copy password"
+              >
+                {copied ? (
+                  <IconCheck className="h-4 w-4" />
+                ) : (
+                  <IconCopy className="h-4 w-4" />
+                )}
+              </Button>
+            </div>
+          )}
+          {error && (
+            <p className="text-sm text-destructive">
+              {error instanceof Error ? error.message : "Failed to load credentials"}
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/client/src/hooks/use-vault.ts
+++ b/client/src/hooks/use-vault.ts
@@ -235,6 +235,18 @@ export function useDeleteVaultAppRole() {
   });
 }
 
+export function useOperatorCredentials() {
+  return useQuery<{ username: string; password: string }>({
+    queryKey: ["vault", "operator-credentials"],
+    queryFn: () =>
+      apiFetch<{ username: string; password: string }>(
+        "/api/vault/operator-credentials",
+      ),
+    enabled: false,
+    retry: false,
+  });
+}
+
 export function useAppRoleStacks(id: string | undefined) {
   return useQuery<{ id: string; name: string }[]>({
     queryKey: ["vault", "approles", id, "stacks"],

--- a/deployment/development/worktree_start.sh
+++ b/deployment/development/worktree_start.sh
@@ -99,12 +99,14 @@ PY
 PROFILE=""
 RESET=false
 SKIP_SEED=false
+FORCE_SEED=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --profile) PROFILE="$2"; shift 2 ;;
         --reset) RESET=true; shift ;;
         --skip-seed) SKIP_SEED=true; shift ;;
+        --seed) FORCE_SEED=true; shift ;;
         -h|--help)
             sed -n '2,12p' "$0"
             exit 0
@@ -280,10 +282,63 @@ docker push "$AGENT_SIDECAR_IMAGE_TAG"
 log_ok "Agent sidecar image pushed"
 
 # ---------------------------------------------------------------------------
+# Capture any extra networks dynamically joined at runtime (e.g. via
+# joinSelf resource outputs like the vault network) so they survive the
+# container recreate that --build triggers.
+# ---------------------------------------------------------------------------
+MINI_INFRA_CONTAINER="${COMPOSE_PROJECT_NAME}-mini-infra-1"
+EXTRA_NETWORKS=""
+if docker inspect "$MINI_INFRA_CONTAINER" >/dev/null 2>&1; then
+    COMPOSE_NETWORKS=$(docker compose -f "$COMPOSE_FILE" config --format json 2>/dev/null \
+        | python3 -c "
+import sys, json
+cfg = json.load(sys.stdin)
+project = cfg.get('name', '')
+nets = set(['default'])
+for svc in cfg.get('services', {}).values():
+    for net_name in svc.get('networks', {}).keys():
+        nets.add(net_name)
+for n in nets:
+    print(f'{project}_{n}')
+" 2>/dev/null)
+    CURRENT_NETWORKS=$(docker inspect "$MINI_INFRA_CONTAINER" \
+        --format '{{range $k, $v := .NetworkSettings.Networks}}{{$k}}{{"\n"}}{{end}}' 2>/dev/null)
+    for net in $CURRENT_NETWORKS; do
+        is_compose=false
+        for cn in $COMPOSE_NETWORKS; do
+            [ "$net" = "$cn" ] && is_compose=true && break
+        done
+        [ "$is_compose" = false ] && EXTRA_NETWORKS="$EXTRA_NETWORKS $net"
+    done
+    [ -n "$EXTRA_NETWORKS" ] && log_info "Will restore extra networks after rebuild:$EXTRA_NETWORKS"
+fi
+
+# ---------------------------------------------------------------------------
 # Build + start the full stack
 # ---------------------------------------------------------------------------
 log_info "Building and starting Mini Infra (project=$COMPOSE_PROJECT_NAME)..."
 docker compose -f "$COMPOSE_FILE" up -d --build
+
+# ---------------------------------------------------------------------------
+# Restore extra networks stripped by the container recreate
+# ---------------------------------------------------------------------------
+if [ -n "$EXTRA_NETWORKS" ]; then
+    log_info "Waiting for ${MINI_INFRA_CONTAINER} to start before restoring networks..."
+    for i in $(seq 1 30); do
+        STATUS=$(docker inspect "$MINI_INFRA_CONTAINER" --format '{{.State.Status}}' 2>/dev/null)
+        [ "$STATUS" = "running" ] && break
+        sleep 1
+    done
+    for net in $EXTRA_NETWORKS; do
+        if docker network inspect "$net" >/dev/null 2>&1; then
+            docker network connect "$net" "$MINI_INFRA_CONTAINER" 2>/dev/null \
+                && log_ok "Rejoined network: $net" \
+                || log_warn "Failed to rejoin network: $net (may already be connected)"
+        else
+            log_warn "Skipping network $net (no longer exists)"
+        fi
+    done
+fi
 
 # ---------------------------------------------------------------------------
 # Wait for health, then seed
@@ -306,9 +361,19 @@ log_ok "Mini Infra is healthy"
 
 DETAILS_FILE="$PROJECT_ROOT/environment-details.xml"
 
+# Detect whether this instance has already been seeded by checking the
+# existing environment-details.xml. Skip the seeder on rebuilds unless
+# --seed or --reset was passed — matching the behaviour of start.sh.
+ALREADY_SEEDED=false
+if [ -f "$DETAILS_FILE" ] && grep -q "<seeded>true</seeded>" "$DETAILS_FILE" 2>/dev/null; then
+    ALREADY_SEEDED=true
+fi
+
 if [ "$SKIP_SEED" = true ]; then
     log_warn "Skipping seed step (--skip-seed)"
     write_minimal_environment_details "$DETAILS_FILE"
+elif [ "$ALREADY_SEEDED" = true ] && [ "$FORCE_SEED" = false ] && [ "$RESET" = false ]; then
+    log_info "Instance already seeded — skipping (pass --seed to re-run)"
 elif [ ! -f "$DEV_ENV_FILE" ]; then
     log_warn "Skipping seed step — $DEV_ENV_FILE not found"
     log_warn "Copy $SCRIPT_DIR/dev.env.example to $DEV_ENV_FILE and fill in values."
@@ -327,5 +392,6 @@ echo "  DOCKER_HOST: $DOCKER_HOST"
 echo ""
 echo "  Logs:   DOCKER_HOST=$DOCKER_HOST docker compose -f $COMPOSE_FILE -p $COMPOSE_PROJECT_NAME logs -f"
 echo "  Stop:   DOCKER_HOST=$DOCKER_HOST docker compose -f $COMPOSE_FILE -p $COMPOSE_PROJECT_NAME down"
-echo "  Nuke:   $0 --reset --profile $PROFILE"
+echo "  Re-seed: $0 --seed --profile $PROFILE"
+echo "  Nuke:    $0 --reset --profile $PROFILE"
 echo ""

--- a/server/templates/vault/template.json
+++ b/server/templates/vault/template.json
@@ -1,7 +1,7 @@
 {
   "name": "vault",
   "displayName": "Vault (OpenBao)",
-  "builtinVersion": 4,
+  "builtinVersion": 5,
   "scope": "host",
   "category": "security",
   "description": "Managed OpenBao vault. Bootstrap in the Vault UI under Settings → Vault after deploying.",
@@ -9,8 +9,8 @@
     {
       "name": "host-port",
       "type": "number",
-      "default": 0,
-      "description": "Bind the Vault API on 127.0.0.1 at this host port (0 disables the host binding). Containers on the vault network reach Vault at http://mini-infra-vault-vault:8200 regardless."
+      "default": 8200,
+      "description": "Bind the Vault API on the host at this port. Containers on the vault network reach Vault at http://mini-infra-vault-vault:8200 regardless."
     }
   ],
   "resourceOutputs": [
@@ -37,7 +37,7 @@
             "containerPort": 8200,
             "hostPort": "{{params.host-port}}",
             "protocol": "tcp",
-            "exposeOnHost": false
+            "exposeOnHost": true
           }
         ],
         "mounts": [


### PR DESCRIPTION
## Summary

- **Lock Passphrase button** is now `destructive` (red) and guarded by an `AlertDialog` that explains the consequences before confirming — auto-unseal stops, encrypted credentials become unreadable, existing admin token keeps working until it expires
- **Operator Credentials card** appears on the Vault page when bootstrapped and passphrase is unlocked; reveals the `mini-infra-operator` userpass password via a lazy "Reveal password" button (masked field + copy-to-clipboard)
- **Bootstrap download button** on the complete screen saves unseal keys, root token, and operator credentials to `vault-credentials.txt`
- **Vault stack template** fix: `hostPort` default corrected from `0` → `8200` and `exposeOnHost` from `false` → `true` so the API is actually reachable on the host; `builtinVersion` bumped to 5
- **`worktree_start.sh`** now preserves and restores dynamically-joined runtime networks (e.g. vault `joinSelf` network) across container rebuilds, and skips the seeder on subsequent runs by default — pass `--seed` to force re-seed

## Reviewer notes

- The `useOperatorCredentials` hook uses `enabled: false` so it only fetches when explicitly triggered (not on page load)
- The operator password endpoint (`GET /api/vault/operator-credentials`) already existed server-side; this PR wires up the frontend
- Network restoration logic in `worktree_start.sh` is lifted directly from `start.sh`
- `--seed` flag is new; `--skip-seed` and `--reset` behaviour is unchanged

## Test plan

- [ ] Deploy Vault stack, bootstrap — verify download button produces a valid `vault-credentials.txt`
- [ ] Lock Passphrase — verify red button, confirmation dialog appears with correct explanation
- [ ] Unlock passphrase — verify Operator Credentials card appears, Reveal password works and copy button copies correctly
- [ ] Rebuild with `worktree_start.sh` after vault stack is deployed — verify vault network is restored and Mini Infra can still reach Vault
- [ ] Confirm `worktree_start.sh` skips seeder on second run, and `--seed` re-runs it

🤖 Generated with [Claude Code](https://claude.com/claude-code)