### PR TITLE
feat(stacks,vault): phase 1 — template context, per-service AppRole, vault-kv dynamicEnv, brokered KV API

### DIFF
--- a/docs/stack-bundles-and-installer-improvements.md
+++ b/docs/stack-bundles-and-installer-improvements.md
@@ -1,0 +1,451 @@
+# Stack Bundles & External-Installer Improvements
+
+This document is a forward-looking design exploration prompted by the slackbot-agent-sdk integration. It pairs the friction list in `slackbot-agent-sdk/docs/mini-infra-installer-future.md` (written from the installer side) with what we actually have today inside mini-infra (written from this side), and proposes a coherent set of improvements to the stack/template/vault subsystems.
+
+It is **not** a list of tickets. Most proposals here build on primitives that already exist; the work is mostly exposing and unifying them rather than inventing new mechanics. The header for each proposal calls out how much is genuinely new code vs. wiring of existing pieces.
+
+The bug-fix companion doc is [slackbot-installer-fixes.md](slackbot-installer-fixes.md) (issues #237–#242, shipped in #243). This doc is the next step beyond that — what should the surface look like once the bugs are gone?
+
+---
+
+## 1. Background — why is the slackbot installer interesting?
+
+The slackbot-agent-sdk wants to ship itself as a mini-infra-managed application: a stack template plus the Vault policies, AppRoles, and shared KV secrets it depends on, plus the four custom container images it builds locally. Today its installer is a 686-line Node script ([`environment/install-mini-infra.ts`](../../slackbot-agent-sdk/environment/install-mini-infra.ts)) running 8 sequential stages:
+
+1. reachability (mini-infra + vault)
+2. `docker build` four images
+3. `docker push` four images
+4. create/update Vault policies (one per AppRole) and publish each
+5. create/update Vault AppRoles bound to those policies and apply each
+6. write KV secrets directly to Vault (logs in via mini-infra-operator userpass to get a token)
+7. create or draft+publish the stack template, then instantiate it, then PUT to backfill `mini-infra-stack-id`
+8. apply the stack and poll `/status` every 3s for up to 5 minutes
+
+The script works. But almost everything it does — Vault policies, AppRoles, KV secrets, template publishing — is something mini-infra **already does internally** for its built-in stacks (haproxy, postgres, vault, etc.). The seeder reads JSON template files from `server/templates/*/template.json` ([`builtin-stack-sync.ts:30`](../server/src/services/stacks/builtin-stack-sync.ts:30)), wires up policies and AppRoles, and applies the result. From that angle, **a built-in stack is exactly the kind of bundle the slackbot installer is reinventing**, just hard-coded into the server binary.
+
+The headline opportunity is to take the bundle format that already lives at `server/templates/*/template.json` and let users POST one. Most other items on the list either fall out of that or close small specific gaps (template context, per-service AppRole binding, KV read injection).
+
+The slackbot is a useful forcing function because it's the first non-trivial **third-party** application built on mini-infra. A handful of gaps that didn't matter when only system stacks existed (no scoped KV API, partial template context, no streaming apply) become real once external authors are doing the same dance.
+
+---
+
+## 2. What we already have
+
+Before proposing additions, an honest inventory of the primitives in place. Several of these are 70%-built — the proposals below mostly finish the wiring rather than start fresh.
+
+### Templates and bundles
+
+- **Versioned templates with draft/publish lifecycle** ([`stack-template-service.ts:121`](../server/src/services/stacks/stack-template-service.ts:121)). Drafts are mutable; published versions are immutable and numbered. A re-draft + re-publish produces a new version on the same template.
+- **System templates as JSON files** loaded at startup ([`builtin-stack-sync.ts:30`](../server/src/services/stacks/builtin-stack-sync.ts:30), [`template-file-loader.ts:62`](../server/src/services/stacks/template-file-loader.ts:62)). The schema at `server/templates/{haproxy,vault,postgres,...}/template.json` is **already a bundle format** — services, networks, volumes, parameters, resourceInputs/Outputs, configFiles. It just doesn't yet carry policies/AppRoles/KV alongside the template.
+- **`builtinVersion` field** on each system template — bumping it triggers a re-publish on next boot. This is the version semantics we need for user bundles too.
+
+### Vault
+
+- Admin token cached and (post #237 fix) self-renewing in [`vault-admin-service.ts:111`](../server/src/services/vault/vault-admin-service.ts:111).
+- Policies and AppRoles managed via REST with draft/publish-style apply (`POST /vault/policies/:id/publish`, `POST /vault/approles/:id/apply`).
+- **Per-service AppRole binding columns already exist in the DB** — `Stack.vaultAppRoleId`, `StackService.vaultAppRoleId`, `StackTemplateService.vaultAppRoleId` ([`schema.prisma:1086, 1198, 1390`](../server/prisma/schema.prisma)). What's missing is the resolver actually preferring the service-level binding over the stack-level one when both are set.
+- `GET /api/vault/operator-credentials` returns a userpass account the installer can use to log in to Vault directly. This works as the bridge today; it's also the smell that says we should be brokering KV instead.
+- No `POST /api/vault/kv` route. Direct Vault HTTP is the only path.
+
+### DynamicEnv resolver
+
+- Discriminated union with four kinds today ([`stacks.ts:45`](../lib/types/stacks.ts:45)): `vault-addr`, `vault-role-id`, `vault-wrapped-secret-id`, `pool-management-token`. Resolved at apply time in [`vault-credential-injector.ts:50`](../server/src/services/vault/vault-credential-injector.ts:50).
+- Fail-closed degradation logic already in place (return cached role_id when Vault is briefly unreachable). New resolvers should adopt the same pattern.
+
+### Template substitution context
+
+- Engine already builds a richer context than the validation regex permits. [`template-engine.ts:56`](../server/src/services/stacks/template-engine.ts:56) constructs `{ params, stack: { name, projectName }, volumes, networks }`. But the schema regex at [`schemas.ts:11`](../server/src/services/stacks/schemas.ts:11) only matches `{{params.key-name}}`, so any template using `{{stack.name}}` is rejected at validation time. The engine is ready; the regex is the gate.
+
+### Stack apply
+
+- Async fire-and-forget today via `POST /api/stacks/:id/apply` returning HTTP 200 immediately ([`stacks-apply-route.ts:35`](../server/src/routes/stacks/stacks-apply-route.ts:35)). Reconciliation runs in the background and emits Socket.IO events on `Channel.STACKS` per service action. A blocking/streaming variant doesn't exist; callers either poll or run a Socket.IO client.
+
+### Pool services
+
+- Generated tokens hashed with argon2id, rotated when the `managedBy` service is recreated ([`pool-management-token.ts:30`](../server/src/services/stacks/pool-management-token.ts:30)). Plaintext is only seen by the `managedBy` service via dynamicEnv injection. There's no introspection endpoint for "when was this last rotated".
+
+### API surface and SDK
+
+- Consistent response envelope `{ success, data?, message?, issues? }` across all routes.
+- Strongly-typed Zod schemas in `@mini-infra/types` shared with the client.
+- No published SDK. External tools rebuild the envelope wrapper themselves — slackbot's [`mini-infra-api.ts`](../../slackbot-agent-sdk/environment/install/mini-infra-api.ts) is 52 lines that mostly re-derive what `@mini-infra/types` could give them.
+
+---
+
+## 3. Proposals
+
+Each proposal is sized as **S/M/L** (rough effort) and tagged with how much is new mechanism vs. wiring. Priority is in §4.
+
+### A. Stack Bundles — packaging template + policies + AppRoles + KV in one resource
+
+**Size: L. Mostly composition.** This is the headline change.
+
+**Problem.** The slackbot installer's 8 stages are an external orchestrator doing what the seeder does internally for system stacks. Each stage tracks state across calls (policy IDs, AppRole IDs, template ID, stack ID), each has its own delete endpoint for rollback, and a partial failure leaves dangling objects the user must clean up by hand.
+
+**Design sketch.**
+
+A bundle is a single document — same JSON schema as `server/templates/*/template.json` today, extended with optional sibling sections for the resources a template implicitly depends on:
+
+```yaml
+apiVersion: mini-infra/v1
+kind: StackBundle
+metadata:
+  name: slackbot
+  version: 3            # bundle author's version, monotonically increasing
+  description: ...
+spec:
+  template:             # exactly today's template.json, no changes required
+    name: slackbot
+    scope: environment
+    services: [...]
+    parameters: [...]
+    networks: [...]
+    volumes: [...]
+    resourceInputs: [...]
+    resourceOutputs: [...]
+  vault:
+    policies:           # HCL bodies, by name
+      - name: slackbot-manager
+        body: |
+          path "secret/data/shared/slack" { capabilities = ["read"] }
+      - name: slackbot-worker
+        body: |
+          ...
+    appRoles:           # bound to policies above by name
+      - name: slackbot-manager
+        policy: slackbot-manager
+        tokenPeriod: 1h
+        secretIdNumUses: 0
+      - name: slackbot-worker
+        policy: slackbot-worker
+        tokenPeriod: 1h
+    kv:                 # KV writes the bundle owns
+      - path: shared/slack
+        fields:
+          bot_token: { fromInput: slackBotToken }
+          app_token: { fromInput: slackAppToken }
+      - path: shared/anthropic
+        fields:
+          api_key: { fromInput: anthropicApiKey }
+  inputs:               # values the operator must supply at install time
+    - name: slackBotToken
+      sensitive: true
+      description: "Slack bot user OAuth token (xoxb-...)"
+    - name: anthropicApiKey
+      sensitive: true
+```
+
+Endpoints:
+
+```
+POST /api/stack-bundles                  # ingest a bundle, no apply
+POST /api/stack-bundles/:name/apply      # apply (transactional, idempotent)
+GET  /api/stack-bundles                  # list
+GET  /api/stack-bundles/:name            # current state, version, derived objects
+DELETE /api/stack-bundles/:name          # tear down all derived objects
+```
+
+`apply` semantics:
+
+- **Transactional within a single bundle apply.** Either every derived object lands successfully or the whole apply rolls back. Failures leave the previously-applied bundle version in place (i.e. the system never moves to a partial new state).
+- **Idempotent across applies.** Re-POSTing the same bundle version is a no-op. POSTing a higher version reconciles the diff: drafts a new template version, publishes it, updates policies/AppRoles, writes new KV values, then re-applies the stack with the new template version.
+- **Apply order is fixed and internal:** policies → AppRoles (now that policies exist) → KV writes (now that any apply-time validation can happen) → template draft+publish → stack instantiate (or update parameter values on existing stack) → stack apply.
+
+**DRY notes.**
+
+- The bundle schema **is** the system template schema with a wrapper. Reuse [`template-file-loader.ts`](../server/src/services/stacks/template-file-loader.ts) for the inner template parsing — no new schema duplication.
+- Policy/AppRole creation reuses the existing services. The bundle controller is a thin orchestrator that calls them in order. No new HCL-rendering or AppRole-minting logic.
+- Make the seeder for system stacks **a special case of the bundle pipeline** rather than a parallel codepath. `builtin-stack-sync.ts` becomes "load each `server/templates/*/template.json` as a bundle, mark `source: system`, apply via the same controller". This is the single biggest DRY win — system and user bundles converge on one codepath, and any new bundle-level feature (transactional rollback, drift detection, version diffing) lights up for built-in stacks too without duplicate work.
+
+**Open questions.**
+
+- How does the bundle handle the `inputs` re-bind on an upgrade? When applying v3 over v2, should we silently reuse the v2 input values (stored encrypted), prompt the user, or require explicit `--input slackBotToken=...` flags? Strawman: stored, reused by default; bundle author can mark an input `rotateOnUpgrade: true` to require a fresh value.
+- What's the audit story for KV writes performed by the bundle? They should appear in the events log with `triggeredBy: bundle:slackbot:v3`.
+- Bundle deletion order is policies/AppRoles/KV last, after stacks are torn down. But what about cross-bundle dependencies? Strawman: refuse to delete a bundle if any other bundle's stack uses its outputs (resourceOutputs already model this for stacks).
+
+**Permission scope.** New `bundles:read` and `bundles:write`. The bundle controller internally uses elevated privileges (admin Vault token) so the API key only needs `bundles:write`, not the union of all the underlying scopes. This is the same pattern as `stacks:write` already implying "I can ask the server to do Docker things".
+
+### B. Expand the template substitution context — let `{{stack.id}}`, `{{stack.name}}`, `{{env.X}}` resolve
+
+**Size: S. Wiring only.**
+
+**Problem.** Templates need the stack's database CUID inside an env var so the running app can call `POST /api/stacks/:stackId/pools/...`. Today the slackbot template declares an empty-default `mini-infra-stack-id` parameter and the installer does a follow-up PUT to set it after instantiate. Three round-trips for one substitution that mini-infra already knows.
+
+The engine already builds a `stack.{name,projectName}` context. The validation regex blocks anything other than `{{params.*}}` from passing through. So the user-visible feature is missing for a strictly-smaller reason than implementing it would suggest.
+
+**Design sketch.**
+
+1. Widen the regex in [`schemas.ts:11`](../server/src/services/stacks/schemas.ts:11) to allow `{{<namespace>.<key>}}` for an enumerated set of namespaces: `params`, `stack`, `env`, `volumes`, `networks`. Keep the single-token rule (no concatenation) — that's a useful constraint and the engine relies on it.
+2. Extend the engine context at [`template-engine.ts:30`](../server/src/services/stacks/template-engine.ts:30) to include `stack.id` and an `env` object (environment name, type, networkType, id).
+3. Add a bundle-time validator that fails if a template references `{{stack.id}}` but is host-scoped (no environment), or `{{env.id}}` on a host-scoped template, or any reference whose namespace key doesn't exist in the context.
+
+**DRY notes.**
+
+- Reuse the existing `templateStringPattern` regex; just generalize it.
+- The validator runs in the same pre-publish step as today's parameter validation.
+
+**Open questions.**
+
+- Should `stack.id` be available at the **template** level (i.e. before instantiate) or only at **apply** time? Apply time is fine because dynamicEnv resolves at apply, and string interpolation in service definitions is also at apply (post-#238 fix). Template authoring shows `{{stack.id}}` literally; instantiate doesn't need to substitute it.
+- Should we expose `{{vault.addr}}` here, or leave that to the existing `vault-addr` dynamicEnv? Probably leave it — keeping vault references in dynamicEnv keeps the audit/cred path separate from the substitution path.
+
+### C. `vault-kv` dynamicEnv kind — read KV at apply, inject as env
+
+**Size: S. One new resolver branch.**
+
+**Problem.** Most slackbot services need exactly one or two static secrets at boot (slack-gateway wants `secret/shared/slack.bot_token`). Teaching them the wrapped-secret-id flow + AppRole login + KV read just to fetch one value is a lot of code per service. The "one unified policy across all services" workaround in the slackbot installer is partly because every service runs the same Vault client code, so any service that touches Vault needs the union of all read paths.
+
+**Design sketch.**
+
+New dynamicEnv kind:
+
+```yaml
+dynamicEnv:
+  SLACK_BOT_TOKEN:
+    kind: vault-kv
+    path: shared/slack
+    field: bot_token
+```
+
+Resolver: read at apply time using the admin token (mini-infra already has it), substitute the env value, inject into the container. A fresh apply re-reads. A bundle re-apply triggered by a KV update re-reads. No client SDK in the service.
+
+**Trade-off vs. AppRole flow.**
+
+- Apply-time read = secret is **frozen at the apply moment**. Updating KV requires another apply to propagate. This is the right behaviour for boot-time secrets that don't rotate often.
+- Services that need fresher reads, or that enumerate multiple paths, keep using AppRole. The two patterns coexist; bundle authors pick per-service.
+
+**Audit and rotation.**
+
+- Mini-infra logs the read against the admin token in Vault audit, plus an event in the mini-infra events log (`vault:kv-read for service X path Y`).
+- Rotating a value: bump the KV version (Vault KV v2), trigger a stack apply. Could later add a "watch KV path → trigger apply on change" mode, but explicit reconcile-on-apply is fine to start.
+
+**Security notes.**
+
+- Resolver must redact the value from the resolved-definition trace (we already redact secrets in container env logs; check that's covered).
+- Permission scope: a bundle author adding a `vault-kv` env doesn't grant the running container a Vault token at all. The container only sees the resolved value. This is strictly **safer** than the current AppRole flow for static secrets.
+
+**DRY notes.**
+
+- Single new branch in [`vault-credential-injector.ts:50`](../server/src/services/vault/vault-credential-injector.ts:50). Reuse the existing fail-closed degradation logic — if Vault is briefly unreachable on apply, fail the apply (don't run a service with a missing secret).
+
+### D. Per-service AppRole binding — let the resolver consume what the schema already exposes
+
+**Size: S. Resolver change.**
+
+**Problem.** The slackbot uses one unioned `navi-slackbot` policy with read access to all KV paths because mini-infra's resolver only consumes `Stack.vaultAppRoleId` today. The original design wanted per-service policies (manager reads `shared/anthropic`, slack-gateway reads `shared/slack`, worker reads `users/*`) for least-privilege isolation. The installer's policy file even comments this as a deliberate workaround.
+
+The schema **already** has `StackService.vaultAppRoleId` ([`schema.prisma:1198`](../server/prisma/schema.prisma:1198)) and `StackTemplateService.vaultAppRoleId` ([`schema.prisma:1390`](../server/prisma/schema.prisma:1390)). The columns were added in anticipation of this. The injector just needs to prefer the service-level binding when set.
+
+**Design sketch.**
+
+In [`vault-credential-injector.ts:50`](../server/src/services/vault/vault-credential-injector.ts:50): when resolving dynamicEnv for a service, if `service.vaultAppRoleId` is non-null, use that AppRole; otherwise fall back to `stack.vaultAppRoleId`. The fail-closed degraded mode applies per-service in the same way (cached role_id keyed by AppRole, not by stack).
+
+Bundle/template authoring (after A): each `services[].vaultAppRoleRef: <name>` references an AppRole name from the bundle's `vault.appRoles`. Bundle controller resolves the name to an ID at apply time and writes it to `StackTemplateService.vaultAppRoleId`.
+
+**DRY notes.**
+
+- No new schema, no new endpoints. The change is "look one column to the left" inside a single resolver.
+- The cached role_id table needs to key by AppRole ID (which it already does). Verify the cache eviction story handles a stack swapping a service's AppRole binding without leaving stale entries — almost certainly already correct, but worth a test.
+
+**Open questions.**
+
+- Should we still allow Stack-level binding as a default, or require per-service? Strawman: keep stack-level as the fallback (it's still the common case for small stacks), per-service overrides when set.
+
+### E. Brokered Vault KV API — `POST /api/vault/kv` with scoped permission
+
+**Size: S. Thin shim over admin token.**
+
+**Problem.** The installer logs in to Vault as mini-infra-operator to write KV. It works, but it means the installer has to know the **user-facing Vault address** (which is different in worktree mode), needs `vault:read` to even fetch the operator credentials, and gets no audit attribution beyond "mini-infra-operator wrote KV" — we lose the API key identity.
+
+After **A** (bundles), the installer no longer writes KV directly because the bundle declares it. But the brokered route is still useful for:
+- One-off operational writes ("rotate this token without redeploying anything").
+- External tools that don't yet use bundles.
+- Bundle KV writes themselves — the bundle controller calls this internally.
+
+**Design sketch.**
+
+```
+POST   /api/vault/kv     { path, data: { ... } }       # scope: vault:kv-write
+GET    /api/vault/kv/:path                              # scope: vault:kv-read
+DELETE /api/vault/kv/:path                              # scope: vault:kv-write
+PATCH  /api/vault/kv/:path  { data: { ...partial } }   # KV v2 patch
+```
+
+Mini-infra brokers using its admin token. Audit log includes the API key identity that called it.
+
+**Permission additions.** New `vault:kv-read` and `vault:kv-write` scopes, narrower than today's `vault:admin`. Add to the Editor preset (kv-write), Reader preset (kv-read).
+
+**DRY notes.** The KV writer used by the bundle controller (proposal A) is the same module the route handler uses. Single source of truth for KV interactions with Vault.
+
+### F. Streaming/blocking apply — `POST /api/stacks/:id/apply?wait=jsonl`
+
+**Size: S. New route shape, reuse emitter.**
+
+**Problem.** The slackbot installer polls `/status` every 3s for up to 5 minutes. Polling loses fidelity (you don't see "manager pulled image" or "haproxy frontend rebuilt") and burns the 5-minute timeout on slow image pulls. The Socket.IO events are richer but adding a Socket.IO client to a one-shot Node script is heavy.
+
+**Design sketch.**
+
+Two modes via query param:
+
+- `?wait=true` (or `?wait=result`) — server holds the connection and returns the apply result as a single JSON body when reconciliation finishes. Same shape as the final `stack:apply:completed` event.
+- `?wait=jsonl` — server streams JSON-lines, one per Socket.IO event, and closes the connection after `stack:apply:completed`. Same shape as the events on the wire.
+
+Implementation: route handler subscribes to `Channel.STACKS` filtered by stackId, pipes events through res.write(JSON.stringify(...) + '\n'), closes on the completed event.
+
+**DRY notes.** No new emitter, no new event shapes — the Socket.IO event payloads become the JSONL line format. One new helper for "subscribe and pipe to res", which is also useful for any future SSE-style endpoint.
+
+**Open questions.**
+
+- SSE vs. JSONL? SSE has built-in `EventSource` support in browsers, JSONL is easier from curl/Node fetch. Strawman: support both via `Accept` header (`text/event-stream` → SSE, `application/x-ndjson` → JSONL, default to JSON single-body).
+- Long-poll timeout: cap at, say, 15 minutes for the wait-result variant. JSONL has no cap (the connection stays open until completion).
+
+### G. Pool token introspection — `GET /api/stacks/:id/pools/:svc/management-token-meta`
+
+**Size: S.**
+
+**Problem.** The pool token rotates on every recreate of the `managedBy` service. The plaintext only reaches the manager via dynamicEnv. The installer's reachability check can't validate "the manager will be able to talk to the pool API" before applying — it has to apply, then trust.
+
+**Design sketch.**
+
+```
+GET /api/stacks/:stackId/pools/:serviceName/management-token-meta
+  → { rotatedAt, scope, lastUsedAt? }
+```
+
+No plaintext readback (mini-infra holds the only legitimate copy). Just enough metadata to confirm the dynamicEnv resolved and the manager picked it up.
+
+Stretch: `lastUsedAt` requires recording every pool API call's auth-method timestamp. Useful for spotting "the manager hasn't called us in 10 minutes, is it healthy?" but adds a write per request. Skip in v1.
+
+**DRY notes.** Single route, single Prisma read (the existing `StackService.poolManagementTokenHash` row already has the metadata; just don't return the hash).
+
+### H. Image build endpoint — `POST /api/images/build`
+
+**Size: M. Genuinely new.**
+
+**Problem.** Slackbot's installer shells out to `docker build` against `$DOCKER_HOST`. For worktree dev this means the user has to know which colima profile to target. For CI, this means mounting `/var/run/docker.sock` into the runner.
+
+**Design sketch.**
+
+```
+POST /api/images/build
+{
+  source: { kind: 'git', repo: '...', ref: '...' },
+  dockerfile: 'manager/Dockerfile',
+  context: '.',
+  imageName: 'slackbot-manager',
+  tag: 'v3.1.0'
+}
+→ 202 Accepted, returns buildId
+```
+
+Mini-infra clones (or fetches a cached clone), runs BuildKit, pushes to its local registry. Streams progress via Socket.IO on `Channel.IMAGES`. Returns the resolved registry tag (e.g. `localhost:5101/slackbot-manager:v3.1.0`) on completion.
+
+**Trade-off.** This is **genuinely new** (vs. most other proposals which are wiring), and it's lower priority than the others. Most users have docker locally and the build phase is fast. The main payoff is CI environments where mounting docker.sock is awkward, and dev worktrees where colima profile selection is fiddly.
+
+**Skip if.** The bundle (proposal A) accepts a list of pre-built `ghcr.io/...` image references. Bundle authors who already publish to a public registry don't need the build endpoint at all. The "build inside mini-infra" path is for closed-source, locally-built images.
+
+**Open questions.**
+
+- Source kinds: git is obvious; do we also want `tar` (POST a tarball) for "build this directory I have locally"? Strawman: yes, a `multipart/form-data` upload variant.
+- Caching: BuildKit has a cache; is mini-infra responsible for cleaning it? Probably yes, with a configurable retention.
+- Auth for private git: out of scope for v1; require public repos or pre-baked source tarballs.
+
+### I. `@mini-infra/sdk` — generated TypeScript client
+
+**Size: M. Mostly mechanical.**
+
+**Problem.** Every external tool (slackbot, future tools) re-implements the same fetch wrapper, envelope parsing, error typing. Slackbot's [`mini-infra-api.ts`](../../slackbot-agent-sdk/environment/install/mini-infra-api.ts) is 52 lines that mostly re-derive what `@mini-infra/types` could give them.
+
+**Design sketch.**
+
+Publish `@mini-infra/sdk` as an npm package. Two layers:
+
+1. **Envelope + auth wrapper.** A typed `MiniInfraClient` that accepts `{ baseUrl, apiKey }` and exposes `.get<T>(path)`, `.post<T>(path, body)`, etc., with envelope unwrapping and `MiniInfraApiError` typing. ~80 lines.
+2. **Resource clients.** `client.stacks.list()`, `client.stacks.get(id)`, `client.bundles.apply(name)`, etc., generated from existing Zod schemas in `@mini-infra/types`. Use the same generation step we already run for the OpenAPI-style docs (or introduce one — see below).
+
+**DRY notes.**
+
+- The envelope wrapper exists three times today: in the client, in `@mini-infra/types` consumers, and in slackbot's installer. SDK consolidates.
+- Generated resource clients should derive from a single source: route handlers' Zod request/response schemas. We don't have a route schema registry today — adding one is a precondition for codegen and is independently useful (validation, OpenAPI export).
+
+**Skip-or-defer call.** Lower priority than A–E because every consumer can write their own wrapper. But the line count is small and the maintenance benefit compounds across users.
+
+### J. Non-interactive Vault bootstrap — `POST /api/vault/bootstrap` with passphrase in body
+
+**Size: S.**
+
+**Problem.** The installer's reachability check special-cases "Vault not initialised" and bails with "go to the UI". The bootstrap is interactive (operator chooses a passphrase) and not scriptable.
+
+**Design sketch.**
+
+`POST /api/vault/bootstrap` already exists. Today it requires the operator to be at the UI to receive the unseal keys + admin secret_id (one-time-viewable). Make the same endpoint usable from automation by accepting:
+
+```
+POST /api/vault/bootstrap
+{
+  passphrase: '...',
+  acknowledgeOneTimeReadback: true   # caller affirms it will store the response
+}
+→ 200 { unsealKeys: [...], adminRoleId, adminSecretId, operatorPassword }
+```
+
+For orchestrated installs (bundle apply on a fresh mini-infra), the response is captured by the orchestrator. For UI users, the existing flow is unchanged.
+
+**Audit and safety.**
+
+- Single-shot: subsequent calls return 409. No way to re-bootstrap a live Vault.
+- Response is logged in the events stream as "vault bootstrapped" with no plaintext.
+- Strongly recommend pairing with **A** (bundle apply) — the bundle controller can lazily trigger bootstrap if it gets `initialised: false`, prompting the orchestrator for a passphrase exactly once.
+
+---
+
+## 4. Suggested rollout order
+
+The dependencies between proposals form a small graph:
+
+```
+B (template context)  ──┐
+D (per-service AppRole) ─┤
+C (vault-kv dynamicEnv)  ┼──> A (bundles, the real prize)
+E (brokered KV API)     ─┤
+J (non-int bootstrap)   ─┘
+
+F (streaming apply)  ──> independent, useful for any caller, not a bundle prereq
+G (pool token meta)  ──> independent
+I (SDK)              ──> independent, lower priority
+H (image build)      ──> independent, optional / nice-to-have
+```
+
+**Phase 1 — Close the small specific gaps.** B, D, C, E. Each is small, independently shippable, and each removes a specific workaround in the existing slackbot installer. After this phase, the installer is shorter and cleaner but still 8 stages.
+
+**Phase 2 — Bundles.** A. The big composition step that turns the 8-stage orchestrator into a single POST. Lands cleanly because the underlying primitives (B/D/C/E from phase 1) are already in place. **Make `builtin-stack-sync.ts` use the bundle controller** so system and user stacks converge.
+
+**Phase 3 — Operational quality of life.** F (streaming apply), G (pool meta), J (non-interactive bootstrap), I (SDK). Independent, can be done in any order. Drop H (image build) unless a real CI use case shows up.
+
+**Why this order.** A in isolation is awkward — a bundle resource that still has to do per-service workarounds for things like `{{stack.id}}` and per-service policies is a half-feature. Doing the small unlocks first means the bundle resource lands with a clean authoring story. It also de-risks A by spreading the change across multiple smaller commits that each have an obvious test surface.
+
+**Don't bundle these into one PR.** Each of B, D, C, E should be a separate change with its own test. A is itself a multi-PR feature: schema + ingest, then apply controller, then re-platforming `builtin-stack-sync.ts` onto it.
+
+---
+
+## 5. Out of scope / non-goals
+
+A few things adjacent to this work that are intentionally not on the list:
+
+- **A bundle marketplace / public registry.** Once bundles exist, the question of "where do users find them" is real, but it's a UI/distribution problem that should happen after we have at least one external bundle (slackbot) running through the system. Premature.
+- **Replacing `@mini-infra/types` with OpenAPI as the source of truth.** The Zod-first approach works and the client/server already share types. SDK generation can read Zod directly without an OpenAPI hop.
+- **Multi-cluster / multi-host bundles.** Bundles target one mini-infra instance. Cross-host federation is a separate, much larger conversation.
+- **Helm/Kustomize compatibility.** The bundle format is shaped by what mini-infra needs (services, vault, KV) and what its existing template format already supports. It's not trying to be a Kubernetes manifest. A future "import from Helm chart" tool is conceivable but isn't a goal of the bundle work itself.
+- **Encrypting bundle KV inputs at rest in the bundle file.** Sealed-secret style. Useful but outside the v1 scope; for now bundles take secrets via inputs at apply time, and operators provide them through the same channel they provide other API inputs.
+- **Reverting the slackbot installer's manual stages.** Out of scope here, but the obvious follow-up: once A lands and the slackbot publishes a bundle, the installer collapses to ~50 lines that POST one document. That work happens in slackbot-agent-sdk, not here.
+
+---
+
+## 6. Open architectural questions
+
+A few things worth deciding before phase 2:
+
+1. **Bundle name uniqueness scope.** Per-host? Per-environment? Strawman: bundle names are host-global (like template names today). Re-applying with a different scope/environment is an error.
+2. **Bundle and Application abstraction overlap.** Mini-infra has the "Application" concept (UX layer over a stack). Should an installed bundle automatically materialize as an Application? Strawman: yes, if the bundle declares a single user-facing service or a `displayService` field. The Application listing in the UI is then the natural place to see "I have slackbot v3 installed".
+3. **Bundle outputs as inputs to other bundles.** Like resourceOutputs/Inputs on stacks today. Probably yes long-term (the slackbot would consume haproxy's tunnel URL output as an input), but not necessary for v1 — the slackbot consumes it via the existing stack-level mechanism.
+4. **Should the bundle controller be a server-side singleton, or per-bundle workers?** Strawman: singleton with operation-locks per bundle name (mirrors how stack apply locks per stack ID today).

--- a/docs/stack-definition-reference.md
+++ b/docs/stack-definition-reference.md
@@ -295,17 +295,18 @@ Reference note:
 
 Mini Infra resolves templates from a context that includes:
 
+- `stack.id` — the stack's database ID. Available at apply time (after instantiate), not at template publish time. Useful for services that call back into the Mini Infra API and need to identify their own stack — e.g. `MINI_INFRA_STACK_ID: '{{stack.id}}'` in a service `env`.
 - `stack.name` — the stack's logical name.
 - `stack.projectName` — the Docker project prefix. Resolves to `{envName}-{stackName}` for environment-scoped stacks and `mini-infra-{stackName}` for host-level stacks.
+- `environment.id`, `environment.name`, `environment.type`, `environment.networkType` — environment metadata. **Only available for environment-scoped stacks.** Referencing `{{environment.*}}` in a host-scoped template throws "Unresolved template variable" at apply time.
 - `services.<serviceName>.containerName` — the full Docker container name, e.g. `prod-mystack-web`.
 - `services.<serviceName>.image` — the resolved image reference, e.g. `nginx:1.25`.
-- `env.<VAR_NAME>` — static env vars aggregated from `containerConfig.env` across **all services** in definition order. If two services define the same key, the later one wins.
+- `env.<VAR_NAME>` — static container env vars aggregated from `containerConfig.env` across **all services** in definition order. If two services define the same key, the later one wins. Distinct from `environment.*` above, which carries Mini Infra environment metadata.
 - `volumes.<volumeName>` — the actual Docker volume name, `{projectName}_{volumeName}`.
 - `networks.<networkName>` — the actual Docker network name, `{projectName}_{networkName}`.
 - `params.<paramName>` — resolved parameter values.
 
 Important limits:
 
-- For numeric and boolean typed fields that support parameters, the template must be the entire value, for example `{{params.port}}`.
-- Free-form string fields can contain template expressions because service definitions are resolved recursively at apply time.
-- `configFiles[].content` is also template-resolved before being written.
+- For numeric and boolean typed fields that support parameters, the template must be the entire value and must reference `{{params.<name>}}` only. The narrow regex on these fields rejects other namespaces because they would never coerce to a number.
+- Free-form string fields (e.g. `containerConfig.env` values, `command`, `mounts.source`, `configFiles[].content`) can contain template expressions because service definitions are resolved recursively at apply time. Any of the namespaces above can be used here.

--- a/lib/types/permissions.ts
+++ b/lib/types/permissions.ts
@@ -490,7 +490,14 @@ export const PERMISSION_GROUPS: PermissionGroup[] = [
         domain: "vault-kv",
         action: "write",
         label: "Write KV Secrets",
-        description: "Write, patch, and delete values at Vault KV v2 paths via the broker",
+        description: "Write, patch, and soft-delete values at Vault KV v2 paths via the broker (history preserved on delete)",
+      },
+      {
+        scope: "vault-kv:destroy",
+        domain: "vault-kv",
+        action: "write",
+        label: "Permanently Destroy KV Secrets",
+        description: "Wipe all versions and metadata for a KV path (?permanent=true on DELETE). Irrecoverable — kept distinct from vault-kv:write so a 'rotation editor' role can patch but not destroy.",
       },
     ],
   },
@@ -564,7 +571,8 @@ export const PERMISSION_PRESETS: PermissionPreset[] = [
       "events:write",
       // Stacks routinely seed shared KV secrets that their services consume
       // via the vault-kv dynamicEnv resolver. Granting read alongside write
-      // matches the implicit pattern (write→read).
+      // matches the implicit pattern (write→read). Destroy is intentionally
+      // NOT in this preset — wiping all versions of a secret is admin-only.
       "vault-kv:read",
       "vault-kv:write",
     ],

--- a/lib/types/permissions.ts
+++ b/lib/types/permissions.ts
@@ -23,7 +23,10 @@ export type PermissionDomain =
   | "registry"
   | "stacks"
   | "pools"
-  | "vault";
+  | "vault"
+  // Vault KV broker is a sub-domain so write→read implication works without
+  // entangling KV scopes with the broader vault:write (policies/AppRoles).
+  | "vault-kv";
 
 /** Permission actions */
 export type PermissionAction = "read" | "write" | "use";
@@ -470,6 +473,27 @@ export const PERMISSION_GROUPS: PermissionGroup[] = [
       },
     ],
   },
+  {
+    domain: "vault-kv",
+    label: "Vault KV (Secrets)",
+    description: "Brokered Vault KV v2 secret reads and writes via the Mini Infra admin token",
+    permissions: [
+      {
+        scope: "vault-kv:read",
+        domain: "vault-kv",
+        action: "read",
+        label: "Read KV Secrets",
+        description: "Read values from Vault KV v2 paths (broker uses the admin token; caller does not need a Vault token)",
+      },
+      {
+        scope: "vault-kv:write",
+        domain: "vault-kv",
+        action: "write",
+        label: "Write KV Secrets",
+        description: "Write, patch, and delete values at Vault KV v2 paths via the broker",
+      },
+    ],
+  },
 ];
 
 /** All available permission scopes */
@@ -538,6 +562,11 @@ export const PERMISSION_PRESETS: PermissionPreset[] = [
       "stacks:write",
       "events:read",
       "events:write",
+      // Stacks routinely seed shared KV secrets that their services consume
+      // via the vault-kv dynamicEnv resolver. Granting read alongside write
+      // matches the implicit pattern (write→read).
+      "vault-kv:read",
+      "vault-kv:write",
     ],
   },
   {

--- a/lib/types/stacks.ts
+++ b/lib/types/stacks.ts
@@ -46,7 +46,14 @@ export type DynamicEnvSource =
   | { kind: 'vault-addr' }
   | { kind: 'vault-role-id' }
   | { kind: 'vault-wrapped-secret-id'; ttlSeconds?: number }
-  | { kind: 'pool-management-token'; poolService: string };
+  | { kind: 'pool-management-token'; poolService: string }
+  /**
+   * Read a single field from a Vault KV v2 path at apply time using the
+   * Mini Infra admin token. The container receives the value as a plain
+   * env var — no Vault client SDK or AppRole needed by the running app.
+   * Apply re-runs re-read; KV updates do not propagate until the next apply.
+   */
+  | { kind: 'vault-kv'; path: string; field: string };
 
 /**
  * Per-service configuration for a `Pool` service. Pools are container

--- a/lib/types/user-events.ts
+++ b/lib/types/user-events.ts
@@ -26,6 +26,9 @@ export type UserEventType =
   | 'stack_deploy'
   | 'stack_update'
   | 'stack_destroy'
+  | 'vault_kv_write'
+  | 'vault_kv_patch'
+  | 'vault_kv_delete'
   | 'other';
 
 // Event category enumeration

--- a/server/src/__tests__/dynamic-env-source-schema.test.ts
+++ b/server/src/__tests__/dynamic-env-source-schema.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { stackContainerConfigSchema } from '../services/stacks/schemas';
+
+// Roundtrip the dynamicEnv shape through the container-config schema. Using
+// the public schema keeps coverage on the discriminated union plus the
+// envelope (env/dynamicEnv overlap check, etc.).
+function parseDyn(dynamicEnv: Record<string, unknown>) {
+  return stackContainerConfigSchema.safeParse({ dynamicEnv });
+}
+
+describe('dynamicEnvSource — discriminated union', () => {
+  it('accepts vault-addr', () => {
+    expect(parseDyn({ A: { kind: 'vault-addr' } }).success).toBe(true);
+  });
+
+  it('accepts vault-role-id', () => {
+    expect(parseDyn({ A: { kind: 'vault-role-id' } }).success).toBe(true);
+  });
+
+  it('accepts vault-wrapped-secret-id with optional ttlSeconds', () => {
+    expect(parseDyn({ A: { kind: 'vault-wrapped-secret-id' } }).success).toBe(true);
+    expect(parseDyn({ A: { kind: 'vault-wrapped-secret-id', ttlSeconds: 600 } }).success).toBe(true);
+  });
+
+  it('accepts pool-management-token referencing a service name', () => {
+    expect(parseDyn({ A: { kind: 'pool-management-token', poolService: 'worker' } }).success).toBe(true);
+  });
+});
+
+describe('dynamicEnvSource — vault-kv (new in Phase 1)', () => {
+  it('accepts a well-formed vault-kv entry', () => {
+    expect(
+      parseDyn({ SLACK_BOT_TOKEN: { kind: 'vault-kv', path: 'shared/slack', field: 'bot_token' } }).success,
+    ).toBe(true);
+  });
+
+  it('accepts deeply nested paths', () => {
+    expect(
+      parseDyn({ K: { kind: 'vault-kv', path: 'users/alice_42/api-keys', field: 'primary' } }).success,
+    ).toBe(true);
+  });
+
+  it('rejects empty path', () => {
+    expect(parseDyn({ K: { kind: 'vault-kv', path: '', field: 'f' } }).success).toBe(false);
+  });
+
+  it('rejects leading slash', () => {
+    expect(parseDyn({ K: { kind: 'vault-kv', path: '/shared/slack', field: 'f' } }).success).toBe(false);
+  });
+
+  it('rejects trailing slash', () => {
+    expect(parseDyn({ K: { kind: 'vault-kv', path: 'shared/slack/', field: 'f' } }).success).toBe(false);
+  });
+
+  it('rejects path containing ..', () => {
+    expect(parseDyn({ K: { kind: 'vault-kv', path: 'shared/../etc', field: 'f' } }).success).toBe(false);
+  });
+
+  it('rejects path containing //', () => {
+    expect(parseDyn({ K: { kind: 'vault-kv', path: 'shared//slack', field: 'f' } }).success).toBe(false);
+  });
+
+  it('rejects characters outside the allowlist in the path', () => {
+    expect(parseDyn({ K: { kind: 'vault-kv', path: 'shared/sl ack', field: 'f' } }).success).toBe(false);
+    expect(parseDyn({ K: { kind: 'vault-kv', path: 'shared/slack:bot', field: 'f' } }).success).toBe(false);
+  });
+
+  it('rejects empty field name', () => {
+    expect(parseDyn({ K: { kind: 'vault-kv', path: 'shared/slack', field: '' } }).success).toBe(false);
+  });
+
+  it('rejects characters outside the allowlist in the field', () => {
+    expect(parseDyn({ K: { kind: 'vault-kv', path: 'shared/slack', field: 'bot.token' } }).success).toBe(false);
+    expect(parseDyn({ K: { kind: 'vault-kv', path: 'shared/slack', field: 'bot/token' } }).success).toBe(false);
+  });
+
+  it('rejects unknown discriminant', () => {
+    expect(parseDyn({ K: { kind: 'vault-something-else', path: 'x', field: 'y' } }).success).toBe(false);
+  });
+});

--- a/server/src/__tests__/stack-reconciler-apply-stateless.test.ts
+++ b/server/src/__tests__/stack-reconciler-apply-stateless.test.ts
@@ -121,7 +121,14 @@ function computeHashForService(
       dockerTag: s.dockerTag,
       containerConfig: s.containerConfig as StackContainerConfig,
     })),
-    stack.environment.name
+    {
+      environment: {
+        id: 'env-test',
+        name: stack.environment.name,
+        type: 'nonproduction',
+        networkType: 'local',
+      },
+    }
   );
   const resolved = resolveStackConfigFiles(
     (svc.configFiles as StackConfigFile[]) ?? [],

--- a/server/src/__tests__/stack-reconciler-apply.test.ts
+++ b/server/src/__tests__/stack-reconciler-apply.test.ts
@@ -77,7 +77,14 @@ function computeHashForService(
       dockerTag: s.dockerTag,
       containerConfig: s.containerConfig as StackContainerConfig,
     })),
-    stack.environment.name
+    {
+      environment: {
+        id: 'env-test',
+        name: stack.environment.name,
+        type: 'nonproduction',
+        networkType: 'local',
+      },
+    }
   );
   const resolved = resolveStackConfigFiles(
     (svc.configFiles as StackConfigFile[]) ?? [],

--- a/server/src/__tests__/stack-reconciler-plan.test.ts
+++ b/server/src/__tests__/stack-reconciler-plan.test.ts
@@ -73,7 +73,14 @@ function computeHashForService(
       dockerTag: s.dockerTag,
       containerConfig: s.containerConfig as StackContainerConfig,
     })),
-    stack.environment.name
+    {
+      environment: {
+        id: 'env-test',
+        name: stack.environment.name,
+        type: 'nonproduction',
+        networkType: 'local',
+      },
+    }
   );
   const resolved = resolveStackConfigFiles(
     (svc.configFiles as StackConfigFile[]) ?? [],

--- a/server/src/__tests__/stack-template-engine.test.ts
+++ b/server/src/__tests__/stack-template-engine.test.ts
@@ -27,7 +27,10 @@ function makeContext(): TemplateContext {
         containerConfig: {},
       },
     ],
-    'prod'
+    {
+      stackId: 'stk_abc123',
+      environment: { id: 'env_xyz', name: 'prod', type: 'production', networkType: 'internet' },
+    }
   );
 }
 
@@ -80,6 +83,35 @@ describe('resolveTemplate', () => {
 
   it('returns plain string unchanged', () => {
     expect(resolveTemplate('no variables here', ctx)).toBe('no variables here');
+  });
+
+  it('resolves {{stack.id}} when stackId provided', () => {
+    expect(resolveTemplate('id={{stack.id}}', ctx)).toBe('id=stk_abc123');
+  });
+
+  it('resolves {{environment.id}}, {{environment.name}}, {{environment.type}}, {{environment.networkType}}', () => {
+    expect(resolveTemplate('{{environment.id}}', ctx)).toBe('env_xyz');
+    expect(resolveTemplate('{{environment.name}}', ctx)).toBe('prod');
+    expect(resolveTemplate('{{environment.type}}', ctx)).toBe('production');
+    expect(resolveTemplate('{{environment.networkType}}', ctx)).toBe('internet');
+  });
+
+  it('throws when {{stack.id}} is referenced but not provided', () => {
+    const noIdCtx = buildTemplateContext(
+      { name: 'app', networks: [], volumes: [] },
+      [{ serviceName: 'web', dockerImage: 'nginx', dockerTag: 'latest', containerConfig: {} }],
+      {},
+    );
+    expect(() => resolveTemplate('{{stack.id}}', noIdCtx)).toThrow('Unresolved template variable');
+  });
+
+  it('throws when {{environment.*}} is referenced on a host-scoped stack (no environment)', () => {
+    const hostCtx = buildTemplateContext(
+      { name: 'app', networks: [], volumes: [] },
+      [{ serviceName: 'web', dockerImage: 'nginx', dockerTag: 'latest', containerConfig: {} }],
+      {},
+    );
+    expect(() => resolveTemplate('{{environment.name}}', hostCtx)).toThrow('Unresolved template variable');
   });
 });
 

--- a/server/src/__tests__/stack-template-resolve.test.ts
+++ b/server/src/__tests__/stack-template-resolve.test.ts
@@ -9,8 +9,10 @@ function ctx(params: Record<string, string | number | boolean> = {}) {
   return buildTemplateContext(
     { name: 'app', networks: [], volumes: [] },
     [{ serviceName: 'web', dockerImage: 'nginx', dockerTag: 'latest', containerConfig: {} }],
-    'prod',
-    params,
+    {
+      environment: { id: 'env-1', name: 'prod', type: 'production', networkType: 'local' },
+      params,
+    },
   );
 }
 

--- a/server/src/__tests__/template-substitution-validator.test.ts
+++ b/server/src/__tests__/template-substitution-validator.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateTemplateSubstitutions,
+  parameterNamesFromDefinitions,
+} from '../services/stacks/template-substitution-validator';
+
+function make(over: Partial<Parameters<typeof validateTemplateSubstitutions>[0]> = {}) {
+  return {
+    scope: 'environment',
+    parameterNames: new Set<string>(),
+    services: [],
+    configFiles: [],
+    networks: [],
+    volumes: [],
+    resourceInputs: [],
+    resourceOutputs: [],
+    ...over,
+  };
+}
+
+describe('validateTemplateSubstitutions — happy paths', () => {
+  it('accepts a template with no substitutions', () => {
+    const issues = validateTemplateSubstitutions(
+      make({ services: [{ serviceName: 'web', containerConfig: { env: { K: 'literal' } } }] }),
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('accepts {{params.X}} when X is defined', () => {
+    const issues = validateTemplateSubstitutions(
+      make({
+        parameterNames: new Set(['port']),
+        services: [{ serviceName: 'w', containerConfig: { env: { PORT: '{{params.port}}' } } }],
+      }),
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('accepts all stack.* keys', () => {
+    for (const key of ['id', 'name', 'projectName']) {
+      const issues = validateTemplateSubstitutions(
+        make({ services: [{ containerConfig: { env: { K: `{{stack.${key}}}` } } }] }),
+      );
+      expect(issues, `stack.${key} should be allowed`).toEqual([]);
+    }
+  });
+
+  it('accepts all environment.* keys when scope is environment', () => {
+    for (const key of ['id', 'name', 'type', 'networkType']) {
+      const issues = validateTemplateSubstitutions(
+        make({ services: [{ containerConfig: { env: { K: `{{environment.${key}}}` } } }] }),
+      );
+      expect(issues, `environment.${key} should be allowed`).toEqual([]);
+    }
+  });
+
+  it('accepts substitutions inside configFiles content and command arrays', () => {
+    const issues = validateTemplateSubstitutions(
+      make({
+        parameterNames: new Set(['name']),
+        configFiles: [{ content: 'hostname: {{params.name}}' }],
+        services: [{ containerConfig: { command: ['--id', '{{stack.id}}'] } }],
+      }),
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('accepts whitespace inside the braces', () => {
+    const issues = validateTemplateSubstitutions(
+      make({ services: [{ containerConfig: { env: { K: '{{ stack.id }}' } } }] }),
+    );
+    expect(issues).toEqual([]);
+  });
+});
+
+describe('validateTemplateSubstitutions — typo detection', () => {
+  it('rejects {{stak.id}} (typo in namespace)', () => {
+    const issues = validateTemplateSubstitutions(
+      make({ services: [{ containerConfig: { env: { K: '{{stak.id}}' } } }] }),
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/unknown namespace 'stak'/);
+  });
+
+  it('rejects {{stack.idd}} (typo in stack key)', () => {
+    const issues = validateTemplateSubstitutions(
+      make({ services: [{ containerConfig: { env: { K: '{{stack.idd}}' } } }] }),
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/unknown stack key 'idd'/);
+  });
+
+  it('rejects {{environment.foo}} (typo in environment key)', () => {
+    const issues = validateTemplateSubstitutions(
+      make({ services: [{ containerConfig: { env: { K: '{{environment.foo}}' } } }] }),
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/unknown environment key 'foo'/);
+  });
+
+  it('rejects {{params.unknown}} (parameter not defined)', () => {
+    const issues = validateTemplateSubstitutions(
+      make({
+        parameterNames: new Set(['port']),
+        services: [{ containerConfig: { env: { K: '{{params.unknown}}' } } }],
+      }),
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/unknown parameter 'unknown'/);
+    expect(issues[0].message).toMatch(/'port'/); // Lists what IS defined
+  });
+
+  it('rejects {{noNamespace}} (missing namespace)', () => {
+    const issues = validateTemplateSubstitutions(
+      make({ services: [{ containerConfig: { env: { K: '{{noNamespace}}' } } }] }),
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/missing a namespace/);
+  });
+});
+
+describe('validateTemplateSubstitutions — host-scope guard', () => {
+  it('rejects {{environment.*}} on host-scoped templates', () => {
+    const issues = validateTemplateSubstitutions(
+      make({
+        scope: 'host',
+        services: [{ containerConfig: { env: { K: '{{environment.name}}' } } }],
+      }),
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toMatch(/host-scoped/);
+  });
+
+  it('still accepts {{stack.*}} on host-scoped templates', () => {
+    const issues = validateTemplateSubstitutions(
+      make({
+        scope: 'host',
+        services: [{ containerConfig: { env: { K: '{{stack.id}}' } } }],
+      }),
+    );
+    expect(issues).toEqual([]);
+  });
+});
+
+describe('validateTemplateSubstitutions — issue locations', () => {
+  it('reports JSON-pointer-style paths so authors can locate the issue', () => {
+    const issues = validateTemplateSubstitutions(
+      make({
+        services: [
+          { containerConfig: {} },
+          { containerConfig: { env: { SLACK_TOKEN: '{{stak.id}}' } } },
+        ],
+      }),
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].path).toBe('services[1].containerConfig.env.SLACK_TOKEN');
+  });
+
+  it('collects all issues in a single pass (does not bail on first)', () => {
+    const issues = validateTemplateSubstitutions(
+      make({
+        services: [
+          { containerConfig: { env: { A: '{{stak.id}}', B: '{{environment.foo}}' } } },
+        ],
+        configFiles: [{ content: '{{params.unknown}}' }],
+      }),
+    );
+    expect(issues).toHaveLength(3);
+  });
+
+  it('reports multiple substitutions inside a single string separately', () => {
+    const issues = validateTemplateSubstitutions(
+      make({
+        services: [
+          { containerConfig: { env: { K: 'host={{stak.id}} env={{environment.bad}}' } } },
+        ],
+      }),
+    );
+    expect(issues).toHaveLength(2);
+  });
+});
+
+describe('parameterNamesFromDefinitions', () => {
+  it('extracts names from parameter definitions', () => {
+    expect(
+      parameterNamesFromDefinitions([
+        { name: 'a', type: 'string', default: '' },
+        { name: 'b', type: 'number', default: 0 },
+      ]),
+    ).toEqual(new Set(['a', 'b']));
+  });
+
+  it('returns an empty set for undefined input', () => {
+    expect(parameterNamesFromDefinitions(undefined)).toEqual(new Set());
+  });
+});

--- a/server/src/__tests__/vault-binding-resolver.test.ts
+++ b/server/src/__tests__/vault-binding-resolver.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { resolveEffectiveVaultBinding } from '../services/stacks/vault-binding-resolver';
+
+describe('resolveEffectiveVaultBinding', () => {
+  it('uses stack-level binding when service has no override', () => {
+    const result = resolveEffectiveVaultBinding(
+      { vaultAppRoleId: 'stack-ar', lastAppliedVaultAppRoleId: 'stack-ar' },
+      { vaultAppRoleId: null, lastAppliedVaultAppRoleId: null },
+    );
+    expect(result).toEqual({
+      appRoleId: 'stack-ar',
+      prevBoundAppRoleId: 'stack-ar',
+      recordPerService: false,
+    });
+  });
+
+  it('prefers per-service binding when service has its own override', () => {
+    const result = resolveEffectiveVaultBinding(
+      { vaultAppRoleId: 'stack-ar', lastAppliedVaultAppRoleId: 'stack-ar' },
+      { vaultAppRoleId: 'svc-ar', lastAppliedVaultAppRoleId: 'svc-ar' },
+    );
+    expect(result).toEqual({
+      appRoleId: 'svc-ar',
+      prevBoundAppRoleId: 'svc-ar',
+      recordPerService: true,
+    });
+  });
+
+  it('uses per-service prevBound when service has its own binding (compares like-for-like)', () => {
+    // Per-service binding present; stack also has its own lastApplied. The
+    // service's stable-binding check must compare against the per-service
+    // history, not the stack history, otherwise switching the binding from
+    // stack→service (or vice-versa) would mistakenly pass the stable check.
+    const result = resolveEffectiveVaultBinding(
+      { vaultAppRoleId: 'stack-ar', lastAppliedVaultAppRoleId: 'stack-ar-old' },
+      { vaultAppRoleId: 'svc-ar', lastAppliedVaultAppRoleId: 'svc-ar-prev' },
+    );
+    expect(result.prevBoundAppRoleId).toBe('svc-ar-prev');
+  });
+
+  it('returns null appRoleId when neither stack nor service has a binding', () => {
+    const result = resolveEffectiveVaultBinding(
+      { vaultAppRoleId: null, lastAppliedVaultAppRoleId: null },
+      { vaultAppRoleId: null, lastAppliedVaultAppRoleId: null },
+    );
+    expect(result.appRoleId).toBeNull();
+    expect(result.recordPerService).toBe(false);
+  });
+
+  it('per-service binding with no prior apply yields prevBound=null (fresh binding fails closed)', () => {
+    // First-ever apply with a per-service binding: prev is null, so the
+    // injector must fail-closed if Vault is unreachable instead of degrading.
+    const result = resolveEffectiveVaultBinding(
+      { vaultAppRoleId: null, lastAppliedVaultAppRoleId: null },
+      { vaultAppRoleId: 'svc-ar', lastAppliedVaultAppRoleId: null },
+    );
+    expect(result).toEqual({
+      appRoleId: 'svc-ar',
+      prevBoundAppRoleId: null,
+      recordPerService: true,
+    });
+  });
+
+  it('changing per-service binding leaves prevBound at the old value (stable check will fail)', () => {
+    // User swaps the per-service AppRole. lastApplied still holds the OLD
+    // binding. Resolver returns the new binding with prev=old; injector's
+    // stable-binding check (prev !== current) correctly fails closed.
+    const result = resolveEffectiveVaultBinding(
+      { vaultAppRoleId: null, lastAppliedVaultAppRoleId: null },
+      { vaultAppRoleId: 'svc-new', lastAppliedVaultAppRoleId: 'svc-old' },
+    );
+    expect(result.appRoleId).toBe('svc-new');
+    expect(result.prevBoundAppRoleId).toBe('svc-old');
+  });
+});

--- a/server/src/__tests__/vault-kv-routes.test.ts
+++ b/server/src/__tests__/vault-kv-routes.test.ts
@@ -1,0 +1,228 @@
+import supertest from 'supertest';
+import express from 'express';
+
+// ── Mocks (must be hoisted before route import) ─────────
+
+const mockKvService = {
+  read: vi.fn(),
+  readField: vi.fn(),
+  write: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+};
+
+// Mock the heavy service module fully (it transitively imports prisma via
+// vault-services). Re-export the validators + error class from the lighter
+// vault-kv-paths module so the route's parsePath still exercises real
+// validation surface.
+vi.mock('../services/vault/vault-kv-service', async () => {
+  const paths = await vi.importActual<typeof import('../services/vault/vault-kv-paths')>(
+    '../services/vault/vault-kv-paths',
+  );
+  return {
+    KV_MOUNT: paths.KV_MOUNT,
+    VaultKVError: paths.VaultKVError,
+    validateKvPath: paths.validateKvPath,
+    validateKvFieldName: paths.validateKvFieldName,
+    getVaultKVService: () => mockKvService,
+  };
+});
+
+vi.mock('../lib/logger-factory', () => {
+  const mk = (): any => {
+    const l: any = {};
+    for (const fn of ['info', 'error', 'warn', 'debug', 'fatal', 'trace', 'silent']) l[fn] = vi.fn();
+    l.child = vi.fn(() => l);
+    return l;
+  };
+  return {
+    getLogger: vi.fn(() => mk()),
+    createLogger: vi.fn(() => mk()),
+    appLogger: vi.fn(() => mk()),
+    httpLogger: vi.fn(() => mk()),
+    servicesLogger: vi.fn(() => mk()),
+    buildPinoHttpOptions: vi.fn(() => ({ level: 'silent' })),
+  };
+});
+
+// Stub the audit event recorder so we don't need a DB connection.
+vi.mock('../services/user-events/user-event-service', () => {
+  const createEvent = vi.fn().mockResolvedValue({ id: 'evt-1' });
+  return {
+    UserEventService: vi.fn().mockImplementation(() => ({ createEvent })),
+  };
+});
+
+// Auth middleware: pluggable per-request via the keyPermissions module-level
+// variable so each test can simulate different API key scopes. Fully mocked
+// (no importActual) because the real module transitively imports prisma,
+// which would require DATABASE_URL in the unit test environment.
+let mockApiKeyPermissions: string[] | null = ['vault-kv:read', 'vault-kv:write'];
+
+vi.mock('../middleware/auth', () => ({
+  requirePermission: () => (req: any, _res: any, next: any) => {
+    req.apiKey = { id: 'test-key', permissions: mockApiKeyPermissions };
+    req.user = { id: 'test-user' };
+    next();
+  },
+  getAuthenticatedUser: (req: any) => req.user ?? null,
+  requireAuth: (_req: any, _res: any, next: any) => next(),
+  requireAuthorization: () => (_req: any, _res: any, next: any) => next(),
+  requireOwnership: () => (_req: any, _res: any, next: any) => next(),
+  requireSessionOrApiKey: (_req: any, _res: any, next: any) => next(),
+  getCurrentUserId: (req: any) => req.user?.id ?? null,
+  getCurrentUser: (req: any) => req.user ?? null,
+  isAuthenticated: () => true,
+  getAuthMethod: () => 'api-key',
+  createAuthErrorResponse: () => ({ success: false }),
+}));
+
+import kvRouter from '../routes/vault/kv';
+import { VaultKVError } from '../services/vault/vault-kv-service';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/vault/kv', kvRouter);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockApiKeyPermissions = ['vault-kv:read', 'vault-kv:write'];
+});
+
+describe('GET /api/vault/kv/*splat — read', () => {
+  it('returns the stored object when found', async () => {
+    mockKvService.read.mockResolvedValue({ bot_token: 'xoxb-1', app_token: 'xapp-1' });
+    const res = await supertest(buildApp()).get('/api/vault/kv/shared/slack').expect(200);
+    expect(res.body).toEqual({
+      success: true,
+      data: { path: 'shared/slack', data: { bot_token: 'xoxb-1', app_token: 'xapp-1' } },
+    });
+    expect(mockKvService.read).toHaveBeenCalledWith('shared/slack');
+  });
+
+  it('joins multi-segment splat into a slash-delimited path', async () => {
+    mockKvService.read.mockResolvedValue({ k: 'v' });
+    await supertest(buildApp()).get('/api/vault/kv/users/alice/api-keys').expect(200);
+    expect(mockKvService.read).toHaveBeenCalledWith('users/alice/api-keys');
+  });
+
+  it('returns 404 when service returns null (path missing)', async () => {
+    mockKvService.read.mockResolvedValue(null);
+    const res = await supertest(buildApp()).get('/api/vault/kv/shared/none').expect(404);
+    expect(res.body.code).toBe('path_not_found');
+  });
+
+  it('rejects path containing .. anywhere in a segment', async () => {
+    // Express normalises explicit ../ traversals at the URL level, so the
+    // attack surface for the validator is `..` embedded in a segment
+    // (e.g. `sh..are`) that survives URL parsing intact.
+    const res = await supertest(buildApp()).get('/api/vault/kv/sh..are/x').expect(400);
+    expect(res.body.code).toBe('invalid_path');
+    expect(mockKvService.read).not.toHaveBeenCalled();
+  });
+
+  it('rejects forbidden characters in path', async () => {
+    const res = await supertest(buildApp()).get('/api/vault/kv/shared/sl%3Aack').expect(400);
+    expect(res.body.code).toBe('invalid_path');
+  });
+});
+
+describe('POST /api/vault/kv/*splat — write', () => {
+  it('writes the data and returns 200 with the path', async () => {
+    mockKvService.write.mockResolvedValue(undefined);
+    const res = await supertest(buildApp())
+      .post('/api/vault/kv/shared/slack')
+      .send({ data: { bot_token: 'xoxb' } })
+      .expect(200);
+    expect(res.body).toEqual({ success: true, data: { path: 'shared/slack' } });
+    expect(mockKvService.write).toHaveBeenCalledWith('shared/slack', { bot_token: 'xoxb' });
+  });
+
+  it('rejects body without `data` key', async () => {
+    const res = await supertest(buildApp())
+      .post('/api/vault/kv/shared/x')
+      .send({})
+      .expect(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('maps Vault sealed (503) to 503 with vault_sealed code', async () => {
+    mockKvService.write.mockRejectedValue(
+      new VaultKVError("Vault KV write failed for 'x': sealed", 'vault_sealed', 503),
+    );
+    const res = await supertest(buildApp())
+      .post('/api/vault/kv/shared/x')
+      .send({ data: { k: 'v' } })
+      .expect(503);
+    expect(res.body.code).toBe('vault_sealed');
+  });
+
+  it('maps Vault permission denied (403) to 403', async () => {
+    mockKvService.write.mockRejectedValue(
+      new VaultKVError("permission denied", 'vault_permission_denied', 403),
+    );
+    await supertest(buildApp())
+      .post('/api/vault/kv/shared/x')
+      .send({ data: { k: 'v' } })
+      .expect(403);
+  });
+
+  it('maps Vault rate-limited (429) to 429', async () => {
+    mockKvService.write.mockRejectedValue(
+      new VaultKVError("rate limited", 'vault_rate_limited', 429),
+    );
+    await supertest(buildApp())
+      .post('/api/vault/kv/shared/x')
+      .send({ data: { k: 'v' } })
+      .expect(429);
+  });
+});
+
+describe('PATCH /api/vault/kv/*splat — partial update', () => {
+  it('patches the data and returns 200', async () => {
+    mockKvService.patch.mockResolvedValue(undefined);
+    await supertest(buildApp())
+      .patch('/api/vault/kv/shared/slack')
+      .send({ data: { bot_token: 'rotated' } })
+      .expect(200);
+    expect(mockKvService.patch).toHaveBeenCalledWith('shared/slack', { bot_token: 'rotated' });
+  });
+});
+
+describe('DELETE /api/vault/kv/*splat — destroy gate', () => {
+  it('soft-deletes by default (no permanent flag)', async () => {
+    mockKvService.delete.mockResolvedValue(undefined);
+    const res = await supertest(buildApp()).delete('/api/vault/kv/shared/x').expect(200);
+    expect(mockKvService.delete).toHaveBeenCalledWith('shared/x', { permanent: false });
+    expect(res.body.data.permanent).toBe(false);
+  });
+
+  it('rejects ?permanent=true when API key lacks vault-kv:destroy', async () => {
+    mockApiKeyPermissions = ['vault-kv:read', 'vault-kv:write']; // no destroy
+    const res = await supertest(buildApp())
+      .delete('/api/vault/kv/shared/x?permanent=true')
+      .expect(403);
+    expect(res.body.code).toBe('vault_destroy_forbidden');
+    expect(mockKvService.delete).not.toHaveBeenCalled();
+  });
+
+  it('allows ?permanent=true when API key has vault-kv:destroy', async () => {
+    mockApiKeyPermissions = ['vault-kv:read', 'vault-kv:write', 'vault-kv:destroy'];
+    mockKvService.delete.mockResolvedValue(undefined);
+    const res = await supertest(buildApp())
+      .delete('/api/vault/kv/shared/x?permanent=true')
+      .expect(200);
+    expect(mockKvService.delete).toHaveBeenCalledWith('shared/x', { permanent: true });
+    expect(res.body.data.permanent).toBe(true);
+  });
+
+  it('treats permanent=1 the same as permanent=true', async () => {
+    mockApiKeyPermissions = ['vault-kv:read', 'vault-kv:write', 'vault-kv:destroy'];
+    mockKvService.delete.mockResolvedValue(undefined);
+    await supertest(buildApp()).delete('/api/vault/kv/shared/x?permanent=1').expect(200);
+    expect(mockKvService.delete).toHaveBeenCalledWith('shared/x', { permanent: true });
+  });
+});

--- a/server/src/__tests__/vault-kv-service.test.ts
+++ b/server/src/__tests__/vault-kv-service.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateKvPath,
+  validateKvFieldName,
+  VaultKVError,
+  KV_MOUNT,
+} from '../services/vault/vault-kv-paths';
+
+describe('validateKvPath', () => {
+  it('accepts a simple path', () => {
+    expect(validateKvPath('shared/slack')).toBe('shared/slack');
+  });
+
+  it('accepts deeply nested paths with hyphens, underscores, and digits', () => {
+    expect(validateKvPath('users/alice_42-prod/api-keys')).toBe('users/alice_42-prod/api-keys');
+  });
+
+  it('rejects empty strings', () => {
+    expect(() => validateKvPath('')).toThrow(VaultKVError);
+  });
+
+  it('rejects paths starting with /', () => {
+    expect(() => validateKvPath('/shared/slack')).toThrow(/must not start with/);
+  });
+
+  it('rejects paths ending with /', () => {
+    expect(() => validateKvPath('shared/slack/')).toThrow(/must not end with/);
+  });
+
+  it('rejects paths containing ..', () => {
+    expect(() => validateKvPath('shared/../etc/passwd')).toThrow(/must not contain '\.\.'/);
+  });
+
+  it('rejects paths containing //', () => {
+    expect(() => validateKvPath('shared//slack')).toThrow(/must not contain/);
+  });
+
+  it('rejects characters outside the allowlist (no spaces, colons, etc)', () => {
+    expect(() => validateKvPath('shared/slack:bot')).toThrow(/letters, numbers/);
+    expect(() => validateKvPath('shared/sl ack')).toThrow(/letters, numbers/);
+    expect(() => validateKvPath('shared/slack@v1')).toThrow(/letters, numbers/);
+  });
+
+  it('rejects oversize paths', () => {
+    expect(() => validateKvPath('a'.repeat(257))).toThrow(/exceeds 256/);
+  });
+
+  it('attaches code "invalid_path" to the error', () => {
+    try {
+      validateKvPath('/bad');
+    } catch (err) {
+      expect(err).toBeInstanceOf(VaultKVError);
+      expect((err as VaultKVError).code).toBe('invalid_path');
+    }
+  });
+});
+
+describe('validateKvFieldName', () => {
+  it('accepts simple identifiers', () => {
+    expect(validateKvFieldName('bot_token')).toBe('bot_token');
+    expect(validateKvFieldName('apiKey')).toBe('apiKey');
+    expect(validateKvFieldName('value-1')).toBe('value-1');
+  });
+
+  it('rejects empty strings', () => {
+    expect(() => validateKvFieldName('')).toThrow(VaultKVError);
+  });
+
+  it('rejects characters outside the allowlist', () => {
+    expect(() => validateKvFieldName('bot.token')).toThrow(/letters, numbers/);
+    expect(() => validateKvFieldName('bot/token')).toThrow(/letters, numbers/);
+    expect(() => validateKvFieldName('bot token')).toThrow(/letters, numbers/);
+  });
+});
+
+describe('KV_MOUNT', () => {
+  it('is "secret" — the default KV v2 mount Mini Infra bootstraps', () => {
+    // The dynamicEnv resolver, the route broker, and the seed all rely on
+    // this constant. Changing the mount means coordinated changes elsewhere
+    // (operator policy, bootstrap, seed) — flag if it ever drifts.
+    expect(KV_MOUNT).toBe('secret');
+  });
+});

--- a/server/src/app-factory.ts
+++ b/server/src/app-factory.ts
@@ -77,6 +77,7 @@ import devApiKeyRoutes from "./routes/dev-api-key";
 import vaultRoutes from "./routes/vault";
 import vaultPolicyRoutes from "./routes/vault/policies";
 import vaultAppRoleRoutes from "./routes/vault/approles";
+import vaultKvRoutes from "./routes/vault/kv";
 import { listRouteMeta } from "./lib/openapi-registry";
 
 type RouteDefinition = {
@@ -181,6 +182,10 @@ function getRouteDefinitions(): RouteDefinition[] {
     { id: "onboarding", path: "/api/onboarding", name: "onboardingRoutes", getRouter: () => onboardingRoutes },
     { id: "vaultPolicies", path: "/api/vault/policies", name: "vaultPolicyRoutes", getRouter: () => vaultPolicyRoutes },
     { id: "vaultAppRoles", path: "/api/vault/approles", name: "vaultAppRoleRoutes", getRouter: () => vaultAppRoleRoutes },
+    // KV broker — must be mounted BEFORE the catch-all `/api/vault` router
+    // so requests to `/api/vault/kv/...` reach this router instead of the
+    // shared status/bootstrap router.
+    { id: "vaultKv", path: "/api/vault/kv", name: "vaultKvRoutes", getRouter: () => vaultKvRoutes },
     { id: "vault", path: "/api/vault", name: "vaultRoutes", getRouter: () => vaultRoutes },
     // Dev-only: exchange admin credentials for a full-admin API key. Only
     // registered when ENABLE_DEV_API_KEY_ENDPOINT=true — otherwise getRouter

--- a/server/src/routes/vault/kv.ts
+++ b/server/src/routes/vault/kv.ts
@@ -1,0 +1,180 @@
+import express, {
+  Request,
+  Response,
+  NextFunction,
+  RequestHandler,
+} from "express";
+import { z } from "zod";
+import { requirePermission, getAuthenticatedUser } from "../../middleware/auth";
+import { getLogger } from "../../lib/logger-factory";
+import {
+  getVaultKVService,
+  VaultKVError,
+  validateKvPath,
+} from "../../services/vault/vault-kv-service";
+
+const log = getLogger("platform", "vault-kv-routes");
+
+const router = express.Router();
+
+// ── Helpers ─────────────────────────────────────────────
+
+/**
+ * Pull the KV path from the wildcard route parameter and validate it. The
+ * router mounts on `/api/vault/kv` and uses `*splat` (path-to-regexp v8 named
+ * splat) so any number of slash-separated segments are accepted —
+ * `secret/data/shared/slack` is addressed as `GET /api/vault/kv/shared/slack`.
+ *
+ * `req.params.splat` is an array of segments under path-to-regexp v8; join
+ * them back with `/` before handing to the validator.
+ */
+function parsePath(req: Request, res: Response): string | null {
+  const splat = (req.params as Record<string, unknown>).splat;
+  const raw = Array.isArray(splat)
+    ? (splat as string[]).join("/")
+    : typeof splat === "string"
+      ? splat
+      : "";
+  try {
+    return validateKvPath(raw);
+  } catch (err) {
+    if (err instanceof VaultKVError) {
+      res.status(400).json({ success: false, message: err.message, code: err.code });
+    } else {
+      res.status(400).json({ success: false, message: "Invalid KV path" });
+    }
+    return null;
+  }
+}
+
+function handleVaultKvError(res: Response, err: unknown, action: string): void {
+  if (err instanceof VaultKVError) {
+    const status = err.status ?? (err.code === "vault_not_ready" || err.code === "vault_unavailable" ? 503 : 500);
+    log.warn({ err: err.message, code: err.code, action }, "Vault KV operation failed");
+    res.status(status).json({ success: false, message: err.message, code: err.code });
+    return;
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  log.error({ err: msg, action }, "Vault KV operation failed unexpectedly");
+  res.status(500).json({ success: false, message: msg });
+}
+
+const writeBodySchema = z.object({
+  data: z.record(z.string(), z.unknown()),
+});
+
+// ── Routes ──────────────────────────────────────────────
+
+/**
+ * Read the latest version of a KV path. Returns the data envelope as Vault
+ * returned it (object of field → value), or 404 if the path is missing.
+ */
+router.get(
+  "/*splat",
+  requirePermission("vault-kv:read") as RequestHandler,
+  (async (req: Request, res: Response, _next: NextFunction) => {
+    const path = parsePath(req, res);
+    if (path === null) return;
+    try {
+      const data = await getVaultKVService().read(path);
+      if (data === null) {
+        return res.status(404).json({ success: false, message: `KV path '${path}' not found`, code: "path_not_found" });
+      }
+      // Broker-route reads are explicit operator/installer actions (not the
+      // per-apply dynamicEnv resolver path), so log at info for an audit
+      // trail of who pulled which secret. Resolver-path reads remain debug.
+      log.info({ path, userId: getAuthenticatedUser(req)?.id ?? null }, "KV read via broker");
+      res.json({ success: true, data: { path, data } });
+    } catch (err) {
+      handleVaultKvError(res, err, "read");
+    }
+  }) as RequestHandler,
+);
+
+/**
+ * Write (create or replace) a KV path. The body shape matches Vault KV v2:
+ * `{ data: { field1: value1, ... } }`. Returns 200 with the path written.
+ */
+router.post(
+  "/*splat",
+  requirePermission("vault-kv:write") as RequestHandler,
+  (async (req: Request, res: Response, _next: NextFunction) => {
+    const path = parsePath(req, res);
+    if (path === null) return;
+    const parsed = writeBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid body — expected { data: { ... } }",
+        details: parsed.error.issues,
+      });
+    }
+    try {
+      await getVaultKVService().write(path, parsed.data.data);
+      log.info(
+        { path, userId: getAuthenticatedUser(req)?.id ?? null, fields: Object.keys(parsed.data.data) },
+        "KV write",
+      );
+      res.json({ success: true, data: { path } });
+    } catch (err) {
+      handleVaultKvError(res, err, "write");
+    }
+  }) as RequestHandler,
+);
+
+/**
+ * Patch (server-side merge) a KV path. Same body shape as POST. Useful for
+ * rotating one field without replacing the whole document.
+ */
+router.patch(
+  "/*splat",
+  requirePermission("vault-kv:write") as RequestHandler,
+  (async (req: Request, res: Response, _next: NextFunction) => {
+    const path = parsePath(req, res);
+    if (path === null) return;
+    const parsed = writeBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid body — expected { data: { ... } }",
+        details: parsed.error.issues,
+      });
+    }
+    try {
+      await getVaultKVService().patch(path, parsed.data.data);
+      log.info(
+        { path, userId: getAuthenticatedUser(req)?.id ?? null, fields: Object.keys(parsed.data.data) },
+        "KV patch",
+      );
+      res.json({ success: true, data: { path } });
+    } catch (err) {
+      handleVaultKvError(res, err, "patch");
+    }
+  }) as RequestHandler,
+);
+
+/**
+ * Delete a KV path. Soft-delete by default (KV v2 preserves history); pass
+ * `?permanent=true` to wipe all versions and metadata.
+ */
+router.delete(
+  "/*splat",
+  requirePermission("vault-kv:write") as RequestHandler,
+  (async (req: Request, res: Response, _next: NextFunction) => {
+    const path = parsePath(req, res);
+    if (path === null) return;
+    const permanent = req.query.permanent === "true" || req.query.permanent === "1";
+    try {
+      await getVaultKVService().delete(path, { permanent });
+      log.info(
+        { path, permanent, userId: getAuthenticatedUser(req)?.id ?? null },
+        "KV delete",
+      );
+      res.json({ success: true, data: { path, permanent } });
+    } catch (err) {
+      handleVaultKvError(res, err, "delete");
+    }
+  }) as RequestHandler,
+);
+
+export default router;

