### PR TITLE
fix(containers): mount ContainerFilters and apply Pool instances filter

### DIFF
--- a/client/src/app/containers/ContainerDashboard.tsx
+++ b/client/src/app/containers/ContainerDashboard.tsx
@@ -12,11 +12,12 @@ import {
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
-import { useContainers } from "@/hooks/useContainers";
+import { useContainers, useContainerFilters } from "@/hooks/useContainers";
 import type { ContainerInfo } from "@mini-infra/types";
 import { useConnectivityStatus } from "@/hooks/use-settings";
 import { useSocket } from "@/hooks/use-socket";
 import { ContainerTable } from "./ContainerTable";
+import { ContainerFilters } from "./ContainerFilters";
 import {
   IconAlertCircle,
   IconSettings,
@@ -33,6 +34,18 @@ interface ContainerGroup {
 export function ContainerDashboard() {
   const { formatDateTime } = useFormattedDate();
   const { connected } = useSocket();
+
+  // Filter + sort state (localStorage-backed). `poolInstance` is applied
+  // client-side below; everything else rides on the server query.
+  const {
+    filters,
+    sortBy,
+    sortOrder,
+    updateFilter,
+    updateSort,
+    resetFilters,
+    queryParams,
+  } = useContainerFilters();
 
   // Check Docker connectivity first
   const { data: connectivityData, isLoading: isConnectivityLoading } =
@@ -57,6 +70,7 @@ export function ContainerDashboard() {
     refetch,
   } = useContainers({
     enabled: isDockerConnected === true, // Only fetch when explicitly connected
+    queryParams,
   });
 
   // Fetch PostgreSQL containers
@@ -103,9 +117,17 @@ export function ContainerDashboard() {
     [managedContainerMap]
   );
 
-  // Group containers by environment
+  // Group containers by environment. The `poolInstance` filter is applied
+  // client-side here — the server list endpoint doesn't know about the
+  // `mini-infra.pool-instance` label.
   const containerGroups = React.useMemo((): ContainerGroup[] => {
     if (!containerData?.containers) return [];
+
+    const source = filters.poolInstance
+      ? containerData.containers.filter(
+          (c) => c.labels?.["mini-infra.pool-instance"] === "true",
+        )
+      : containerData.containers;
 
     const envGroups = new Map<string, ContainerGroup>();
     const hostStackGroups = new Map<string, ContainerGroup>();
@@ -113,7 +135,7 @@ export function ContainerDashboard() {
     const managedPostgresContainers: ContainerInfo[] = [];
     const unmanagedContainers: ContainerInfo[] = [];
 
-    containerData.containers.forEach((container) => {
+    source.forEach((container) => {
       const stackName = container.labels["mini-infra.stack"];
 
       // Check if this is a Mini Infra container (main or sidecar)
@@ -186,7 +208,7 @@ export function ContainerDashboard() {
     }
 
     return result;
-  }, [containerData, managedContainerIds]);
+  }, [containerData, managedContainerIds, filters.poolInstance]);
 
   // Log business event when container list is viewed
   React.useEffect(() => {
@@ -356,6 +378,14 @@ export function ContainerDashboard() {
     <div data-tour="containers-table">
       <Card>
           <CardContent className="space-y-4 pt-6">
+            <ContainerFilters
+              filters={filters}
+              updateFilter={updateFilter}
+              resetFilters={resetFilters}
+              sortBy={sortBy}
+              sortOrder={sortOrder}
+              updateSort={updateSort}
+            />
 
             {isLoading && !containerData ? (
               <div className="space-y-2">


### PR DESCRIPTION
## Summary

- Mount `ContainerFilters` in `ContainerDashboard` via the existing `useContainerFilters` hook so the filter UI (search, status, deployment, sort, **Pool instances** chip) is actually visible on `/containers`.
- Apply the `poolInstance` flag client-side by filtering on the `mini-infra.pool-instance=true` label before grouping into per-environment tables.

## Why

The `ContainerFilters` component (with its Pool instances chip — [client/src/app/containers/ContainerFilters.tsx:160](client/src/app/containers/ContainerFilters.tsx#L160)) shipped in [#234](https://github.com/mrgeoffrich/mini-infra/pull/234), but nothing imported it — the filter panel was invisible in the running UI. Verified end-to-end against a live dev instance before this fix.

## Behaviour change to flag

`useContainerFilters` defaults to `{ status: 'running' }` (intentional — see hook). Now that the filter is mounted, the Containers page defaults to *running* containers only on first load. Users can change it in the Status dropdown and the choice is persisted to localStorage. Previously the dashboard showed all containers because the filter state wasn't wired through.

## Test plan

- [x] `pnpm build` succeeds (lib + server + client)
- [x] Live dev: filter UI renders with name search, image search, status, deployment, **Pool instances** chip, sort, and Reset
- [x] Toggling Pool instances on filters out the manager + Mini Infra rows; only `local-pool-test-pool-worker-alpha` remains with the `Pool` badge intact; "Pool instances only" appears in the Active filters strip
- [x] Toggling Pool instances off restores the full grouped list

🤖 Generated with [Claude Code](https://claude.com/claude-code)