### PR TITLE
fix: use dialog flow for Add Output/Input in resource I/O section

### DIFF
--- a/client/src/components/stack-templates/add-resource-io-dialog.tsx
+++ b/client/src/components/stack-templates/add-resource-io-dialog.tsx
@@ -1,0 +1,138 @@
+import { useEffect } from "react";
+import { useForm, Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import type { StackResourceInput, StackResourceOutput } from "@mini-infra/types";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+
+const resourceIOSchema = z.object({
+  type: z.string().min(1, "Type is required"),
+  purpose: z
+    .string()
+    .min(1, "Purpose is required")
+    .regex(/^[a-zA-Z0-9_-]+$/, "Purpose must contain only letters, digits, hyphens, or underscores"),
+  flag: z.boolean(),
+});
+
+type ResourceIOFormValues = z.infer<typeof resourceIOSchema>;
+
+interface AddResourceIODialogProps {
+  mode: "output" | "input";
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (item: StackResourceOutput | StackResourceInput) => void;
+}
+
+export function AddResourceIODialog({
+  mode,
+  open,
+  onOpenChange,
+  onSave,
+}: AddResourceIODialogProps) {
+  const form = useForm<ResourceIOFormValues>({
+    resolver: zodResolver(resourceIOSchema) as Resolver<ResourceIOFormValues>,
+    defaultValues: { type: "", purpose: "", flag: false },
+  });
+
+  useEffect(() => {
+    if (open) {
+      form.reset({ type: "", purpose: "", flag: false });
+    }
+  }, [open, form]);
+
+  function onSubmit(values: ResourceIOFormValues) {
+    if (mode === "output") {
+      onSave({ type: values.type, purpose: values.purpose, joinSelf: values.flag });
+    } else {
+      onSave({ type: values.type, purpose: values.purpose, optional: values.flag });
+    }
+    onOpenChange(false);
+  }
+
+  const flagLabel = mode === "output" ? "Join self" : "Optional";
+  const title = mode === "output" ? "Add Output" : "Add Input";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Type</FormLabel>
+                  <FormControl>
+                    <Input placeholder="e.g. docker-network" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="purpose"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Purpose</FormLabel>
+                  <FormControl>
+                    <Input placeholder="e.g. applications" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="flag"
+              render={({ field }) => (
+                <FormItem className="flex items-center gap-2 space-y-0">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                  <FormLabel className="cursor-pointer font-normal">
+                    {flagLabel}
+                  </FormLabel>
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button type="submit">{title}</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/stack-templates/template-resource-io-section.tsx
+++ b/client/src/components/stack-templates/template-resource-io-section.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -6,6 +7,7 @@ import type {
   StackResourceInput,
   StackResourceOutput,
 } from "@mini-infra/types";
+import { AddResourceIODialog } from "./add-resource-io-dialog";
 
 interface TemplateResourceIOSectionProps {
   resourceInputs: StackResourceInput[];
@@ -26,6 +28,9 @@ export function TemplateResourceIOSection({
   readOnly = false,
   onChange,
 }: TemplateResourceIOSectionProps) {
+  const [outputDialogOpen, setOutputDialogOpen] = useState(false);
+  const [inputDialogOpen, setInputDialogOpen] = useState(false);
+
   function updateInputs(next: StackResourceInput[]) {
     onChange(next, resourceOutputs);
   }
@@ -50,12 +55,7 @@ export function TemplateResourceIOSection({
               type="button"
               size="sm"
               variant="outline"
-              onClick={() =>
-                updateOutputs([
-                  ...resourceOutputs,
-                  { type: "", purpose: "", joinSelf: false },
-                ])
-              }
+              onClick={() => setOutputDialogOpen(true)}
             >
               <IconPlus className="mr-1 h-4 w-4" />
               Add Output
@@ -152,12 +152,7 @@ export function TemplateResourceIOSection({
               type="button"
               size="sm"
               variant="outline"
-              onClick={() =>
-                updateInputs([
-                  ...resourceInputs,
-                  { type: "", purpose: "", optional: false },
-                ])
-              }
+              onClick={() => setInputDialogOpen(true)}
             >
               <IconPlus className="mr-1 h-4 w-4" />
               Add Input
@@ -244,6 +239,19 @@ export function TemplateResourceIOSection({
           </div>
         )}
       </div>
+
+      <AddResourceIODialog
+        mode="output"
+        open={outputDialogOpen}
+        onOpenChange={setOutputDialogOpen}
+        onSave={(item) => updateOutputs([...resourceOutputs, item as StackResourceOutput])}
+      />
+      <AddResourceIODialog
+        mode="input"
+        open={inputDialogOpen}
+        onOpenChange={setInputDialogOpen}
+        onSave={(item) => updateInputs([...resourceInputs, item as StackResourceInput])}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #223 — clicking **Add Output** or **Add Input** in the stack template editor's Resource I/O section showed an immediate "Validation failed" toast and added no row.

## Root Cause

The old code added an empty row `{ type: "", purpose: "" }` to state and immediately called `onChange`, triggering an auto-save draft request. The backend schema requires both fields to be non-empty, so it returned a 400 before the user could fill anything in.

## Fix

Replaced the inline-add approach with a dialog flow matching the pattern used by Parameters, Services, etc. elsewhere in the editor:

- Clicking **Add Output** / **Add Input** now opens an `AddResourceIODialog` component
- The dialog collects `type`, `purpose`, and the boolean flag (`joinSelf` for outputs, `optional` for inputs) with client-side zod validation matching the backend schema (`min(1)` + `/^[a-zA-Z0-9_-]+$/` for purpose)
- On confirm with valid data, the new row is appended to state and `onChange` fires — guaranteeing the draft save always has valid data
- Cancel dismisses with no state change

A single parameterized `AddResourceIODialog` component handles both output and input to keep things DRY.

## Validation

Validated via playwright-cli browser automation:
- [x] Regression: clicking Add Output/Add Input no longer fires a 400 or shows a "Validation failed" toast
- [x] Client-side validation: submitting the empty dialog shows inline "Type is required" / "Purpose is required" errors, dialog stays open
- [x] Happy path (output): filling type=`docker-network`, purpose=`applications` and confirming adds Outputs (1) to the list
- [x] Happy path (input): filling type=`docker-network`, purpose=`shared-net`, Optional=true and confirming adds Inputs (1) to the list
- [x] Zero console errors throughout

Screenshots available in `screenshots/` on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)