### PR TITLE
feat(dev): add worktree description to environment-details.xml and worktrees.yaml

### DIFF
--- a/.claude/skills/diagnose-dev/SKILL.md
+++ b/.claude/skills/diagnose-dev/SKILL.md
@@ -22,6 +22,12 @@ You're debugging a running instance of Mini Infra — a Docker host management w
 
 Read the API key from `environment-details.xml` at the project root (`//admin/apiKey`). If the file is absent or the element is empty, ask the user for the key.
 
+- **Worktree purpose**: optionally recorded in `environment-details.xml` — read it to understand the job this environment was created for:
+  ```bash
+  xmllint --xpath 'string(//environment/description/short)' environment-details.xml
+  xmllint --xpath 'string(//environment/description/long)'  environment-details.xml
+  ```
+
 ## Diagnosis Workflow
 
 ### 1. Understand the problem

--- a/.claude/skills/fix-and-validate/SKILL.md
+++ b/.claude/skills/fix-and-validate/SKILL.md
@@ -91,6 +91,13 @@ ADMIN_EMAIL=$(xmllint --xpath 'string(//environment/admin/email)' environment-de
 ADMIN_PASSWORD=$(xmllint --xpath 'string(//environment/admin/password)' environment-details.xml)
 ```
 
+Optionally read the worktree description to understand the job this environment was created for:
+
+```bash
+xmllint --xpath 'string(//environment/description/short)' environment-details.xml
+xmllint --xpath 'string(//environment/description/long)'  environment-details.xml
+```
+
 If the environment **already exists**, rebuild the containers to pick up your code changes:
 
 ```bash

--- a/.claude/skills/test-dev/SKILL.md
+++ b/.claude/skills/test-dev/SKILL.md
@@ -44,6 +44,12 @@ You're running UI tests against a live instance of Mini Infra — a Docker host 
 
 - **Source code**: available in the current working directory
 
+- **Worktree purpose**: optionally recorded in `environment-details.xml` — read it to understand the job this environment was created for:
+  ```bash
+  xmllint --xpath 'string(//environment/description/short)' environment-details.xml
+  xmllint --xpath 'string(//environment/description/long)'  environment-details.xml
+  ```
+
 ---
 
 ## Testing Workflow

--- a/deployment/development/lib/env-details.ts
+++ b/deployment/development/lib/env-details.ts
@@ -9,6 +9,7 @@ export interface XmlAdminDetails {
 export interface EnvironmentDetailsSummary {
   seeded: boolean;
   admin: XmlAdminDetails;
+  description?: { short?: string; long?: string };
 }
 
 export function xmlEscape(value: string): string {
@@ -52,6 +53,10 @@ export function readEnvironmentDetails(filePath: string): EnvironmentDetailsSumm
       password: extractTag(xml, 'password', 'admin'),
       apiKey: extractTag(xml, 'apiKey', 'admin'),
     },
+    description: {
+      short: extractTag(xml, 'short', 'description'),
+      long: extractTag(xml, 'long', 'description'),
+    },
   };
 }
 
