### PR TITLE
refactor: split haproxy-frontend-manager into focused modules

### DIFF
--- a/server/src/services/haproxy/frontend-manager/__tests__/acl-rule-operations.test.ts
+++ b/server/src/services/haproxy/frontend-manager/__tests__/acl-rule-operations.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  addACL,
+  addBackendSwitchingRule,
+  addHostnameRouting,
+  removeACLByName,
+  removeBackendSwitchingRuleByAclName,
+} from "../acl-rule-operations";
+import type { HAProxyDataPlaneClient } from "../../haproxy-dataplane-client";
+
+type MockClient = {
+  addACL: ReturnType<typeof vi.fn>;
+  addBackendSwitchingRule: ReturnType<typeof vi.fn>;
+  getACLs: ReturnType<typeof vi.fn>;
+  getBackendSwitchingRules: ReturnType<typeof vi.fn>;
+  deleteACL: ReturnType<typeof vi.fn>;
+  deleteBackendSwitchingRule: ReturnType<typeof vi.fn>;
+};
+
+function buildClient(): MockClient {
+  return {
+    addACL: vi.fn().mockResolvedValue(undefined),
+    addBackendSwitchingRule: vi.fn().mockResolvedValue(undefined),
+    getACLs: vi.fn().mockResolvedValue([]),
+    getBackendSwitchingRules: vi.fn().mockResolvedValue([]),
+    deleteACL: vi.fn().mockResolvedValue(undefined),
+    deleteBackendSwitchingRule: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const asClient = (c: MockClient) => c as unknown as HAProxyDataPlaneClient;
+
+describe("acl-rule-operations", () => {
+  let client: MockClient;
+
+  beforeEach(() => {
+    client = buildClient();
+  });
+
+  describe("addACL", () => {
+    it("splits the criterion into fetch method and value before calling the client", async () => {
+      await addACL("fe_app", "acl_host", "hdr(host) -i example.com", asClient(client));
+
+      expect(client.addACL).toHaveBeenCalledWith(
+        "fe_app",
+        "acl_host",
+        "hdr(host)",
+        "-i example.com"
+      );
+    });
+
+    it("throws when the criterion has no space separator", async () => {
+      await expect(
+        addACL("fe_app", "acl_host", "no-space", asClient(client))
+      ).rejects.toThrow("Invalid ACL criterion format");
+      expect(client.addACL).not.toHaveBeenCalled();
+    });
+
+    it("swallows 409 responses as already-exists", async () => {
+      client.addACL.mockRejectedValue({ response: { status: 409 } });
+
+      await expect(
+        addACL("fe_app", "acl_host", "hdr(host) -i x.com", asClient(client))
+      ).resolves.toBeUndefined();
+    });
+
+    it("swallows errors whose message contains 'already exists'", async () => {
+      client.addACL.mockRejectedValue(new Error("ACL already exists"));
+
+      await expect(
+        addACL("fe_app", "acl_host", "hdr(host) -i x.com", asClient(client))
+      ).resolves.toBeUndefined();
+    });
+
+    it("rethrows other errors wrapped with cause", async () => {
+      const boom = new Error("boom");
+      client.addACL.mockRejectedValue(boom);
+
+      await expect(
+        addACL("fe_app", "acl_host", "hdr(host) -i x.com", asClient(client))
+      ).rejects.toMatchObject({
+        message: expect.stringContaining("Failed to add ACL"),
+        cause: boom,
+      });
+    });
+  });
+
+  describe("addBackendSwitchingRule", () => {
+    it("sends the rule with the 'if' condition", async () => {
+      await addBackendSwitchingRule("fe_app", "acl_host", "be_api", asClient(client));
+
+      expect(client.addBackendSwitchingRule).toHaveBeenCalledWith(
+        "fe_app",
+        "be_api",
+        "acl_host",
+        "if"
+      );
+    });
+
+    it("swallows 409 already-exists errors", async () => {
+      client.addBackendSwitchingRule.mockRejectedValue({ response: { status: 409 } });
+
+      await expect(
+        addBackendSwitchingRule("fe_app", "acl_host", "be_api", asClient(client))
+      ).resolves.toBeUndefined();
+    });
+
+    it("rethrows other errors wrapped with cause", async () => {
+      const boom = new Error("network down");
+      client.addBackendSwitchingRule.mockRejectedValue(boom);
+
+      await expect(
+        addBackendSwitchingRule("fe_app", "acl_host", "be_api", asClient(client))
+      ).rejects.toMatchObject({
+        message: expect.stringContaining("Failed to add backend switching rule"),
+        cause: boom,
+      });
+    });
+  });
+
+  describe("addHostnameRouting", () => {
+    it("adds an ACL keyed off the hostname and then a switching rule", async () => {
+      await addHostnameRouting("fe_app", "api.example.com", "be_api", asClient(client));
+
+      expect(client.addACL).toHaveBeenCalledWith(
+        "fe_app",
+        "acl_api_example_com",
+        "hdr(host)",
+        "-i api.example.com"
+      );
+      expect(client.addBackendSwitchingRule).toHaveBeenCalledWith(
+        "fe_app",
+        "be_api",
+        "acl_api_example_com",
+        "if"
+      );
+    });
+
+    it("orders ACL creation before the switching rule", async () => {
+      const calls: string[] = [];
+      client.addACL.mockImplementation(async () => {
+        calls.push("acl");
+      });
+      client.addBackendSwitchingRule.mockImplementation(async () => {
+        calls.push("rule");
+      });
+
+      await addHostnameRouting("fe_app", "api.example.com", "be_api", asClient(client));
+
+      expect(calls).toEqual(["acl", "rule"]);
+    });
+  });
+
+  describe("removeACLByName", () => {
+    it("fetches the ACL list when no prefetched list is provided", async () => {
+      client.getACLs.mockResolvedValue([
+        { acl_name: "acl_other" },
+        { acl_name: "acl_target" },
+      ]);
+
+      const removed = await removeACLByName("fe_app", "acl_target", asClient(client));
+
+      expect(client.getACLs).toHaveBeenCalledWith("fe_app");
+      expect(client.deleteACL).toHaveBeenCalledWith("fe_app", 1);
+      expect(removed).toBe(true);
+    });
+
+    it("skips the fetch when a prefetched list is provided", async () => {
+      const prefetched = [{ acl_name: "acl_target" }];
+
+      await removeACLByName("fe_app", "acl_target", asClient(client), prefetched);
+
+      expect(client.getACLs).not.toHaveBeenCalled();
+      expect(client.deleteACL).toHaveBeenCalledWith("fe_app", 0);
+    });
+
+    it("returns false and does not delete when the ACL is not present", async () => {
+      client.getACLs.mockResolvedValue([{ acl_name: "acl_other" }]);
+
+      const removed = await removeACLByName("fe_app", "acl_missing", asClient(client));
+
+      expect(removed).toBe(false);
+      expect(client.deleteACL).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("removeBackendSwitchingRuleByAclName", () => {
+    it("fetches the rule list when no prefetched list is provided", async () => {
+      client.getBackendSwitchingRules.mockResolvedValue([
+        { cond_test: "acl_a" },
+        { cond_test: "acl_target" },
+      ]);
+
+      const removed = await removeBackendSwitchingRuleByAclName(
+        "fe_app",
+        "acl_target",
+        asClient(client)
+      );
+
+      expect(client.getBackendSwitchingRules).toHaveBeenCalledWith("fe_app");
+      expect(client.deleteBackendSwitchingRule).toHaveBeenCalledWith("fe_app", 1);
+      expect(removed).toBe(true);
+    });
+
+    it("skips the fetch when a prefetched list is provided", async () => {
+      const prefetched = [{ cond_test: "acl_target" }];
+
+      await removeBackendSwitchingRuleByAclName(
+        "fe_app",
+        "acl_target",
+        asClient(client),
+        prefetched
+      );
+
+      expect(client.getBackendSwitchingRules).not.toHaveBeenCalled();
+      expect(client.deleteBackendSwitchingRule).toHaveBeenCalledWith("fe_app", 0);
+    });
+
+    it("returns false when no matching rule is found", async () => {
+      client.getBackendSwitchingRules.mockResolvedValue([{ cond_test: "acl_other" }]);
+
+      const removed = await removeBackendSwitchingRuleByAclName(
+        "fe_app",
+        "acl_missing",
+        asClient(client)
+      );
+
+      expect(removed).toBe(false);
+      expect(client.deleteBackendSwitchingRule).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/server/src/services/haproxy/frontend-manager/__tests__/environment-route-synchronizer.test.ts
+++ b/server/src/services/haproxy/frontend-manager/__tests__/environment-route-synchronizer.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { syncEnvironmentRoutes } from "../environment-route-synchronizer";
+import type { HAProxyDataPlaneClient } from "../../haproxy-dataplane-client";
+import type { PrismaClient } from "../../../../generated/prisma/client";
+
+vi.mock("../shared-frontend-repository", () => ({
+  findSharedFrontendsWithRoutes: vi.fn(),
+}));
+
+import { findSharedFrontendsWithRoutes } from "../shared-frontend-repository";
+
+type ClientMock = {
+  getACLs: ReturnType<typeof vi.fn>;
+  getBackendSwitchingRules: ReturnType<typeof vi.fn>;
+  deleteACL: ReturnType<typeof vi.fn>;
+  deleteBackendSwitchingRule: ReturnType<typeof vi.fn>;
+  addACL: ReturnType<typeof vi.fn>;
+  addBackendSwitchingRule: ReturnType<typeof vi.fn>;
+};
+
+function buildClient(): ClientMock {
+  return {
+    getACLs: vi.fn().mockResolvedValue([]),
+    getBackendSwitchingRules: vi.fn().mockResolvedValue([]),
+    deleteACL: vi.fn().mockResolvedValue(undefined),
+    deleteBackendSwitchingRule: vi.fn().mockResolvedValue(undefined),
+    addACL: vi.fn().mockResolvedValue(undefined),
+    addBackendSwitchingRule: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const asClient = (c: ClientMock) => c as unknown as HAProxyDataPlaneClient;
+const asPrisma = () => ({}) as unknown as PrismaClient;
+
+describe("syncEnvironmentRoutes", () => {
+  let client: ClientMock;
+
+  beforeEach(() => {
+    client = buildClient();
+    vi.mocked(findSharedFrontendsWithRoutes).mockReset();
+  });
+
+  it("returns zero synced and no errors when no shared frontends exist", async () => {
+    vi.mocked(findSharedFrontendsWithRoutes).mockResolvedValue([]);
+
+    const result = await syncEnvironmentRoutes("env_1", asClient(client), asPrisma());
+
+    expect(result).toEqual({ synced: 0, errors: [] });
+    expect(client.getACLs).not.toHaveBeenCalled();
+  });
+
+  it("removes orphaned ACLs that are not in the expected route set", async () => {
+    vi.mocked(findSharedFrontendsWithRoutes).mockResolvedValue([
+      {
+        frontendName: "http_frontend_env_1",
+        routes: [
+          { aclName: "acl_keep", hostname: "keep.example.com", backendName: "be_keep" },
+        ],
+      },
+    ] as never);
+
+    client.getACLs.mockResolvedValue([
+      { acl_name: "acl_keep" },
+      { acl_name: "acl_orphan" },
+    ]);
+    client.getBackendSwitchingRules.mockResolvedValue([]);
+
+    const result = await syncEnvironmentRoutes("env_1", asClient(client), asPrisma());
+
+    expect(client.deleteACL).toHaveBeenCalledWith("http_frontend_env_1", 1);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("removes orphaned backend switching rules whose cond_test is not expected", async () => {
+    vi.mocked(findSharedFrontendsWithRoutes).mockResolvedValue([
+      {
+        frontendName: "http_frontend_env_1",
+        routes: [
+          { aclName: "acl_keep", hostname: "keep.example.com", backendName: "be_keep" },
+        ],
+      },
+    ] as never);
+
+    client.getACLs.mockResolvedValue([{ acl_name: "acl_keep" }]);
+    client.getBackendSwitchingRules.mockResolvedValue([
+      { cond_test: "acl_keep" },
+      { cond_test: "acl_orphan_rule" },
+    ]);
+
+    await syncEnvironmentRoutes("env_1", asClient(client), asPrisma());
+
+    expect(client.deleteBackendSwitchingRule).toHaveBeenCalledWith(
+      "http_frontend_env_1",
+      1
+    );
+  });
+
+  it("adds routes that are in the DB but missing from HAProxy", async () => {
+    vi.mocked(findSharedFrontendsWithRoutes).mockResolvedValue([
+      {
+        frontendName: "http_frontend_env_1",
+        routes: [
+          { aclName: "acl_missing", hostname: "missing.example.com", backendName: "be_missing" },
+        ],
+      },
+    ] as never);
+
+    client.getACLs.mockResolvedValue([]);
+    client.getBackendSwitchingRules.mockResolvedValue([]);
+
+    const result = await syncEnvironmentRoutes("env_1", asClient(client), asPrisma());
+
+    expect(client.addACL).toHaveBeenCalledWith(
+      "http_frontend_env_1",
+      "acl_missing_example_com",
+      "hdr(host)",
+      "-i missing.example.com"
+    );
+    expect(client.addBackendSwitchingRule).toHaveBeenCalledWith(
+      "http_frontend_env_1",
+      "be_missing",
+      "acl_missing_example_com",
+      "if"
+    );
+    expect(result.synced).toBe(1);
+  });
+
+  it("does not re-add a route whose ACL and rule already exist in HAProxy", async () => {
+    vi.mocked(findSharedFrontendsWithRoutes).mockResolvedValue([
+      {
+        frontendName: "http_frontend_env_1",
+        routes: [
+          { aclName: "acl_present", hostname: "present.example.com", backendName: "be_present" },
+        ],
+      },
+    ] as never);
+
+    client.getACLs.mockResolvedValue([{ acl_name: "acl_present" }]);
+    client.getBackendSwitchingRules.mockResolvedValue([{ cond_test: "acl_present" }]);
+
+    const result = await syncEnvironmentRoutes("env_1", asClient(client), asPrisma());
+
+    expect(client.addACL).not.toHaveBeenCalled();
+    expect(client.addBackendSwitchingRule).not.toHaveBeenCalled();
+    expect(result.synced).toBe(0);
+  });
+
+  it("accumulates errors for individual route failures without throwing", async () => {
+    vi.mocked(findSharedFrontendsWithRoutes).mockResolvedValue([
+      {
+        frontendName: "http_frontend_env_1",
+        routes: [
+          { aclName: "acl_ok", hostname: "ok.example.com", backendName: "be_ok" },
+          { aclName: "acl_bad", hostname: "bad.example.com", backendName: "be_bad" },
+        ],
+      },
+    ] as never);
+
+    client.getACLs.mockResolvedValue([]);
+    client.getBackendSwitchingRules.mockResolvedValue([]);
+    client.addACL.mockImplementation(async (_fe, aclName) => {
+      if (aclName === "acl_bad_example_com") throw new Error("nope");
+    });
+
+    const result = await syncEnvironmentRoutes("env_1", asClient(client), asPrisma());
+
+    expect(result.synced).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("bad.example.com");
+  });
+
+  it("throws with the cause preserved when the frontend lookup fails", async () => {
+    const boom = new Error("db down");
+    vi.mocked(findSharedFrontendsWithRoutes).mockRejectedValue(boom);
+
+    await expect(
+      syncEnvironmentRoutes("env_1", asClient(client), asPrisma())
+    ).rejects.toMatchObject({
+      message: expect.stringContaining("Failed to sync environment routes"),
+      cause: boom,
+    });
+  });
+
+  it("reuses the prefetched ACL list when deleting orphans (no extra round trip)", async () => {
+    vi.mocked(findSharedFrontendsWithRoutes).mockResolvedValue([
+      {
+        frontendName: "http_frontend_env_1",
+        routes: [],
+      },
+    ] as never);
+
+    client.getACLs.mockResolvedValue([{ acl_name: "acl_orphan" }]);
+    client.getBackendSwitchingRules.mockResolvedValue([]);
+
+    await syncEnvironmentRoutes("env_1", asClient(client), asPrisma());
+
+    // getACLs is only called once — removeACLByName uses the prefetched list
+    expect(client.getACLs).toHaveBeenCalledTimes(1);
+    expect(client.deleteACL).toHaveBeenCalledWith("http_frontend_env_1", 0);
+  });
+
+  it("iterates over multiple shared frontends independently", async () => {
+    vi.mocked(findSharedFrontendsWithRoutes).mockResolvedValue([
+      {
+        frontendName: "http_frontend_env_1",
+        routes: [
+          { aclName: "acl_a", hostname: "a.example.com", backendName: "be_a" },
+        ],
+      },
+      {
+        frontendName: "https_frontend_env_1",
+        routes: [
+          { aclName: "acl_b", hostname: "b.example.com", backendName: "be_b" },
+        ],
+      },
+    ] as never);
+
+    client.getACLs.mockResolvedValue([]);
+    client.getBackendSwitchingRules.mockResolvedValue([]);
+
+    const result = await syncEnvironmentRoutes("env_1", asClient(client), asPrisma());
+
+    expect(client.getACLs).toHaveBeenCalledWith("http_frontend_env_1");
+    expect(client.getACLs).toHaveBeenCalledWith("https_frontend_env_1");
+    expect(result.synced).toBe(2);
+  });
+});

--- a/server/src/services/haproxy/frontend-manager/__tests__/route-operations.test.ts
+++ b/server/src/services/haproxy/frontend-manager/__tests__/route-operations.test.ts
@@ -1,0 +1,459 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the certificate deployer module BEFORE importing route-operations,
+// since the SSL deployer transitively imports it.
+vi.mock("../../haproxy-certificate-deployer", () => ({
+  haproxyCertificateDeployer: {
+    fetchAndDeployCertificate: vi.fn().mockResolvedValue("cert.pem"),
+    removeCertificateIfUnused: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import {
+  addRouteToSharedFrontend,
+  removeRouteFromSharedFrontend,
+  updateFrontendBackend,
+  updateRoute,
+} from "../route-operations";
+import { haproxyCertificateDeployer } from "../../haproxy-certificate-deployer";
+import type { HAProxyDataPlaneClient } from "../../haproxy-dataplane-client";
+import type { PrismaClient } from "../../../../generated/prisma/client";
+
+type ClientMock = {
+  addACL: ReturnType<typeof vi.fn>;
+  addBackendSwitchingRule: ReturnType<typeof vi.fn>;
+  getACLs: ReturnType<typeof vi.fn>;
+  getBackendSwitchingRules: ReturnType<typeof vi.fn>;
+  deleteACL: ReturnType<typeof vi.fn>;
+  deleteBackendSwitchingRule: ReturnType<typeof vi.fn>;
+  updateBackendSwitchingRule: ReturnType<typeof vi.fn>;
+  addFrontendBind: ReturnType<typeof vi.fn>;
+};
+
+function buildClient(): ClientMock {
+  return {
+    addACL: vi.fn().mockResolvedValue(undefined),
+    addBackendSwitchingRule: vi.fn().mockResolvedValue(undefined),
+    getACLs: vi.fn().mockResolvedValue([]),
+    getBackendSwitchingRules: vi.fn().mockResolvedValue([]),
+    deleteACL: vi.fn().mockResolvedValue(undefined),
+    deleteBackendSwitchingRule: vi.fn().mockResolvedValue(undefined),
+    updateBackendSwitchingRule: vi.fn().mockResolvedValue(undefined),
+    addFrontendBind: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+type PrismaMock = {
+  hAProxyFrontend: {
+    findUnique: ReturnType<typeof vi.fn>;
+  };
+  hAProxyRoute: {
+    findFirst: ReturnType<typeof vi.fn>;
+    findUnique: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+};
+
+function buildPrisma(): PrismaMock {
+  return {
+    hAProxyFrontend: {
+      findUnique: vi.fn(),
+    },
+    hAProxyRoute: {
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+  };
+}
+
+const asClient = (c: ClientMock) => c as unknown as HAProxyDataPlaneClient;
+const asPrisma = (p: PrismaMock) => p as unknown as PrismaClient;
+
+describe("route-operations", () => {
+  let client: ClientMock;
+  let prisma: PrismaMock;
+
+  beforeEach(() => {
+    client = buildClient();
+    prisma = buildPrisma();
+    vi.mocked(haproxyCertificateDeployer.fetchAndDeployCertificate).mockClear();
+  });
+
+  describe("updateFrontendBackend", () => {
+    it("updates the switching rule in place when a matching rule exists", async () => {
+      client.getBackendSwitchingRules.mockResolvedValue([
+        { cond_test: "acl_other", name: "be_other", cond: "if" },
+        { cond_test: "acl_api_example_com", name: "be_old", cond: "if" },
+      ]);
+
+      await updateFrontendBackend(
+        "fe_app",
+        "api.example.com",
+        "be_new",
+        asClient(client)
+      );
+
+      expect(client.updateBackendSwitchingRule).toHaveBeenCalledWith("fe_app", 1, {
+        name: "be_new",
+        cond: "if",
+        cond_test: "acl_api_example_com",
+      });
+    });
+
+    it("falls back to addHostnameRouting when no matching rule exists", async () => {
+      client.getBackendSwitchingRules.mockResolvedValue([
+        { cond_test: "acl_other", name: "be_other", cond: "if" },
+      ]);
+
+      await updateFrontendBackend(
+        "fe_app",
+        "api.example.com",
+        "be_new",
+        asClient(client)
+      );
+
+      expect(client.updateBackendSwitchingRule).not.toHaveBeenCalled();
+      expect(client.addACL).toHaveBeenCalled();
+      expect(client.addBackendSwitchingRule).toHaveBeenCalled();
+    });
+  });
+
+  describe("addRouteToSharedFrontend", () => {
+    const sharedFrontend = {
+      id: "fe_1",
+      frontendName: "http_frontend_env_1",
+      isSharedFrontend: true,
+    };
+
+    beforeEach(() => {
+      prisma.hAProxyFrontend.findUnique.mockResolvedValue(sharedFrontend);
+      prisma.hAProxyRoute.findFirst.mockResolvedValue(null);
+      prisma.hAProxyRoute.create.mockResolvedValue({
+        id: "route_1",
+        hostname: "api.example.com",
+        aclName: "acl_api_example_com",
+        backendName: "be_api",
+        sourceType: "manual",
+        useSSL: false,
+      });
+    });
+
+    it("throws when the shared frontend is missing", async () => {
+      prisma.hAProxyFrontend.findUnique.mockResolvedValue(null);
+
+      await expect(
+        addRouteToSharedFrontend(
+          "missing",
+          "api.example.com",
+          "be_api",
+          "manual",
+          "src_1",
+          asClient(client),
+          asPrisma(prisma)
+        )
+      ).rejects.toThrow(/Shared frontend not found/);
+    });
+
+    it("throws when the frontend record is not a shared frontend", async () => {
+      prisma.hAProxyFrontend.findUnique.mockResolvedValue({
+        ...sharedFrontend,
+        isSharedFrontend: false,
+      });
+
+      await expect(
+        addRouteToSharedFrontend(
+          "fe_1",
+          "api.example.com",
+          "be_api",
+          "manual",
+          "src_1",
+          asClient(client),
+          asPrisma(prisma)
+        )
+      ).rejects.toThrow(/is not a shared frontend/);
+    });
+
+    it("returns the existing DTO without re-creating HAProxy state when the hostname is already routed", async () => {
+      prisma.hAProxyRoute.findFirst.mockResolvedValue({
+        id: "existing_route",
+        hostname: "api.example.com",
+        aclName: "acl_api_example_com",
+        backendName: "be_api",
+        sourceType: "manual",
+        useSSL: false,
+      });
+
+      const result = await addRouteToSharedFrontend(
+        "fe_1",
+        "api.example.com",
+        "be_api",
+        "manual",
+        "src_1",
+        asClient(client),
+        asPrisma(prisma)
+      );
+
+      expect(result.id).toBe("existing_route");
+      expect(client.addACL).not.toHaveBeenCalled();
+      expect(client.addBackendSwitchingRule).not.toHaveBeenCalled();
+      expect(prisma.hAProxyRoute.create).not.toHaveBeenCalled();
+    });
+
+    it("adds hostname routing and persists a new route row on the happy path", async () => {
+      const result = await addRouteToSharedFrontend(
+        "fe_1",
+        "api.example.com",
+        "be_api",
+        "manual",
+        "src_1",
+        asClient(client),
+        asPrisma(prisma)
+      );
+
+      expect(client.addACL).toHaveBeenCalled();
+      expect(client.addBackendSwitchingRule).toHaveBeenCalled();
+      expect(prisma.hAProxyRoute.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          sharedFrontendId: "fe_1",
+          hostname: "api.example.com",
+          aclName: "acl_api_example_com",
+          backendName: "be_api",
+          sourceType: "manual",
+          manualFrontendId: "src_1",
+          useSSL: false,
+          tlsCertificateId: null,
+          status: "active",
+        }),
+      });
+      expect(result.id).toBe("route_1");
+    });
+
+    it("uploads the certificate for SNI when SSL options are provided", async () => {
+      await addRouteToSharedFrontend(
+        "fe_1",
+        "api.example.com",
+        "be_api",
+        "manual",
+        "src_1",
+        asClient(client),
+        asPrisma(prisma),
+        { useSSL: true, tlsCertificateId: "cert_123" }
+      );
+
+      expect(
+        haproxyCertificateDeployer.fetchAndDeployCertificate
+      ).toHaveBeenCalledWith(
+        "cert_123",
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ gracefulNotFound: true })
+      );
+    });
+
+    it("leaves manualFrontendId null for stack-sourced routes", async () => {
+      await addRouteToSharedFrontend(
+        "fe_1",
+        "api.example.com",
+        "be_api",
+        "stack",
+        "src_1",
+        asClient(client),
+        asPrisma(prisma)
+      );
+
+      expect(prisma.hAProxyRoute.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          sourceType: "stack",
+          manualFrontendId: null,
+        }),
+      });
+    });
+  });
+
+  describe("removeRouteFromSharedFrontend", () => {
+    it("throws when the shared frontend is not found", async () => {
+      prisma.hAProxyFrontend.findUnique.mockResolvedValue(null);
+
+      await expect(
+        removeRouteFromSharedFrontend(
+          "missing",
+          "api.example.com",
+          asClient(client),
+          asPrisma(prisma)
+        )
+      ).rejects.toThrow(/Shared frontend not found/);
+    });
+
+    it("removes ACL + switching rule from HAProxy and deletes the route row", async () => {
+      prisma.hAProxyFrontend.findUnique.mockResolvedValue({
+        id: "fe_1",
+        frontendName: "http_frontend_env_1",
+      });
+      prisma.hAProxyRoute.findFirst.mockResolvedValue({ id: "route_1" });
+      client.getACLs.mockResolvedValue([{ acl_name: "acl_api_example_com" }]);
+      client.getBackendSwitchingRules.mockResolvedValue([
+        { cond_test: "acl_api_example_com" },
+      ]);
+
+      await removeRouteFromSharedFrontend(
+        "fe_1",
+        "api.example.com",
+        asClient(client),
+        asPrisma(prisma)
+      );
+
+      expect(client.deleteBackendSwitchingRule).toHaveBeenCalledWith(
+        "http_frontend_env_1",
+        0
+      );
+      expect(client.deleteACL).toHaveBeenCalledWith("http_frontend_env_1", 0);
+      expect(prisma.hAProxyRoute.delete).toHaveBeenCalledWith({
+        where: { id: "route_1" },
+      });
+    });
+
+    it("continues when the DB route is missing but HAProxy state is still present", async () => {
+      prisma.hAProxyFrontend.findUnique.mockResolvedValue({
+        id: "fe_1",
+        frontendName: "http_frontend_env_1",
+      });
+      prisma.hAProxyRoute.findFirst.mockResolvedValue(null);
+      client.getACLs.mockResolvedValue([{ acl_name: "acl_api_example_com" }]);
+      client.getBackendSwitchingRules.mockResolvedValue([
+        { cond_test: "acl_api_example_com" },
+      ]);
+
+      await removeRouteFromSharedFrontend(
+        "fe_1",
+        "api.example.com",
+        asClient(client),
+        asPrisma(prisma)
+      );
+
+      expect(client.deleteACL).toHaveBeenCalled();
+      expect(prisma.hAProxyRoute.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updateRoute", () => {
+    const existingRoute = {
+      id: "route_1",
+      hostname: "api.example.com",
+      aclName: "acl_api_example_com",
+      backendName: "be_api",
+      useSSL: false,
+      tlsCertificateId: null,
+      priority: 0,
+      status: "active",
+      sharedFrontend: { frontendName: "http_frontend_env_1" },
+    };
+
+    beforeEach(() => {
+      prisma.hAProxyRoute.findUnique.mockResolvedValue(existingRoute);
+      prisma.hAProxyRoute.update.mockImplementation(({ data }) =>
+        Promise.resolve({
+          ...existingRoute,
+          ...data,
+        })
+      );
+    });
+
+    it("throws when the route is not found", async () => {
+      prisma.hAProxyRoute.findUnique.mockResolvedValue(null);
+
+      await expect(
+        updateRoute("missing", { hostname: "x" }, asClient(client), asPrisma(prisma))
+      ).rejects.toThrow(/Route not found/);
+    });
+
+    it("recreates ACL + rule under the new name when hostname changes", async () => {
+      client.getACLs.mockResolvedValue([{ acl_name: "acl_api_example_com" }]);
+      client.getBackendSwitchingRules.mockResolvedValue([
+        { cond_test: "acl_api_example_com" },
+      ]);
+
+      await updateRoute(
+        "route_1",
+        { hostname: "v2.example.com" },
+        asClient(client),
+        asPrisma(prisma)
+      );
+
+      expect(client.deleteBackendSwitchingRule).toHaveBeenCalled();
+      expect(client.deleteACL).toHaveBeenCalled();
+      expect(client.addACL).toHaveBeenCalledWith(
+        "http_frontend_env_1",
+        "acl_v2_example_com",
+        "hdr(host)",
+        "-i v2.example.com"
+      );
+      expect(prisma.hAProxyRoute.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "route_1" },
+          data: expect.objectContaining({
+            hostname: "v2.example.com",
+            aclName: "acl_v2_example_com",
+          }),
+        })
+      );
+    });
+
+    it("updates only the switching rule in place when only the backend changes", async () => {
+      client.getBackendSwitchingRules.mockResolvedValue([
+        { cond_test: "acl_api_example_com" },
+      ]);
+
+      await updateRoute(
+        "route_1",
+        { backendName: "be_new" },
+        asClient(client),
+        asPrisma(prisma)
+      );
+
+      expect(client.updateBackendSwitchingRule).toHaveBeenCalledWith(
+        "http_frontend_env_1",
+        0,
+        { name: "be_new", cond: "if", cond_test: "acl_api_example_com" }
+      );
+      expect(client.deleteACL).not.toHaveBeenCalled();
+    });
+
+    it("only touches the DB when nothing routing-related changes (metadata-only update)", async () => {
+      await updateRoute(
+        "route_1",
+        { status: "disabled", priority: 5 },
+        asClient(client),
+        asPrisma(prisma)
+      );
+
+      expect(client.updateBackendSwitchingRule).not.toHaveBeenCalled();
+      expect(client.deleteACL).not.toHaveBeenCalled();
+      expect(prisma.hAProxyRoute.update).toHaveBeenCalled();
+    });
+
+    it("allows clearing the tls certificate id by passing null", async () => {
+      prisma.hAProxyRoute.findUnique.mockResolvedValue({
+        ...existingRoute,
+        tlsCertificateId: "cert_123",
+      });
+
+      await updateRoute(
+        "route_1",
+        { tlsCertificateId: null },
+        asClient(client),
+        asPrisma(prisma)
+      );
+
+      expect(prisma.hAProxyRoute.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ tlsCertificateId: null }),
+        })
+      );
+    });
+  });
+});

--- a/server/src/services/haproxy/frontend-manager/__tests__/shared-frontend-repository.test.ts
+++ b/server/src/services/haproxy/frontend-manager/__tests__/shared-frontend-repository.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { toRouteDTO, toSharedFrontendDTO } from "../shared-frontend-repository";
+import type {
+  HAProxyFrontend,
+  HAProxyRoute,
+} from "../../../../generated/prisma/client";
+
+/**
+ * Mapper tests. The Prisma-touching helpers (findSharedFrontend, createRouteRecord, etc.)
+ * are thin wrappers — covered by the route-operations integration-style tests that
+ * stub the Prisma surface directly.
+ */
+
+describe("toSharedFrontendDTO", () => {
+  it("projects only the fields the DTO exposes", () => {
+    const record = {
+      id: "fe_1",
+      frontendType: "shared",
+      containerName: null,
+      containerId: null,
+      containerPort: null,
+      environmentId: "env_1",
+      frontendName: "http_frontend_env_1",
+      backendName: "",
+      hostname: "",
+      bindPort: 80,
+      bindAddress: "*",
+      useSSL: false,
+      tlsCertificateId: null,
+      sslBindPort: 443,
+      isSharedFrontend: true,
+      sharedFrontendId: null,
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as unknown as HAProxyFrontend;
+
+    const dto = toSharedFrontendDTO(record);
+
+    expect(dto).toEqual({
+      id: "fe_1",
+      frontendName: "http_frontend_env_1",
+      environmentId: "env_1",
+      isSharedFrontend: true,
+      bindPort: 80,
+      bindAddress: "*",
+      useSSL: false,
+      tlsCertificateId: null,
+    });
+  });
+
+  it("passes through tlsCertificateId and useSSL when SSL is configured", () => {
+    const record = {
+      id: "fe_2",
+      frontendName: "https_frontend_env_1",
+      environmentId: "env_1",
+      isSharedFrontend: true,
+      bindPort: 443,
+      bindAddress: "*",
+      useSSL: true,
+      tlsCertificateId: "cert_123",
+    } as unknown as HAProxyFrontend;
+
+    const dto = toSharedFrontendDTO(record);
+
+    expect(dto.useSSL).toBe(true);
+    expect(dto.tlsCertificateId).toBe("cert_123");
+  });
+});
+
+describe("toRouteDTO", () => {
+  it("projects the route's public fields and drops internals like createdAt", () => {
+    const record = {
+      id: "route_1",
+      sharedFrontendId: "fe_1",
+      hostname: "api.example.com",
+      aclName: "acl_api_example_com",
+      backendName: "be_api",
+      priority: 0,
+      sourceType: "manual",
+      manualFrontendId: null,
+      useSSL: false,
+      tlsCertificateId: null,
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as unknown as HAProxyRoute;
+
+    const dto = toRouteDTO(record);
+
+    expect(dto).toEqual({
+      id: "route_1",
+      hostname: "api.example.com",
+      aclName: "acl_api_example_com",
+      backendName: "be_api",
+      sourceType: "manual",
+      useSSL: false,
+    });
+    expect(dto).not.toHaveProperty("createdAt");
+    expect(dto).not.toHaveProperty("priority");
+  });
+
+  it("preserves the sourceType verbatim for stack-sourced routes", () => {
+    const record = {
+      id: "route_2",
+      hostname: "app.example.com",
+      aclName: "acl_app_example_com",
+      backendName: "be_app",
+      sourceType: "stack",
+      useSSL: true,
+    } as unknown as HAProxyRoute;
+
+    expect(toRouteDTO(record).sourceType).toBe("stack");
+  });
+});

--- a/server/src/services/haproxy/frontend-manager/acl-rule-operations.ts
+++ b/server/src/services/haproxy/frontend-manager/acl-rule-operations.ts
@@ -1,0 +1,195 @@
+import { getLogger } from "../../../lib/logger-factory";
+import { HAProxyDataPlaneClient } from "../haproxy-dataplane-client";
+import { generateACLName } from "../haproxy-naming";
+import {
+  DataPlaneACL,
+  DataPlaneBackendSwitchingRule,
+} from "./frontend-types";
+
+const logger = getLogger("haproxy", "acl-rule-operations");
+
+/** Detect DataPlane "already exists" responses that are safe to swallow. */
+function isAlreadyExistsError(error: unknown): boolean {
+  const status = (error as { response?: { status?: number } })?.response?.status;
+  if (status === 409) return true;
+  const message = error instanceof Error ? error.message : "";
+  return message.includes("already exists");
+}
+
+/**
+ * Add an ACL to a frontend, tolerating 409/"already exists" by logging a warning
+ * and continuing. The criterion is passed as a full string (e.g. "hdr(host) -i example.com")
+ * and split into fetch method + value before being sent to the DataPlane client.
+ */
+export async function addACL(
+  frontendName: string,
+  aclName: string,
+  fullCriterion: string,
+  haproxyClient: HAProxyDataPlaneClient
+): Promise<void> {
+  logger.info({ frontendName, aclName, fullCriterion }, "Adding ACL to frontend");
+
+  const firstSpaceIndex = fullCriterion.indexOf(" ");
+  if (firstSpaceIndex === -1) {
+    throw new Error(`Invalid ACL criterion format: ${fullCriterion}`);
+  }
+  const criterion = fullCriterion.substring(0, firstSpaceIndex).trim();
+  const value = fullCriterion.substring(firstSpaceIndex + 1).trim();
+
+  try {
+    await haproxyClient.addACL(frontendName, aclName, criterion, value);
+    logger.info({ frontendName, aclName }, "Successfully added ACL to frontend");
+  } catch (error) {
+    if (isAlreadyExistsError(error)) {
+      logger.warn({ frontendName, aclName }, "ACL already exists, continuing");
+      return;
+    }
+    logger.error({ error, frontendName, aclName }, "Failed to add ACL");
+    throw new Error(`Failed to add ACL: ${error}`, { cause: error });
+  }
+}
+
+/**
+ * Add a backend switching rule to a frontend, tolerating 409/"already exists"
+ * by logging a warning and continuing.
+ */
+export async function addBackendSwitchingRule(
+  frontendName: string,
+  aclName: string,
+  backendName: string,
+  haproxyClient: HAProxyDataPlaneClient
+): Promise<void> {
+  logger.info(
+    { frontendName, aclName, backendName },
+    "Adding backend switching rule to frontend"
+  );
+
+  try {
+    await haproxyClient.addBackendSwitchingRule(
+      frontendName,
+      backendName,
+      aclName,
+      "if"
+    );
+    logger.info(
+      { frontendName, backendName, aclName },
+      "Successfully added backend switching rule"
+    );
+  } catch (error) {
+    if (isAlreadyExistsError(error)) {
+      logger.warn(
+        { frontendName, backendName },
+        "Backend switching rule already exists, continuing"
+      );
+      return;
+    }
+    logger.error(
+      { error, frontendName, backendName },
+      "Failed to add backend switching rule"
+    );
+    throw new Error(`Failed to add backend switching rule: ${error}`, {
+      cause: error,
+    });
+  }
+}
+
+/**
+ * Add hostname-based routing to a frontend. Creates the ACL for hostname matching
+ * and the corresponding backend switching rule.
+ */
+export async function addHostnameRouting(
+  frontendName: string,
+  hostname: string,
+  backendName: string,
+  haproxyClient: HAProxyDataPlaneClient
+): Promise<void> {
+  logger.info(
+    { frontendName, hostname, backendName },
+    "Adding hostname routing to frontend"
+  );
+
+  try {
+    const aclName = generateACLName(hostname);
+    await addACL(
+      frontendName,
+      aclName,
+      `hdr(host) -i ${hostname}`,
+      haproxyClient
+    );
+    await addBackendSwitchingRule(frontendName, aclName, backendName, haproxyClient);
+    logger.info(
+      { frontendName, hostname, backendName },
+      "Successfully added hostname routing"
+    );
+  } catch (error) {
+    logger.error(
+      { error, frontendName, hostname, backendName },
+      "Failed to add hostname routing"
+    );
+    throw error;
+  }
+}
+
+/**
+ * Remove the ACL with the given name from a frontend, if it exists.
+ *
+ * @param prefetchedACLs Optional pre-fetched ACL list. When provided, this
+ *   function skips the extra round-trip to `getACLs`. Callers that already
+ *   hold a list (e.g. the environment synchronizer) should pass it through.
+ * @returns `true` if an ACL was deleted, `false` if it was not present.
+ */
+export async function removeACLByName(
+  frontendName: string,
+  aclName: string,
+  haproxyClient: HAProxyDataPlaneClient,
+  prefetchedACLs?: readonly Record<string, unknown>[]
+): Promise<boolean> {
+  const acls = (prefetchedACLs ??
+    (await haproxyClient.getACLs(frontendName))) as Array<DataPlaneACL>;
+  const aclIndex = acls.findIndex((acl) => acl.acl_name === aclName);
+
+  if (aclIndex === -1) {
+    logger.warn({ frontendName, aclName }, "ACL not found in HAProxy");
+    return false;
+  }
+
+  logger.info({ frontendName, aclName, aclIndex }, "Removing ACL");
+  await haproxyClient.deleteACL(frontendName, aclIndex);
+  return true;
+}
+
+/**
+ * Remove the backend switching rule matching the given ACL name from a frontend,
+ * if present.
+ *
+ * @param prefetchedRules Optional pre-fetched rule list (same semantics as
+ *   `prefetchedACLs` on `removeACLByName`).
+ * @returns `true` if a rule was deleted, `false` if none matched.
+ */
+export async function removeBackendSwitchingRuleByAclName(
+  frontendName: string,
+  aclName: string,
+  haproxyClient: HAProxyDataPlaneClient,
+  prefetchedRules?: readonly Record<string, unknown>[]
+): Promise<boolean> {
+  const rules = (prefetchedRules ??
+    (await haproxyClient.getBackendSwitchingRules(
+      frontendName
+    ))) as Array<DataPlaneBackendSwitchingRule>;
+  const ruleIndex = rules.findIndex((rule) => rule.cond_test === aclName);
+
+  if (ruleIndex === -1) {
+    logger.warn(
+      { frontendName, aclName },
+      "Backend switching rule not found in HAProxy"
+    );
+    return false;
+  }
+
+  logger.info(
+    { frontendName, aclName, ruleIndex },
+    "Removing backend switching rule"
+  );
+  await haproxyClient.deleteBackendSwitchingRule(frontendName, ruleIndex);
+  return true;
+}

--- a/server/src/services/haproxy/frontend-manager/deployment-frontend-operations.ts
+++ b/server/src/services/haproxy/frontend-manager/deployment-frontend-operations.ts
@@ -1,0 +1,159 @@
+import { getLogger } from "../../../lib/logger-factory";
+import { PrismaClient } from "../../../generated/prisma/client";
+import { HAProxyDataPlaneClient } from "../haproxy-dataplane-client";
+import { generateFrontendName } from "../haproxy-naming";
+import { addHostnameRouting } from "./acl-rule-operations";
+import { configurePerDeploymentSSL } from "./ssl-binding-deployer";
+
+const logger = getLogger("haproxy", "deployment-frontend-operations");
+
+export interface CreateFrontendForDeploymentOptions {
+  tlsCertificateId?: string;
+  prisma?: PrismaClient;
+  bindPort?: number;
+  bindAddress?: string;
+}
+
+/**
+ * Create (or update routing on) a per-deployment frontend for a hostname.
+ *
+ * SSL behaviour is intentionally forgiving: an SSL configuration failure is
+ * logged but does NOT throw. The frontend has already been created and the
+ * hostname routing is attached — marking the whole operation failed would
+ * force the caller to roll back both, which was never the intent. Do not
+ * change this to throw without updating all callers.
+ */
+export async function createFrontendForDeployment(
+  hostname: string,
+  backendName: string,
+  applicationName: string,
+  environmentId: string,
+  haproxyClient: HAProxyDataPlaneClient,
+  options?: CreateFrontendForDeploymentOptions
+): Promise<string> {
+  const bindPort = options?.bindPort ?? 80;
+  const bindAddress = options?.bindAddress ?? "*";
+  logger.info(
+    {
+      hostname,
+      backendName,
+      applicationName,
+      environmentId,
+      bindPort,
+      bindAddress,
+    },
+    "Creating frontend for deployment"
+  );
+
+  try {
+    const frontendName = generateFrontendName(applicationName, environmentId);
+
+    const existingFrontend = await haproxyClient.getFrontend(frontendName);
+    if (existingFrontend) {
+      logger.warn(
+        { frontendName },
+        "Frontend already exists, will update routing rules"
+      );
+    } else {
+      logger.info({ frontendName }, "Creating new frontend");
+      await haproxyClient.createFrontend({ name: frontendName, mode: "http" });
+
+      logger.info(
+        { frontendName, bindAddress, bindPort },
+        "Adding bind to frontend"
+      );
+      await haproxyClient.addFrontendBind(frontendName, bindAddress, bindPort);
+    }
+
+    await addHostnameRouting(frontendName, hostname, backendName, haproxyClient);
+
+    if (options?.tlsCertificateId && options?.prisma) {
+      logger.info(
+        { frontendName, tlsCertificateId: options.tlsCertificateId },
+        "SSL certificate provided, deploying to HAProxy and adding SSL binding"
+      );
+
+      try {
+        await configurePerDeploymentSSL(
+          frontendName,
+          options.tlsCertificateId,
+          options.prisma,
+          haproxyClient,
+          bindAddress
+        );
+
+        logger.info(
+          { frontendName, tlsCertificateId: options.tlsCertificateId },
+          "Successfully configured SSL binding"
+        );
+      } catch (sslError) {
+        logger.error(
+          {
+            error: sslError,
+            frontendName,
+            tlsCertificateId: options.tlsCertificateId,
+          },
+          "Failed to configure SSL binding - frontend created but SSL not enabled"
+        );
+        // Intentionally swallowed — see method comment.
+      }
+    }
+
+    logger.info(
+      { frontendName, hostname, backendName, hasSsl: !!options?.tlsCertificateId },
+      "Successfully created frontend with hostname routing"
+    );
+
+    return frontendName;
+  } catch (error) {
+    logger.error(
+      { error, hostname, backendName },
+      "Failed to create frontend for deployment"
+    );
+    throw new Error(`Failed to create frontend: ${error}`, { cause: error });
+  }
+}
+
+/**
+ * Remove a frontend. Treats DataPlane 404 as "already removed" and returns
+ * successfully — callers rely on this idempotency during stack teardown.
+ */
+export async function removeFrontend(
+  frontendName: string,
+  haproxyClient: HAProxyDataPlaneClient
+): Promise<void> {
+  logger.info({ frontendName }, "Removing frontend");
+
+  try {
+    await haproxyClient.deleteFrontend(frontendName);
+    logger.info({ frontendName }, "Successfully removed frontend");
+  } catch (error) {
+    if ((error as { response?: { status?: number } })?.response?.status === 404) {
+      logger.warn(
+        { frontendName },
+        "Frontend not found, considering it already removed"
+      );
+      return;
+    }
+
+    logger.error({ error, frontendName }, "Failed to remove frontend");
+    throw new Error(`Failed to remove frontend: ${error}`, { cause: error });
+  }
+}
+
+/**
+ * Get the current HAProxy configuration for a frontend, or `null` if missing.
+ */
+export async function getFrontendStatus(
+  frontendName: string,
+  haproxyClient: HAProxyDataPlaneClient
+): Promise<Record<string, unknown> | null> {
+  logger.info({ frontendName }, "Getting frontend status");
+
+  try {
+    return await haproxyClient.getFrontend(frontendName);
+  } catch (error) {
+    logger.error({ error, frontendName }, "Failed to get frontend status");
+    throw error;
+  }
+}

--- a/server/src/services/haproxy/frontend-manager/environment-route-synchronizer.ts
+++ b/server/src/services/haproxy/frontend-manager/environment-route-synchronizer.ts
@@ -1,0 +1,137 @@
+import { getLogger } from "../../../lib/logger-factory";
+import { PrismaClient } from "../../../generated/prisma/client";
+import { HAProxyDataPlaneClient } from "../haproxy-dataplane-client";
+import {
+  addHostnameRouting,
+  removeACLByName,
+  removeBackendSwitchingRuleByAclName,
+} from "./acl-rule-operations";
+import {
+  DataPlaneACL,
+  DataPlaneBackendSwitchingRule,
+} from "./frontend-types";
+import { findSharedFrontendsWithRoutes } from "./shared-frontend-repository";
+
+const logger = getLogger("haproxy", "environment-route-synchronizer");
+
+/**
+ * Sync all shared-frontend routes for an environment against HAProxy state.
+ *
+ * Reconciles HAProxy's ACL + switching-rule sets with the DB route list:
+ * - Removes ACLs/rules present in HAProxy but not in the DB (orphans).
+ * - Adds ACLs/rules present in the DB but missing in HAProxy.
+ *
+ * Returns a summary of added routes and per-operation error strings. Never
+ * throws for per-route failures — those are collected into `errors` so the
+ * remediator can report partial progress.
+ */
+export async function syncEnvironmentRoutes(
+  environmentId: string,
+  haproxyClient: HAProxyDataPlaneClient,
+  prisma: PrismaClient
+): Promise<{ synced: number; errors: string[] }> {
+  logger.info({ environmentId }, "Syncing environment routes");
+
+  const errors: string[] = [];
+  let synced = 0;
+
+  try {
+    const sharedFrontends = await findSharedFrontendsWithRoutes(
+      environmentId,
+      prisma
+    );
+
+    for (const frontend of sharedFrontends) {
+      const frontendName = frontend.frontendName;
+
+      const haproxyACLs = (await haproxyClient.getACLs(
+        frontendName
+      )) as Array<DataPlaneACL>;
+      const haproxyRules = (await haproxyClient.getBackendSwitchingRules(
+        frontendName
+      )) as Array<DataPlaneBackendSwitchingRule>;
+
+      const expectedACLs = new Set(frontend.routes.map((r) => r.aclName));
+
+      for (const acl of haproxyACLs) {
+        if (!expectedACLs.has(acl.acl_name)) {
+          try {
+            logger.info(
+              { frontendName, aclName: acl.acl_name },
+              "Removing orphaned ACL"
+            );
+            await removeACLByName(
+              frontendName,
+              acl.acl_name,
+              haproxyClient,
+              haproxyACLs
+            );
+          } catch (err) {
+            errors.push(`Failed to remove orphaned ACL ${acl.acl_name}: ${err}`);
+          }
+        }
+      }
+
+      for (const rule of haproxyRules) {
+        if (!expectedACLs.has(rule.cond_test)) {
+          try {
+            logger.info(
+              { frontendName, aclName: rule.cond_test },
+              "Removing orphaned rule"
+            );
+            await removeBackendSwitchingRuleByAclName(
+              frontendName,
+              rule.cond_test,
+              haproxyClient,
+              haproxyRules
+            );
+          } catch (err) {
+            errors.push(`Failed to remove orphaned rule: ${err}`);
+          }
+        }
+      }
+
+      for (const route of frontend.routes) {
+        const aclExists = haproxyACLs.some(
+          (a) => a.acl_name === route.aclName
+        );
+        const ruleExists = haproxyRules.some(
+          (r) => r.cond_test === route.aclName
+        );
+
+        if (!aclExists || !ruleExists) {
+          try {
+            logger.info(
+              { frontendName, hostname: route.hostname },
+              "Adding missing route to HAProxy"
+            );
+            await addHostnameRouting(
+              frontendName,
+              route.hostname,
+              route.backendName,
+              haproxyClient
+            );
+            synced++;
+          } catch (err) {
+            errors.push(`Failed to add route for ${route.hostname}: ${err}`);
+          }
+        }
+      }
+    }
+
+    logger.info(
+      { environmentId, synced, errorCount: errors.length },
+      "Completed environment routes sync"
+    );
+
+    return { synced, errors };
+  } catch (error) {
+    logger.error(
+      { error, environmentId },
+      "Failed to sync environment routes"
+    );
+    throw new Error(`Failed to sync environment routes: ${error}`, {
+      cause: error,
+    });
+  }
+}

--- a/server/src/services/haproxy/frontend-manager/frontend-types.ts
+++ b/server/src/services/haproxy/frontend-manager/frontend-types.ts
@@ -1,0 +1,54 @@
+/**
+ * Typed shapes for HAProxy DataPlane API responses and DTOs returned by
+ * HAProxyFrontendManager. Centralising these kills the inline-cast noise
+ * (`(r: { cond_test?: string }) => ...`) scattered across the manager.
+ */
+
+/**
+ * Shape of a single ACL entry returned by DataPlane `getACLs`. The index
+ * signature matches the underlying `Record<string, unknown>` returned by the
+ * client — we only care about `acl_name` here.
+ */
+export interface DataPlaneACL {
+  acl_name: string;
+  [key: string]: unknown;
+}
+
+/** Shape of a backend switching rule returned by DataPlane `getBackendSwitchingRules`. */
+export interface DataPlaneBackendSwitchingRule {
+  cond_test: string;
+  [key: string]: unknown;
+}
+
+/** DTO returned from `getOrCreateSharedFrontend`. */
+export interface SharedFrontendDTO {
+  id: string;
+  frontendName: string;
+  environmentId: string | null;
+  isSharedFrontend: boolean;
+  bindPort: number;
+  bindAddress: string;
+  useSSL: boolean;
+  tlsCertificateId: string | null;
+}
+
+/** DTO returned from `addRouteToSharedFrontend`. */
+export interface HAProxyRouteDTO {
+  id: string;
+  hostname: string;
+  aclName: string;
+  backendName: string;
+  sourceType: string;
+  useSSL: boolean;
+}
+
+/** DTO returned from `updateRoute`. */
+export interface UpdatedHAProxyRouteDTO {
+  id: string;
+  hostname: string;
+  aclName: string;
+  backendName: string;
+  useSSL: boolean;
+  priority: number;
+  status: string;
+}

--- a/server/src/services/haproxy/frontend-manager/route-operations.ts
+++ b/server/src/services/haproxy/frontend-manager/route-operations.ts
@@ -1,0 +1,304 @@
+import { getLogger } from "../../../lib/logger-factory";
+import { PrismaClient } from "../../../generated/prisma/client";
+import { HAProxyDataPlaneClient } from "../haproxy-dataplane-client";
+import { generateACLName } from "../haproxy-naming";
+import {
+  addHostnameRouting,
+  removeACLByName,
+  removeBackendSwitchingRuleByAclName,
+} from "./acl-rule-operations";
+import { HAProxyRouteDTO, UpdatedHAProxyRouteDTO } from "./frontend-types";
+import {
+  createRouteRecord,
+  findRouteByHostname,
+  findSharedFrontendById,
+  toRouteDTO,
+} from "./shared-frontend-repository";
+import { uploadCertificateForSNI } from "./ssl-binding-deployer";
+
+const logger = getLogger("haproxy", "route-operations");
+
+/**
+ * Update an existing frontend's backend switching rule for a given hostname.
+ * If the rule does not exist, a new one is created (same self-heal semantics
+ * as the original manager had inline).
+ */
+export async function updateFrontendBackend(
+  frontendName: string,
+  hostname: string,
+  newBackendName: string,
+  haproxyClient: HAProxyDataPlaneClient
+): Promise<void> {
+  logger.info(
+    { frontendName, hostname, newBackendName },
+    "Updating frontend backend"
+  );
+
+  try {
+    const aclName = generateACLName(hostname);
+    const existingRules = await haproxyClient.getBackendSwitchingRules(frontendName);
+
+    const ruleIndex = existingRules.findIndex(
+      (rule: { cond_test?: string }) => rule.cond_test === aclName
+    );
+
+    if (ruleIndex === -1) {
+      logger.warn(
+        { frontendName, aclName },
+        "No existing rule found, creating new one"
+      );
+      // Missing rule => fall back to the full add-hostname-routing path. ACL
+      // may also be missing, and addHostnameRouting handles both with its
+      // already-exists tolerance.
+      await addHostnameRouting(frontendName, hostname, newBackendName, haproxyClient);
+      return;
+    }
+
+    await haproxyClient.updateBackendSwitchingRule(frontendName, ruleIndex, {
+      name: newBackendName,
+      cond: "if",
+      cond_test: aclName,
+    });
+
+    logger.info(
+      { frontendName, hostname, newBackendName },
+      "Successfully updated frontend backend"
+    );
+  } catch (error) {
+    logger.error(
+      { error, frontendName, hostname, newBackendName },
+      "Failed to update frontend backend"
+    );
+    throw error;
+  }
+}
+
+/**
+ * Add a route (ACL + backend switching rule) to a shared frontend. If a route
+ * already exists for the given hostname it is returned as-is and HAProxy state
+ * is not touched — callers relied on this idempotency in the original.
+ */
+export async function addRouteToSharedFrontend(
+  sharedFrontendId: string,
+  hostname: string,
+  backendName: string,
+  sourceType: "manual" | "stack",
+  sourceId: string,
+  haproxyClient: HAProxyDataPlaneClient,
+  prisma: PrismaClient,
+  sslOptions?: { useSSL: boolean; tlsCertificateId?: string }
+): Promise<HAProxyRouteDTO> {
+  logger.info(
+    { sharedFrontendId, hostname, backendName, sourceType, sourceId },
+    "Adding route to shared frontend"
+  );
+
+  try {
+    const sharedFrontend = await findSharedFrontendById(sharedFrontendId, prisma);
+    if (!sharedFrontend) {
+      throw new Error(`Shared frontend not found: ${sharedFrontendId}`);
+    }
+    if (!sharedFrontend.isSharedFrontend) {
+      throw new Error(`Frontend ${sharedFrontendId} is not a shared frontend`);
+    }
+
+    const frontendName = sharedFrontend.frontendName;
+    const aclName = generateACLName(hostname);
+
+    const existingRoute = await findRouteByHostname(sharedFrontendId, hostname, prisma);
+    if (existingRoute) {
+      logger.warn(
+        { hostname, sharedFrontendId },
+        "Route already exists for this hostname"
+      );
+      return toRouteDTO(existingRoute);
+    }
+
+    await addHostnameRouting(frontendName, hostname, backendName, haproxyClient);
+
+    if (sslOptions?.useSSL && sslOptions?.tlsCertificateId) {
+      // Ensure the cert lands in /etc/haproxy/ssl/ for SNI selection.
+      await uploadCertificateForSNI(
+        sslOptions.tlsCertificateId,
+        prisma,
+        haproxyClient
+      );
+    }
+
+    const route = await createRouteRecord(
+      {
+        sharedFrontendId,
+        hostname,
+        aclName,
+        backendName,
+        sourceType,
+        sourceId,
+        useSSL: sslOptions?.useSSL ?? false,
+        tlsCertificateId: sslOptions?.tlsCertificateId ?? null,
+      },
+      prisma
+    );
+
+    logger.info(
+      { routeId: route.id, hostname, backendName, frontendName },
+      "Successfully added route to shared frontend"
+    );
+
+    return toRouteDTO(route);
+  } catch (error) {
+    logger.error(
+      { error, sharedFrontendId, hostname, backendName },
+      "Failed to add route to shared frontend"
+    );
+    throw new Error(`Failed to add route to shared frontend: ${error}`, {
+      cause: error,
+    });
+  }
+}
+
+/**
+ * Remove a route from a shared frontend. Removes the ACL + switching rule from
+ * HAProxy and deletes the route row. Missing HAProxy objects are treated as
+ * "already removed" warnings — the DB delete still happens.
+ */
+export async function removeRouteFromSharedFrontend(
+  sharedFrontendId: string,
+  hostname: string,
+  haproxyClient: HAProxyDataPlaneClient,
+  prisma: PrismaClient
+): Promise<void> {
+  logger.info(
+    { sharedFrontendId, hostname },
+    "Removing route from shared frontend"
+  );
+
+  try {
+    const sharedFrontend = await findSharedFrontendById(sharedFrontendId, prisma);
+    if (!sharedFrontend) {
+      throw new Error(`Shared frontend not found: ${sharedFrontendId}`);
+    }
+
+    const frontendName = sharedFrontend.frontendName;
+    const aclName = generateACLName(hostname);
+
+    const route = await findRouteByHostname(sharedFrontendId, hostname, prisma);
+    if (!route) {
+      logger.warn(
+        { hostname, sharedFrontendId },
+        "Route not found in database, may have been already removed"
+      );
+    }
+
+    await removeBackendSwitchingRuleByAclName(frontendName, aclName, haproxyClient);
+    await removeACLByName(frontendName, aclName, haproxyClient);
+
+    if (route) {
+      await prisma.hAProxyRoute.delete({ where: { id: route.id } });
+    }
+
+    logger.info(
+      { hostname, frontendName },
+      "Successfully removed route from shared frontend"
+    );
+  } catch (error) {
+    logger.error(
+      { error, sharedFrontendId, hostname },
+      "Failed to remove route from shared frontend"
+    );
+    throw new Error(`Failed to remove route from shared frontend: ${error}`, {
+      cause: error,
+    });
+  }
+}
+
+/**
+ * Update an existing route. Handles three distinct change sets:
+ * - hostname changed (maybe with backend too): re-create ACL + rule under the
+ *   new hostname, leaving the old ACL/rule removed.
+ * - backend-only change: update the switching rule in place.
+ * - other fields only (priority / status / useSSL / cert): DB only.
+ */
+export async function updateRoute(
+  routeId: string,
+  updates: {
+    hostname?: string;
+    backendName?: string;
+    useSSL?: boolean;
+    tlsCertificateId?: string | null;
+    priority?: number;
+    status?: string;
+  },
+  haproxyClient: HAProxyDataPlaneClient,
+  prisma: PrismaClient
+): Promise<UpdatedHAProxyRouteDTO> {
+  logger.info({ routeId, updates }, "Updating route");
+
+  try {
+    const existingRoute = await prisma.hAProxyRoute.findUnique({
+      where: { id: routeId },
+      include: { sharedFrontend: true },
+    });
+
+    if (!existingRoute) {
+      throw new Error(`Route not found: ${routeId}`);
+    }
+
+    const frontendName = existingRoute.sharedFrontend.frontendName;
+    const oldAclName = existingRoute.aclName;
+
+    if (updates.hostname && updates.hostname !== existingRoute.hostname) {
+      await removeBackendSwitchingRuleByAclName(frontendName, oldAclName, haproxyClient);
+      await removeACLByName(frontendName, oldAclName, haproxyClient);
+
+      await addHostnameRouting(
+        frontendName,
+        updates.hostname,
+        updates.backendName ?? existingRoute.backendName,
+        haproxyClient
+      );
+    } else if (
+      updates.backendName &&
+      updates.backendName !== existingRoute.backendName
+    ) {
+      await updateFrontendBackend(
+        frontendName,
+        existingRoute.hostname,
+        updates.backendName,
+        haproxyClient
+      );
+    }
+
+    const updatedRoute = await prisma.hAProxyRoute.update({
+      where: { id: routeId },
+      data: {
+        hostname: updates.hostname ?? existingRoute.hostname,
+        aclName: updates.hostname
+          ? generateACLName(updates.hostname)
+          : existingRoute.aclName,
+        backendName: updates.backendName ?? existingRoute.backendName,
+        useSSL: updates.useSSL ?? existingRoute.useSSL,
+        tlsCertificateId:
+          updates.tlsCertificateId !== undefined
+            ? updates.tlsCertificateId
+            : existingRoute.tlsCertificateId,
+        ...(updates.priority !== undefined && { priority: updates.priority }),
+        ...(updates.status !== undefined && { status: updates.status }),
+      },
+    });
+
+    logger.info({ routeId, updates }, "Successfully updated route");
+
+    return {
+      id: updatedRoute.id,
+      hostname: updatedRoute.hostname,
+      aclName: updatedRoute.aclName,
+      backendName: updatedRoute.backendName,
+      useSSL: updatedRoute.useSSL,
+      priority: updatedRoute.priority,
+      status: updatedRoute.status,
+    };
+  } catch (error) {
+    logger.error({ error, routeId, updates }, "Failed to update route");
+    throw new Error(`Failed to update route: ${error}`, { cause: error });
+  }
+}

--- a/server/src/services/haproxy/frontend-manager/shared-frontend-creator.ts
+++ b/server/src/services/haproxy/frontend-manager/shared-frontend-creator.ts
@@ -1,0 +1,141 @@
+import { getLogger } from "../../../lib/logger-factory";
+import { PrismaClient } from "../../../generated/prisma/client";
+import { HAProxyDataPlaneClient } from "../haproxy-dataplane-client";
+import { generateSharedFrontendName } from "../haproxy-naming";
+import { SharedFrontendDTO } from "./frontend-types";
+import {
+  createSharedFrontendRecord,
+  findSharedFrontend,
+  toSharedFrontendDTO,
+} from "./shared-frontend-repository";
+import { configureSharedSSL } from "./ssl-binding-deployer";
+
+const logger = getLogger("haproxy", "shared-frontend-creator");
+
+export interface GetOrCreateSharedFrontendOptions {
+  bindPort?: number;
+  bindAddress?: string;
+  tlsCertificateId?: string;
+}
+
+/**
+ * Get or create a shared frontend for an environment.
+ *
+ * Behaviour by `type`:
+ * - `http`: creates the HAProxy frontend with a plain bind on `bindPort`.
+ * - `https` **with** `tlsCertificateId`: creates the frontend, deploys the
+ *   certificate, and attaches an SSL bind that points at the SNI directory.
+ * - `https` **without** `tlsCertificateId`: creates the frontend but adds no
+ *   bind — the SSL endpoint creates the bind later. This is deliberate; do
+ *   not regress it into a plain bind.
+ *
+ * Always creates / reuses a matching `HAProxyFrontend` row in the database.
+ */
+export async function getOrCreateSharedFrontend(
+  environmentId: string,
+  type: "http" | "https",
+  haproxyClient: HAProxyDataPlaneClient,
+  prisma: PrismaClient,
+  options?: GetOrCreateSharedFrontendOptions
+): Promise<SharedFrontendDTO> {
+  const frontendName = generateSharedFrontendName(environmentId, type);
+  const bindPort = options?.bindPort ?? (type === "https" ? 443 : 80);
+  const bindAddress = options?.bindAddress ?? "*";
+  const tlsCertificateId = options?.tlsCertificateId;
+
+  logger.info(
+    {
+      environmentId,
+      type,
+      frontendName,
+      bindPort,
+      bindAddress,
+      hasTlsCert: !!tlsCertificateId,
+    },
+    "Getting or creating shared frontend"
+  );
+
+  try {
+    const existingFrontend = await findSharedFrontend(
+      environmentId,
+      bindPort,
+      prisma
+    );
+
+    if (existingFrontend) {
+      logger.info(
+        { frontendName: existingFrontend.frontendName, environmentId },
+        "Shared frontend already exists in database"
+      );
+      return toSharedFrontendDTO(existingFrontend);
+    }
+
+    const existingHAProxyFrontend = await haproxyClient.getFrontend(frontendName);
+
+    if (!existingHAProxyFrontend) {
+      logger.info({ frontendName }, "Creating shared frontend in HAProxy");
+      await haproxyClient.createFrontend({ name: frontendName, mode: "http" });
+
+      if (type === "https" && tlsCertificateId) {
+        logger.info(
+          { frontendName, bindAddress, bindPort, tlsCertificateId },
+          "Configuring HTTPS shared frontend with SSL"
+        );
+        await configureSharedSSL(
+          frontendName,
+          tlsCertificateId,
+          prisma,
+          haproxyClient,
+          bindAddress,
+          bindPort
+        );
+      } else if (type === "https") {
+        // HTTPS without cert: bind is deferred until SSL endpoint configures it.
+        logger.info(
+          { frontendName, bindPort },
+          "HTTPS shared frontend created without bind - SSL must be configured separately"
+        );
+      } else {
+        logger.info(
+          { frontendName, bindAddress, bindPort },
+          "Adding bind to HTTP shared frontend"
+        );
+        await haproxyClient.addFrontendBind(frontendName, bindAddress, bindPort);
+      }
+    } else {
+      logger.info({ frontendName }, "Shared frontend already exists in HAProxy");
+    }
+
+    const newFrontend = await createSharedFrontendRecord(
+      {
+        environmentId,
+        frontendName,
+        bindPort,
+        bindAddress,
+        useSSL: type === "https" && !!tlsCertificateId,
+        tlsCertificateId: tlsCertificateId ?? null,
+      },
+      prisma
+    );
+
+    logger.info(
+      {
+        frontendId: newFrontend.id,
+        frontendName,
+        environmentId,
+        useSSL: newFrontend.useSSL,
+      },
+      "Created shared frontend"
+    );
+
+    return toSharedFrontendDTO(newFrontend);
+  } catch (error) {
+    logger.error(
+      { error, environmentId, type },
+      "Failed to get or create shared frontend"
+    );
+    throw new Error(`Failed to get or create shared frontend: ${error}`, {
+      cause: error,
+    });
+  }
+}

--- a/server/src/services/haproxy/frontend-manager/shared-frontend-repository.ts
+++ b/server/src/services/haproxy/frontend-manager/shared-frontend-repository.ts
@@ -1,0 +1,142 @@
+import {
+  HAProxyFrontend,
+  HAProxyRoute,
+  PrismaClient,
+} from "../../../generated/prisma/client";
+import { HAProxyRouteDTO, SharedFrontendDTO } from "./frontend-types";
+
+/**
+ * Pure mappers + Prisma wrappers for shared-frontend / route persistence.
+ *
+ * Keeping these in one place kills the copy-paste of
+ * `{ id, frontendName, environmentId, isSharedFrontend, bindPort, bindAddress, useSSL, tlsCertificateId }`
+ * that appeared in every `getOrCreate` branch, and centralises the
+ * `{ id, hostname, aclName, backendName, sourceType, useSSL }` route projection
+ * that was repeated in both `addRoute` branches.
+ */
+
+export function toSharedFrontendDTO(record: HAProxyFrontend): SharedFrontendDTO {
+  return {
+    id: record.id,
+    frontendName: record.frontendName,
+    environmentId: record.environmentId,
+    isSharedFrontend: record.isSharedFrontend,
+    bindPort: record.bindPort,
+    bindAddress: record.bindAddress,
+    useSSL: record.useSSL,
+    tlsCertificateId: record.tlsCertificateId,
+  };
+}
+
+export function toRouteDTO(record: HAProxyRoute): HAProxyRouteDTO {
+  return {
+    id: record.id,
+    hostname: record.hostname,
+    aclName: record.aclName,
+    backendName: record.backendName,
+    sourceType: record.sourceType,
+    useSSL: record.useSSL,
+  };
+}
+
+export async function findSharedFrontend(
+  environmentId: string,
+  bindPort: number,
+  prisma: PrismaClient
+): Promise<HAProxyFrontend | null> {
+  return prisma.hAProxyFrontend.findFirst({
+    where: {
+      environmentId,
+      isSharedFrontend: true,
+      frontendType: "shared",
+      bindPort,
+    },
+  });
+}
+
+export async function findSharedFrontendById(
+  id: string,
+  prisma: PrismaClient
+): Promise<HAProxyFrontend | null> {
+  return prisma.hAProxyFrontend.findUnique({ where: { id } });
+}
+
+export async function createSharedFrontendRecord(
+  params: {
+    environmentId: string;
+    frontendName: string;
+    bindPort: number;
+    bindAddress: string;
+    useSSL: boolean;
+    tlsCertificateId: string | null;
+  },
+  prisma: PrismaClient
+): Promise<HAProxyFrontend> {
+  return prisma.hAProxyFrontend.create({
+    data: {
+      frontendType: "shared",
+      frontendName: params.frontendName,
+      // Shared frontends don't have a single backend or hostname
+      backendName: "",
+      hostname: "",
+      bindPort: params.bindPort,
+      bindAddress: params.bindAddress,
+      isSharedFrontend: true,
+      environmentId: params.environmentId,
+      status: "active",
+      useSSL: params.useSSL,
+      tlsCertificateId: params.tlsCertificateId,
+    },
+  });
+}
+
+export async function findRouteByHostname(
+  sharedFrontendId: string,
+  hostname: string,
+  prisma: PrismaClient
+): Promise<HAProxyRoute | null> {
+  return prisma.hAProxyRoute.findFirst({
+    where: { sharedFrontendId, hostname },
+  });
+}
+
+export async function createRouteRecord(
+  params: {
+    sharedFrontendId: string;
+    hostname: string;
+    aclName: string;
+    backendName: string;
+    sourceType: "manual" | "stack";
+    sourceId: string;
+    useSSL: boolean;
+    tlsCertificateId: string | null;
+  },
+  prisma: PrismaClient
+): Promise<HAProxyRoute> {
+  return prisma.hAProxyRoute.create({
+    data: {
+      sharedFrontendId: params.sharedFrontendId,
+      hostname: params.hostname,
+      aclName: params.aclName,
+      backendName: params.backendName,
+      sourceType: params.sourceType,
+      manualFrontendId: params.sourceType === "manual" ? params.sourceId : null,
+      useSSL: params.useSSL,
+      tlsCertificateId: params.tlsCertificateId,
+      status: "active",
+    },
+  });
+}
+
+export async function findSharedFrontendsWithRoutes(
+  environmentId: string,
+  prisma: PrismaClient
+): Promise<Array<HAProxyFrontend & { routes: HAProxyRoute[] }>> {
+  return prisma.hAProxyFrontend.findMany({
+    where: {
+      environmentId,
+      isSharedFrontend: true,
+    },
+    include: { routes: true },
+  });
+}

--- a/server/src/services/haproxy/frontend-manager/ssl-binding-deployer.ts
+++ b/server/src/services/haproxy/frontend-manager/ssl-binding-deployer.ts
@@ -1,0 +1,160 @@
+import { getLogger } from "../../../lib/logger-factory";
+import { PrismaClient } from "../../../generated/prisma/client";
+import { HAProxyDataPlaneClient } from "../haproxy-dataplane-client";
+import { haproxyCertificateDeployer } from "../haproxy-certificate-deployer";
+
+const logger = getLogger("haproxy", "ssl-binding-deployer");
+
+/**
+ * Configure SSL for a per-deployment frontend.
+ *
+ * Deploys the certificate to HAProxy and attaches it as a specific file path in
+ * the SSL bind (`ssl_certificate: /etc/haproxy/ssl/<filename>`). Uses the
+ * certificate's blob name as the source for the filename and requires an
+ * ACTIVE cert record — both are the historical semantics of the per-deployment
+ * path and must not drift to the shared-frontend flavour.
+ */
+export async function configurePerDeploymentSSL(
+  frontendName: string,
+  tlsCertificateId: string,
+  prisma: PrismaClient,
+  haproxyClient: HAProxyDataPlaneClient,
+  bindAddress: string = "*"
+): Promise<void> {
+  logger.info(
+    { frontendName, tlsCertificateId },
+    "Configuring SSL binding for frontend"
+  );
+
+  try {
+    const certFileName = await haproxyCertificateDeployer.fetchAndDeployCertificate(
+      tlsCertificateId,
+      prisma,
+      haproxyClient,
+      { requireActive: true, fileNameSource: "blobName" }
+    );
+
+    if (!certFileName) {
+      throw new Error(`Failed to deploy certificate: ${tlsCertificateId}`);
+    }
+
+    logger.info(
+      { frontendName, bindAddress, port: 443, certFileName },
+      "Adding SSL binding to frontend"
+    );
+
+    await haproxyClient.addFrontendBind(frontendName, bindAddress, 443, {
+      ssl: true,
+      ssl_certificate: `/etc/haproxy/ssl/${certFileName}`,
+    });
+
+    logger.info(
+      { frontendName, tlsCertificateId },
+      "Successfully configured SSL binding"
+    );
+  } catch (error) {
+    logger.error(
+      { error, frontendName, tlsCertificateId },
+      "Failed to configure SSL binding"
+    );
+    throw error;
+  }
+}
+
+/**
+ * Configure SSL for a shared frontend.
+ *
+ * Deploys the certificate to HAProxy and attaches an SSL bind that points at
+ * the certificate *directory* (`/etc/haproxy/ssl/`) rather than a specific file.
+ * HAProxy then selects the correct cert per request via SNI. Uses the primary
+ * domain as the filename source — the shared-frontend convention.
+ */
+export async function configureSharedSSL(
+  frontendName: string,
+  tlsCertificateId: string,
+  prisma: PrismaClient,
+  haproxyClient: HAProxyDataPlaneClient,
+  bindAddress: string = "*",
+  bindPort: number = 443
+): Promise<void> {
+  logger.info(
+    { frontendName, tlsCertificateId, bindPort },
+    "Configuring SSL for shared frontend"
+  );
+
+  const certFileName = await haproxyCertificateDeployer.fetchAndDeployCertificate(
+    tlsCertificateId,
+    prisma,
+    haproxyClient,
+    { fileNameSource: "primaryDomain" }
+  );
+
+  if (!certFileName) {
+    throw new Error(`Failed to deploy certificate: ${tlsCertificateId}`);
+  }
+
+  logger.info(
+    { frontendName, bindAddress, bindPort, certFileName },
+    "Adding SSL binding to shared frontend"
+  );
+
+  await haproxyClient.addFrontendBind(frontendName, bindAddress, bindPort, {
+    ssl: true,
+    // Directory path for SNI-based certificate selection
+    ssl_certificate: `/etc/haproxy/ssl/`,
+  });
+
+  logger.info(
+    { frontendName, tlsCertificateId },
+    "Successfully configured SSL for shared frontend"
+  );
+}
+
+/**
+ * Upload a certificate to HAProxy storage for SNI-based selection.
+ *
+ * The certificate is uploaded to /etc/haproxy/ssl/ where the shared HTTPS
+ * frontend bind is pointing. HAProxy will select the correct certificate
+ * automatically based on the SNI hostname. Missing certificates are handled
+ * gracefully — a no-op rather than a throw — which matches the historical
+ * call sites that tolerate a cert record being absent.
+ */
+export async function uploadCertificateForSNI(
+  tlsCertificateId: string,
+  prisma: PrismaClient,
+  haproxyClient: HAProxyDataPlaneClient
+): Promise<void> {
+  logger.info(
+    { tlsCertificateId },
+    "Uploading certificate to HAProxy for SNI selection"
+  );
+
+  const certFileName = await haproxyCertificateDeployer.fetchAndDeployCertificate(
+    tlsCertificateId,
+    prisma,
+    haproxyClient,
+    { gracefulNotFound: true }
+  );
+
+  if (certFileName) {
+    logger.info(
+      { certFileName, tlsCertificateId },
+      "Certificate uploaded successfully for SNI selection"
+    );
+  }
+}
+
+/**
+ * Remove a certificate from HAProxy storage when no deployment still needs it.
+ */
+export async function removeCertificateFromHAProxy(
+  tlsCertificateId: string,
+  prisma: PrismaClient,
+  haproxyClient: HAProxyDataPlaneClient
+): Promise<void> {
+  await haproxyCertificateDeployer.removeCertificateIfUnused(
+    tlsCertificateId,
+    prisma,
+    haproxyClient
+  );
+}

--- a/server/src/services/haproxy/haproxy-frontend-manager.ts
+++ b/server/src/services/haproxy/haproxy-frontend-manager.ts
@@ -1,811 +1,136 @@
-import { getLogger } from "../../lib/logger-factory";
-import { HAProxyDataPlaneClient } from "./haproxy-dataplane-client";
 import { PrismaClient } from "../../generated/prisma/client";
+import { HAProxyDataPlaneClient } from "./haproxy-dataplane-client";
 import {
-  generateFrontendName,
-  generateACLName,
-  generateSharedFrontendName,
-} from "./haproxy-naming";
-import { haproxyCertificateDeployer } from "./haproxy-certificate-deployer";
-
-const logger = getLogger("haproxy", "haproxy-frontend-manager");
+  addHostnameRouting as addHostnameRoutingOp,
+} from "./frontend-manager/acl-rule-operations";
+import {
+  createFrontendForDeployment as createFrontendForDeploymentOp,
+  CreateFrontendForDeploymentOptions,
+  getFrontendStatus as getFrontendStatusOp,
+  removeFrontend as removeFrontendOp,
+} from "./frontend-manager/deployment-frontend-operations";
+import { syncEnvironmentRoutes as syncEnvironmentRoutesOp } from "./frontend-manager/environment-route-synchronizer";
+import {
+  HAProxyRouteDTO,
+  SharedFrontendDTO,
+  UpdatedHAProxyRouteDTO,
+} from "./frontend-manager/frontend-types";
+import {
+  addRouteToSharedFrontend as addRouteToSharedFrontendOp,
+  removeRouteFromSharedFrontend as removeRouteFromSharedFrontendOp,
+  updateFrontendBackend as updateFrontendBackendOp,
+  updateRoute as updateRouteOp,
+} from "./frontend-manager/route-operations";
+import {
+  getOrCreateSharedFrontend as getOrCreateSharedFrontendOp,
+  GetOrCreateSharedFrontendOptions,
+} from "./frontend-manager/shared-frontend-creator";
+import {
+  removeCertificateFromHAProxy as removeCertificateFromHAProxyOp,
+  uploadCertificateForSNI as uploadCertificateForSNIOp,
+} from "./frontend-manager/ssl-binding-deployer";
 
 /**
  * HAProxyFrontendManager handles frontend creation and management for deployments
- * Includes ACL configuration for hostname-based routing
+ * and shared frontends with hostname-based routing.
+ *
+ * The behaviour lives in focused modules under `./frontend-manager/`. This class
+ * is the delegation shell that preserves the public API for downstream callers
+ * (`actions/*`, `routes/haproxy-frontends.ts`, `manual-frontend-manager.ts`,
+ * `stack-routing-manager.ts`, `haproxy-post-apply.ts`, `index.ts`).
  */
 export class HAProxyFrontendManager {
-  /**
-   * Create a frontend for a deployment with hostname-based routing
-   *
-   * @param hostname The hostname to route (e.g., api.example.com)
-   * @param backendName The backend to route to
-   * @param applicationName The application name for naming
-   * @param environmentId The environment ID for naming
-   * @param haproxyClient The HAProxy DataPlane client instance
-   * @param options Optional configuration
-   * @param options.tlsCertificateId TLS certificate ID for SSL binding
-   * @param options.prisma Prisma client instance (required if tlsCertificateId is provided)
-   * @param options.bindPort The port to bind on (default: 80)
-   * @param options.bindAddress The address to bind on (default: *)
-   * @returns The name of the created frontend
-   */
   async createFrontendForDeployment(
     hostname: string,
     backendName: string,
     applicationName: string,
     environmentId: string,
     haproxyClient: HAProxyDataPlaneClient,
-    options?: {
-      tlsCertificateId?: string;
-      prisma?: PrismaClient;
-      bindPort?: number;
-      bindAddress?: string;
-    }
+    options?: CreateFrontendForDeploymentOptions
   ): Promise<string> {
-    const bindPort = options?.bindPort ?? 80;
-    const bindAddress = options?.bindAddress ?? "*";
-    logger.info(
-      {
-        hostname,
-        backendName,
-        applicationName,
-        environmentId,
-        bindPort,
-        bindAddress,
-      },
-      "Creating frontend for deployment"
+    return createFrontendForDeploymentOp(
+      hostname,
+      backendName,
+      applicationName,
+      environmentId,
+      haproxyClient,
+      options
     );
-
-    try {
-      // Generate frontend name: fe_{applicationName}_{environmentId}
-      const frontendName = generateFrontendName(
-        applicationName,
-        environmentId
-      );
-
-      // Check if frontend already exists
-      const existingFrontend = await this.getFrontend(
-        frontendName,
-        haproxyClient
-      );
-      if (existingFrontend) {
-        logger.warn(
-          { frontendName },
-          "Frontend already exists, will update routing rules"
-        );
-      } else {
-        // Create frontend
-        logger.info({ frontendName }, "Creating new frontend");
-        await haproxyClient.createFrontend({
-          name: frontendName,
-          mode: "http",
-        });
-
-        // Add bind configuration
-        logger.info(
-          { frontendName, bindAddress, bindPort },
-          "Adding bind to frontend"
-        );
-        await haproxyClient.addFrontendBind(
-          frontendName,
-          bindAddress,
-          bindPort
-        );
-      }
-
-      // Add hostname routing (ACL + backend switching rule)
-      await this.addHostnameRouting(
-        frontendName,
-        hostname,
-        backendName,
-        haproxyClient
-      );
-
-      // Handle SSL certificate deployment if provided
-      if (options?.tlsCertificateId && options?.prisma) {
-        logger.info(
-          { frontendName, tlsCertificateId: options.tlsCertificateId },
-          "SSL certificate provided, deploying to HAProxy and adding SSL binding"
-        );
-
-        try {
-          await this.configureSslBinding(
-            frontendName,
-            options.tlsCertificateId,
-            options.prisma,
-            haproxyClient,
-            bindAddress
-          );
-
-          logger.info(
-            { frontendName, tlsCertificateId: options.tlsCertificateId },
-            "Successfully configured SSL binding"
-          );
-        } catch (sslError) {
-          logger.error(
-            { error: sslError, frontendName, tlsCertificateId: options.tlsCertificateId },
-            "Failed to configure SSL binding - frontend created but SSL not enabled"
-          );
-          // Don't throw - frontend is created, SSL configuration failed
-        }
-      }
-
-      logger.info(
-        { frontendName, hostname, backendName, hasSsl: !!options?.tlsCertificateId },
-        "Successfully created frontend with hostname routing"
-      );
-
-      return frontendName;
-    } catch (error) {
-      logger.error(
-        { error, hostname, backendName },
-        "Failed to create frontend for deployment"
-      );
-      throw new Error(`Failed to create frontend: ${error}`, { cause: error });
-    }
   }
 
-  /**
-   * Add hostname-based routing to a frontend
-   * This creates an ACL for hostname matching and a backend switching rule
-   *
-   * @param frontendName The frontend to add routing to
-   * @param hostname The hostname to match
-   * @param backendName The backend to route to
-   * @param haproxyClient The HAProxy DataPlane client instance
-   */
   async addHostnameRouting(
     frontendName: string,
     hostname: string,
     backendName: string,
     haproxyClient: HAProxyDataPlaneClient
   ): Promise<void> {
-    logger.info(
-      { frontendName, hostname, backendName },
-      "Adding hostname routing to frontend"
-    );
-
-    try {
-      // Generate ACL name from hostname (replace dots with underscores)
-      const aclName = generateACLName(hostname);
-
-      // Add ACL for hostname matching
-      logger.info({ frontendName, aclName, hostname }, "Creating ACL");
-      await this.addACL(
-        frontendName,
-        aclName,
-        `hdr(host) -i ${hostname}`,
-        haproxyClient
-      );
-
-      // Add backend switching rule
-      logger.info(
-        { frontendName, aclName, backendName },
-        "Adding backend switching rule"
-      );
-      await this.addBackendSwitchingRule(
-        frontendName,
-        aclName,
-        backendName,
-        haproxyClient
-      );
-
-      logger.info(
-        { frontendName, hostname, backendName },
-        "Successfully added hostname routing"
-      );
-    } catch (error) {
-      logger.error(
-        { error, frontendName, hostname, backendName },
-        "Failed to add hostname routing"
-      );
-      throw error;
-    }
+    return addHostnameRoutingOp(frontendName, hostname, backendName, haproxyClient);
   }
 
-  /**
-   * Add an ACL to a frontend
-   *
-   * @param frontendName The frontend to add ACL to
-   * @param aclName The name of the ACL
-   * @param fullCriterion The full ACL criterion (e.g., "hdr(host) -i example.com")
-   * @param haproxyClient The HAProxy DataPlane client instance
-   */
-  private async addACL(
-    frontendName: string,
-    aclName: string,
-    fullCriterion: string,
-    haproxyClient: HAProxyDataPlaneClient
-  ): Promise<void> {
-    logger.info(
-      { frontendName, aclName, fullCriterion },
-      "Adding ACL to frontend"
-    );
-
-    try {
-      // Split criterion into fetch method and value
-      // e.g., "hdr(host) -i example.com" -> criterion: "hdr(host)", value: "-i example.com"
-      const firstSpaceIndex = fullCriterion.indexOf(' ');
-      if (firstSpaceIndex === -1) {
-        throw new Error(`Invalid ACL criterion format: ${fullCriterion}`);
-      }
-      const criterion = fullCriterion.substring(0, firstSpaceIndex).trim();
-      const value = fullCriterion.substring(firstSpaceIndex + 1).trim();
-
-      await haproxyClient.addACL(frontendName, aclName, criterion, value);
-
-      logger.info(
-        { frontendName, aclName },
-        "Successfully added ACL to frontend"
-      );
-    } catch (error) {
-      // If ACL already exists, log warning but don't throw
-      if (
-        (error as { response?: { status?: number } })?.response?.status === 409 ||
-        (error instanceof Error ? error.message : "").includes("already exists")
-      ) {
-        logger.warn(
-          { frontendName, aclName },
-          "ACL already exists, continuing"
-        );
-        return;
-      }
-
-      logger.error({ error, frontendName, aclName }, "Failed to add ACL");
-      throw new Error(`Failed to add ACL: ${error}`, { cause: error });
-    }
-  }
-
-  /**
-   * Add a backend switching rule to a frontend
-   *
-   * @param frontendName The frontend to add the rule to
-   * @param aclName The ACL name to use in the condition
-   * @param backendName The backend to switch to
-   * @param haproxyClient The HAProxy DataPlane client instance
-   */
-  private async addBackendSwitchingRule(
-    frontendName: string,
-    aclName: string,
-    backendName: string,
-    haproxyClient: HAProxyDataPlaneClient
-  ): Promise<void> {
-    logger.info(
-      { frontendName, aclName, backendName },
-      "Adding backend switching rule to frontend"
-    );
-
-    try {
-      await haproxyClient.addBackendSwitchingRule(
-        frontendName,
-        backendName,
-        aclName,
-        'if'
-      );
-
-      logger.info(
-        { frontendName, backendName, aclName },
-        "Successfully added backend switching rule"
-      );
-    } catch (error) {
-      // If rule already exists, log warning but don't throw
-      if (
-        (error as { response?: { status?: number } })?.response?.status === 409 ||
-        (error instanceof Error ? error.message : "").includes("already exists")
-      ) {
-        logger.warn(
-          { frontendName, backendName },
-          "Backend switching rule already exists, continuing"
-        );
-        return;
-      }
-
-      logger.error(
-        { error, frontendName, backendName },
-        "Failed to add backend switching rule"
-      );
-      throw new Error(`Failed to add backend switching rule: ${error}`, { cause: error });
-    }
-  }
-
-  /**
-   * Remove a frontend
-   *
-   * @param frontendName The frontend to remove
-   * @param haproxyClient The HAProxy DataPlane client instance
-   */
   async removeFrontend(
     frontendName: string,
     haproxyClient: HAProxyDataPlaneClient
   ): Promise<void> {
-    logger.info({ frontendName }, "Removing frontend");
-
-    try {
-      await haproxyClient.deleteFrontend(frontendName);
-
-      logger.info({ frontendName }, "Successfully removed frontend");
-    } catch (error) {
-      // If frontend doesn't exist, consider it already removed
-      if ((error as { response?: { status?: number } })?.response?.status === 404) {
-        logger.warn(
-          { frontendName },
-          "Frontend not found, considering it already removed"
-        );
-        return;
-      }
-
-      logger.error({ error, frontendName }, "Failed to remove frontend");
-      throw new Error(`Failed to remove frontend: ${error}`, { cause: error });
-    }
+    return removeFrontendOp(frontendName, haproxyClient);
   }
 
-  /**
-   * Update the backend for a frontend's routing rule
-   *
-   * @param frontendName The frontend to update
-   * @param hostname The hostname to update routing for
-   * @param newBackendName The new backend to route to
-   * @param haproxyClient The HAProxy DataPlane client instance
-   */
   async updateFrontendBackend(
     frontendName: string,
     hostname: string,
     newBackendName: string,
     haproxyClient: HAProxyDataPlaneClient
   ): Promise<void> {
-    logger.info(
-      { frontendName, hostname, newBackendName },
-      "Updating frontend backend"
+    return updateFrontendBackendOp(
+      frontendName,
+      hostname,
+      newBackendName,
+      haproxyClient
     );
-
-    try {
-      const aclName = generateACLName(hostname);
-
-      // Get existing rules
-      const existingRules = await haproxyClient.getBackendSwitchingRules(
-        frontendName
-      );
-
-      // Find the rule that matches our ACL
-      const ruleIndex = existingRules.findIndex(
-        (rule: { cond_test?: string }) => rule.cond_test === aclName
-      );
-
-      if (ruleIndex === -1) {
-        logger.warn(
-          { frontendName, aclName },
-          "No existing rule found, creating new one"
-        );
-        await this.addBackendSwitchingRule(
-          frontendName,
-          aclName,
-          newBackendName,
-          haproxyClient
-        );
-        return;
-      }
-
-      // Update the existing rule
-      await haproxyClient.updateBackendSwitchingRule(frontendName, ruleIndex, {
-        name: newBackendName,
-        cond: "if",
-        cond_test: aclName,
-      });
-
-      logger.info(
-        { frontendName, hostname, newBackendName },
-        "Successfully updated frontend backend"
-      );
-    } catch (error) {
-      logger.error(
-        { error, frontendName, hostname, newBackendName },
-        "Failed to update frontend backend"
-      );
-      throw error;
-    }
   }
 
-  /**
-   * Configure SSL binding for a frontend
-   *
-   * This method:
-   * 1. Retrieves the certificate from the database
-   * 2. Gets the certificate from Azure Key Vault
-   * 3. Deploys it to HAProxy via DataPlane API
-   * 4. Adds an SSL binding on port 443
-   *
-   * @param frontendName The frontend to configure SSL for
-   * @param tlsCertificateId The TLS certificate ID from database
-   * @param prisma Prisma client instance
-   * @param haproxyClient HAProxy DataPlane client instance
-   * @param bindAddress The address to bind on (default: *)
-   */
-  private async configureSslBinding(
-    frontendName: string,
-    tlsCertificateId: string,
-    prisma: PrismaClient,
-    haproxyClient: HAProxyDataPlaneClient,
-    bindAddress: string = "*"
-  ): Promise<void> {
-    logger.info(
-      { frontendName, tlsCertificateId },
-      "Configuring SSL binding for frontend"
-    );
-
-    try {
-      // Fetch, prepare, and deploy certificate to HAProxy
-      const certFileName = await haproxyCertificateDeployer.fetchAndDeployCertificate(
-        tlsCertificateId,
-        prisma,
-        haproxyClient,
-        { requireActive: true, fileNameSource: "blobName" }
-      );
-
-      if (!certFileName) {
-        throw new Error(`Failed to deploy certificate: ${tlsCertificateId}`);
-      }
-
-      // Add SSL binding to frontend (port 443)
-      logger.info(
-        { frontendName, bindAddress, port: 443, certFileName },
-        "Adding SSL binding to frontend"
-      );
-
-      await haproxyClient.addFrontendBind(
-        frontendName,
-        bindAddress,
-        443,
-        {
-          ssl: true,
-          ssl_certificate: `/etc/haproxy/ssl/${certFileName}`,
-        }
-      );
-
-      logger.info(
-        { frontendName, tlsCertificateId },
-        "Successfully configured SSL binding"
-      );
-    } catch (error) {
-      logger.error(
-        { error, frontendName, tlsCertificateId },
-        "Failed to configure SSL binding"
-      );
-      throw error;
-    }
-  }
-
-  /**
-   * Get frontend status
-   *
-   * @param frontendName The frontend to get status for
-   * @param haproxyClient The HAProxy DataPlane client instance
-   * @returns The frontend configuration, or null if not found
-   */
   async getFrontendStatus(
     frontendName: string,
     haproxyClient: HAProxyDataPlaneClient
   ): Promise<Record<string, unknown> | null> {
-    logger.info({ frontendName }, "Getting frontend status");
-
-    try {
-      return await this.getFrontend(frontendName, haproxyClient);
-    } catch (error) {
-      logger.error({ error, frontendName }, "Failed to get frontend status");
-      throw error;
-    }
+    return getFrontendStatusOp(frontendName, haproxyClient);
   }
 
-  /**
-   * Get a frontend by name
-   *
-   * @param frontendName The frontend name
-   * @param haproxyClient The HAProxy DataPlane client instance
-   * @returns The frontend configuration, or null if not found
-   */
-  private async getFrontend(
-    frontendName: string,
-    haproxyClient: HAProxyDataPlaneClient
-  ): Promise<Record<string, unknown> | null> {
-    return haproxyClient.getFrontend(frontendName);
-  }
-
-  /**
-   * Get or create a shared frontend for an environment
-   *
-   * @param environmentId The environment ID
-   * @param type The frontend type ('http' or 'https')
-   * @param haproxyClient The HAProxy DataPlane client instance
-   * @param prisma Prisma client instance
-   * @param options Optional configuration
-   * @param options.bindPort The port to bind on (default: 80 for http, 443 for https)
-   * @param options.bindAddress The address to bind on (default: *)
-   * @param options.tlsCertificateId TLS certificate ID for HTTPS frontends - if provided, SSL will be configured
-   * @returns The shared frontend database record
-   */
   async getOrCreateSharedFrontend(
     environmentId: string,
     type: "http" | "https",
     haproxyClient: HAProxyDataPlaneClient,
     prisma: PrismaClient,
-    options?: {
-      bindPort?: number;
-      bindAddress?: string;
-      tlsCertificateId?: string;
-    }
-  ): Promise<{
-    id: string;
-    frontendName: string;
-    environmentId: string | null;
-    isSharedFrontend: boolean;
-    bindPort: number;
-    bindAddress: string;
-    useSSL: boolean;
-    tlsCertificateId: string | null;
-  }> {
-    const frontendName = generateSharedFrontendName(environmentId, type);
-    const bindPort = options?.bindPort ?? (type === "https" ? 443 : 80);
-    const bindAddress = options?.bindAddress ?? "*";
-    const tlsCertificateId = options?.tlsCertificateId;
-
-    logger.info(
-      { environmentId, type, frontendName, bindPort, bindAddress, hasTlsCert: !!tlsCertificateId },
-      "Getting or creating shared frontend"
-    );
-
-    try {
-      // Check if shared frontend already exists in database
-      const existingFrontend = await prisma.hAProxyFrontend.findFirst({
-        where: {
-          environmentId,
-          isSharedFrontend: true,
-          frontendType: "shared",
-          bindPort,
-        },
-      });
-
-      if (existingFrontend) {
-        logger.info(
-          { frontendName: existingFrontend.frontendName, environmentId },
-          "Shared frontend already exists in database"
-        );
-        return {
-          id: existingFrontend.id,
-          frontendName: existingFrontend.frontendName,
-          environmentId: existingFrontend.environmentId,
-          isSharedFrontend: existingFrontend.isSharedFrontend,
-          bindPort: existingFrontend.bindPort,
-          bindAddress: existingFrontend.bindAddress,
-          useSSL: existingFrontend.useSSL,
-          tlsCertificateId: existingFrontend.tlsCertificateId,
-        };
-      }
-
-      // Check if frontend exists in HAProxy
-      const existingHAProxyFrontend = await this.getFrontend(
-        frontendName,
-        haproxyClient
-      );
-
-      if (!existingHAProxyFrontend) {
-        // Create frontend in HAProxy
-        logger.info({ frontendName }, "Creating shared frontend in HAProxy");
-        await haproxyClient.createFrontend({
-          name: frontendName,
-          mode: "http",
-        });
-
-        // Add bind configuration based on type and SSL options
-        if (type === "https" && tlsCertificateId) {
-          // HTTPS with certificate - configure SSL from the start
-          logger.info(
-            { frontendName, bindAddress, bindPort, tlsCertificateId },
-            "Configuring HTTPS shared frontend with SSL"
-          );
-          await this.configureSharedFrontendSSL(
-            frontendName,
-            tlsCertificateId,
-            prisma,
-            haproxyClient,
-            bindAddress,
-            bindPort
-          );
-        } else if (type === "https") {
-          // HTTPS without certificate - don't create bind yet
-          // The SSL endpoint will create the bind with proper SSL configuration later
-          logger.info(
-            { frontendName, bindPort },
-            "HTTPS shared frontend created without bind - SSL must be configured separately"
-          );
-        } else {
-          // HTTP - create plain bind
-          logger.info(
-            { frontendName, bindAddress, bindPort },
-            "Adding bind to HTTP shared frontend"
-          );
-          await haproxyClient.addFrontendBind(
-            frontendName,
-            bindAddress,
-            bindPort
-          );
-        }
-      } else {
-        logger.info(
-          { frontendName },
-          "Shared frontend already exists in HAProxy"
-        );
-      }
-
-      // Create database record
-      const newFrontend = await prisma.hAProxyFrontend.create({
-        data: {
-          frontendType: "shared",
-          frontendName,
-          backendName: "", // Shared frontends don't have a single backend
-          hostname: "", // Shared frontends route multiple hostnames
-          bindPort,
-          bindAddress,
-          isSharedFrontend: true,
-          environmentId,
-          status: "active",
-          useSSL: type === "https" && !!tlsCertificateId,
-          tlsCertificateId: tlsCertificateId ?? null,
-        },
-      });
-
-      logger.info(
-        { frontendId: newFrontend.id, frontendName, environmentId, useSSL: newFrontend.useSSL },
-        "Created shared frontend"
-      );
-
-      return {
-        id: newFrontend.id,
-        frontendName: newFrontend.frontendName,
-        environmentId: newFrontend.environmentId,
-        isSharedFrontend: newFrontend.isSharedFrontend,
-        bindPort: newFrontend.bindPort,
-        bindAddress: newFrontend.bindAddress,
-        useSSL: newFrontend.useSSL,
-        tlsCertificateId: newFrontend.tlsCertificateId,
-      };
-    } catch (error) {
-      logger.error(
-        { error, environmentId, type },
-        "Failed to get or create shared frontend"
-      );
-      throw new Error(`Failed to get or create shared frontend: ${error}`, { cause: error });
-    }
-  }
-
-  /**
-   * Configure SSL for a shared frontend
-   * This deploys the certificate and creates an SSL-enabled bind
-   *
-   * @param frontendName The frontend name
-   * @param tlsCertificateId The TLS certificate ID
-   * @param prisma Prisma client instance
-   * @param haproxyClient HAProxy DataPlane client instance
-   * @param bindAddress The address to bind on
-   * @param bindPort The port to bind on (default: 443)
-   */
-  private async configureSharedFrontendSSL(
-    frontendName: string,
-    tlsCertificateId: string,
-    prisma: PrismaClient,
-    haproxyClient: HAProxyDataPlaneClient,
-    bindAddress: string = "*",
-    bindPort: number = 443
-  ): Promise<void> {
-    logger.info(
-      { frontendName, tlsCertificateId, bindPort },
-      "Configuring SSL for shared frontend"
-    );
-
-    // Fetch, prepare, and deploy certificate to HAProxy
-    const certFileName = await haproxyCertificateDeployer.fetchAndDeployCertificate(
-      tlsCertificateId,
-      prisma,
+    options?: GetOrCreateSharedFrontendOptions
+  ): Promise<SharedFrontendDTO> {
+    return getOrCreateSharedFrontendOp(
+      environmentId,
+      type,
       haproxyClient,
-      { fileNameSource: "primaryDomain" }
-    );
-
-    if (!certFileName) {
-      throw new Error(`Failed to deploy certificate: ${tlsCertificateId}`);
-    }
-
-    // Add SSL-enabled bind
-    logger.info(
-      { frontendName, bindAddress, bindPort, certFileName },
-      "Adding SSL binding to shared frontend"
-    );
-
-    await haproxyClient.addFrontendBind(
-      frontendName,
-      bindAddress,
-      bindPort,
-      {
-        ssl: true,
-        ssl_certificate: `/etc/haproxy/ssl/`,  // Directory path for SNI-based certificate selection
-      }
-    );
-
-    logger.info(
-      { frontendName, tlsCertificateId },
-      "Successfully configured SSL for shared frontend"
+      prisma,
+      options
     );
   }
 
-  /**
-   * Upload a certificate to HAProxy storage for SNI-based selection.
-   *
-   * The certificate is uploaded to /etc/haproxy/ssl/ where the shared
-   * HTTPS frontend bind is pointing. HAProxy will automatically select
-   * the correct certificate based on the SNI hostname.
-   *
-   * @param tlsCertificateId The TLS certificate ID from database
-   * @param prisma Prisma client instance
-   * @param haproxyClient HAProxy DataPlane client instance
-   */
   async uploadCertificateForSNI(
     tlsCertificateId: string,
     prisma: PrismaClient,
     haproxyClient: HAProxyDataPlaneClient
   ): Promise<void> {
-    logger.info(
-      { tlsCertificateId },
-      "Uploading certificate to HAProxy for SNI selection"
-    );
-
-    const certFileName = await haproxyCertificateDeployer.fetchAndDeployCertificate(
-      tlsCertificateId,
-      prisma,
-      haproxyClient,
-      { gracefulNotFound: true }
-    );
-
-    if (certFileName) {
-      logger.info(
-        { certFileName, tlsCertificateId },
-        "Certificate uploaded successfully for SNI selection"
-      );
-    }
+    return uploadCertificateForSNIOp(tlsCertificateId, prisma, haproxyClient);
   }
 
-  /**
-   * Remove a certificate from HAProxy storage.
-   *
-   * This should be called when a deployment is removed and its certificate
-   * is no longer needed by any other deployments.
-   *
-   * @param tlsCertificateId The TLS certificate ID from database
-   * @param prisma Prisma client instance
-   * @param haproxyClient HAProxy DataPlane client instance
-   */
   async removeCertificateFromHAProxy(
     tlsCertificateId: string,
     prisma: PrismaClient,
     haproxyClient: HAProxyDataPlaneClient
   ): Promise<void> {
-    await haproxyCertificateDeployer.removeCertificateIfUnused(
+    return removeCertificateFromHAProxyOp(
       tlsCertificateId,
       prisma,
       haproxyClient
     );
   }
 
-  /**
-   * Add a route (ACL + backend switching rule) to a shared frontend
-   *
-   * @param sharedFrontendId The shared frontend database ID
-   * @param hostname The hostname to route
-   * @param backendName The backend to route to
-   * @param sourceType The source type ('deployment' or 'manual')
-   * @param sourceId The source ID (deployment config ID or manual frontend ID)
-   * @param haproxyClient The HAProxy DataPlane client instance
-   * @param prisma Prisma client instance
-   * @param sslOptions Optional SSL configuration
-   * @returns The created route database record
-   */
   async addRouteToSharedFrontend(
     sharedFrontendId: string,
     hostname: string,
@@ -815,225 +140,33 @@ export class HAProxyFrontendManager {
     haproxyClient: HAProxyDataPlaneClient,
     prisma: PrismaClient,
     sslOptions?: { useSSL: boolean; tlsCertificateId?: string }
-  ): Promise<{
-    id: string;
-    hostname: string;
-    aclName: string;
-    backendName: string;
-    sourceType: string;
-    useSSL: boolean;
-  }> {
-    logger.info(
-      { sharedFrontendId, hostname, backendName, sourceType, sourceId },
-      "Adding route to shared frontend"
+  ): Promise<HAProxyRouteDTO> {
+    return addRouteToSharedFrontendOp(
+      sharedFrontendId,
+      hostname,
+      backendName,
+      sourceType,
+      sourceId,
+      haproxyClient,
+      prisma,
+      sslOptions
     );
-
-    try {
-      // Get the shared frontend
-      const sharedFrontend = await prisma.hAProxyFrontend.findUnique({
-        where: { id: sharedFrontendId },
-      });
-
-      if (!sharedFrontend) {
-        throw new Error(`Shared frontend not found: ${sharedFrontendId}`);
-      }
-
-      if (!sharedFrontend.isSharedFrontend) {
-        throw new Error(
-          `Frontend ${sharedFrontendId} is not a shared frontend`
-        );
-      }
-
-      const frontendName = sharedFrontend.frontendName;
-      const aclName = generateACLName(hostname);
-
-      // Check if route already exists
-      const existingRoute = await prisma.hAProxyRoute.findFirst({
-        where: {
-          sharedFrontendId,
-          hostname,
-        },
-      });
-
-      if (existingRoute) {
-        logger.warn(
-          { hostname, sharedFrontendId },
-          "Route already exists for this hostname"
-        );
-        return {
-          id: existingRoute.id,
-          hostname: existingRoute.hostname,
-          aclName: existingRoute.aclName,
-          backendName: existingRoute.backendName,
-          sourceType: existingRoute.sourceType,
-          useSSL: existingRoute.useSSL,
-        };
-      }
-
-      // Add ACL and backend switching rule to HAProxy
-      await this.addHostnameRouting(
-        frontendName,
-        hostname,
-        backendName,
-        haproxyClient
-      );
-
-      // If SSL is enabled and we have a certificate, upload it to HAProxy
-      // This ensures the certificate is in /etc/haproxy/ssl/ for SNI selection
-      if (sslOptions?.useSSL && sslOptions?.tlsCertificateId) {
-        await this.uploadCertificateForSNI(
-          sslOptions.tlsCertificateId,
-          prisma,
-          haproxyClient
-        );
-      }
-
-      // Create route record in database
-      const route = await prisma.hAProxyRoute.create({
-        data: {
-          sharedFrontendId,
-          hostname,
-          aclName,
-          backendName,
-          sourceType,
-          manualFrontendId: sourceType === "manual" ? sourceId : null,
-          useSSL: sslOptions?.useSSL ?? false,
-          tlsCertificateId: sslOptions?.tlsCertificateId ?? null,
-          status: "active",
-        },
-      });
-
-      logger.info(
-        { routeId: route.id, hostname, backendName, frontendName },
-        "Successfully added route to shared frontend"
-      );
-
-      return {
-        id: route.id,
-        hostname: route.hostname,
-        aclName: route.aclName,
-        backendName: route.backendName,
-        sourceType: route.sourceType,
-        useSSL: route.useSSL,
-      };
-    } catch (error) {
-      logger.error(
-        { error, sharedFrontendId, hostname, backendName },
-        "Failed to add route to shared frontend"
-      );
-      throw new Error(`Failed to add route to shared frontend: ${error}`, { cause: error });
-    }
   }
 
-  /**
-   * Remove a route from a shared frontend
-   *
-   * @param sharedFrontendId The shared frontend database ID
-   * @param hostname The hostname to remove
-   * @param haproxyClient The HAProxy DataPlane client instance
-   * @param prisma Prisma client instance
-   */
   async removeRouteFromSharedFrontend(
     sharedFrontendId: string,
     hostname: string,
     haproxyClient: HAProxyDataPlaneClient,
     prisma: PrismaClient
   ): Promise<void> {
-    logger.info(
-      { sharedFrontendId, hostname },
-      "Removing route from shared frontend"
+    return removeRouteFromSharedFrontendOp(
+      sharedFrontendId,
+      hostname,
+      haproxyClient,
+      prisma
     );
-
-    try {
-      // Get the shared frontend
-      const sharedFrontend = await prisma.hAProxyFrontend.findUnique({
-        where: { id: sharedFrontendId },
-      });
-
-      if (!sharedFrontend) {
-        throw new Error(`Shared frontend not found: ${sharedFrontendId}`);
-      }
-
-      const frontendName = sharedFrontend.frontendName;
-      const aclName = generateACLName(hostname);
-
-      // Get the route from database
-      const route = await prisma.hAProxyRoute.findFirst({
-        where: {
-          sharedFrontendId,
-          hostname,
-        },
-      });
-
-      if (!route) {
-        logger.warn(
-          { hostname, sharedFrontendId },
-          "Route not found in database, may have been already removed"
-        );
-      }
-
-      // Remove backend switching rule from HAProxy
-      const existingRules =
-        await haproxyClient.getBackendSwitchingRules(frontendName);
-      const ruleIndex = existingRules.findIndex(
-        (rule: { cond_test?: string }) => rule.cond_test === aclName
-      );
-
-      if (ruleIndex !== -1) {
-        logger.info(
-          { frontendName, aclName, ruleIndex },
-          "Removing backend switching rule"
-        );
-        await haproxyClient.deleteBackendSwitchingRule(frontendName, ruleIndex);
-      } else {
-        logger.warn(
-          { frontendName, aclName },
-          "Backend switching rule not found in HAProxy"
-        );
-      }
-
-      // Remove ACL from HAProxy
-      const existingACLs = await haproxyClient.getACLs(frontendName);
-      const aclIndex = existingACLs.findIndex(
-        (acl: { acl_name?: string }) => acl.acl_name === aclName
-      );
-
-      if (aclIndex !== -1) {
-        logger.info({ frontendName, aclName, aclIndex }, "Removing ACL");
-        await haproxyClient.deleteACL(frontendName, aclIndex);
-      } else {
-        logger.warn({ frontendName, aclName }, "ACL not found in HAProxy");
-      }
-
-      // Delete route from database
-      if (route) {
-        await prisma.hAProxyRoute.delete({
-          where: { id: route.id },
-        });
-      }
-
-      logger.info(
-        { hostname, frontendName },
-        "Successfully removed route from shared frontend"
-      );
-    } catch (error) {
-      logger.error(
-        { error, sharedFrontendId, hostname },
-        "Failed to remove route from shared frontend"
-      );
-      throw new Error(`Failed to remove route from shared frontend: ${error}`, { cause: error });
-    }
   }
 
-  /**
-   * Update an existing route
-   *
-   * @param routeId The route database ID
-   * @param updates The updates to apply
-   * @param haproxyClient The HAProxy DataPlane client instance
-   * @param prisma Prisma client instance
-   * @returns The updated route
-   */
   async updateRoute(
     routeId: string,
     updates: {
@@ -1046,242 +179,17 @@ export class HAProxyFrontendManager {
     },
     haproxyClient: HAProxyDataPlaneClient,
     prisma: PrismaClient
-  ): Promise<{
-    id: string;
-    hostname: string;
-    aclName: string;
-    backendName: string;
-    useSSL: boolean;
-    priority: number;
-    status: string;
-  }> {
-    logger.info({ routeId, updates }, "Updating route");
-
-    try {
-      // Get the existing route
-      const existingRoute = await prisma.hAProxyRoute.findUnique({
-        where: { id: routeId },
-        include: { sharedFrontend: true },
-      });
-
-      if (!existingRoute) {
-        throw new Error(`Route not found: ${routeId}`);
-      }
-
-      const frontendName = existingRoute.sharedFrontend.frontendName;
-      const oldAclName = existingRoute.aclName;
-
-      // If hostname is being changed, we need to update ACL and rule
-      if (updates.hostname && updates.hostname !== existingRoute.hostname) {
-        // Remove old ACL and rule
-        const existingRules =
-          await haproxyClient.getBackendSwitchingRules(frontendName);
-        const ruleIndex = existingRules.findIndex(
-          (rule: { cond_test?: string }) => rule.cond_test === oldAclName
-        );
-
-        if (ruleIndex !== -1) {
-          await haproxyClient.deleteBackendSwitchingRule(
-            frontendName,
-            ruleIndex
-          );
-        }
-
-        const existingACLs = await haproxyClient.getACLs(frontendName);
-        const aclIndex = existingACLs.findIndex(
-          (acl: { acl_name?: string }) => acl.acl_name === oldAclName
-        );
-
-        if (aclIndex !== -1) {
-          await haproxyClient.deleteACL(frontendName, aclIndex);
-        }
-
-        // Add new ACL and rule
-        await this.addHostnameRouting(
-          frontendName,
-          updates.hostname,
-          updates.backendName ?? existingRoute.backendName,
-          haproxyClient
-        );
-      } else if (
-        updates.backendName &&
-        updates.backendName !== existingRoute.backendName
-      ) {
-        // Only backend changed, update the rule
-        await this.updateFrontendBackend(
-          frontendName,
-          existingRoute.hostname,
-          updates.backendName,
-          haproxyClient
-        );
-      }
-
-      // Update database record
-      const updatedRoute = await prisma.hAProxyRoute.update({
-        where: { id: routeId },
-        data: {
-          hostname: updates.hostname ?? existingRoute.hostname,
-          aclName: updates.hostname
-            ? generateACLName(updates.hostname)
-            : existingRoute.aclName,
-          backendName: updates.backendName ?? existingRoute.backendName,
-          useSSL: updates.useSSL ?? existingRoute.useSSL,
-          tlsCertificateId:
-            updates.tlsCertificateId !== undefined
-              ? updates.tlsCertificateId
-              : existingRoute.tlsCertificateId,
-          ...(updates.priority !== undefined && { priority: updates.priority }),
-          ...(updates.status !== undefined && { status: updates.status }),
-        },
-      });
-
-      logger.info({ routeId, updates }, "Successfully updated route");
-
-      return {
-        id: updatedRoute.id,
-        hostname: updatedRoute.hostname,
-        aclName: updatedRoute.aclName,
-        backendName: updatedRoute.backendName,
-        useSSL: updatedRoute.useSSL,
-        priority: updatedRoute.priority,
-        status: updatedRoute.status,
-      };
-    } catch (error) {
-      logger.error({ error, routeId, updates }, "Failed to update route");
-      throw new Error(`Failed to update route: ${error}`, { cause: error });
-    }
+  ): Promise<UpdatedHAProxyRouteDTO> {
+    return updateRouteOp(routeId, updates, haproxyClient, prisma);
   }
 
-  /**
-   * Sync all routes for an environment (used by remediation)
-   * This ensures HAProxy config matches database state
-   *
-   * @param environmentId The environment ID
-   * @param haproxyClient The HAProxy DataPlane client instance
-   * @param prisma Prisma client instance
-   */
   async syncEnvironmentRoutes(
     environmentId: string,
     haproxyClient: HAProxyDataPlaneClient,
     prisma: PrismaClient
-  ): Promise<{
-    synced: number;
-    errors: string[];
-  }> {
-    logger.info({ environmentId }, "Syncing environment routes");
-
-    const errors: string[] = [];
-    let synced = 0;
-
-    try {
-      // Get all shared frontends for this environment
-      const sharedFrontends = await prisma.hAProxyFrontend.findMany({
-        where: {
-          environmentId,
-          isSharedFrontend: true,
-        },
-        include: {
-          routes: true,
-        },
-      });
-
-      for (const frontend of sharedFrontends) {
-        const frontendName = frontend.frontendName;
-
-        // Get current ACLs and rules from HAProxy
-        const haproxyACLs = await haproxyClient.getACLs(frontendName);
-        const haproxyRules =
-          await haproxyClient.getBackendSwitchingRules(frontendName);
-
-        // Build set of expected ACL names from database routes
-        const expectedACLs = new Set(frontend.routes.map((r) => r.aclName));
-
-        // Find ACLs in HAProxy that are not in database (should be removed)
-        for (const acl of haproxyACLs as Array<{ acl_name: string }>) {
-          if (!expectedACLs.has(acl.acl_name)) {
-            try {
-              logger.info(
-                { frontendName, aclName: acl.acl_name },
-                "Removing orphaned ACL"
-              );
-              const aclIndex = haproxyACLs.findIndex(
-                (a: { acl_name?: string }) => a.acl_name === acl.acl_name
-              );
-              if (aclIndex !== -1) {
-                await haproxyClient.deleteACL(frontendName, aclIndex);
-              }
-            } catch (err) {
-              errors.push(`Failed to remove orphaned ACL ${acl.acl_name}: ${err}`);
-            }
-          }
-        }
-
-        // Find rules in HAProxy that reference ACLs not in database
-        for (const rule of haproxyRules as Array<{ cond_test: string }>) {
-          if (!expectedACLs.has(rule.cond_test)) {
-            try {
-              logger.info(
-                { frontendName, aclName: rule.cond_test },
-                "Removing orphaned rule"
-              );
-              const ruleIndex = haproxyRules.findIndex(
-                (r: { cond_test?: string }) => r.cond_test === rule.cond_test
-              );
-              if (ruleIndex !== -1) {
-                await haproxyClient.deleteBackendSwitchingRule(
-                  frontendName,
-                  ruleIndex
-                );
-              }
-            } catch (err) {
-              errors.push(`Failed to remove orphaned rule: ${err}`);
-            }
-          }
-        }
-
-        // Ensure all database routes exist in HAProxy
-        for (const route of frontend.routes) {
-          const aclExists = haproxyACLs.some(
-            (a: { acl_name?: string }) => a.acl_name === route.aclName
-          );
-          const ruleExists = haproxyRules.some(
-            (r: { cond_test?: string }) => r.cond_test === route.aclName
-          );
-
-          if (!aclExists || !ruleExists) {
-            try {
-              logger.info(
-                { frontendName, hostname: route.hostname },
-                "Adding missing route to HAProxy"
-              );
-              await this.addHostnameRouting(
-                frontendName,
-                route.hostname,
-                route.backendName,
-                haproxyClient
-              );
-              synced++;
-            } catch (err) {
-              errors.push(
-                `Failed to add route for ${route.hostname}: ${err}`
-              );
-            }
-          }
-        }
-      }
-
-      logger.info(
-        { environmentId, synced, errorCount: errors.length },
-        "Completed environment routes sync"
-      );
-
-      return { synced, errors };
-    } catch (error) {
-      logger.error({ error, environmentId }, "Failed to sync environment routes");
-      throw new Error(`Failed to sync environment routes: ${error}`, { cause: error });
-    }
+  ): Promise<{ synced: number; errors: string[] }> {
+    return syncEnvironmentRoutesOp(environmentId, haproxyClient, prisma);
   }
 }
 
-// Export singleton instance
 export const haproxyFrontendManager = new HAProxyFrontendManager();


### PR DESCRIPTION
## Summary

Split the 1287-line `haproxy-frontend-manager.ts` monolith into eight focused modules under `services/haproxy/frontend-manager/`. Public API is unchanged — the class remains as a thin delegation shell so downstream callers (`actions/*`, `routes/haproxy-frontends.ts`, `stack-routing-manager.ts`, `manual-frontend-manager.ts`, `haproxy-post-apply.ts`, `index.ts`) don't need edits.

## Why

The original file mixed six concerns in one class, each repeating the same `try/catch/log/rethrow` skeleton, the same 409-already-exists swallowing, and the same inline `Record<string, unknown>` casts for DataPlane responses. Hard to navigate, hard to test, and edits to one concern risked breaking another.

## Module split

| Module | Responsibility |
|---|---|
| `frontend-types.ts` | DataPlane response shapes + DTOs — kills inline casts |
| `acl-rule-operations.ts` | ACL/rule add+remove with shared 409-tolerance; optional prefetched-list params so sync paths don't add round trips |
| `ssl-binding-deployer.ts` | The two deliberately different SSL flows: per-deployment file-specific vs shared directory-based for SNI |
| `shared-frontend-repository.ts` | DTO mappers + Prisma wrappers |
| `shared-frontend-creator.ts` | `getOrCreateSharedFrontend` orchestration (HTTP / HTTPS-no-cert / HTTPS-with-cert branches preserved) |
| `route-operations.ts` | `addRouteToSharedFrontend`, `removeRouteFromSharedFrontend`, `updateRoute`, `updateFrontendBackend` |
| `environment-route-synchronizer.ts` | Reconcile HAProxy ↔ DB route state with per-route error accumulation |
| `deployment-frontend-operations.ts` | `createFrontendForDeployment` / `removeFrontend` / `getFrontendStatus` — preserves the intentional swallow-SSL-errors semantic |

Orchestrator (`haproxy-frontend-manager.ts`) drops from 1287 → 195 lines; every method body is a one-line delegation.

## Behaviour preserved

- **Every public method signature** on `HAProxyFrontendManager` and the `haproxyFrontendManager` singleton is unchanged.
- **Two SSL variants stay distinct** — per-deployment uses `ssl_certificate: /etc/haproxy/ssl/<file>` with `requireActive: true`; shared uses directory-based `ssl_certificate: /etc/haproxy/ssl/` for SNI selection. They are now explicit functions (`configurePerDeploymentSSL` vs `configureSharedSSL`) rather than hidden branches.
- **`createFrontendForDeployment` still swallows SSL errors** (logs + continues) — this is a deliberate legacy semantic, not a new bug.
- **409 / 404 / already-exists tolerances** centralised but not flattened.
- **Round-trip count unchanged in `syncEnvironmentRoutes`** via new optional `prefetchedACLs` / `prefetchedRules` params on the remove helpers.

## Tests

42 new Vitest tests across four files, targeting the primitives and orchestration:

- `acl-rule-operations.test.ts` (16) — criterion splitting, 409 swallowing, error wrapping with `cause`, prefetched-list usage
- `shared-frontend-repository.test.ts` (3) — DTO mapper projections
- `route-operations.test.ts` (14) — update-in-place vs fallback-to-add, missing/non-shared/idempotent cases, SSL cert upload, `sourceType` preservation, hostname-change vs backend-only vs metadata-only update paths
- `environment-route-synchronizer.test.ts` (9) — orphan removal, missing-route addition, error accumulation, prefetched list reuse, multi-frontend iteration

Skipped test coverage for pure delegation on the orchestrator and trivial wrappers, per the refactor-large-file skill's value-per-line guidance.

## Verification

- `npm run build -w server` — ✅
- `npm run lint -w server` on new files — ✅ (6 pre-existing errors remain in unrelated vault/stacks/operator-passphrase code)
- `npm test -w server` — 1325 passing + 42 new, 1 skipped, 5 pre-existing failures in `environment-api.test.ts` confirmed via `git stash` to exist identically on main
- Zero downstream caller changes needed

## Test plan

- [ ] Deploy to dev; confirm stack apply still creates shared HTTP + HTTPS frontends with routes
- [ ] Issue a TLS certificate and watch the SNI directory path get populated (shared-frontend path)
- [ ] Create a per-deployment frontend with an attached cert (per-deployment path) and confirm the file-specific `ssl_certificate` binding
- [ ] Trigger an environment route sync and confirm orphan ACLs/rules are removed and missing ones are re-added

🤖 Generated with [Claude Code](https://claude.com/claude-code)