--- a/server/src/routes/vault/kv.ts
+++ b/server/src/routes/vault/kv.ts
@@ -7,15 +7,51 @@ import express, {
 import { z } from "zod";
 import { requirePermission, getAuthenticatedUser } from "../../middleware/auth";
 import { getLogger } from "../../lib/logger-factory";
+import { hasPermission, type UserEventType } from "@mini-infra/types";
 import {
   getVaultKVService,
   VaultKVError,
   validateKvPath,
 } from "../../services/vault/vault-kv-service";
+import { UserEventService } from "../../services/user-events/user-event-service";
 
 const log = getLogger("platform", "vault-kv-routes");
 
 const router = express.Router();
+
+// Audit-trail writes (queryable in UI; survives log rotation). Keep failures
+// non-fatal — losing the audit row should never break the operation itself.
+async function recordKvAuditEvent(
+  req: Request,
+  eventType: UserEventType,
+  path: string,
+  status: 'completed' | 'failed',
+  metadata: Record<string, unknown>,
+  errorMessage?: string,
+): Promise<void> {
+  try {
+    const user = getAuthenticatedUser(req);
+    const apiKeyId = req.apiKey?.id ?? null;
+    await new UserEventService().createEvent({
+      eventType,
+      eventCategory: 'security',
+      eventName: `KV ${eventType.replace('vault_kv_', '')}: ${path}`,
+      userId: user?.id,
+      triggeredBy: req.apiKey ? 'api' : 'manual',
+      status,
+      progress: status === 'completed' ? 100 : 0,
+      resourceType: 'system',
+      resourceName: `vault-kv:${path}`,
+      description: errorMessage ?? `Brokered Vault KV ${eventType.replace('vault_kv_', '')}`,
+      metadata: { path, apiKeyId, ...metadata },
+    });
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), eventType, path },
+      "Failed to record KV audit event (non-fatal)",
+    );
+  }
+}
 
 // ── Helpers ─────────────────────────────────────────────
 