@@ -64,6 +69,8 @@ export interface MinimalEnvironmentDetailsInput {
   uiPort: number;
   registryPort: number;
   agentSidecarImageTag: string;
+  shortDescription?: string;
+  longDescription?: string;
 }
 
 function isoWithUtcOffset(): string {
@@ -71,14 +78,25 @@ function isoWithUtcOffset(): string {
   return new Date().toISOString().replace(/\.\d{3}Z$/, '+00:00');
 }
 
+function buildDescriptionBlock(short?: string, long?: string): string {
+  if (!short && !long) return '';
+  const t = (v: string | undefined): string => xmlEscape(v || '');
+  const lines = ['  <description>'];
+  if (short) lines.push(`    <short>${t(short)}</short>`);
+  if (long) lines.push(`    <long>${t(long)}</long>`);
+  lines.push('  </description>');
+  return lines.join('\n') + '\n';
+}
+
 export function writeMinimalEnvironmentDetails(
   filePath: string,
   input: MinimalEnvironmentDetailsInput,
 ): void {
+  const descBlock = buildDescriptionBlock(input.shortDescription, input.longDescription);
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <environment>
   <generated>${xmlEscape(isoWithUtcOffset())}</generated>
-  <seeded>false</seeded>
+${descBlock}  <seeded>false</seeded>
   <worktree>
     <profile>${xmlEscape(input.profile)}</profile>
     <path>${xmlEscape(input.projectRoot)}</path>
@@ -128,6 +146,8 @@ export interface FullEnvironmentDetailsInput {
   githubConfigured: boolean;
   localEnvironment: LocalEnvironmentSummary | null;
   stacks: StackSummary[];
+  shortDescription?: string;
+  longDescription?: string;
 }
 
 export function writeFullEnvironmentDetails(
@@ -160,10 +180,11 @@ export function writeFullEnvironmentDetails(
       `  </localEnvironment>`
     : '';
 
+  const descBlock = buildDescriptionBlock(input.shortDescription, input.longDescription);
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <environment>
   <generated>${t(isoWithUtcOffset())}</generated>
-  <seeded>true</seeded>
+${descBlock}  <seeded>true</seeded>
   <worktree>
     <profile>${t(input.profile)}</profile>
     <path>${t(input.projectRoot)}</path>

--- a/deployment/development/lib/registry.ts
+++ b/deployment/development/lib/registry.ts
@@ -24,6 +24,7 @@ export interface WorktreeEntry {
   admin_email?: string;
   admin_password?: string;
   api_key?: string;
+  description?: string;
   seeded: boolean;
   updated_at: string;
 }
@@ -67,6 +68,7 @@ export function upsertEntry(
     admin_email: partial.admin_email ?? existing?.admin_email,
     admin_password: partial.admin_password ?? existing?.admin_password,
     api_key: partial.api_key ?? existing?.api_key,
+    description: partial.description ?? existing?.description,
     seeded: partial.seeded ?? existing?.seeded ?? false,
     updated_at: new Date().toISOString(),
   };

--- a/deployment/development/lib/seeder.ts
+++ b/deployment/development/lib/seeder.ts
@@ -35,6 +35,8 @@ export interface SeederInput {
   agentSidecarImageTag: string;
   devEnvPath: string;
   detailsFile: string;
+  shortDescription?: string;
+  longDescription?: string;
 }
 
 export interface SeederOutput {
@@ -551,6 +553,8 @@ export async function seed(input: SeederInput): Promise<SeederOutput> {
     githubConfigured: Boolean(env.GITHUB_TOKEN),
     localEnvironment,
     stacks,
+    shortDescription: input.shortDescription,
+    longDescription: input.longDescription,
   });
   logOk(`Wrote ${input.detailsFile}`);
 

--- a/deployment/development/worktree-list.ts
+++ b/deployment/development/worktree-list.ts
@@ -71,6 +71,7 @@ function main(): void {
   if (args.wide) {
     rows.push([
       'PROFILE',
+      'DESCRIPTION',
       'URL',
       'UI',
       'REG',
@@ -84,6 +85,7 @@ function main(): void {
     for (const e of values) {
       rows.push([
         e.profile,
+        dash(e.description),
         dash(e.url),
         e.ui_port ? String(e.ui_port) : '-',
         e.registry_port ? String(e.registry_port) : '-',
@@ -96,10 +98,11 @@ function main(): void {
       ]);
     }
   } else {
-    rows.push(['PROFILE', 'URL', 'ADMIN EMAIL', 'SEEDED', 'PATH']);
+    rows.push(['PROFILE', 'DESCRIPTION', 'URL', 'ADMIN EMAIL', 'SEEDED', 'PATH']);
     for (const e of values) {
       rows.push([
         e.profile,
+        dash(e.description),
         dash(e.url),
         dash(e.admin_email),
         e.seeded ? 'yes' : 'no',

--- a/deployment/development/worktree-start.ts
+++ b/deployment/development/worktree-start.ts
@@ -5,7 +5,7 @@
 // dedicated Colima VM (its own Docker daemon) and a namespaced Compose project.
 // Ports are allocated from ~/.mini-infra/worktrees.yaml so re-runs are stable.
 //
-// Usage: tsx worktree-start.ts [--profile <name>] [--reset] [--skip-seed] [--seed]
+// Usage: tsx worktree-start.ts [--profile <name>] [--description <short>] [--long-description <long>] [--reset] [--skip-seed] [--seed]
 //
 // After the app is healthy, this script calls the in-process seeder (POST
 // /setup, issue an admin API key, seed service configs, apply HAProxy stack)
@@ -24,6 +24,7 @@ import {
   MINI_INFRA_HOME,
   migrateFromJsonIfNeeded,
   upsertEntry,
+  loadRegistry,
 } from './lib/registry.js';
 import { readEnvironmentDetails, writeMinimalEnvironmentDetails } from './lib/env-details.js';
 import { isColimaRunning, startColima } from './lib/colima.js';
@@ -103,6 +104,8 @@ interface Args {
   reset: boolean;
   skipSeed: boolean;
   forceSeed: boolean;
+  description?: string;
+  longDescription?: string;
 }
 
 function parseCliArgs(): Args {
@@ -113,6 +116,8 @@ function parseCliArgs(): Args {
         reset: { type: 'boolean', default: false },
         'skip-seed': { type: 'boolean', default: false },
         seed: { type: 'boolean', default: false },
+        description: { type: 'string' },
+        'long-description': { type: 'string' },
         help: { type: 'boolean', short: 'h', default: false },
       },
       allowPositionals: false,
@@ -126,11 +131,18 @@ function parseCliArgs(): Args {
       reset: Boolean(values.reset),
       skipSeed: Boolean(values['skip-seed']),
       forceSeed: Boolean(values.seed),
+      description: values.description as string | undefined,
+      longDescription: values['long-description'] as string | undefined,
     };
   } catch (err) {
     logError(`Unknown arg: ${err instanceof Error ? err.message : String(err)}`);
     process.exit(1);
   }
+}
+
+function warnWordCount(value: string, max: number, label: string): void {
+  const count = value.trim().split(/\s+/).filter(Boolean).length;
+  if (count > max) logWarn(`${label} is ${count} words (recommended max ${max})`);
 }
 
 async function confirm(prompt: string): Promise<boolean> {
@@ -193,6 +205,34 @@ async function main(): Promise<void> {
   fs.mkdirSync(MINI_INFRA_HOME, { recursive: true });
   migrateFromJsonIfNeeded();
 
+  // Description resolution
+  const existingEntry = loadRegistry()[profile];
+  let shortDesc: string | undefined;
+  let longDesc: string | undefined;
+
+  if (args.description) {
+    shortDesc = args.description;
+    longDesc = args.longDescription;
+    warnWordCount(shortDesc, 10, 'Short description');
+    if (longDesc) warnWordCount(longDesc, 50, 'Long description');
+  } else if (existingEntry?.description) {
+    shortDesc = existingEntry.description;
+    logInfo(`Worktree description: ${shortDesc}`);
+  } else {
+    const rl = readline.createInterface({ input, output });
+    try {
+      shortDesc = (await rl.question('Short description (≤10 words, what is this worktree for?): ')).trim();
+      warnWordCount(shortDesc, 10, 'Short description');
+      const longRaw = (await rl.question('Long description (≤50 words, optional — press Enter to skip): ')).trim();
+      if (longRaw) {
+        longDesc = longRaw;
+        warnWordCount(longDesc, 50, 'Long description');
+      }
+    } finally {
+      rl.close();
+    }
+  }
+
   // Port allocation
   const { ui_port: uiPort, registry_port: registryPort } = allocatePorts(profile);
   // Persist early so the entry exists even if later steps fail
@@ -203,6 +243,7 @@ async function main(): Promise<void> {
     ui_port: uiPort,
     registry_port: registryPort,
     url: `http://localhost:${uiPort}`,
+    description: shortDesc,
   });
   logInfo(`Ports: UI=${uiPort}, registry=${registryPort}`);
 
@@ -407,6 +448,8 @@ async function main(): Promise<void> {
     uiPort,
     registryPort,
     agentSidecarImageTag,
+    shortDescription: shortDesc,
+    longDescription: longDesc,
   };
 
   let seededThisRun = false;
@@ -432,6 +475,8 @@ async function main(): Promise<void> {
         agentSidecarImageTag,
         devEnvPath: DEV_ENV_FILE,
         detailsFile,
+        shortDescription: shortDesc,
+        longDescription: longDesc,
       });
       upsertEntry({
         profile,
@@ -443,6 +488,7 @@ async function main(): Promise<void> {
         admin_email: result.adminEmail,
         admin_password: result.adminPassword,
         api_key: result.apiKey,
+        description: shortDesc,
         seeded: true,
       });
       logOk('Updated central registry (~/.mini-infra/worktrees.yaml) with admin credentials');
@@ -469,6 +515,7 @@ async function main(): Promise<void> {
       admin_email: details?.admin.email,
       admin_password: details?.admin.password,
       api_key: details?.admin.apiKey,
+      description: shortDesc,
     });
   }
 


### PR DESCRIPTION
## Summary

- Adds a short (≤10 words) and optional long (≤50 words) description to each worktree environment, captured at first startup and persisted in both `environment-details.xml` and `~/.mini-infra/worktrees.yaml`
- `worktree-start.ts` prompts interactively on first run; re-runs preserve the existing description silently; `--description` / `--long-description` flags allow non-interactive override or update
- `worktree-list.ts` gains a `DESCRIPTION` column in both default and `--wide` table modes
- `diagnose-dev`, `test-dev`, and `fix-and-validate` SKILL.md files updated with XPath snippets to read the new `//description/short` and `//description/long` fields

## Motivation

With multiple worktrees running simultaneously it's easy to forget what each one was created for. This gives every environment a human-readable label that any skill or developer can read back without grepping git history.

## Changed files

| File | Change |
|---|---|
| `deployment/development/lib/env-details.ts` | New `shortDescription`/`longDescription` fields on both input interfaces; `buildDescriptionBlock()` helper; both write functions emit `<description>` block; `readEnvironmentDetails()` returns `description.short`/`description.long` |
| `deployment/development/lib/registry.ts` | `WorktreeEntry.description?` field; merged in `upsertEntry()` |
| `deployment/development/lib/seeder.ts` | `SeederInput.shortDescription`/`longDescription` threaded through to `writeFullEnvironmentDetails()` |
| `deployment/development/worktree-start.ts` | `--description` / `--long-description` flags; interactive prompt on first run; word-count warnings; descriptions wired through all `upsertEntry()` and `seed()` calls |
| `deployment/development/worktree-list.ts` | `DESCRIPTION` column after `PROFILE` in both table modes |
| `.claude/skills/{diagnose-dev,test-dev,fix-and-validate}/SKILL.md` | XPath snippet to read description from `environment-details.xml` |

## Test plan

- [ ] Run `worktree-start.ts` on a fresh profile — confirm prompt appears and description is written to both XML and YAML
- [ ] Re-run same profile — confirm no prompt and existing description is preserved
- [ ] Re-run with `--description "override"` — confirm both files are updated
- [ ] Run `worktree_list.sh` — confirm `DESCRIPTION` column appears
- [ ] Inspect `~/.mini-infra/worktrees.yaml` — confirm `description` field is present
- [ ] TypeScript builds pass: `pnpm build:lib && pnpm --filter mini-infra-server build` ✅ (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)