### PR TITLE
feat(dev): auto-deploy + auto-unlock managed Vault on worktree start

### DIFF
--- a/.claude/skills/diagnose-dev/SKILL.md
+++ b/.claude/skills/diagnose-dev/SKILL.md
@@ -157,6 +157,24 @@ docker logs mini-infra-dev --tail 50
 docker exec mini-infra-dev ps aux
 ```
 
+#### Vault locked? re-unlock
+
+The dev seeder bootstraps the managed Vault with a fixed passphrase and unlocks it on every `worktree_start.sh` run. If you see `permission denied` from Vault, `Operator passphrase must be unlocked`, or `/api/vault/status` reporting `passphrase.state: locked`, the in-memory passphrase has dropped (typically after an in-place container restart). Re-unlock without a UI round-trip:
+
+```bash
+API_KEY=$(xmllint --xpath 'string(//admin/apiKey)' environment-details.xml)
+PASSPHRASE=$(xmllint --xpath 'string(//environment/admin/vaultPassphrase)' environment-details.xml)
+curl -s -X POST -H "x-api-key: $API_KEY" -H 'content-type: application/json' \
+  -d "{\"passphrase\":\"$PASSPHRASE\"}" \
+  "$MINI_INFRA_URL/api/vault/passphrase/unlock"
+
+# Confirm
+curl -s -H "x-api-key: $API_KEY" "$MINI_INFRA_URL/api/vault/status" \
+  | jq '.data | {reachable, sealState, passphrase: .passphrase.state}'
+```
+
+If `<vaultPassphrase>` is missing from the XML (older worktrees pre-auto-unlock), re-run `deployment/development/worktree_start.sh` — the seeder will repopulate it.
+
 #### Using Playwright for UI issues
 
 If the issue is visual or involves user interaction, load the Playwright CLI skill (`.claude/skills/playwright-cli/SKILL.md`) and use a persistent headed browser session to reproduce and inspect the problem:

--- a/deployment/development/lib/env-details.ts
+++ b/deployment/development/lib/env-details.ts
@@ -4,6 +4,7 @@ export interface XmlAdminDetails {
   email?: string;
   password?: string;
   apiKey?: string;
+  vaultPassphrase?: string;
 }
 
 export interface EnvironmentDetailsSummary {
@@ -52,6 +53,7 @@ export function readEnvironmentDetails(filePath: string): EnvironmentDetailsSumm
       email: extractTag(xml, 'email', 'admin'),
       password: extractTag(xml, 'password', 'admin'),
       apiKey: extractTag(xml, 'apiKey', 'admin'),
+      vaultPassphrase: extractTag(xml, 'vaultPassphrase', 'admin'),
     },
     description: {
       short: extractTag(xml, 'short', 'description'),
@@ -141,6 +143,7 @@ export interface FullEnvironmentDetailsInput {
   adminEmail: string;
   adminPassword: string;
   apiKey: string;
+  vaultPassphrase: string;
   azureConfigured: boolean;
   cloudflareConfigured: boolean;
   githubConfigured: boolean;
@@ -202,6 +205,7 @@ ${descBlock}  <seeded>true</seeded>
     <email>${t(input.adminEmail)}</email>
     <password>${t(input.adminPassword)}</password>
     <apiKey>${t(input.apiKey)}</apiKey>
+    <vaultPassphrase>${t(input.vaultPassphrase)}</vaultPassphrase>
   </admin>
   <connectedServices>
     <azure configured="${input.azureConfigured}"/>

--- a/deployment/development/lib/seeder.ts
+++ b/deployment/development/lib/seeder.ts
@@ -85,6 +85,12 @@ interface SystemSetting {
 const HEALTH_PATH = '/health';
 const SEED_DEBUG = process.env.SEED_DEBUG === '1';
 
+// Fixed passphrase used for the dev-only managed Vault. Persisted to
+// environment-details.xml so re-runs of this seeder (and skills like
+// diagnose-dev) can call /api/vault/passphrase/unlock after a server restart
+// without operator intervention. NOT for production use.
+export const DEV_VAULT_PASSPHRASE = 'UnWrapMiniInfra100';
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -380,11 +386,19 @@ async function ensureLocalEnvironment(api: ApiClient, env: DevEnv): Promise<stri
   return id;
 }
 
-async function findTemplate(api: ApiClient, needle: string): Promise<string | null> {
+async function findTemplate(
+  api: ApiClient,
+  needle: string,
+  opts: { exact?: boolean } = {},
+): Promise<string | null> {
   const res = await api.get<unknown>('/api/stack-templates');
   if (res.status !== 200) return null;
   const items = pickItems<Template>(res.body);
-  const match = items.find((t) => (t.name || '').toLowerCase().includes(needle));
+  const lower = needle.toLowerCase();
+  const match = items.find((t) => {
+    const name = (t.name || '').toLowerCase();
+    return opts.exact ? name === lower : name.includes(lower);
+  });
   return match?.id || null;
 }
 
@@ -424,7 +438,11 @@ async function ensureHaproxyStack(api: ApiClient, envId: string): Promise<string
   return id;
 }
 
-async function applyAndWaitForSynced(api: ApiClient, stackId: string): Promise<void> {
+async function applyAndWaitForSynced(
+  api: ApiClient,
+  stackId: string,
+  label: string,
+): Promise<void> {
   // Snapshot pre-apply status + lastAppliedAt. The status field may still read
   // "error" (or whatever) from a prior run until the reconciler finishes this
   // one, so lastAppliedAt is the authoritative "reconciler completed a new run"
@@ -439,11 +457,11 @@ async function applyAndWaitForSynced(api: ApiClient, stackId: string): Promise<v
   }
 
   if (prevStatus.toLowerCase() === 'synced') {
-    logSkip('HAProxy stack is already Synced — skipping apply');
+    logSkip(`${label} stack is already Synced — skipping apply`);
     return;
   }
 
-  logInfo(`Applying HAProxy stack (current status: ${prevStatus || 'unknown'})`);
+  logInfo(`Applying ${label} stack (current status: ${prevStatus || 'unknown'})`);
   const applyRes = await api.post(`/api/stacks/${stackId}/apply`, {});
   if (applyRes.status !== 200 && applyRes.status !== 202) {
     logError(`Apply returned ${applyRes.status}: ${applyRes.bodyText}`);
@@ -464,15 +482,140 @@ async function applyAndWaitForSynced(api: ApiClient, stackId: string): Promise<v
     lastStatus = polledStatus;
     const lower = polledStatus.toLowerCase();
     if (lower === 'synced') {
-      logOk('HAProxy stack is Synced');
+      logOk(`${label} stack is Synced`);
       return;
     }
     if (lower === 'error') {
-      logError('HAProxy stack apply failed (status=error)');
+      logError(`${label} stack apply failed (status=error)`);
       return;
     }
   }
-  logSkip(`Timed out waiting for HAProxy to sync (last status: ${lastStatus || 'unknown'})`);
+  logSkip(`Timed out waiting for ${label} to sync (last status: ${lastStatus || 'unknown'})`);
+}
+
+async function ensureVaultStack(api: ApiClient): Promise<string | null> {
+  const stackName = 'vault';
+  logInfo(`Looking for existing ${stackName} host stack`);
+  // Vault is host-scoped — no environmentId filter, but the listing returns
+  // all stacks the caller can see, so we still match by name.
+  const list = await api.get<unknown>('/api/stacks');
+  if (list.status === 200) {
+    const items = pickItems<Stack>(list.body);
+    const existing = items.find((s) => s.name === stackName);
+    if (existing?.id) {
+      logSkip(`Vault stack already exists (id=${existing.id})`);
+      return existing.id;
+    }
+  }
+  logInfo('Locating Vault stack template');
+  // Exact-name match: there's also a `hello-vault` template in the catalog
+  // which is environment-scoped, so a substring match would land on the wrong
+  // one and reject our host-scoped instantiate.
+  const templateId = await findTemplate(api, 'vault', { exact: true });
+  if (!templateId) {
+    logSkip('Vault template not found — skipping Vault setup');
+    return null;
+  }
+  // Host-scoped instantiate: no environmentId.
+  const res = await api.post<unknown>(
+    `/api/stack-templates/${templateId}/instantiate`,
+    { name: stackName },
+  );
+  if (res.status !== 201) {
+    logError(`Vault instantiate returned ${res.status}: ${res.bodyText}`);
+    return null;
+  }
+  const created = pickObject<Stack>(res.body);
+  const id = created?.id || '';
+  if (!id) {
+    logError(`Vault instantiate response missing id: ${res.bodyText}`);
+    return null;
+  }
+  logOk(`Vault stack created (id=${id})`);
+  return id;
+}
+
+interface VaultStatusResponse {
+  initialised?: boolean;
+  bootstrappedAt?: string | null;
+  reachable?: boolean;
+  address?: string | null;
+  stackId?: string | null;
+  passphrase?: { state?: 'uninitialised' | 'locked' | 'unlocked' };
+}
+
+/**
+ * Bootstrap-or-unlock the managed Vault using the dev passphrase. Idempotent:
+ * - already unlocked → skip
+ * - locked          → POST /api/vault/passphrase/unlock
+ * - uninitialised   → POST /api/vault/bootstrap (requires address + stackId
+ *                     populated by the post-install action of a vault stack apply)
+ * - unreachable     → log skip
+ *
+ * Always returns. Failures are logged but non-fatal so a partly-broken Vault
+ * never breaks the rest of the dev environment.
+ */
+export async function ensureVaultUnlocked(api: ApiClient): Promise<void> {
+  // Refresh status — the server reads VaultState and probes the address.
+  const statusRes = await api.get<{ data?: VaultStatusResponse } | VaultStatusResponse>(
+    '/api/vault/status',
+  );
+  if (statusRes.status !== 200) {
+    logSkip(`Vault status returned ${statusRes.status} — skipping unlock`);
+    return;
+  }
+  const body = statusRes.body as { data?: VaultStatusResponse } | VaultStatusResponse | null;
+  const status = (body && 'data' in body && body.data ? body.data : body) as
+    | VaultStatusResponse
+    | null;
+  if (!status) {
+    logSkip('Vault status response missing body — skipping unlock');
+    return;
+  }
+  if (!status.reachable) {
+    logSkip('Vault unreachable — skipping unlock (deploy the vault stack first)');
+    return;
+  }
+  const passphraseState = status.passphrase?.state ?? 'uninitialised';
+
+  if (passphraseState === 'unlocked') {
+    logSkip('Vault passphrase already unlocked');
+    return;
+  }
+
+  if (passphraseState === 'locked') {
+    logInfo('Unlocking Vault passphrase');
+    const res = await api.post('/api/vault/passphrase/unlock', {
+      passphrase: DEV_VAULT_PASSPHRASE,
+    });
+    if (res.status === 200 || res.status === 201) {
+      logOk('Vault passphrase unlocked');
+    } else {
+      logError(
+        `Vault unlock returned ${res.status}: ${res.bodyText} (passphrase mismatch? wipe colima VM to reset)`,
+      );
+    }
+    return;
+  }
+
+  // passphraseState === 'uninitialised' → bootstrap.
+  if (!status.address || !status.stackId) {
+    logSkip(
+      'Vault is reachable but address/stackId missing — re-apply the vault stack so register-vault-address runs',
+    );
+    return;
+  }
+  logInfo('Bootstrapping Vault (one-time)');
+  const res = await api.post('/api/vault/bootstrap', {
+    passphrase: DEV_VAULT_PASSPHRASE,
+    address: status.address,
+    stackId: status.stackId,
+  });
+  if (res.status === 200 || res.status === 201) {
+    logOk('Vault bootstrapped');
+  } else {
+    logError(`Vault bootstrap returned ${res.status}: ${res.bodyText}`);
+  }
 }
 
 async function markOnboardingComplete(api: ApiClient): Promise<void> {
@@ -530,8 +673,13 @@ export async function seed(input: SeederInput): Promise<SeederOutput> {
   const localEnvId = await ensureLocalEnvironment(api, env);
   const haproxyStackId = await ensureHaproxyStack(api, localEnvId);
   if (haproxyStackId) {
-    await applyAndWaitForSynced(api, haproxyStackId);
+    await applyAndWaitForSynced(api, haproxyStackId, 'HAProxy');
   }
+  const vaultStackId = await ensureVaultStack(api);
+  if (vaultStackId) {
+    await applyAndWaitForSynced(api, vaultStackId, 'Vault');
+  }
+  await ensureVaultUnlocked(api);
   await markOnboardingComplete(api);
 
   logInfo(`Writing ${input.detailsFile}`);
@@ -548,6 +696,7 @@ export async function seed(input: SeederInput): Promise<SeederOutput> {
     adminEmail: env.ADMIN_EMAIL,
     adminPassword: env.ADMIN_PASSWORD,
     apiKey,
+    vaultPassphrase: DEV_VAULT_PASSPHRASE,
     azureConfigured: Boolean(env.AZURE_STORAGE_CONNECTION_STRING),
     cloudflareConfigured: Boolean(env.CLOUDFLARE_API_TOKEN && env.CLOUDFLARE_ACCOUNT_ID),
     githubConfigured: Boolean(env.GITHUB_TOKEN),

--- a/deployment/development/worktree-start.ts
+++ b/deployment/development/worktree-start.ts
@@ -28,7 +28,8 @@ import {
 } from './lib/registry.js';
 import { readEnvironmentDetails, writeMinimalEnvironmentDetails } from './lib/env-details.js';
 import { isColimaRunning, startColima } from './lib/colima.js';
-import { seed } from './lib/seeder.js';
+import { seed, ensureVaultUnlocked } from './lib/seeder.js';
+import { ApiClient } from './lib/api.js';
 
 const SCRIPT_DIR = path.dirname(new URL(import.meta.url).pathname);
 const PROJECT_ROOT = path.resolve(SCRIPT_DIR, '..', '..');
@@ -517,6 +518,21 @@ async function main(): Promise<void> {
       api_key: details?.admin.apiKey,
       description: shortDesc,
     });
+
+    // Server restarts re-lock the operator passphrase; re-unlock here so admin
+    // operations (publish policy, mint AppRole secret-id) keep working without
+    // a manual visit to /vault. Only attempt if we have an API key from a
+    // prior seed.
+    if (details?.admin.apiKey) {
+      const api = new ApiClient(`http://localhost:${uiPort}`, details.admin.apiKey);
+      try {
+        await ensureVaultUnlocked(api);
+      } catch (err) {
+        logWarn(
+          `Vault unlock attempt failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
   }
 
   console.log('');

--- a/docs/blocker-admin-cant-mint-secret-id.md
+++ b/docs/blocker-admin-cant-mint-secret-id.md
@@ -1,0 +1,284 @@
+# Blocker: `mini-infra-admin` AppRole token can't mint secret-ids for tenant AppRoles
+
+## Resolution (post-mortem)
+
+Root cause was investigation path #4: the in-memory admin token does not
+survive a server restart. The operator passphrase wraps the AppRole creds at
+rest and locks itself in memory at boot, so `authenticateAsAdmin()` is gated
+on a human visiting `/vault` and re-entering the passphrase. With no admin
+token, every authenticated Vault call (including `auth/approle/role/<x>/secret-id`)
+goes out without a valid token and Vault correctly returns `permission denied`.
+
+Fixed in dev by auto-unlocking the operator passphrase on every
+`worktree_start.sh` invocation — the seeder bootstraps the managed Vault
+with a fixed dev passphrase and the worktree-start script re-runs the unlock
+step on already-seeded paths after a restart. See
+[deployment/development/lib/seeder.ts](../deployment/development/lib/seeder.ts)
+(`ensureVaultUnlocked`) and the audit/log lines below for the exact
+"unreachable" / "permission denied" mapping that should be tightened in
+`vault-credential-injector.ts` separately.
+
+The investigation notes below are kept as a record of how the bug presented
+end-to-end (worker crash-loop → missing secret-id → permission denied → admin
+token never acquired) so future Vault auth issues can be diagnosed faster.
+
+## TL;DR
+
+After Vault is bootstrapped and mini-infra hands its HTTP client off from the
+root token to the `mini-infra-admin` AppRole token, calls that mint a wrapped
+secret-id for any tenant AppRole (e.g. `navi-slackbot`) return
+`permission denied` from Vault. This breaks **every** stack apply / pool spawn
+that uses `dynamicEnv: { kind: vault-wrapped-secret-id }`, because the
+`VaultCredentialInjector` quietly degrades to "role_id only" mode and the
+spawned container has no way to AppRole-login at runtime — it dies on the
+first secret read.
+
+The exact failing request:
+
+```
+Vault POST /v1/auth/approle/role/navi-slackbot/secret-id failed: permission denied
+```
+
+The same call **succeeded** during the initial install at 22:49 (the
+worker-channel container holds a valid wrapped secret-id from that window).
+After that point — and certainly after the mini-infra container restart
+during today's `worktree_start.sh` rebuild — every subsequent attempt fails.
+
+## Symptom in user-facing terms
+
+- Slackbot deploys cleanly the first time (worker-channel comes up healthy).
+- DMs trigger a per-DM pool worker spawn. The spawn **half-succeeds**:
+  - Container is created and joins the right networks.
+  - `VAULT_ADDR` and `VAULT_ROLE_ID` are injected.
+  - `VAULT_WRAPPED_SECRET_ID` is **missing**.
+- Worker container crash-loops: `Error: Missing required env var: ANTHROPIC_API_KEY`
+  (it can't AppRole-login to Vault, so the Vault fetch in `worker/src/config.ts`
+  silently fails and `required('ANTHROPIC_API_KEY')` throws).
+- Manager times out at 30s waiting for the worker's NATS ready signal.
+- A fresh `POST /api/stacks/<id>/apply` for the same stack hits the **same**
+  permission denied — proving this is not pool-spawner-specific.
+
+## Evidence
+
+### From the mini-infra app log (`/app/server/logs/app.1.log`)
+
+Pool spawn at 23:17:
+
+```json
+{"level":"warn","time":"2026-04-25T23:17:54.892Z","component":"platform","subcomponent":"vault-credential-injector","err":"Vault POST /v1/auth/approle/role/navi-slackbot/secret-id failed: permission denied","approle":"navi-slackbot","msg":"Vault unreachable while resolving dynamic env"}
+```
+
+Re-apply of the existing slackbot stack at 23:22 (same problem, three
+services trying in parallel):
+
+```json
+{"level":"warn","time":"2026-04-25T23:22:13.602Z","component":"platform","subcomponent":"vault-credential-injector","err":"Vault POST /v1/auth/approle/role/navi-slackbot/secret-id failed: permission denied","approle":"navi-slackbot","msg":"Vault unreachable while resolving dynamic env"}
+{"level":"info","time":"2026-04-25T23:22:13.602Z","component":"platform","subcomponent":"vault-credential-injector","approleId":"cmoewture019407kpjht44i6r","msg":"Vault unreachable; proceeding with role_id only (stable binding, cached role_id)"}
+```
+
+Note the misleading log message — Vault is **reachable** (the request
+returned a response). It just denied the action. The injector treats any
+exception in this code path as "vault unreachable" and falls back to
+degraded mode.
+
+Code at fault for the misleading message:
+[server/src/services/vault/vault-credential-injector.ts:111-119](../server/src/services/vault/vault-credential-injector.ts) —
+the `catch` block logs `Vault unreachable` regardless of root cause.
+
+### From the spawned worker container
+
+Env vars actually injected (confirmed via `docker inspect`):
+
+```
+NATS_URL=nats://nats:4222
+DATA_DIR=/data
+VAULT_ADDR=http://mini-infra-vault-vault:8200
+VAULT_ROLE_ID=295a60c9-a8e0-c89e-4232-0d631ba4a348
+WORKER_ID=w-49b29bfaef64e724
+NATS_CREDS=<…>
+```
+
+Crash loop:
+
+```
+Error: Missing required env var: ANTHROPIC_API_KEY
+    at required (file:///app/worker/dist/config.js:6:15)
+    at file:///app/worker/dist/config.js:22:22
+```
+
+The worker calls `loadSharedSecretsIntoEnv()` first, which depends on a
+working AppRole login (which needs `VAULT_WRAPPED_SECRET_ID`). The login
+fails, the fetch fails silently, and then `required('ANTHROPIC_API_KEY')`
+throws.
+
+### From the openbao server log
+
+`docker logs mini-infra-vault-vault` shows almost nothing relevant —
+OpenBao OSS doesn't log permission denials by default. There's a single
+line about a previous secret-id lease being revoked, then silence.
+**Enabling an audit device on Vault would be the fastest way to confirm
+the actual policy attached to the failing request.**
+
+## What's known about the surrounding state
+
+### Policies (per `GET /api/vault/policies`)
+
+`mini-infra-admin` policy is present, marked published, with `lastAppliedAt`
+populated. `draftHclBody` matches `publishedHclBody` (no drift in mini-infra's
+DB). The HCL body matches the hardcoded constant in
+[server/src/services/vault/vault-admin-service.ts:31-49](../server/src/services/vault/vault-admin-service.ts):
+
+```hcl
+path "auth/*" {
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+```
+
+Per Vault path-matching rules, `auth/*` should match
+`auth/approle/role/navi-slackbot/secret-id`. So either:
+
+- The policy in Vault doesn't actually match the source HCL (publish step
+  silently failed, or got rolled back, or was never run), **or**
+- The `mini-infra-admin` AppRole token is bound to a *different* policy
+  than `mini-infra-admin`, **or**
+- The token mini-infra is presenting isn't the admin token at all (e.g.
+  fell back to a more limited token after a renewal/re-login).
+
+### AppRoles (per `GET /api/vault/approles`)
+
+`navi-slackbot` AppRole exists, last applied at 22:49:07 (during install).
+Looks healthy from mini-infra's DB perspective.
+
+### Timing
+
+| Time | Event |
+|---|---|
+| 22:20 | Vault stack deployed (`vault v2`) |
+| 22:49 | Slackbot stack first applied — **worked**, worker-channel got valid `VAULT_WRAPPED_SECRET_ID` |
+| 22:57 | First DM-pool spawn — failed (template substitution bug, since fixed) |
+| ~23:15 | mini-infra container rebuilt + restarted via `worktree_start.sh` |
+| 23:17 | Second DM-pool spawn — **first observation of `permission denied`** |
+| 23:22 | Stack re-apply — **same permission denied** |
+
+The break correlates exactly with the mini-infra restart. That points at
+the in-memory admin auth flow rather than persistent Vault state.
+
+## What was ruled out
+
+- **Not a pool-spawner-specific bug.** Confirmed by reproducing the same
+  permission denied on a stack re-apply (which uses the same
+  `VaultCredentialInjector` code path on stateful services).
+- **Not network connectivity to Vault.** The HTTP request reached Vault
+  and got a structured `permission denied` response, not a connection
+  error.
+- **Not an obvious draft/published mismatch.** `mini-infra-admin` policy
+  has both bodies set and they look identical via the API.
+- **Not the `mini-infra-vault-net` typo** in pool-spawner.ts. That's a
+  separate bug (now fixed in source — see "Related fixes" below) — it
+  prevented network attachment but not credential injection.
+
+## Investigation paths
+
+In rough order of cost / likely return:
+
+### 1. Confirm what policy the running admin token actually has
+
+Hit `auth/token/lookup-self` from inside mini-infra using its current
+admin token. Look at the `policies` field on the response. If it's not
+`["mini-infra-admin"]` (plus `default`), the AppRole→policy binding is
+the bug.
+
+The cleanest way to do this without bypass-code:
+
+```ts
+// Add a temporary diagnostic route in server/src/routes/vault-routes.ts:
+//
+//   router.get('/api/vault/admin/whoami', async (req, res) => {
+//     const client = getVaultServices().admin.getClient();
+//     const me = await client.request('GET', '/v1/auth/token/lookup-self');
+//     res.json(me);
+//   });
+//
+// Hit it with the admin API key, inspect, then revert.
+```
+
+### 2. Confirm what policy is on the AppRole in Vault
+
+```
+GET /v1/auth/approle/role/mini-infra-admin
+```
+
+Check `token_policies` on the response. Should include `mini-infra-admin`.
+
+### 3. Re-publish the `mini-infra-admin` policy from the UI
+
+Settings → Vault → Policies → mini-infra-admin → Publish.
+
+If the publish silently no-ops (because draft == published) but the
+underlying call to Vault re-syncs the policy body, this might unblock
+without a code change. Cheap to try.
+
+### 4. Trace the bootstrap → admin handover path
+
+Read [server/src/services/vault/vault-admin-service.ts:200-330](../server/src/services/vault/vault-admin-service.ts)
+end to end. The interesting block is the bootstrap flow:
+
+- `initRes.root_token` →
+- writes mini-infra-admin policy + AppRole →
+- mints a secret_id →
+- AppRole-logs-in to get `loginRes.auth.client_token` →
+- `client.setToken(adminToken)` → done.
+
+Audit whether step 4 always completes successfully *and* whether the
+in-memory admin token survives the restart vs. needing to re-derive from
+stored AppRole creds at boot. The "stored AppRole creds" path is in
+`authenticateAsAdmin()` (line 383) — does it use the right policy?
+
+Hypothesis worth checking: after bootstrap, the admin AppRole is rebound
+or re-policied somewhere, and on subsequent boots `authenticateAsAdmin`
+gets a token with reduced policy.
+
+### 5. Enable a Vault audit device
+
+```
+POST /v1/sys/audit/file
+{ "type": "file", "options": { "file_path": "/openbao/logs/audit.log" } }
+```
+
+Then trigger the failing call again. The audit log will show the exact
+token accessor, its policies, the request path, and which policy rule
+denied it. This is the surest answer to "why is this denied".
+
+## Related fixes shipped during this debug session
+
+While diagnosing this, three independent bugs in `pool-spawner.ts` were
+patched. Two are deployed; one is in source but needs a
+`worktree_start.sh` cycle to ship:
+
+| # | Bug | Status |
+|---|---|---|
+| 1 | `service.dockerImage` / `dockerTag` reached Docker as raw `{{params.X}}` template strings | Fixed: `resolveServiceConfigs` is called and resolved values are used. Deployed. |
+| 2 | Pool spawn didn't include the synthesised `<project>_default` network → no DNS to `nats` | Fixed: `synthesiseDefaultNetworkIfNeeded` now called consistently with stack-reconciler. Deployed. |
+| 3 | Hardcoded vault network name `mini-infra-vault-net` (actual: `mini-infra-vault`) | Fixed: now resolves from `infraResource` table. **Not yet deployed.** |
+
+All three were in [server/src/services/stacks/pool-spawner.ts](../server/src/services/stacks/pool-spawner.ts).
+The last one is gated on this Vault permission blocker — no point burning
+another rebuild cycle until tenant AppRole secret-ids can actually be
+minted.
+
+## Reproduction
+
+1. Worktree: `bold-raman-95d3c9` (Colima profile +
+   `unix:///Users/geoff/.colima/bold-raman-95d3c9/docker.sock`).
+2. Slackbot stack id: `cmoexllek01bk07kp6bkrjkka`.
+3. Trigger:
+   ```bash
+   curl -s -X POST -H "x-api-key: <admin-key>" \
+     "http://localhost:3101/api/stacks/cmoexllek01bk07kp6bkrjkka/apply" -d '{}'
+   sleep 3
+   docker exec mini-infra-bold-raman-95d3c9-mini-infra-1 \
+     tail -20 /app/server/logs/app.1.log | grep vault-credential
+   ```
+4. Expected: `permission denied` on `auth/approle/role/navi-slackbot/secret-id`,
+   then `Vault unreachable; proceeding with role_id only (stable binding,
+   cached role_id)`.

--- a/server/src/services/stacks/pool-spawner.ts
+++ b/server/src/services/stacks/pool-spawner.ts
@@ -3,11 +3,19 @@ import type {
   PoolConfig,
   StackContainerConfig,
   StackNetwork,
+  StackParameterDefinition,
+  StackParameterValue,
 } from '@mini-infra/types';
 import type { DockerExecutorService } from '../docker-executor';
 import { VaultCredentialInjector } from '../vault/vault-credential-injector';
 import { vaultServicesReady } from '../vault/vault-services';
 import { getLogger } from '../../lib/logger-factory';
+import {
+  buildStackTemplateContext,
+  mergeParameterValues,
+  resolveServiceConfigs,
+  synthesiseDefaultNetworkIfNeeded,
+} from './utils';
 
 const log = getLogger('stacks', 'pool-spawner');
 
@@ -82,17 +90,35 @@ export async function spawnPoolInstance(
 ): Promise<PoolSpawnResult> {
   const stack = await prisma.stack.findUnique({
     where: { id: ctx.stackId },
-    include: { environment: true },
+    include: { environment: true, services: { orderBy: { order: 'asc' } } },
   });
   if (!stack) return { success: false, error: 'Stack not found' };
 
-  const service = await prisma.stackService.findFirst({
-    where: { stackId: ctx.stackId, serviceName: ctx.serviceName, serviceType: 'Pool' },
-  });
+  const service = stack.services.find(
+    (s) => s.serviceName === ctx.serviceName && s.serviceType === 'Pool',
+  );
   if (!service) return { success: false, error: 'Pool service not found' };
 
-  const containerConfig = service.containerConfig as unknown as StackContainerConfig;
-  const poolConfig = service.poolConfig as unknown as PoolConfig | null;
+  // Resolve `{{params.X}}`, `{{volumes.X}}`, etc. on the service definition —
+  // mirrors what stack-reconciler does on apply. Pool services were skipped
+  // here previously, so `dockerImage`/`dockerTag` and any templated
+  // `containerConfig` field reached Docker as the raw template string (and
+  // `docker pull` rejects them as invalid references).
+  const params = mergeParameterValues(
+    (stack.parameters as unknown as StackParameterDefinition[]) ?? [],
+    (stack.parameterValues as unknown as Record<string, StackParameterValue>) ?? {},
+  );
+  const templateContext = buildStackTemplateContext(stack, params);
+  const { resolvedDefinitions } = resolveServiceConfigs(stack.services, templateContext);
+  const resolvedDef = resolvedDefinitions.get(ctx.serviceName);
+  if (!resolvedDef) {
+    return { success: false, error: 'Pool service missing from resolved definitions' };
+  }
+
+  const dockerImage = resolvedDef.dockerImage;
+  const dockerTag = resolvedDef.dockerTag;
+  const containerConfig = resolvedDef.containerConfig as StackContainerConfig;
+  const poolConfig = (resolvedDef.poolConfig ?? null) as PoolConfig | null;
   if (!poolConfig) return { success: false, error: 'Pool service missing poolConfig' };
 
   const projectName = stack.environment
@@ -145,15 +171,19 @@ export async function spawnPoolInstance(
 
   // Pull image (with registry auth resolution).
   try {
-    log.info({ image: service.dockerImage, tag: service.dockerTag, containerName }, 'Pulling image for pool spawn');
-    await dockerExecutor.pullImageWithAutoAuth(`${service.dockerImage}:${service.dockerTag}`);
+    log.info({ image: dockerImage, tag: dockerTag, containerName }, 'Pulling image for pool spawn');
+    await dockerExecutor.pullImageWithAutoAuth(`${dockerImage}:${dockerTag}`);
   } catch (err) {
     return { success: false, error: `Image pull failed: ${err instanceof Error ? err.message : String(err)}` };
   }
 
-  // Build the network list: stack-owned networks prefixed with projectName.
-  const stackNetworks = (stack.networks as unknown as StackNetwork[]) ?? [];
-  const networkNames = stackNetworks.map((n) => `${projectName}_${n.name}`);
+  // Build the network list. Mirror stack-reconciler: declared networks plus
+  // the synthesised `<project>_default` for multi-service stacks. Without
+  // the synthesis call, pool containers attach only to the vault network +
+  // bridge and can't resolve sibling stack services by name (e.g. `nats`).
+  const declaredNetworks = (stack.networks as unknown as StackNetwork[]) ?? [];
+  const networks = synthesiseDefaultNetworkIfNeeded(declaredNetworks, stack.services);
+  const networkNames = networks.map((n) => `${projectName}_${n.name}`);
 
   // Labels that match static stack containers, plus pool-instance markers.
   const labels: Record<string, string> = {
@@ -217,7 +247,7 @@ export async function spawnPoolInstance(
   let containerId: string;
   try {
     const container = await dockerExecutor.createLongRunningContainer({
-      image: `${service.dockerImage}:${service.dockerTag}`,
+      image: `${dockerImage}:${dockerTag}`,
       name: containerName,
       projectName,
       serviceName: ctx.serviceName,
@@ -257,17 +287,33 @@ export async function spawnPoolInstance(
     }
   }
 
-  // Vault network when a binding is in play.
+  // Vault network when a binding is in play. Resolve the actual docker
+  // network name from `infraResource` rather than hardcoding it — vault
+  // resource networks are named `mini-infra-vault` (host scope) or
+  // `<env>-vault` (environment scope), never `mini-infra-vault-net`.
   const needsVaultNet = effectiveAppRoleId && Object.keys(vaultEnv).length > 0;
   if (needsVaultNet) {
-    const docker = dockerExecutor.getDockerClient();
-    try {
-      await docker.getNetwork('mini-infra-vault-net').connect({ Container: containerId });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (!/already exists/i.test(msg)) {
-        log.warn({ containerId, err: msg }, 'Failed to attach vault network (non-fatal)');
+    const vaultResource = await prisma.infraResource.findFirst({
+      where: {
+        type: 'docker-network',
+        purpose: 'vault',
+        ...(stack.environmentId
+          ? { environmentId: stack.environmentId, scope: 'environment' }
+          : { scope: 'host', environmentId: null }),
+      },
+    });
+    if (vaultResource) {
+      const docker = dockerExecutor.getDockerClient();
+      try {
+        await docker.getNetwork(vaultResource.name).connect({ Container: containerId });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (!/already exists/i.test(msg)) {
+          log.warn({ containerId, network: vaultResource.name, err: msg }, 'Failed to attach vault network (non-fatal)');
+        }
       }
+    } else {
+      log.warn({ containerId, stackId: ctx.stackId }, 'Vault InfraResource not found; skipping vault network attach');
     }
   }
 


### PR DESCRIPTION
## Summary

Three loosely-related fixes from one debug session:

1. **Auto-deploy + auto-unlock the managed Vault on every `worktree_start.sh`**, so Mini Infra stays continuously authenticated to Vault across server restarts.
2. **Three pool-spawner bugfixes** found while diagnosing why slackbot pool workers couldn't fetch secrets.
3. **Investigation notes** captured during the diagnosis, kept as a record so future Vault auth issues can be tracked back faster.

## 1. Vault auto-unlock (the headline)

Worktree seeder now:
- Instantiates and applies the host-scoped `vault` stack (post-install action populates `VaultState.address` + `stackId`).
- On first run, bootstraps Vault with a fixed dev passphrase (`UnWrapMiniInfra100`); on subsequent runs unlocks the existing one.
- Persists the passphrase into `environment-details.xml` under `<admin>` so dev tooling can re-unlock without prompting.

`worktree-start` additionally re-runs the unlock step on the already-seeded path, so a server restart followed by `worktree_start.sh` brings Vault back to "unlocked" automatically — no manual UI step.

### Why
Mini Infra needs to stay continuously authenticated to its managed Vault. After any server restart the in-memory operator passphrase locks, the admin AppRole token is dropped, and admin paths (`PUT sys/policies/acl/...`, `POST auth/approle/role/<x>/secret-id`) start returning `permission denied`. That broke "republish policy" with a raw 500 and silently degraded `VaultCredentialInjector` to role_id-only mode (which is exactly what the investigation doc in this PR was tracking).

## 2. pool-spawner.ts fixes

Three independent bugs, all in `server/src/services/stacks/pool-spawner.ts`:

| # | Bug | Fix |
|---|---|---|
| 1 | Pool services skipped template resolution; `dockerImage` / `dockerTag` reached Docker as raw `{{params.X}}` template strings | Call `resolveServiceConfigs()` on the resolved stack services and use the resolved values |
| 2 | Pool spawn skipped `synthesiseDefaultNetworkIfNeeded()`, so containers had no DNS to sibling services like `nats` | Mirror stack-reconciler — synthesise the `<project>_default` network |
| 3 | Hardcoded vault network name `mini-infra-vault-net` (actual name: `mini-infra-vault` host / `<env>-vault` env) | Resolve from `InfraResource` by `purpose=vault` with the right scope/env filter |

## 3. Investigation doc

`docs/blocker-admin-cant-mint-secret-id.md` — end-to-end symptoms (worker crash-loop → missing wrapped secret-id → `permission denied` on `auth/approle/role/<x>/secret-id`) plus the investigation paths that led to the fix. Top-of-file resolution note points at the auto-unlock work so future readers don't think the blocker is still open.

## Notes for reviewer

- Existing dev envs need a one-time wipe (`colima delete <profile> --data --force`) to switch to the canonical passphrase. There's no rotate-passphrase flow yet.
- `findTemplate()` now supports `{ exact: true }`; the vault lookup uses exact match because `hello-vault` would otherwise win the substring race.
- The dev passphrase is dev-only — production should not adopt this pattern as-is, since it stores the unwrap key on the host filesystem.
- A follow-up worth doing (not in this PR): tighten `VaultCredentialInjector` to log "permission denied" rather than "Vault unreachable" when Vault returns a structured 403. The current message was actively misleading during the debug session.

## Test plan

- [x] Fresh wipe + `worktree_start.sh --description ...`: vault stack deploys, bootstraps, all subsequent `/api/vault/status` calls report `unlocked`.
- [x] Republish `mini-infra-admin` from `/vault/policies` → succeeds (previously 500).
- [x] `docker restart mini-infra-...` → status flips to `locked`. Re-run `worktree_start.sh` (no flags, already-seeded path) → status back to `unlocked`. No re-seed needed.
- [x] `environment-details.xml` contains `<vaultPassphrase>UnWrapMiniInfra100</vaultPassphrase>` under `<admin>`.
- [ ] Pool-spawner fixes verified end-to-end (slackbot pool worker spawns and reads secrets) — covered by the original debug session evidence in `docs/blocker-admin-cant-mint-secret-id.md`; not re-run on this branch since vault auto-unlock was the gating fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)