@@ -47,9 +83,38 @@ function parsePath(req: Request, res: Response): string | null {
   }
 }
 
+/**
+ * Translate a `VaultKVError` code into the HTTP status the broker should
+ * surface. Transient/upstream issues become 5xx so clients retry; client
+ * errors (bad path, bad data) stay 4xx so they don't.
+ */
+function statusForKvErrorCode(code: string, fallback: number | undefined): number {
+  switch (code) {
+    case "invalid_path":
+    case "invalid_field":
+    case "invalid_data":
+      return 400;
+    case "vault_permission_denied":
+      return 403;
+    case "path_not_found":
+    case "field_not_found":
+      return 404;
+    case "vault_rate_limited":
+      return 429;
+    case "vault_not_ready":
+    case "vault_unavailable":
+    case "vault_sealed":
+    case "vault_standby":
+      return 503;
+    case "vault_error":
+    default:
+      return fallback ?? 500;
+  }
+}
+
 function handleVaultKvError(res: Response, err: unknown, action: string): void {
   if (err instanceof VaultKVError) {
-    const status = err.status ?? (err.code === "vault_not_ready" || err.code === "vault_unavailable" ? 503 : 500);
+    const status = statusForKvErrorCode(err.code, err.status);
     log.warn({ err: err.message, code: err.code, action }, "Vault KV operation failed");
     res.status(status).json({ success: false, message: err.message, code: err.code });
     return;
@@ -109,14 +174,18 @@ router.post(
         details: parsed.error.issues,
       });
     }
+    const fields = Object.keys(parsed.data.data);
     try {
       await getVaultKVService().write(path, parsed.data.data);
       log.info(
-        { path, userId: getAuthenticatedUser(req)?.id ?? null, fields: Object.keys(parsed.data.data) },
+        { path, userId: getAuthenticatedUser(req)?.id ?? null, fields },
         "KV write",
       );
+      await recordKvAuditEvent(req, "vault_kv_write", path, "completed", { fields });
       res.json({ success: true, data: { path } });
     } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await recordKvAuditEvent(req, "vault_kv_write", path, "failed", { fields }, msg);
       handleVaultKvError(res, err, "write");
     }
   }) as RequestHandler,
@@ -140,14 +209,18 @@ router.patch(
         details: parsed.error.issues,
       });
     }
+    const fields = Object.keys(parsed.data.data);
     try {
       await getVaultKVService().patch(path, parsed.data.data);
       log.info(
-        { path, userId: getAuthenticatedUser(req)?.id ?? null, fields: Object.keys(parsed.data.data) },
+        { path, userId: getAuthenticatedUser(req)?.id ?? null, fields },
         "KV patch",
       );
+      await recordKvAuditEvent(req, "vault_kv_patch", path, "completed", { fields });
       res.json({ success: true, data: { path } });
     } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await recordKvAuditEvent(req, "vault_kv_patch", path, "failed", { fields }, msg);
       handleVaultKvError(res, err, "patch");
     }
   }) as RequestHandler,
@@ -156,6 +229,11 @@ router.patch(
 /**
  * Delete a KV path. Soft-delete by default (KV v2 preserves history); pass
  * `?permanent=true` to wipe all versions and metadata.
+ *
+ * Permission gate is two-stage: the route requires `vault-kv:write` for any
+ * delete; if `?permanent=true`, the handler additionally checks
+ * `vault-kv:destroy`. Session (UI) users bypass the destroy check because
+ * they always have full access (see `requirePermission` middleware).
  */
 router.delete(
   "/*splat",
@@ -164,14 +242,29 @@ router.delete(
     const path = parsePath(req, res);
     if (path === null) return;
     const permanent = req.query.permanent === "true" || req.query.permanent === "1";
+    if (permanent && req.apiKey && !hasPermission(req.apiKey.permissions, "vault-kv:destroy")) {
+      log.warn(
+        { keyId: req.apiKey.id, path },
+        "API key permission denied for vault-kv:destroy",
+      );
+      return res.status(403).json({
+        success: false,
+        message: "?permanent=true requires the vault-kv:destroy scope",
+        code: "vault_destroy_forbidden",
+        requiredPermissions: ["vault-kv:destroy"],
+      });
+    }
     try {
       await getVaultKVService().delete(path, { permanent });
       log.info(
         { path, permanent, userId: getAuthenticatedUser(req)?.id ?? null },
         "KV delete",
       );
+      await recordKvAuditEvent(req, "vault_kv_delete", path, "completed", { permanent });
       res.json({ success: true, data: { path, permanent } });
     } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await recordKvAuditEvent(req, "vault_kv_delete", path, "failed", { permanent }, msg);
       handleVaultKvError(res, err, "delete");
     }
   }) as RequestHandler,

--- a/server/src/services/stacks/pool-spawner.ts
+++ b/server/src/services/stacks/pool-spawner.ts
@@ -9,6 +9,7 @@ import type {
 import type { DockerExecutorService } from '../docker-executor';
 import { VaultCredentialInjector } from '../vault/vault-credential-injector';
 import { vaultServicesReady } from '../vault/vault-services';
+import { resolveEffectiveVaultBinding } from './vault-binding-resolver';
 import { getLogger } from '../../lib/logger-factory';
 import {
   buildStackTemplateContext,
@@ -131,11 +132,11 @@ export async function spawnPoolInstance(
     ctx.instanceId,
   );
 
-  // Resolve Vault dynamic env (service-level binding overrides stack-level).
-  const effectiveAppRoleId = service.vaultAppRoleId ?? stack.vaultAppRoleId ?? null;
+  // Resolve Vault dynamic env via the shared effective-binding helper —
+  // single source of truth for service-level vs. stack-level fallback.
+  const binding = resolveEffectiveVaultBinding(stack, service);
   let vaultEnv: Record<string, string> = {};
   if (
-    effectiveAppRoleId &&
     vaultServicesReady() &&
     containerConfig.dynamicEnv &&
     Object.values(containerConfig.dynamicEnv).some((src) => src.kind !== 'pool-management-token')
@@ -144,11 +145,12 @@ export async function spawnPoolInstance(
       const injector = new VaultCredentialInjector(prisma);
       const res = await injector.resolve(
         {
-          appRoleId: effectiveAppRoleId,
+          appRoleId: binding.appRoleId,
           // Freshly-spawned instances never start in degraded mode —
-          // fail loudly if Vault is unreachable.
+          // fail loudly if Vault is unreachable. failClosed=false is fine
+          // because a fresh spawn has nothing to fall back to anyway.
           failClosed: false,
-          prevBoundAppRoleId: null,
+          prevBoundAppRoleId: binding.prevBoundAppRoleId,
           poolTokens: {},
         },
         containerConfig,
@@ -298,7 +300,7 @@ export async function spawnPoolInstance(
   // belt-and-suspenders behaviour for AppRole-bound pool services whose
   // dynamicEnv was working only because pool-spawner attached vault for them.
   const declaredPurposes = new Set(containerConfig.joinResourceNetworks ?? []);
-  if (effectiveAppRoleId && Object.keys(vaultEnv).length > 0) {
+  if (binding.appRoleId && Object.keys(vaultEnv).length > 0) {
     declaredPurposes.add('vault');
   }
   if (declaredPurposes.size > 0) {

--- a/server/src/services/stacks/schemas.ts
+++ b/server/src/services/stacks/schemas.ts
@@ -64,6 +64,20 @@ export const parameterValuesSchema = z.record(
 
 // Sub-schemas for JSON field shapes
 
+// KV path/field shape mirrors VaultKVService validation (vault-kv-service.ts).
+// Kept narrow so the schema rejects malformed entries before they reach the
+// resolver — Vault KV v2 paths don't allow leading '/' or '..', and field
+// names must be simple identifiers because they're injected as env keys'
+// values.
+const kvPathSchema = z
+  .string()
+  .min(1)
+  .max(256)
+  .regex(/^[a-zA-Z0-9_/-]+$/, "vault-kv path may only contain letters, numbers, '_', '-', '/'")
+  .refine((p) => !p.startsWith("/") && !p.endsWith("/") && !p.includes("..") && !p.includes("//"), {
+    message: "vault-kv path must not start/end with '/' or contain '..' or '//'",
+  });
+
 const dynamicEnvSourceSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("vault-addr") }),
   z.object({ kind: z.literal("vault-role-id") }),
@@ -74,6 +88,11 @@ const dynamicEnvSourceSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("pool-management-token"),
     poolService: z.string().min(1).regex(/^[a-zA-Z0-9_-]+$/),
+  }),
+  z.object({
+    kind: z.literal("vault-kv"),
+    path: kvPathSchema,
+    field: z.string().min(1).max(100).regex(/^[a-zA-Z0-9_-]+$/, "vault-kv field may only contain letters, numbers, '_', '-'"),
   }),
 ]);
 

--- a/server/src/services/stacks/stack-reconciler.ts
+++ b/server/src/services/stacks/stack-reconciler.ts
@@ -41,6 +41,7 @@ import { StackServiceHandlers, type ServiceHandlerContext } from './stack-servic
 import { VaultCredentialInjector } from '../vault/vault-credential-injector';
 import { vaultServicesReady } from '../vault/vault-services';
 import { rotatePoolManagementTokens } from './pool-management-token';
+import { resolveEffectiveVaultBinding } from './vault-binding-resolver';
 
 export class StackReconciler {
   private containerManager: StackContainerManager;
@@ -268,7 +269,8 @@ export class StackReconciler {
       // conceptually complete (handled inside prepareServiceContainer) and
       // before any container is created, so wrapped secret_ids have the
       // tightest possible lifetime around container start.
-      const resolvedEnvOverrides = await this.resolveVaultEnv(stack, resolvedDefinitions, poolTokens, log);
+      const { overrides: resolvedEnvOverrides, serviceBindingsToRecord: serviceBindingsToRecordApply } =
+        await this.resolveVaultEnv(stack, stack.services, resolvedDefinitions, poolTokens, log);
 
       for (const action of actions) {
         const actionStart = Date.now();
@@ -345,6 +347,28 @@ export class StackReconciler {
           removedAt: null,
         },
       });
+
+      // 8b. Record per-service AppRole bindings that were just applied so
+      // the next apply's stable-binding check can degrade gracefully when
+      // Vault is briefly unreachable. Only services with their OWN binding
+      // need this; services that fall back to the stack-level binding rely
+      // on the Stack row's lastAppliedVaultAppRoleId above.
+      if (allSucceeded && serviceBindingsToRecordApply.size > 0) {
+        const successfulServiceNames = new Set(
+          serviceResults.filter((r) => r.success).map((r) => r.serviceName),
+        );
+        await Promise.all(
+          Array.from(serviceBindingsToRecordApply, ([serviceName, appRoleId]) => {
+            if (!successfulServiceNames.has(serviceName)) return Promise.resolve();
+            const svcRow = serviceMap.get(serviceName);
+            if (!svcRow) return Promise.resolve();
+            return this.prisma.stackService.update({
+              where: { id: svcRow.id },
+              data: { lastAppliedVaultAppRoleId: appRoleId },
+            });
+          }),
+        );
+      }
 
       // 9. Record deployment history
       await this.prisma.stackDeployment.create({
@@ -496,7 +520,8 @@ export class StackReconciler {
         stackId,
         recreatedCallers,
       );
-      const resolvedEnvOverrides = await this.resolveVaultEnv(stack, resolvedDefinitions, poolTokens, log);
+      const { overrides: resolvedEnvOverrides, serviceBindingsToRecord: serviceBindingsToRecordUpdate } =
+        await this.resolveVaultEnv(stack, stack.services, resolvedDefinitions, poolTokens, log);
 
       for (const action of actions) {
         const svc = serviceMap.get(action.serviceName);
@@ -543,6 +568,23 @@ export class StackReconciler {
         },
       });
 
+      if (allSucceeded && serviceBindingsToRecordUpdate.size > 0) {
+        const successfulServiceNames = new Set(
+          serviceResults.filter((r) => r.success).map((r) => r.serviceName),
+        );
+        await Promise.all(
+          Array.from(serviceBindingsToRecordUpdate, ([serviceName, appRoleId]) => {
+            if (!successfulServiceNames.has(serviceName)) return Promise.resolve();
+            const svcRow = serviceMap.get(serviceName);
+            if (!svcRow) return Promise.resolve();
+            return this.prisma.stackService.update({
+              where: { id: svcRow.id },
+              data: { lastAppliedVaultAppRoleId: appRoleId },
+            });
+          }),
+        );
+      }
+
       await this.prisma.stackDeployment.create({
         data: {
           stackId,
@@ -574,9 +616,17 @@ export class StackReconciler {
 
   /**
    * Resolve dynamic-env values (Vault + pool-management-token) for every
-   * service that declares `dynamicEnv`. Returns per-service env overrides.
+   * service that declares `dynamicEnv`. Returns per-service env overrides
+   * plus a map of services whose per-service AppRole binding succeeded
+   * (so the caller can record `service.lastAppliedVaultAppRoleId` for the
+   * fail-closed stable-binding check on the next apply).
+   *
+   * Effective AppRole per service: `service.vaultAppRoleId ?? stack.vaultAppRoleId`.
+   * Effective `prevBoundAppRoleId` follows the same fallback so the stable-
+   * binding check compares like-for-like.
+   *
    * Services with *only* pool-management-token entries are resolved even
-   * when the stack has no Vault binding. Throws on any per-service Vault
+   * when no AppRole binding is present. Throws on any per-service Vault
    * failure so apply aborts cleanly before touching containers.
    */
   private async resolveVaultEnv(
@@ -585,13 +635,24 @@ export class StackReconciler {
       vaultFailClosed: boolean;
       lastAppliedVaultAppRoleId: string | null;
     },
+    services: Array<{
+      serviceName: string;
+      vaultAppRoleId: string | null;
+      lastAppliedVaultAppRoleId: string | null;
+    }>,
     resolvedDefinitions: Map<string, StackServiceDefinition>,
     poolTokens: Record<string, string>,
     log: Logger,
-  ): Promise<Map<string, Record<string, string>>> {
+  ): Promise<{
+    overrides: Map<string, Record<string, string>>;
+    /** serviceName → effective AppRoleId, populated only for services with their OWN binding. */
+    serviceBindingsToRecord: Map<string, string>;
+  }> {
     const overrides = new Map<string, Record<string, string>>();
-    const vaultBound = Boolean(stack.vaultAppRoleId) && vaultServicesReady();
-    const injector = vaultBound ? new VaultCredentialInjector(this.prisma) : null;
+    const serviceBindingsToRecord = new Map<string, string>();
+    const serviceByName = new Map(services.map((s) => [s.serviceName, s]));
+    const vaultReady = vaultServicesReady();
+    const injector = vaultReady ? new VaultCredentialInjector(this.prisma) : null;
 
     for (const [serviceName, serviceDef] of resolvedDefinitions.entries()) {
       // Pool services never get a container at apply time — skip resolution
@@ -600,16 +661,25 @@ export class StackReconciler {
       const dynamicEnv = serviceDef.containerConfig?.dynamicEnv;
       if (!dynamicEnv) continue;
 
-      const hasVaultEntries = Object.values(dynamicEnv).some(
+      const hasAppRoleEntries = Object.values(dynamicEnv).some(
+        (src) => src.kind === 'vault-role-id' || src.kind === 'vault-wrapped-secret-id',
+      );
+      const hasVaultTouchEntries = Object.values(dynamicEnv).some(
         (src) => src.kind !== 'pool-management-token',
       );
       const hasPoolTokenEntries = Object.values(dynamicEnv).some(
         (src) => src.kind === 'pool-management-token',
       );
 
-      // No Vault binding but service wants a pool-management-token — resolve
-      // those entries directly without touching Vault.
-      if (!vaultBound && hasPoolTokenEntries && !hasVaultEntries) {
+      const svcRow = serviceByName.get(serviceName) ?? {
+        vaultAppRoleId: null,
+        lastAppliedVaultAppRoleId: null,
+      };
+      const binding = resolveEffectiveVaultBinding(stack, svcRow);
+
+      // Pool-token-only entries: resolve inline without invoking Vault. Used
+      // when a stack has Pool services but no other Vault dependencies.
+      if (!hasVaultTouchEntries && hasPoolTokenEntries) {
         const values: Record<string, string> = {};
         for (const [key, src] of Object.entries(dynamicEnv)) {
           if (src.kind === 'pool-management-token') {
@@ -621,20 +691,31 @@ export class StackReconciler {
         continue;
       }
 
-      // Vault binding present — injector handles both vault-* and
-      // pool-management-token kinds (pool tokens flow through `args`).
-      if (!injector || !stack.vaultAppRoleId) continue;
+      // Anything else (vault-addr / vault-role-id / vault-wrapped-secret-id /
+      // vault-kv) goes through the injector. Vault must be ready; AppRole
+      // entries additionally require a binding (the injector enforces this).
+      if (!injector) continue;
+      if (hasAppRoleEntries && !binding.appRoleId) {
+        // Be loud rather than silent — the apply would otherwise leave the
+        // service running without the env vars it asked for.
+        throw new Error(
+          `Service "${serviceName}" declares vault-role-id or vault-wrapped-secret-id but no AppRole is bound on the service or stack`,
+        );
+      }
       try {
         const res = await injector.resolve(
           {
-            appRoleId: stack.vaultAppRoleId,
+            appRoleId: binding.appRoleId,
             failClosed: stack.vaultFailClosed,
-            prevBoundAppRoleId: stack.lastAppliedVaultAppRoleId,
+            prevBoundAppRoleId: binding.prevBoundAppRoleId,
             poolTokens,
           },
           serviceDef.containerConfig,
         );
         if (res) overrides.set(serviceName, res.values);
+        if (binding.recordPerService && binding.appRoleId) {
+          serviceBindingsToRecord.set(serviceName, binding.appRoleId);
+        }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         log.error(
@@ -647,7 +728,7 @@ export class StackReconciler {
         );
       }
     }
-    return overrides;
+    return { overrides, serviceBindingsToRecord };
   }
 
   /**

--- a/server/src/services/stacks/stack-template-service.ts
+++ b/server/src/services/stacks/stack-template-service.ts
@@ -26,6 +26,10 @@ import type {
 import { toServiceCreateInput, serializeStack, mergeParameterValues } from "./utils";
 import { CloudflareService } from "../cloudflare/cloudflare-service";
 import { networkUtils } from "../network-utils";
+import {
+  parameterNamesFromDefinitions,
+  validateTemplateSubstitutions,
+} from "./template-substitution-validator";
 
 // Input shape for upserting system templates from builtin definitions
 export interface UpsertSystemTemplateInput {
@@ -410,6 +414,31 @@ export class StackTemplateService {
     }
     if (template.source === "system") {
       throw new TemplateError("Cannot modify system templates", 403);
+    }
+
+    // Catch substitution typos (e.g. {{stak.id}}, {{environment.foo}}) at
+    // draft-save time so the operator sees them immediately instead of
+    // discovering them at apply when a real deploy is in flight.
+    const issues = validateTemplateSubstitutions({
+      scope: template.scope,
+      parameterNames: parameterNamesFromDefinitions(input.parameters),
+      services: input.services,
+      configFiles: input.configFiles,
+      networks: input.networks,
+      volumes: input.volumes,
+      resourceInputs: input.resourceInputs,
+      resourceOutputs: input.resourceOutputs,
+    });
+    if (issues.length > 0) {
+      const summary = issues
+        .slice(0, 5)
+        .map((i) => `${i.path}: ${i.message}`)
+        .join('; ');
+      const suffix = issues.length > 5 ? ` (+${issues.length - 5} more)` : '';
+      throw new TemplateError(
+        `Template substitution validation failed: ${summary}${suffix}`,
+        400,
+      );
     }
 
     const configFileInputs = input.configFiles ?? [];

--- a/server/src/services/stacks/template-engine.ts
+++ b/server/src/services/stacks/template-engine.ts
@@ -1,4 +1,6 @@
 import {
+  EnvironmentNetworkType,
+  EnvironmentType,
   StackConfigFile,
   StackContainerConfig,
   StackNetwork,
@@ -7,13 +9,43 @@ import {
   StackVolume,
 } from '@mini-infra/types';
 
+export interface TemplateContextStack {
+  id?: string;
+  name: string;
+  projectName: string;
+}
+
+export interface TemplateContextEnvironment {
+  id: string;
+  name: string;
+  type: EnvironmentType;
+  networkType: EnvironmentNetworkType;
+}
+
 export interface TemplateContext {
-  stack: { name: string; projectName: string };
+  stack: TemplateContextStack;
   services: Record<string, { containerName: string; image: string }>;
+  /**
+   * Static container env vars merged across services. Internal to the engine —
+   * not currently reachable via `{{env.*}}` substitution because the schema
+   * regex restricts substitution to the `params|stack|environment` namespaces.
+   */
   env: Record<string, string>;
   volumes: Record<string, string>;
   networks: Record<string, string>;
   params: Record<string, StackParameterValue>;
+  /**
+   * Present only for environment-scoped stacks. Host-scoped templates that
+   * reference `{{environment.*}}` will fail at apply with an "Unresolved
+   * template variable" error from `resolveTemplate`.
+   */
+  environment?: TemplateContextEnvironment;
+}
+
+export interface BuildTemplateContextOptions {
+  stackId?: string;
+  environment?: TemplateContextEnvironment;
+  params?: Record<string, StackParameterValue>;
 }
 
 export function buildTemplateContext(
@@ -24,10 +56,10 @@ export function buildTemplateContext(
     dockerTag: string;
     containerConfig: StackContainerConfig;
   }[],
-  environmentName?: string,
-  params?: Record<string, StackParameterValue>
+  options: BuildTemplateContextOptions = {}
 ): TemplateContext {
-  const projectName = environmentName ? `${environmentName}-${stack.name}` : `mini-infra-${stack.name}`;
+  const { stackId, environment, params } = options;
+  const projectName = environment ? `${environment.name}-${stack.name}` : `mini-infra-${stack.name}`;
 
   const svcMap: Record<string, { containerName: string; image: string }> = {};
   const envMap: Record<string, string> = {};
@@ -52,14 +84,18 @@ export function buildTemplateContext(
     networkMap[n.name] = `${projectName}_${n.name}`;
   }
 
-  return {
-    stack: { name: stack.name, projectName },
+  const ctx: TemplateContext = {
+    stack: { name: stack.name, projectName, ...(stackId !== undefined ? { id: stackId } : {}) },
     services: svcMap,
     env: envMap,
     volumes: volumeMap,
     networks: networkMap,
     params: params ?? {},
   };
+
+  if (environment) ctx.environment = environment;
+
+  return ctx;
 }
 
 export function resolveTemplate(template: string, context: TemplateContext): string {

--- a/server/src/services/stacks/template-substitution-validator.ts
+++ b/server/src/services/stacks/template-substitution-validator.ts
@@ -1,0 +1,159 @@
+/**
+ * Pre-publish validator for `{{...}}` template substitutions.
+ *
+ * Catches authoring typos at publish time instead of letting them surface
+ * as "Unresolved template variable" errors during apply (which can be
+ * minutes after the user clicked publish, with the apply potentially
+ * blocking other work). Also enforces the host-vs-environment scope
+ * invariants: `{{environment.*}}` is meaningless on a host-scoped template.
+ *
+ * Pure — no DB access, no logger. Walks the input tree once, collects every
+ * issue, and returns them all so the user sees one shot of feedback rather
+ * than fixing-and-retrying one error at a time.
+ */
+
+import type { StackParameterDefinition } from '@mini-infra/types';
+
+const ALLOWED_STACK_KEYS = ['id', 'name', 'projectName'] as const;
+const ALLOWED_ENVIRONMENT_KEYS = ['id', 'name', 'type', 'networkType'] as const;
+const SUBSTITUTION_PATTERN = /\{\{\s*([^}]+?)\s*\}\}/g;
+
+export interface TemplateSubstitutionIssue {
+  /** JSON-pointer-style location of the offending value, e.g. `services[2].containerConfig.env.SLACK_TOKEN`. */
+  path: string;
+  /** The raw substitution token, e.g. `{{stak.id}}`. */
+  token: string;
+  /** Why it was rejected. Operator-friendly. */
+  message: string;
+}
+
+export interface ValidateInput {
+  /** Template `scope` — `'host'` blocks `{{environment.*}}` references. */
+  scope: 'host' | 'environment' | 'any' | string;
+  /** Defined parameter names (from the draft) for `{{params.X}}` lookup. */
+  parameterNames: Set<string>;
+  /** All template fields that may contain `{{...}}`. Walks recursively. */
+  services: unknown;
+  configFiles: unknown;
+  networks: unknown;
+  volumes: unknown;
+  resourceInputs: unknown;
+  resourceOutputs: unknown;
+}
+
+export function validateTemplateSubstitutions(input: ValidateInput): TemplateSubstitutionIssue[] {
+  const issues: TemplateSubstitutionIssue[] = [];
+  const ctx = {
+    scope: input.scope,
+    parameterNames: input.parameterNames,
+    issues,
+  };
+  walk(input.services, 'services', ctx);
+  walk(input.configFiles, 'configFiles', ctx);
+  walk(input.networks, 'networks', ctx);
+  walk(input.volumes, 'volumes', ctx);
+  walk(input.resourceInputs, 'resourceInputs', ctx);
+  walk(input.resourceOutputs, 'resourceOutputs', ctx);
+  return issues;
+}
+
+/** Convenience for `(parameters: StackParameterDefinition[]) => Set<string>`. */
+export function parameterNamesFromDefinitions(
+  parameters: StackParameterDefinition[] | undefined,
+): Set<string> {
+  return new Set((parameters ?? []).map((p) => p.name));
+}
+
+interface WalkContext {
+  scope: string;
+  parameterNames: Set<string>;
+  issues: TemplateSubstitutionIssue[];
+}
+
+function walk(node: unknown, path: string, ctx: WalkContext): void {
+  if (typeof node === 'string') {
+    checkString(node, path, ctx);
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (let i = 0; i < node.length; i++) {
+      walk(node[i], `${path}[${i}]`, ctx);
+    }
+    return;
+  }
+  if (node !== null && typeof node === 'object') {
+    for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+      walk(v, path ? `${path}.${k}` : k, ctx);
+    }
+  }
+}
+
+function checkString(value: string, path: string, ctx: WalkContext): void {
+  if (!value.includes('{{')) return;
+  // Reset regex state — `g` flag preserves lastIndex between calls.
+  SUBSTITUTION_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = SUBSTITUTION_PATTERN.exec(value)) !== null) {
+    const token = match[0];
+    const inner = match[1].trim();
+    const dot = inner.indexOf('.');
+    if (dot < 0) {
+      ctx.issues.push({
+        path,
+        token,
+        message: `'${token}' is missing a namespace — expected one of params|stack|environment`,
+      });
+      continue;
+    }
+    const namespace = inner.slice(0, dot);
+    const key = inner.slice(dot + 1);
+    switch (namespace) {
+      case 'params':
+        if (!ctx.parameterNames.has(key)) {
+          ctx.issues.push({
+            path,
+            token,
+            message: `'${token}' references unknown parameter '${key}' (defined parameters: ${formatList(ctx.parameterNames)})`,
+          });
+        }
+        break;
+      case 'stack':
+        if (!ALLOWED_STACK_KEYS.includes(key as typeof ALLOWED_STACK_KEYS[number])) {
+          ctx.issues.push({
+            path,
+            token,
+            message: `'${token}' references unknown stack key '${key}' (allowed: ${ALLOWED_STACK_KEYS.join(', ')})`,
+          });
+        }
+        break;
+      case 'environment':
+        if (ctx.scope === 'host') {
+          ctx.issues.push({
+            path,
+            token,
+            message: `'${token}' references the environment namespace, but this template is host-scoped (templates only see environment metadata when scope='environment' or 'any')`,
+          });
+          break;
+        }
+        if (!ALLOWED_ENVIRONMENT_KEYS.includes(key as typeof ALLOWED_ENVIRONMENT_KEYS[number])) {
+          ctx.issues.push({
+            path,
+            token,
+            message: `'${token}' references unknown environment key '${key}' (allowed: ${ALLOWED_ENVIRONMENT_KEYS.join(', ')})`,
+          });
+        }
+        break;
+      default:
+        ctx.issues.push({
+          path,
+          token,
+          message: `'${token}' uses unknown namespace '${namespace}' (allowed: params, stack, environment)`,
+        });
+    }
+  }
+}
+
+function formatList(set: Set<string>): string {
+  if (set.size === 0) return 'none defined';
+  return Array.from(set).map((n) => `'${n}'`).join(', ');
+}

--- a/server/src/services/stacks/utils.ts
+++ b/server/src/services/stacks/utils.ts
@@ -179,6 +179,7 @@ export function mergeParameterValues(
 
 export function buildStackTemplateContext(
   stack: {
+    id?: string;
     name: string;
     networks: unknown;
     volumes: unknown;
@@ -188,7 +189,15 @@ export function buildStackTemplateContext(
       dockerTag: string;
       containerConfig: unknown;
     }>;
-    environment?: { name: string } | null;
+    // Accept Prisma's broader `string` for type/networkType and narrow inside.
+    // The DB schema constrains these via the Environment row; downstream
+    // template substitution treats them as opaque values.
+    environment?: {
+      id: string;
+      name: string;
+      type: string;
+      networkType: string;
+    } | null;
   },
   params?: Record<string, StackParameterValue>
 ) {
@@ -204,8 +213,18 @@ export function buildStackTemplateContext(
       dockerTag: s.dockerTag,
       containerConfig: s.containerConfig as unknown as StackContainerConfig,
     })),
-    stack.environment?.name,
-    params
+    {
+      stackId: stack.id,
+      environment: stack.environment
+        ? {
+            id: stack.environment.id,
+            name: stack.environment.name,
+            type: stack.environment.type as import('@mini-infra/types').EnvironmentType,
+            networkType: stack.environment.networkType as import('@mini-infra/types').EnvironmentNetworkType,
+          }
+        : undefined,
+      params,
+    }
   );
 }
 

--- a/server/src/services/stacks/vault-binding-resolver.ts
+++ b/server/src/services/stacks/vault-binding-resolver.ts
@@ -1,0 +1,36 @@
+/**
+ * Resolve the *effective* Vault AppRole binding for a service.
+ *
+ * A service may carry its own `vaultAppRoleId` override. If it does, that
+ * override wins; otherwise the stack-level binding applies. The fail-closed
+ * stable-binding check on the next apply must compare against the matching
+ * "previous" — per-service vs. stack-level — so this helper returns both.
+ *
+ * Returned `recordPerService` indicates whether the caller should write
+ * `service.lastAppliedVaultAppRoleId` after a successful apply. Stack-level
+ * bindings are tracked on the Stack row instead and never need a per-service
+ * write, even when a service consumes them.
+ */
+export interface EffectiveVaultBinding {
+  appRoleId: string | null;
+  prevBoundAppRoleId: string | null;
+  recordPerService: boolean;
+}
+
+export function resolveEffectiveVaultBinding(
+  stack: { vaultAppRoleId: string | null; lastAppliedVaultAppRoleId: string | null },
+  service: { vaultAppRoleId: string | null; lastAppliedVaultAppRoleId: string | null },
+): EffectiveVaultBinding {
+  if (service.vaultAppRoleId) {
+    return {
+      appRoleId: service.vaultAppRoleId,
+      prevBoundAppRoleId: service.lastAppliedVaultAppRoleId,
+      recordPerService: true,
+    };
+  }
+  return {
+    appRoleId: stack.vaultAppRoleId,
+    prevBoundAppRoleId: stack.lastAppliedVaultAppRoleId,
+    recordPerService: false,
+  };
+}

--- a/server/src/services/vault/vault-admin-service.ts
+++ b/server/src/services/vault/vault-admin-service.ts
@@ -9,6 +9,10 @@ import { emitToChannel } from "../../lib/socket";
 import { Channel, ServerEvent } from "@mini-infra/types";
 import type { OperationStep } from "@mini-infra/types";
 import type { VaultBootstrapResult } from "@mini-infra/types";
+// Single source of truth for the admin policy HCL. Imported by the seeder so
+// the DB row, the bootstrap-time write, and the per-login self-heal all
+// publish the same body — no drift when capabilities are added or removed.
+import { MINI_INFRA_ADMIN_HCL } from "./vault-policy-bodies";
 
 const log = getLogger("platform", "vault-admin-service");
 
@@ -28,25 +32,7 @@ const MINI_INFRA_OPERATOR_POLICY_NAME = "mini-infra-operator";
 const MINI_INFRA_ADMIN_APPROLE_NAME = "mini-infra-admin";
 const MINI_INFRA_OPERATOR_USERPASS_NAME = "mini-infra-operator";
 
-const ADMIN_POLICY_HCL = `# mini-infra-admin — managed by Mini Infra. Do not edit directly.
-# Full administrative access used by Mini Infra's own admin AppRole.
-
-path "sys/*" {
-  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
-}
-
-path "auth/*" {
-  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
-}
-
-path "secret/*" {
-  capabilities = ["create", "read", "update", "delete", "list"]
-}
-
-path "identity/*" {
-  capabilities = ["create", "read", "update", "delete", "list"]
-}
-`;
+const ADMIN_POLICY_HCL = MINI_INFRA_ADMIN_HCL;
 
 const OPERATOR_POLICY_HCL = `# mini-infra-operator — userpass policy for human operator logging into the
 # Vault UI to inspect state and debug. Deliberately NOT admin-equivalent: all
@@ -408,6 +394,21 @@ export class VaultAdminService {
     const secretId = await this.stateService.readAdminSecretId();
     const res = await this.client.appRoleLogin(roleId, secretId);
     this.adoptAuthResponse(res);
+    // Reconcile the admin policy with the source-of-truth HCL on every
+    // successful login. Idempotent overwrite — keeps policy capabilities in
+    // sync with the codebase even after upgrades that add new capabilities
+    // (e.g. KV `patch` for the brokered Vault KV API).
+    try {
+      await this.client.writePolicy(MINI_INFRA_ADMIN_POLICY_NAME, ADMIN_POLICY_HCL);
+    } catch (err) {
+      // Non-fatal — apply will surface a clearer error if the policy is
+      // missing capabilities. We still want the login to succeed so the
+      // operator can investigate via the UI.
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Failed to refresh admin policy on login (non-fatal)",
+      );
+    }
   }
 
   hasAdminToken(): boolean {

--- a/server/src/services/vault/vault-credential-injector.ts
+++ b/server/src/services/vault/vault-credential-injector.ts
@@ -163,6 +163,18 @@ export class VaultCredentialInjector {
     };
   }
 
+  /**
+   * Read each `vault-kv` entry's value via the admin-token broker. The
+   * returned values are merged into the in-memory `resolvedEnvOverrides`
+   * Map and handed to Docker's `createContainer` Env field at apply.
+   *
+   * Never persisted: stack snapshots / diffs use the unresolved template
+   * only, so KV values can't leak to the DB or `lastAppliedSnapshot`. Never
+   * logged: no log site stringifies `containerConfig.env` after merging,
+   * and Docker daemon errors don't echo Env contents. If you add a new log
+   * site that includes `containerConfig`, redact `env` and `dynamicEnv` —
+   * the global pino redact patterns only match known auth-key heuristics.
+   */
   private async resolveKvEntries(
     dynamicEnv: Record<string, DynamicEnvSource>,
   ): Promise<Record<string, string>> {

--- a/server/src/services/vault/vault-credential-injector.ts
+++ b/server/src/services/vault/vault-credential-injector.ts
@@ -2,6 +2,7 @@ import type { PrismaClient } from "../../lib/prisma";
 import type { StackContainerConfig, DynamicEnvSource } from "@mini-infra/types";
 import { getLogger } from "../../lib/logger-factory";
 import { getVaultServices } from "./vault-services";
+import { getVaultKVService, VaultKVError } from "./vault-kv-service";
 
 const log = getLogger("platform", "vault-credential-injector");
 
@@ -12,12 +13,20 @@ const log = getLogger("platform", "vault-credential-injector");
 export const DEFAULT_WRAPPED_SECRET_ID_TTL_SECONDS = 300;
 
 export interface InjectorArgs {
-  appRoleId: string;
+  /**
+   * AppRole ID for entries that need it (`vault-role-id`,
+   * `vault-wrapped-secret-id`). Pass null when the service has no AppRole
+   * binding — `vault-kv`, `vault-addr`, and `pool-management-token` entries
+   * are still resolved. Throws if any entry needs an AppRole and none is
+   * supplied.
+   */
+  appRoleId: string | null;
   failClosed: boolean;
   /**
-   * The AppRole ID bound to this stack on the last successful apply, if any.
-   * If present and equals `appRoleId`, the binding is considered stable and
-   * fail-closed degradation is allowed. If it differs, we always fail-closed.
+   * The AppRole ID bound to this stack/service on the last successful apply,
+   * if any. If present and equals `appRoleId`, the binding is considered
+   * stable and fail-closed degradation is allowed. If it differs, we always
+   * fail-closed.
    */
   prevBoundAppRoleId: string | null;
   /**
@@ -58,13 +67,6 @@ export class VaultCredentialInjector {
     if (!dynamicEnv || Object.keys(dynamicEnv).length === 0) return null;
 
     const services = getVaultServices();
-    const approle = await this.prisma.vaultAppRole.findUnique({
-      where: { id: args.appRoleId },
-    });
-    if (!approle) {
-      throw new Error(`Vault AppRole ${args.appRoleId} not found`);
-    }
-
     const meta = await services.stateService.getMeta();
     const vaultAddress = meta?.address ?? "";
     if (!vaultAddress) {
@@ -77,52 +79,100 @@ export class VaultCredentialInjector {
     const needsRoleId = Object.values(dynamicEnv).some(
       (src) => src.kind === "vault-role-id",
     );
+    const needsAppRole = needsMint || needsRoleId;
+    const needsKv = Object.values(dynamicEnv).some((src) => src.kind === "vault-kv");
 
-    let roleId: string | null = approle.cachedRoleId ?? null;
+    let approle: { id: string; name: string; cachedRoleId: string | null } | null = null;
+    if (needsAppRole) {
+      if (!args.appRoleId) {
+        throw new Error(
+          "dynamicEnv contains vault-role-id or vault-wrapped-secret-id but no AppRole is bound to this service or stack",
+        );
+      }
+      approle = await this.prisma.vaultAppRole.findUnique({
+        where: { id: args.appRoleId },
+      });
+      if (!approle) {
+        throw new Error(`Vault AppRole ${args.appRoleId} not found`);
+      }
+    }
+
+    let roleId: string | null = approle?.cachedRoleId ?? null;
     let wrappedSecretId: string | undefined;
+    let kvValues: Record<string, string> = {};
     const ttlSeconds = pickTtlSeconds(dynamicEnv);
 
     const client = services.admin.getClient();
     if (!client) {
-      return this.degradedOrThrow(args, roleId, vaultAddress, dynamicEnv, approle.cachedRoleId);
+      return this.degradedOrThrow(args, roleId, vaultAddress, dynamicEnv, approle?.cachedRoleId ?? null);
     }
 
     try {
-      if (needsRoleId && !roleId) {
-        roleId = await client.readAppRoleId(approle.name);
-        // Best-effort cache
-        await this.prisma.vaultAppRole.update({
-          where: { id: approle.id },
-          data: { cachedRoleId: roleId },
-        }).catch((err: unknown) => {
-          log.debug(
-            { err: err instanceof Error ? err.message : String(err) },
-            "Failed to cache role_id (non-fatal)",
+      if (approle) {
+        if (needsRoleId && !roleId) {
+          roleId = await client.readAppRoleId(approle.name);
+          // Best-effort cache
+          await this.prisma.vaultAppRole.update({
+            where: { id: approle.id },
+            data: { cachedRoleId: roleId },
+          }).catch((err: unknown) => {
+            log.debug(
+              { err: err instanceof Error ? err.message : String(err) },
+              "Failed to cache role_id (non-fatal)",
+            );
+          });
+        }
+        if (needsMint) {
+          const wrapped = await client.mintWrappedAppRoleSecretId(
+            approle.name,
+            ttlSeconds,
           );
-        });
+          wrappedSecretId = wrapped.wrap_info.token;
+        }
       }
-      if (needsMint) {
-        const wrapped = await client.mintWrappedAppRoleSecretId(
-          approle.name,
-          ttlSeconds,
-        );
-        wrappedSecretId = wrapped.wrap_info.token;
+
+      if (needsKv) {
+        kvValues = await this.resolveKvEntries(dynamicEnv);
       }
     } catch (err) {
+      // KV failures are not eligible for the AppRole stable-binding degrade
+      // (no role_id cache to fall back on), so they bubble up.
+      if (err instanceof VaultKVError) {
+        log.error(
+          { err: err.message, code: err.code },
+          "Vault KV resolution failed",
+        );
+        throw new Error(`Vault KV resolution failed: ${err.message}`, { cause: err });
+      }
       log.warn(
         {
           err: err instanceof Error ? err.message : String(err),
-          approle: approle.name,
+          approle: approle?.name,
         },
         "Vault unreachable while resolving dynamic env",
       );
-      return this.degradedOrThrow(args, roleId, vaultAddress, dynamicEnv, approle.cachedRoleId);
+      return this.degradedOrThrow(args, roleId, vaultAddress, dynamicEnv, approle?.cachedRoleId ?? null);
     }
 
     return {
-      values: buildValues(dynamicEnv, vaultAddress, roleId, wrappedSecretId, args.poolTokens ?? {}),
+      values: {
+        ...buildValues(dynamicEnv, vaultAddress, roleId, wrappedSecretId, args.poolTokens ?? {}),
+        ...kvValues,
+      },
       degraded: false,
     };
+  }
+
+  private async resolveKvEntries(
+    dynamicEnv: Record<string, DynamicEnvSource>,
+  ): Promise<Record<string, string>> {
+    const kvService = getVaultKVService();
+    const out: Record<string, string> = {};
+    for (const [envKey, source] of Object.entries(dynamicEnv)) {
+      if (source.kind !== "vault-kv") continue;
+      out[envKey] = await kvService.readField(source.path, source.field);
+    }
+    return out;
   }
 
   private degradedOrThrow(
@@ -134,6 +184,27 @@ export class VaultCredentialInjector {
   ): InjectorResult {
     const { failClosed, prevBoundAppRoleId, appRoleId } = args;
     const poolTokens = args.poolTokens ?? {};
+    // Vault-kv entries cannot be degraded — there's no cache. If any are
+    // present and we're in this branch (Vault unreachable), apply must fail.
+    const hasKv = Object.values(dynamicEnv).some((s) => s.kind === "vault-kv");
+    if (hasKv) {
+      throw new Error(
+        "Vault is unreachable and dynamicEnv contains vault-kv entries; cannot apply",
+      );
+    }
+    // Services without any AppRole-needing entry (e.g. only vault-addr) can
+    // safely degrade because vaultAddress is read from local state, not from
+    // Vault. The stable-binding guard below only applies when an AppRole is
+    // actually in play.
+    const hasAppRoleEntry = Object.values(dynamicEnv).some(
+      (s) => s.kind === "vault-role-id" || s.kind === "vault-wrapped-secret-id",
+    );
+    if (!hasAppRoleEntry) {
+      return {
+        values: buildValues(dynamicEnv, vaultAddress, roleId, undefined, poolTokens),
+        degraded: true,
+      };
+    }
     if (!failClosed) {
       return {
         values: buildValues(dynamicEnv, vaultAddress, roleId, undefined, poolTokens),
@@ -184,6 +255,11 @@ function buildValues(
         if (token) values[key] = token;
         break;
       }
+      case "vault-kv":
+        // Resolved separately via VaultKVService and merged at the call site.
+        // Skipped here because buildValues only handles entries this function
+        // knows how to fill from its arguments.
+        break;
     }
   }
   return values;

--- a/server/src/services/vault/vault-http-client.ts
+++ b/server/src/services/vault/vault-http-client.ts
@@ -394,6 +394,31 @@ export class VaultHttpClient {
     }
   }
 
+  /**
+   * KV v2 patch — server-side merge against the latest version. Requires the
+   * `update` capability on the data path and `Content-Type: application/merge-patch+json`.
+   */
+  async kvPatch(mount: string, path: string, data: Record<string, unknown>): Promise<void> {
+    await this.request("PATCH", `${mount}/data/${path}`, {
+      body: { data },
+      headers: { "Content-Type": "application/merge-patch+json" },
+    });
+  }
+
+  /**
+   * KV v2 soft-delete — marks the latest version deleted but preserves
+   * history (versions can be undeleted via `undelete`). Use `kvDestroy` for
+   * permanent removal, or `kvDeleteMetadata` to wipe everything.
+   */
+  async kvDelete(mount: string, path: string): Promise<void> {
+    await this.request("DELETE", `${mount}/data/${path}`, { allow404: true });
+  }
+
+  /** KV v2 destroy of all versions and metadata for a path. */
+  async kvDeleteMetadata(mount: string, path: string): Promise<void> {
+    await this.request("DELETE", `${mount}/metadata/${path}`, { allow404: true });
+  }
+
   // ── Circuit breaker ───────────────────────────────────
 
   private isCircuitOpen(): boolean {

--- a/server/src/services/vault/vault-kv-paths.ts
+++ b/server/src/services/vault/vault-kv-paths.ts
@@ -1,0 +1,64 @@
+/**
+ * Pure path/field validators for Vault KV v2. Kept in their own module
+ * (no logger, no prisma, no Vault client imports) so they can be exercised
+ * by unit tests without dragging the full Vault wiring in.
+ */
+
+const MAX_KV_PATH_LEN = 256;
+const KV_PATH_PATTERN = /^[a-zA-Z0-9_/-]+$/;
+const KV_FIELD_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+export class VaultKVError extends Error {
+  constructor(message: string, readonly code: string, readonly status?: number) {
+    super(message);
+    this.name = "VaultKVError";
+  }
+}
+
+export function validateKvPath(path: string): string {
+  if (typeof path !== "string" || path.length === 0) {
+    throw new VaultKVError("KV path must be a non-empty string", "invalid_path");
+  }
+  if (path.length > MAX_KV_PATH_LEN) {
+    throw new VaultKVError(`KV path exceeds ${MAX_KV_PATH_LEN} characters`, "invalid_path");
+  }
+  if (path.startsWith("/")) {
+    throw new VaultKVError("KV path must not start with '/'", "invalid_path");
+  }
+  if (path.endsWith("/")) {
+    throw new VaultKVError("KV path must not end with '/'", "invalid_path");
+  }
+  if (path.includes("..")) {
+    throw new VaultKVError("KV path must not contain '..'", "invalid_path");
+  }
+  if (path.includes("//")) {
+    throw new VaultKVError("KV path must not contain '//'", "invalid_path");
+  }
+  if (!KV_PATH_PATTERN.test(path)) {
+    throw new VaultKVError(
+      "KV path may only contain letters, numbers, '_', '-', '/'",
+      "invalid_path",
+    );
+  }
+  return path;
+}
+
+export function validateKvFieldName(field: string): string {
+  if (typeof field !== "string" || field.length === 0) {
+    throw new VaultKVError("KV field name must be a non-empty string", "invalid_field");
+  }
+  if (!KV_FIELD_PATTERN.test(field)) {
+    throw new VaultKVError(
+      "KV field name may only contain letters, numbers, '_', '-'",
+      "invalid_field",
+    );
+  }
+  return field;
+}
+
+/**
+ * The default KV v2 mount Mini Infra writes against. Bootstrap mounts KV v2
+ * at this path; the operator policy, route handlers, and dynamicEnv resolver
+ * all refer to the same mount via this constant.
+ */
+export const KV_MOUNT = "secret";

--- a/server/src/services/vault/vault-kv-service.ts
+++ b/server/src/services/vault/vault-kv-service.ts
@@ -1,0 +1,160 @@
+import { getLogger } from "../../lib/logger-factory";
+import { getVaultServices, vaultServicesReady } from "./vault-services";
+import { VaultHttpError } from "./vault-http-client";
+import {
+  KV_MOUNT,
+  VaultKVError,
+  validateKvPath,
+  validateKvFieldName,
+} from "./vault-kv-paths";
+
+const log = getLogger("platform", "vault-kv-service");
+
+// Re-export so consumers can keep importing from this module without
+// chasing the validators down a side path.
+export { KV_MOUNT, VaultKVError, validateKvPath, validateKvFieldName };
+
+/**
+ * Brokered access to Vault KV v2. Holds the admin client (so callers don't
+ * need their own Vault token) and is the single source of truth shared by
+ * the `/api/vault/kv` routes and the `vault-kv` dynamicEnv resolver branch.
+ *
+ * Uses `getAuthenticatedClient()` (not the cached `getClient()`) so a dropped
+ * admin token after a renewal failure triggers a fresh AppRole login on the
+ * next request, instead of firing an unauthenticated request that Vault
+ * rejects with 403.
+ */
+export class VaultKVService {
+  private async client() {
+    if (!vaultServicesReady()) {
+      throw new VaultKVError("Vault services not initialised", "vault_not_ready");
+    }
+    try {
+      return await getVaultServices().admin.getAuthenticatedClient();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new VaultKVError(
+        `Vault admin client unavailable: ${msg}`,
+        "vault_unavailable",
+      );
+    }
+  }
+
+  async read(path: string): Promise<Record<string, unknown> | null> {
+    validateKvPath(path);
+    try {
+      const c = await this.client();
+      return await c.kvRead(KV_MOUNT, path);
+    } catch (err) {
+      throw wrapVaultError(err, "read", path);
+    }
+  }
+
+  /**
+   * Read a single field from a KV path. Returns the value as a string
+   * (booleans/numbers are JSON-stringified per dynamicEnv expectations).
+   * Throws `VaultKVError(field_not_found)` if the field is missing.
+   */
+  async readField(path: string, field: string): Promise<string> {
+    validateKvPath(path);
+    validateKvFieldName(field);
+    let data: Record<string, unknown> | null;
+    try {
+      const c = await this.client();
+      data = await c.kvRead(KV_MOUNT, path);
+    } catch (err) {
+      throw wrapVaultError(err, "read", path);
+    }
+    if (data == null) {
+      throw new VaultKVError(`KV path '${path}' not found`, "path_not_found", 404);
+    }
+    if (!(field in data)) {
+      throw new VaultKVError(
+        `KV path '${path}' has no field '${field}'`,
+        "field_not_found",
+        404,
+      );
+    }
+    const value = data[field];
+    if (value === null || value === undefined) {
+      throw new VaultKVError(
+        `KV path '${path}' field '${field}' is null/undefined`,
+        "field_not_found",
+        404,
+      );
+    }
+    return typeof value === "string" ? value : JSON.stringify(value);
+  }
+
+  async write(path: string, data: Record<string, unknown>): Promise<void> {
+    validateKvPath(path);
+    if (!data || typeof data !== "object" || Array.isArray(data)) {
+      throw new VaultKVError("KV data must be an object", "invalid_data");
+    }
+    try {
+      const c = await this.client();
+      await c.kvWrite(KV_MOUNT, path, data);
+      log.info({ path }, "KV write succeeded");
+    } catch (err) {
+      throw wrapVaultError(err, "write", path);
+    }
+  }
+
+  /** KV v2 server-side merge against the latest version. */
+  async patch(path: string, data: Record<string, unknown>): Promise<void> {
+    validateKvPath(path);
+    if (!data || typeof data !== "object" || Array.isArray(data)) {
+      throw new VaultKVError("KV data must be an object", "invalid_data");
+    }
+    try {
+      const c = await this.client();
+      await c.kvPatch(KV_MOUNT, path, data);
+      log.info({ path }, "KV patch succeeded");
+    } catch (err) {
+      throw wrapVaultError(err, "patch", path);
+    }
+  }
+
+  /**
+   * Soft-delete the latest version (history preserved). Pass
+   * `permanent: true` to wipe all versions and metadata.
+   */
+  async delete(path: string, opts: { permanent?: boolean } = {}): Promise<void> {
+    validateKvPath(path);
+    try {
+      const c = await this.client();
+      if (opts.permanent) {
+        await c.kvDeleteMetadata(KV_MOUNT, path);
+      } else {
+        await c.kvDelete(KV_MOUNT, path);
+      }
+      log.info({ path, permanent: !!opts.permanent }, "KV delete succeeded");
+    } catch (err) {
+      throw wrapVaultError(err, "delete", path);
+    }
+  }
+}
+
+function wrapVaultError(err: unknown, op: string, path: string): VaultKVError {
+  if (err instanceof VaultKVError) return err;
+  if (err instanceof VaultHttpError) {
+    return new VaultKVError(
+      `Vault KV ${op} failed for '${path}': ${err.message}`,
+      "vault_error",
+      err.status,
+    );
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  return new VaultKVError(`Vault KV ${op} failed for '${path}': ${msg}`, "vault_error");
+}
+
+let kvServiceSingleton: VaultKVService | null = null;
+export function getVaultKVService(): VaultKVService {
+  if (!kvServiceSingleton) kvServiceSingleton = new VaultKVService();
+  return kvServiceSingleton;
+}
+
+/** Test-only reset for the singleton. */
+export function __resetVaultKVServiceForTests(): void {
+  kvServiceSingleton = null;
+}

--- a/server/src/services/vault/vault-kv-service.ts
+++ b/server/src/services/vault/vault-kv-service.ts
@@ -135,17 +135,40 @@ export class VaultKVService {
   }
 }
 
+/**
+ * Map a low-level Vault HTTP error into a structured KV error with a code
+ * the route handler can translate to a meaningful HTTP status. Vault is
+ * sometimes specific (`sealed`, `standby`, `permission denied`) and
+ * sometimes generic — we lean on the response status and the well-known
+ * error strings rather than fragile regex on the body.
+ */
 function wrapVaultError(err: unknown, op: string, path: string): VaultKVError {
   if (err instanceof VaultKVError) return err;
   if (err instanceof VaultHttpError) {
+    const code = classifyVaultHttpError(err);
     return new VaultKVError(
       `Vault KV ${op} failed for '${path}': ${err.message}`,
-      "vault_error",
+      code,
       err.status,
     );
   }
   const msg = err instanceof Error ? err.message : String(err);
   return new VaultKVError(`Vault KV ${op} failed for '${path}': ${msg}`, "vault_error");
+}
+
+function classifyVaultHttpError(err: VaultHttpError): string {
+  // 503 from Vault means sealed or standby — both are transient and the
+  // caller should retry once Mini Infra reconnects.
+  if (err.status === 503) {
+    if (err.errors.some((e) => /sealed/i.test(e))) return "vault_sealed";
+    if (err.errors.some((e) => /standby/i.test(e))) return "vault_standby";
+    return "vault_unavailable";
+  }
+  if (err.status === 429) return "vault_rate_limited";
+  if (err.status === 412) return "vault_standby"; // Vault sends 412 for read-after-write on a standby node
+  if (err.status === 403) return "vault_permission_denied";
+  if (err.status === 0) return "vault_unavailable"; // network-level failure
+  return "vault_error";
 }
 
 let kvServiceSingleton: VaultKVService | null = null;

--- a/server/src/services/vault/vault-policy-bodies.ts
+++ b/server/src/services/vault/vault-policy-bodies.ts
@@ -1,0 +1,27 @@
+/**
+ * Source of truth for system policy HCL bodies. Both the bootstrap path
+ * (`vault-admin-service.ts`) and the DB seed (`vault-seed.ts`) import from
+ * here so updates land in lockstep — adding a capability in one place but
+ * not the other was the bug that surfaced when the brokered Vault KV API
+ * needed `patch`.
+ */
+
+export const MINI_INFRA_ADMIN_HCL = `# mini-infra-admin — managed by Mini Infra. Do not edit directly.
+# Full administrative access used by Mini Infra's own admin AppRole.
+
+path "sys/*" {
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+path "auth/*" {
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+path "secret/*" {
+  capabilities = ["create", "read", "update", "delete", "list", "patch"]
+}
+
+path "identity/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+`;

--- a/server/src/services/vault/vault-seed.ts
+++ b/server/src/services/vault/vault-seed.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from "../../lib/prisma";
 import { getLogger } from "../../lib/logger-factory";
+import { MINI_INFRA_ADMIN_HCL } from "./vault-policy-bodies";
 
 const log = getLogger("platform", "vault-seed");
 
@@ -73,25 +74,8 @@ export async function seedVaultPolicies(prisma: PrismaClient): Promise<void> {
   log.info({ count: policies.length }, "Vault policies seeded");
 }
 
-const MINI_INFRA_ADMIN_HCL = `# mini-infra-admin — managed by Mini Infra.
-# Full administrative access used by Mini Infra's own admin AppRole.
-
-path "sys/*" {
-  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
-}
-
-path "auth/*" {
-  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
-}
-
-path "secret/*" {
-  capabilities = ["create", "read", "update", "delete", "list"]
-}
-
-path "identity/*" {
-  capabilities = ["create", "read", "update", "delete", "list"]
-}
-`;
+// MINI_INFRA_ADMIN_HCL imported from ./vault-policy-bodies — single source of
+// truth shared with vault-admin-service.ts (bootstrap + per-login self-heal).
 
 const MINI_INFRA_OPERATOR_HCL = `# mini-infra-operator — userpass human-operator access.
 # Read-only visibility + secret management + change own password. Keep in sync


### PR DESCRIPTION
## Summary

Phase 1 of the improvements proposed in [docs/stack-bundles-and-installer-improvements.md](docs/stack-bundles-and-installer-improvements.md) — four small unlocks that close specific workarounds the slackbot-agent-sdk installer ships today, plus the design doc itself.

Each unlock builds on a primitive that already exists in mini-infra; the work is mostly wiring + finishing rather than new mechanism. After this lands, Phase 2 (the bundle resource that collapses the 8-stage installer into one POST) has a clean authoring story to plug into.

### What's in the PR

- **B — Template substitution context.** Engine now exposes `{{stack.id}}` and a new `{{environment.{id,name,type,networkType}}}` namespace. The slackbot installer's "set `mini-infra-stack-id` parameter via follow-up PUT after instantiate" workaround is no longer needed.
- **D — Per-service Vault AppRole binding.** New shared helper `resolveEffectiveVaultBinding` is honoured by both the reconciler and the pool spawner — services with their own `vaultAppRoleId` override the stack-level binding, with matching `prevBoundAppRoleId` for the fail-closed stable-binding check. Schema columns existed already; only the resolver consumption was missing.
- **C — `vault-kv` dynamicEnv kind.** New variant on `DynamicEnvSource` that reads a single field from a Vault KV v2 path at apply time using the Mini Infra admin token. Lets services that just need one or two static secrets at boot skip the AppRole + wrapped-secret-id dance entirely.
- **E — Brokered Vault KV API.** New `POST/GET/PATCH/DELETE /api/vault/kv/*splat` gated by new `vault-kv:read`/`vault-kv:write` scopes (separate domain so write→read implication doesn't entangle with `vault:write` for policies/AppRoles). Removes the installer's need to log into Vault directly using mini-infra-operator userpass.

### Cross-cutting changes

- Admin policy gained the `patch` capability (required for `kvPatch`).
- Admin policy HCL extracted to `vault-policy-bodies.ts` as the single source of truth shared by bootstrap and DB seed — no more hand-synchronised duplicates between `vault-admin-service.ts` and `vault-seed.ts`.
- Admin policy is now self-healed on every login so capability additions propagate to existing bootstrapped Vaults without requiring a manual republish.
- VaultKVService uses `getAuthenticatedClient` so a dropped admin token after a renewal failure triggers re-login instead of firing an unauthenticated request.
- `pool-spawner.ts` migrated to use the same `resolveEffectiveVaultBinding` helper as the reconciler — no two implementations of the same rule.

### Verification

- `pnpm build:all` clean.
- `pnpm --filter mini-infra-server lint` clean.
- 35 new unit tests across template engine, binding resolver, KV path validators, and DynamicEnv schema — all pass alongside the existing 1000+ unit tests.
- 13 baseline test failures pre-existing on main (unrelated `DATABASE_URL` not set in unit setup; every stacktrace ends in `prisma.ts:38`).

### What was reviewed and addressed

A separate review subagent flagged 2 high-impact bugs and 5 quality concerns; both bugs and 4 of the 5 concerns are fixed in this PR. Deferred (low priority, worth its own follow-up):
- Integration-style route tests for the KV broker (path-traversal edge cases, splat parameter shape under express 5).
- Promote KV writes to `UserEventService` for queryable audit trail (today they're info-level pino lines).
- `vault-kv:destroy` permission split for "rotation editor"-style presets.
- KV value redaction sweep across container-create error paths.
- Vault HTTP status mapping in broker errors (e.g. surface 503 sealed differently from 500 generic).

## Test plan

- [ ] CI: lint + tests + build green.
- [ ] On a worktree dev: `curl -X POST -H "X-API-Key: $KEY" -d '{"data":{"a":"v1"}}' http://localhost:31xx/api/vault/kv/shared/smoketest` returns 200.
- [ ] `curl -X PATCH -H "X-API-Key: $KEY" -d '{"data":{"a":"updated"}}' http://localhost:31xx/api/vault/kv/shared/smoketest` returns 200 (verifies admin policy patch capability).
- [ ] Read returns the merged document.
- [ ] DELETE with `?permanent=true` returns 200; subsequent GET returns 404.
- [ ] `curl http://localhost:31xx/api/vault/kv/shared/anything` without `X-API-Key` returns 401.
- [ ] Apply a stack with a service whose `dynamicEnv` contains a `vault-kv` entry — confirm the env var lands in the running container and the service has no AppRole binding.
- [ ] Apply a stack with one service overriding `vaultAppRoleId` while the stack has its own — confirm the per-service binding wins and `service.lastAppliedVaultAppRoleId` is recorded after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)