### PR TITLE
refactor(stacks,vault): consolidate apply pipeline + unify service facades

### DIFF
--- a/server/src/__tests__/builtin-vault-reconcile.integration.test.ts
+++ b/server/src/__tests__/builtin-vault-reconcile.integration.test.ts
@@ -35,6 +35,7 @@ function makePolicySvc(): PolicyServiceFacade {
     }),
     update: vi.fn().mockImplementation((id: string) => Promise.resolve({ id, displayName: 'updated' })),
     publish: vi.fn().mockImplementation((id: string) => Promise.resolve({ id })),
+    delete: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -48,11 +49,15 @@ function makeAppRoleSvc(): AppRoleServiceFacade {
     }),
     update: vi.fn().mockImplementation((id: string) => Promise.resolve({ id })),
     apply: vi.fn().mockImplementation((id: string) => Promise.resolve({ id })),
+    delete: vi.fn().mockResolvedValue(undefined),
   };
 }
 
 function makeKVSvc(): KVServiceFacade {
-  return { write: vi.fn().mockResolvedValue(undefined) };
+  return {
+    write: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
 }
 
 // ─── DB fixtures ──────────────────────────────────────────────────────────────
@@ -266,12 +271,14 @@ describe('runBuiltinVaultReconcile — core reconcile loop', () => {
       create: vi.fn(),
       update: vi.fn(),
       publish: vi.fn(),
+      delete: vi.fn(),
     };
     const secondAppRoleSvc: AppRoleServiceFacade = {
       getByName: vi.fn().mockResolvedValue({ id: 'ar-1-idem-approle' }),
       create: vi.fn(),
       update: vi.fn(),
       apply: vi.fn().mockResolvedValue({ id: 'ar-1-idem-approle' }),
+      delete: vi.fn(),
     };
     const second = await runStackVaultReconciler(testPrisma, stackId, input, {
       getPolicyService: async () => secondPolicySvc,

--- a/server/src/__tests__/stack-vault-reconciler.integration.test.ts
+++ b/server/src/__tests__/stack-vault-reconciler.integration.test.ts
@@ -125,6 +125,7 @@ function makePolicySvc(opts: { throwOnCreate?: boolean; throwOnPublish?: boolean
     publish: opts.throwOnPublish
       ? vi.fn().mockRejectedValue(new Error('policy publish failed'))
       : vi.fn().mockImplementation((id: string) => Promise.resolve({ id })),
+    delete: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -140,6 +141,7 @@ function makeAppRoleSvc(opts: { throwOnApply?: boolean } = {}): AppRoleServiceFa
     apply: opts.throwOnApply
       ? vi.fn().mockRejectedValue(new Error('approle apply failed'))
       : vi.fn().mockImplementation((id: string) => Promise.resolve({ id })),
+    delete: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -148,6 +150,7 @@ function makeKVSvc(opts: { throwOnWrite?: boolean } = {}): KVServiceFacade {
     write: opts.throwOnWrite
       ? vi.fn().mockRejectedValue(new Error('kv write failed'))
       : vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/server/src/__tests__/stack-vault-reconciler.test.ts
+++ b/server/src/__tests__/stack-vault-reconciler.test.ts
@@ -116,6 +116,7 @@ function makePolicySvc(opts: { existing?: { id: string; displayName: string } | 
     publish: opts.throwOnPublish
       ? vi.fn().mockRejectedValue(new Error('policy publish failed'))
       : vi.fn().mockResolvedValue({ id: existing?.id ?? 'pol-1' }),
+    delete: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -130,6 +131,7 @@ function makeAppRoleSvc(opts: { existing?: { id: string } | null; throwOnCreate?
     apply: opts.throwOnApply
       ? vi.fn().mockRejectedValue(new Error('approle apply failed'))
       : vi.fn().mockResolvedValue({ id: existing?.id ?? 'ar-1' }),
+    delete: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -138,6 +140,7 @@ function makeKVSvc(opts: { throwOnWrite?: boolean } = {}): KVServiceFacade {
     write: opts.throwOnWrite
       ? vi.fn().mockRejectedValue(new Error('kv write failed'))
       : vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/server/src/__tests__/stacks/stack-vault-deleter.integration.test.ts
+++ b/server/src/__tests__/stacks/stack-vault-deleter.integration.test.ts
@@ -71,8 +71,11 @@ function makePolicySvc(opts: {
   return {
     getByName: vi.fn().mockImplementation((name: string) => {
       const id = (opts.existing ?? {})[name];
-      return Promise.resolve(id ? { id } : null);
+      return Promise.resolve(id ? { id, displayName: name } : null);
     }),
+    create: vi.fn().mockResolvedValue({ id: 'pol-unused', displayName: 'unused' }),
+    update: vi.fn().mockResolvedValue({ id: 'pol-unused', displayName: 'unused' }),
+    publish: vi.fn().mockResolvedValue({ id: 'pol-unused' }),
     delete: vi.fn().mockImplementation((id: string) => {
       const shouldFail = (opts.failOn ?? []).includes(id);
       if (shouldFail) return Promise.reject(new Error(`delete failed for ${id}`));
@@ -90,6 +93,9 @@ function makeAppRoleSvc(opts: {
       const id = (opts.existing ?? {})[name];
       return Promise.resolve(id ? { id } : null);
     }),
+    create: vi.fn().mockResolvedValue({ id: 'ar-unused' }),
+    update: vi.fn().mockResolvedValue({ id: 'ar-unused' }),
+    apply: vi.fn().mockResolvedValue({ id: 'ar-unused' }),
     delete: vi.fn().mockImplementation((id: string) => {
       const shouldFail = (opts.failOn ?? []).includes(id);
       if (shouldFail) return Promise.reject(new Error(`delete failed for ${id}`));
@@ -100,6 +106,7 @@ function makeAppRoleSvc(opts: {
 
 function makeKVSvc(opts: { failOn?: string[]; notFound?: string[] } = {}): KVDeleteFacade {
   return {
+    write: vi.fn().mockResolvedValue(undefined),
     delete: vi.fn().mockImplementation((path: string) => {
       if ((opts.notFound ?? []).includes(path)) {
         const err = new Error('404 not found');

--- a/server/src/routes/stacks/stacks-apply-route.ts
+++ b/server/src/routes/stacks/stacks-apply-route.ts
@@ -11,15 +11,8 @@ import { buildStackOperationServices } from '../../services/stacks/stack-operati
 import { stackOperationLock } from '../../services/stacks/operation-lock';
 import { StackUserEvent } from '../../services/stacks/stack-user-event';
 import { findEmptyStackParameters } from '../../services/stacks/parameter-validation';
-import { runStackVaultReconciler } from '../../services/stacks/stack-vault-reconciler';
-import { vaultServicesReady } from '../../services/vault/vault-services';
+import { runStackVaultApplyPhase } from '../../services/stacks/stack-vault-apply-orchestrator';
 import { pruneOrphanedInputValues as doPruneOrphanedInputValues } from '../../services/stacks/orphan-input-pruner';
-import type {
-  TemplateInputDeclaration,
-  TemplateVaultAppRole,
-  TemplateVaultKv,
-  TemplateVaultPolicy,
-} from '@mini-infra/types';
 import {
   emitStackApplyStarted,
   emitStackApplyServiceResult,
@@ -183,9 +176,16 @@ async function runApplyInBackground(args: RunApplyArgs): Promise<void> {
     const totalEmitActions = allStartedActions.length;
 
     try {
-      // Pre-service Vault reconciliation phase — only when the template version
-      // declares a non-empty vault section and Vault services are ready.
-      await runVaultPhaseIfNeeded(stackId, triggeredBy);
+      // Pre-service Vault reconciliation phase — short-circuits when the
+      // template has no vault section. Throws if Vault is required but not
+      // ready, or if the reconciler returns an error result.
+      const vaultPhase = await runStackVaultApplyPhase(prisma, stackId, {
+        triggeredBy,
+        requireVaultReady: true,
+      });
+      if (vaultPhase.status === 'error') {
+        throw new Error(vaultPhase.error ?? 'Vault reconciliation phase failed');
+      }
 
       const result = await reconciler.apply(stackId, {
         ...applyArgs,
@@ -269,112 +269,6 @@ async function runApplyInBackground(args: RunApplyArgs): Promise<void> {
   } finally {
     stackOperationLock.release(stackId);
   }
-}
-
-/**
- * Load the stack's current template version and run the Vault pre-service
- * reconciliation phase if the template has a non-empty vault section.
- *
- * After a successful vault phase, writes `StackService.vaultAppRoleId` for any
- * service whose template-declared `vaultAppRoleRef` resolves to a concrete
- * AppRole ID created by this apply. The snapshot write and service ID writes
- * are committed in a single transaction so a crash between them cannot leave
- * the snapshot recorded while services remain unbound.
- */
-async function runVaultPhaseIfNeeded(
-  stackId: string,
-  triggeredBy: string | undefined,
-): Promise<void> {
-  const stack = await prisma.stack.findUnique({
-    where: { id: stackId },
-    select: {
-      templateId: true,
-      templateVersion: true,
-      services: { select: { id: true, serviceName: true } },
-    },
-  });
-
-  if (!stack?.templateId || stack.templateVersion == null) return;
-
-  const templateVersion = await prisma.stackTemplateVersion.findFirst({
-    where: {
-      templateId: stack.templateId,
-      version: stack.templateVersion,
-    },
-    select: {
-      version: true,
-      inputs: true,
-      vaultPolicies: true,
-      vaultAppRoles: true,
-      vaultKv: true,
-      services: { select: { serviceName: true, vaultAppRoleRef: true } },
-    },
-  });
-
-  if (!templateVersion) return;
-
-  const policies = (templateVersion.vaultPolicies as TemplateVaultPolicy[] | null) ?? [];
-  const appRoles = (templateVersion.vaultAppRoles as TemplateVaultAppRole[] | null) ?? [];
-  const kv = (templateVersion.vaultKv as TemplateVaultKv[] | null) ?? [];
-  const inputs = (templateVersion.inputs as TemplateInputDeclaration[] | null) ?? [];
-
-  const hasVault = policies.length > 0 || appRoles.length > 0 || kv.length > 0;
-  if (!hasVault) return;
-
-  if (!vaultServicesReady()) {
-    throw new Error('Vault services are not initialised; cannot run vault reconciliation phase');
-  }
-
-  const vaultResult = await runStackVaultReconciler(prisma, stackId, {
-    stackId,
-    templateVersion: templateVersion.version,
-    inputs,
-    vault: { policies, appRoles, kv },
-    userId: triggeredBy,
-  });
-
-  if (vaultResult.status === 'error') {
-    throw new Error(vaultResult.error ?? 'Vault reconciliation phase failed');
-  }
-
-  // On noop the snapshot is already in the DB — nothing to write.
-  if (vaultResult.status === 'noop' || !vaultResult.encryptedSnapshot) return;
-
-  // Build a map from serviceName → vaultAppRoleRef using the template version's
-  // service definitions. `StackService` rows do not carry vaultAppRoleRef (that
-  // field lives only on StackTemplateServiceDefinition).
-  const templateRefByServiceName = new Map<string, string>(
-    templateVersion.services
-      .filter((s) => s.vaultAppRoleRef != null)
-      .map((s) => [s.serviceName, s.vaultAppRoleRef as string]),
-  );
-
-  // Pair each running StackService with the concrete AppRole ID resolved during
-  // this apply, then commit both the snapshot update and all service ID writes
-  // in a single transaction so a crash cannot leave them out of sync.
-  const serviceUpdates = (stack.services ?? [])
-    .map((svc) => {
-      const ref = templateRefByServiceName.get(svc.serviceName);
-      const concreteId = ref ? vaultResult.appliedAppRoleIdByName[ref] : undefined;
-      return concreteId ? { id: svc.id, vaultAppRoleId: concreteId } : null;
-    })
-    .filter((u): u is { id: string; vaultAppRoleId: string } => u !== null);
-
-  await prisma.$transaction([
-    prisma.stack.update({
-      where: { id: stackId },
-      data: {
-        lastAppliedVaultSnapshot: vaultResult.encryptedSnapshot,
-        lastFailureReason: null,
-      },
-    }),
-    ...serviceUpdates.map((u) =>
-      prisma.stackService.update({
-        where: { id: u.id },
-        data: { vaultAppRoleId: u.vaultAppRoleId },
-      }),
-    ),
-  ]);
 }
 
 async function maybeRestoreHAProxy(

--- a/server/src/services/stacks/builtin-vault-reconcile.ts
+++ b/server/src/services/stacks/builtin-vault-reconcile.ts
@@ -1,14 +1,8 @@
 import type { PrismaClient } from "../../lib/prisma";
 import { getLogger } from "../../lib/logger-factory";
-import { runStackVaultReconciler } from "./stack-vault-reconciler";
+import { runStackVaultApplyPhase } from "./stack-vault-apply-orchestrator";
 import { vaultServicesReady } from "../vault/vault-services";
 import type { LoadedTemplate } from "./template-file-loader";
-import type {
-  TemplateInputDeclaration,
-  TemplateVaultAppRole,
-  TemplateVaultKv,
-  TemplateVaultPolicy,
-} from "@mini-infra/types";
 
 export const BUNDLES_DRIVE_BUILTIN = process.env.BUNDLES_DRIVE_BUILTIN === "true";
 
@@ -32,25 +26,46 @@ export async function runBuiltinVaultReconcile(
 
   const builtinStacks = await prisma.stack.findMany({
     where: { builtinVersion: { not: null }, status: { not: "removed" } },
-    select: { id: true, name: true, templateId: true, templateVersion: true },
+    select: { id: true, name: true },
   });
 
   for (const stack of builtinStacks) {
     const entry = templateByName.get(stack.name);
     if (!entry) continue;
 
-    const template = entry.template;
-    const vaultSection = template.vault;
-
+    const vaultSection = entry.template.vault;
     const hasVault =
       (vaultSection?.policies?.length ?? 0) > 0 ||
       (vaultSection?.appRoles?.length ?? 0) > 0 ||
       (vaultSection?.kv?.length ?? 0) > 0;
-
     if (!hasVault) continue;
 
     try {
-      await reconcileBuiltinStackVault(prisma, stack.id, stack.name, template, log);
+      const result = await runStackVaultApplyPhase(prisma, stack.id, {
+        triggeredBy: undefined,
+      });
+
+      if (result.status === "error") {
+        log.error(
+          { stackName: stack.name, stackId: stack.id, error: result.error },
+          "Vault reconcile returned error for builtin stack",
+        );
+      } else if (result.status === "applied") {
+        log.info(
+          {
+            stackName: stack.name,
+            stackId: stack.id,
+            appliedAppRoles: result.appRolesMapped,
+            servicesBound: result.servicesBound,
+          },
+          "Builtin vault reconcile applied",
+        );
+      } else {
+        log.debug(
+          { stackName: stack.name, stackId: stack.id, status: result.status },
+          "Builtin vault reconcile no changes",
+        );
+      }
     } catch (err) {
       log.error(
         {
@@ -62,111 +77,4 @@ export async function runBuiltinVaultReconcile(
       );
     }
   }
-}
-
-async function reconcileBuiltinStackVault(
-  prisma: PrismaClient,
-  stackId: string,
-  stackName: string,
-  template: LoadedTemplate,
-  log: ReturnType<typeof getLogger>,
-): Promise<void> {
-  // Use the template version stored on the stack row, falling back to the
-  // disk version. System templates typically keep these in sync.
-  const stackRow = await prisma.stack.findUnique({
-    where: { id: stackId },
-    select: { templateId: true, templateVersion: true, services: { select: { id: true, serviceName: true } } },
-  });
-  if (!stackRow?.templateId || stackRow.templateVersion == null) return;
-
-  // Load vault fields from the persisted template version in the DB so we use
-  // exactly what was upserted, not stale in-memory disk state.
-  const dbTemplateVersion = await prisma.stackTemplateVersion.findFirst({
-    where: { templateId: stackRow.templateId, version: stackRow.templateVersion },
-    select: {
-      version: true,
-      inputs: true,
-      vaultPolicies: true,
-      vaultAppRoles: true,
-      vaultKv: true,
-      services: { select: { serviceName: true, vaultAppRoleRef: true } },
-    },
-  });
-
-  if (!dbTemplateVersion) {
-    log.warn({ stackName, stackId }, "No DB template version found for builtin stack — skipping vault reconcile");
-    return;
-  }
-
-  const policies = (dbTemplateVersion.vaultPolicies as TemplateVaultPolicy[] | null) ?? [];
-  const appRoles = (dbTemplateVersion.vaultAppRoles as TemplateVaultAppRole[] | null) ?? [];
-  const kv = (dbTemplateVersion.vaultKv as TemplateVaultKv[] | null) ?? [];
-  const inputs = (dbTemplateVersion.inputs as TemplateInputDeclaration[] | null) ?? [];
-
-  const hasVault = policies.length > 0 || appRoles.length > 0 || kv.length > 0;
-  if (!hasVault) return;
-
-  log.info({ stackName, stackId, templateVersion: dbTemplateVersion.version }, "Running vault reconcile for builtin stack");
-
-  const result = await runStackVaultReconciler(prisma, stackId, {
-    stackId,
-    templateVersion: dbTemplateVersion.version,
-    inputs,
-    vault: { policies, appRoles, kv },
-    userId: undefined,
-  });
-
-  if (result.status === "error") {
-    log.error(
-      { stackName, stackId, error: result.error },
-      "Vault reconcile returned error for builtin stack",
-    );
-    return;
-  }
-
-  if (result.status === "noop" || !result.encryptedSnapshot) {
-    log.debug({ stackName, stackId }, "Vault reconcile noop — no changes");
-    return;
-  }
-
-  // Commit the snapshot and any service AppRole ID writes atomically.
-  const templateRefByServiceName = new Map<string, string>(
-    dbTemplateVersion.services
-      .filter((s) => s.vaultAppRoleRef != null)
-      .map((s) => [s.serviceName, s.vaultAppRoleRef as string]),
-  );
-
-  const serviceUpdates = (stackRow.services ?? [])
-    .map((svc) => {
-      const ref = templateRefByServiceName.get(svc.serviceName);
-      const concreteId = ref ? result.appliedAppRoleIdByName[ref] : undefined;
-      return concreteId ? { id: svc.id, vaultAppRoleId: concreteId } : null;
-    })
-    .filter((u): u is { id: string; vaultAppRoleId: string } => u !== null);
-
-  await prisma.$transaction([
-    prisma.stack.update({
-      where: { id: stackId },
-      data: {
-        lastAppliedVaultSnapshot: result.encryptedSnapshot,
-        lastFailureReason: null,
-      },
-    }),
-    ...serviceUpdates.map((u) =>
-      prisma.stackService.update({
-        where: { id: u.id },
-        data: { vaultAppRoleId: u.vaultAppRoleId },
-      }),
-    ),
-  ]);
-
-  log.info(
-    {
-      stackName,
-      stackId,
-      appliedAppRoles: Object.keys(result.appliedAppRoleIdByName).length,
-      servicesBound: serviceUpdates.length,
-    },
-    "Builtin vault reconcile applied",
-  );
 }

--- a/server/src/services/stacks/stack-vault-apply-orchestrator.ts
+++ b/server/src/services/stacks/stack-vault-apply-orchestrator.ts
@@ -1,0 +1,172 @@
+/**
+ * Stack apply — Vault phase orchestrator.
+ *
+ * Owns the workflow that wraps `runStackVaultReconciler`:
+ *   1. Loads the stack's current `StackTemplateVersion` (vault sections + inputs
+ *      + service `vaultAppRoleRef` mappings) from the DB.
+ *   2. Short-circuits when the template has no vault section.
+ *   3. Runs the reconciler.
+ *   4. On a successful apply, transactionally commits the new snapshot blob and
+ *      writes `StackService.vaultAppRoleId` for any service whose
+ *      `vaultAppRoleRef` resolved to a concrete AppRole this run.
+ *
+ * Two callers exist — the user-initiated apply route and the boot-time builtin
+ * reconcile loop. Both used to inline this logic; consolidating it here ensures
+ * the same DB shape and the same transaction layout regardless of trigger.
+ */
+
+import type { PrismaClient } from "../../lib/prisma";
+import { vaultServicesReady } from "../vault/vault-services";
+import { runStackVaultReconciler } from "./stack-vault-reconciler";
+import type { VaultServiceLoaders } from "./vault-services-loader";
+import type {
+  TemplateInputDeclaration,
+  TemplateVaultAppRole,
+  TemplateVaultKv,
+  TemplateVaultPolicy,
+} from "@mini-infra/types";
+
+export type VaultApplyPhaseStatus = "applied" | "noop" | "skipped" | "error";
+
+export interface VaultApplyPhaseResult {
+  status: VaultApplyPhaseStatus;
+  /** "applied" only — number of services that got a `vaultAppRoleId` written. */
+  servicesBound?: number;
+  /** "applied" only — count of distinct AppRole names mapped this run. */
+  appRolesMapped?: number;
+  /** "error" only — combined failure reason from the reconciler. */
+  error?: string;
+}
+
+export interface VaultApplyPhaseOptions {
+  /** User who triggered the apply (undefined for system-initiated runs). */
+  triggeredBy: string | undefined;
+  /**
+   * When true, the orchestrator throws if Vault services are not initialised.
+   * The user-initiated apply route uses this — Vault must be ready before a
+   * user-triggered apply touches a vault-bearing template. Boot-time builtin
+   * reconciles set this to false because Vault may legitimately not be ready
+   * yet when the loop runs.
+   */
+  requireVaultReady?: boolean;
+}
+
+/**
+ * Run the Vault phase for one stack apply.
+ *
+ * Returns:
+ *   - `skipped`  — no template, no version, empty vault section, or Vault not
+ *                  ready (when `requireVaultReady` is false).
+ *   - `noop`     — reconciler ran but every resource already matched.
+ *   - `applied`  — reconciler wrote at least one resource; snapshot + bindings
+ *                  committed.
+ *   - `error`    — reconciler failed; rollback (if any) has already run inside
+ *                  the reconciler. The stack row's status/lastFailureReason are
+ *                  set by the reconciler.
+ *
+ * Throws only when `requireVaultReady` is true and Vault is not initialised.
+ */
+export async function runStackVaultApplyPhase(
+  prisma: PrismaClient,
+  stackId: string,
+  opts: VaultApplyPhaseOptions,
+  serviceOverrides?: VaultServiceLoaders,
+): Promise<VaultApplyPhaseResult> {
+  const stack = await prisma.stack.findUnique({
+    where: { id: stackId },
+    select: {
+      templateId: true,
+      templateVersion: true,
+      services: { select: { id: true, serviceName: true } },
+    },
+  });
+
+  if (!stack?.templateId || stack.templateVersion == null) {
+    return { status: "skipped" };
+  }
+
+  const templateVersion = await prisma.stackTemplateVersion.findFirst({
+    where: { templateId: stack.templateId, version: stack.templateVersion },
+    select: {
+      version: true,
+      inputs: true,
+      vaultPolicies: true,
+      vaultAppRoles: true,
+      vaultKv: true,
+      services: { select: { serviceName: true, vaultAppRoleRef: true } },
+    },
+  });
+
+  if (!templateVersion) return { status: "skipped" };
+
+  const policies = (templateVersion.vaultPolicies as TemplateVaultPolicy[] | null) ?? [];
+  const appRoles = (templateVersion.vaultAppRoles as TemplateVaultAppRole[] | null) ?? [];
+  const kv = (templateVersion.vaultKv as TemplateVaultKv[] | null) ?? [];
+  const inputs = (templateVersion.inputs as TemplateInputDeclaration[] | null) ?? [];
+
+  const hasVault = policies.length > 0 || appRoles.length > 0 || kv.length > 0;
+  if (!hasVault) return { status: "skipped" };
+
+  if (!vaultServicesReady()) {
+    if (opts.requireVaultReady) {
+      throw new Error("Vault services are not initialised; cannot run vault reconciliation phase");
+    }
+    return { status: "skipped" };
+  }
+
+  const result = await runStackVaultReconciler(
+    prisma,
+    stackId,
+    {
+      stackId,
+      templateVersion: templateVersion.version,
+      inputs,
+      vault: { policies, appRoles, kv },
+      userId: opts.triggeredBy,
+    },
+    serviceOverrides,
+  );
+
+  if (result.status === "error") {
+    return { status: "error", error: result.error };
+  }
+  if (result.status === "noop" || !result.encryptedSnapshot) {
+    return { status: "noop" };
+  }
+
+  const templateRefByServiceName = new Map<string, string>(
+    templateVersion.services
+      .filter((s) => s.vaultAppRoleRef != null)
+      .map((s) => [s.serviceName, s.vaultAppRoleRef as string]),
+  );
+
+  const serviceUpdates = (stack.services ?? [])
+    .map((svc) => {
+      const ref = templateRefByServiceName.get(svc.serviceName);
+      const concreteId = ref ? result.appliedAppRoleIdByName[ref] : undefined;
+      return concreteId ? { id: svc.id, vaultAppRoleId: concreteId } : null;
+    })
+    .filter((u): u is { id: string; vaultAppRoleId: string } => u !== null);
+
+  await prisma.$transaction([
+    prisma.stack.update({
+      where: { id: stackId },
+      data: {
+        lastAppliedVaultSnapshot: result.encryptedSnapshot,
+        lastFailureReason: null,
+      },
+    }),
+    ...serviceUpdates.map((u) =>
+      prisma.stackService.update({
+        where: { id: u.id },
+        data: { vaultAppRoleId: u.vaultAppRoleId },
+      }),
+    ),
+  ]);
+
+  return {
+    status: "applied",
+    servicesBound: serviceUpdates.length,
+    appRolesMapped: Object.keys(result.appliedAppRoleIdByName).length,
+  };
+}

--- a/server/src/services/stacks/stack-vault-deleter.ts
+++ b/server/src/services/stacks/stack-vault-deleter.ts
@@ -22,6 +22,7 @@ import type { PrismaClient } from "../../lib/prisma";
 import { getLogger } from "../../lib/logger-factory";
 import { decryptSnapshot } from "./stack-vault-snapshot";
 import { UserEventService } from "../user-events/user-event-service";
+import { resolveVaultServiceFacades, type VaultServiceLoaders } from "./vault-services-loader";
 
 const log = getLogger("stacks", "stack-vault-deleter");
 
@@ -46,49 +47,19 @@ type VaultDeleteEventType =
   | "stack_vault_kv_delete";
 
 // =====================
-// Service facades (injectable for tests)
+// Service facade re-exports — kept under the legacy `*DeleteFacade` names
+// so existing imports keep resolving; canonical types live in
+// `vault-services-loader.ts`.
 // =====================
 
-export interface PolicyDeleteFacade {
-  getByName(name: string): Promise<{ id: string } | null>;
-  delete(id: string): Promise<void>;
-}
+export type {
+  VaultPolicyFacade as PolicyDeleteFacade,
+  VaultAppRoleFacade as AppRoleDeleteFacade,
+  VaultKVFacade as KVDeleteFacade,
+} from "./vault-services-loader";
 
-export interface AppRoleDeleteFacade {
-  getByName(name: string): Promise<{ id: string } | null>;
-  delete(id: string): Promise<void>;
-}
-
-export interface KVDeleteFacade {
-  delete(path: string, opts?: { permanent?: boolean }): Promise<void>;
-}
-
-export interface VaultDeleterServices {
-  getPolicyService?: (prisma: PrismaClient) => Promise<PolicyDeleteFacade>;
-  getAppRoleService?: (prisma: PrismaClient) => Promise<AppRoleDeleteFacade>;
-  getKVService?: () => Promise<KVDeleteFacade>;
-}
-
-// =====================
-// Default service loaders
-// =====================
-
-async function defaultPolicyService(prisma: PrismaClient): Promise<PolicyDeleteFacade> {
-  const { VaultPolicyService } = await import("../vault/vault-policy-service");
-  const { getVaultServices } = await import("../vault/vault-services");
-  return new VaultPolicyService(prisma, getVaultServices().admin);
-}
-
-async function defaultAppRoleService(prisma: PrismaClient): Promise<AppRoleDeleteFacade> {
-  const { VaultAppRoleService } = await import("../vault/vault-approle-service");
-  const { getVaultServices } = await import("../vault/vault-services");
-  return new VaultAppRoleService(prisma, getVaultServices().admin);
-}
-
-async function defaultKVService(): Promise<KVDeleteFacade> {
-  const { getVaultKVService } = await import("../vault/vault-kv-service");
-  return getVaultKVService();
-}
+/** Alias retained for callers that still pass `VaultDeleterServices`. */
+export type VaultDeleterServices = VaultServiceLoaders;
 
 // =====================
 // Helpers
@@ -212,21 +183,20 @@ export async function runStackVaultDeleter(
 
   const userEventSvc = new UserEventService(prisma);
 
-  const getPolicySvc = services?.getPolicyService ?? defaultPolicyService;
-  const getAppRoleSvc = services?.getAppRoleService ?? defaultAppRoleService;
-  const getKVSvc = services?.getKVService ?? defaultKVService;
-
   const kvPaths = Object.keys(snapshot.kv);
   const appRoleNames = Object.keys(snapshot.appRoles);
   const policyNames = Object.keys(snapshot.policies);
 
-  const hasKv = kvPaths.length > 0;
-  const hasAppRoles = appRoleNames.length > 0;
-  const hasPolicies = policyNames.length > 0;
-
-  const policySvc = hasPolicies ? await getPolicySvc(prisma) : null;
-  const appRoleSvc = hasAppRoles ? await getAppRoleSvc(prisma) : null;
-  const kvSvc = hasKv ? await getKVSvc() : null;
+  const { policy: policySvc, appRole: appRoleSvc, kv: kvSvc } =
+    await resolveVaultServiceFacades(
+      prisma,
+      {
+        policy: policyNames.length > 0,
+        appRole: appRoleNames.length > 0,
+        kv: kvPaths.length > 0,
+      },
+      services,
+    );
 
   // ── 1. KV ──
   for (const path of kvPaths) {

--- a/server/src/services/stacks/stack-vault-reconciler.ts
+++ b/server/src/services/stacks/stack-vault-reconciler.ts
@@ -48,6 +48,13 @@ import {
   type SnapshotV2KvEntry,
   type AppliedThisRun,
 } from "./stack-vault-snapshot";
+import {
+  resolveVaultServiceFacades,
+  type VaultPolicyFacade,
+  type VaultAppRoleFacade,
+  type VaultKVFacade,
+  type VaultServiceLoaders,
+} from "./vault-services-loader";
 import type {
   TemplateInputDeclaration,
   TemplateVaultAppRole,
@@ -94,27 +101,6 @@ export interface StackVaultReconcileResult {
 /** SHA-256 of an arbitrary string — used for content-hash idempotency. */
 function sha256(data: string): string {
   return crypto.createHash("sha256").update(data).digest("hex");
-}
-
-/**
- * Lazy-import Vault services inside the function body to avoid pulling the
- * full Vault wiring into unit tests that don't need it.
- */
-async function getVaultPolicyService(prisma: PrismaClient) {
-  const { VaultPolicyService } = await import("../vault/vault-policy-service");
-  const { getVaultServices } = await import("../vault/vault-services");
-  return new VaultPolicyService(prisma, getVaultServices().admin);
-}
-
-async function getVaultAppRoleService(prisma: PrismaClient) {
-  const { VaultAppRoleService } = await import("../vault/vault-approle-service");
-  const { getVaultServices } = await import("../vault/vault-services");
-  return new VaultAppRoleService(prisma, getVaultServices().admin);
-}
-
-async function getVaultKVSvc() {
-  const { getVaultKVService } = await import("../vault/vault-kv-service");
-  return getVaultKVService();
 }
 
 /** Build a Vault-safe lowercase-alphanumeric-hyphen name from a template-rendered string. */
@@ -193,9 +179,9 @@ async function rollbackApplied(
   rollbackTriggeredBy: string,
   svc: UserEventService,
   services: {
-    policyService: PolicyServiceFacade | null;
-    appRoleService: AppRoleServiceFacade | null;
-    kvService: KVServiceFacade | null;
+    policyService: VaultPolicyFacade | null;
+    appRoleService: VaultAppRoleFacade | null;
+    kvService: VaultKVFacade | null;
   },
 ): Promise<string | null> {
   const { kvToRestore, appRolesToRestore, policiesToRestore } = computeRestoreItems({
@@ -338,11 +324,7 @@ export async function runStackVaultReconciler(
   prisma: PrismaClient,
   stackId: string,
   input: StackVaultReconcilerInput,
-  services?: {
-    getPolicyService?: (prisma: PrismaClient) => Promise<PolicyServiceFacade>;
-    getAppRoleService?: (prisma: PrismaClient) => Promise<AppRoleServiceFacade>;
-    getKVService?: () => Promise<KVServiceFacade>;
-  },
+  services?: VaultServiceLoaders,
 ): Promise<StackVaultReconcileResult> {
   const { templateVersion, inputs, vault, userId } = input;
 
@@ -437,24 +419,17 @@ export async function runStackVaultReconciler(
   const userEventSvc = new UserEventService(prisma);
   let anyApplied = false;
 
-  // Lazy-load service facades
-  const policyService = policies.length > 0
-    ? (services?.getPolicyService
-      ? await services.getPolicyService(prisma)
-      : await getVaultPolicyService(prisma))
-    : null;
-
-  const appRoleService = appRoles.length > 0
-    ? (services?.getAppRoleService
-      ? await services.getAppRoleService(prisma)
-      : await getVaultAppRoleService(prisma))
-    : null;
-
-  const kvService = kvEntries.length > 0
-    ? (services?.getKVService
-      ? await services.getKVService()
-      : await getVaultKVSvc())
-    : null;
+  // Lazy-load only the facades whose phase is non-empty.
+  const { policy: policyService, appRole: appRoleService, kv: kvService } =
+    await resolveVaultServiceFacades(
+      prisma,
+      {
+        policy: policies.length > 0,
+        appRole: appRoles.length > 0,
+        kv: kvEntries.length > 0,
+      },
+      services,
+    );
 
   // Helper: handle a phase failure with rollback
   async function handlePhaseFailure(failMsg: string): Promise<StackVaultReconcileResult> {
@@ -823,38 +798,13 @@ async function markStackError(prisma: PrismaClient, stackId: string, reason: str
 }
 
 // =====================
-// Service facades (for injection in tests)
+// Service facades — re-exported from vault-services-loader so existing
+// imports (`PolicyServiceFacade`, `AppRoleServiceFacade`, `KVServiceFacade`)
+// continue to resolve. New code should import the canonical names directly.
 // =====================
 
-export interface PolicyServiceFacade {
-  getByName(name: string): Promise<{ id: string; displayName: string } | null>;
-  create(input: { name: string; displayName: string; description?: string; draftHclBody: string }, userId: string): Promise<{ id: string; displayName: string }>;
-  update(id: string, input: { draftHclBody?: string; displayName?: string }, userId: string): Promise<{ id: string; displayName: string }>;
-  publish(id: string): Promise<{ id: string }>;
-}
-
-export interface AppRoleServiceFacade {
-  getByName(name: string): Promise<{ id: string } | null>;
-  create(input: {
-    name: string;
-    policyId: string;
-    secretIdNumUses?: number;
-    secretIdTtl?: string;
-    tokenTtl?: string;
-    tokenMaxTtl?: string;
-    tokenPeriod?: string;
-  }, userId: string): Promise<{ id: string }>;
-  update(id: string, input: {
-    policyId?: string;
-    secretIdNumUses?: number;
-    secretIdTtl?: string;
-    tokenTtl?: string;
-    tokenMaxTtl?: string;
-    tokenPeriod?: string;
-  }): Promise<{ id: string }>;
-  apply(id: string): Promise<{ id: string }>;
-}
-
-export interface KVServiceFacade {
-  write(path: string, data: Record<string, unknown>): Promise<void>;
-}
+export type {
+  VaultPolicyFacade as PolicyServiceFacade,
+  VaultAppRoleFacade as AppRoleServiceFacade,
+  VaultKVFacade as KVServiceFacade,
+} from "./vault-services-loader";

--- a/server/src/services/stacks/vault-services-loader.ts
+++ b/server/src/services/stacks/vault-services-loader.ts
@@ -1,0 +1,131 @@
+/**
+ * Unified Vault service facades for the stack-vault pipeline.
+ *
+ * Both the apply phase (stack-vault-reconciler) and the cascade-delete phase
+ * (stack-vault-deleter) need a small subset of the real Vault*Service classes.
+ * Each consumer used to define its own narrow interface and its own lazy
+ * loader; this module is the single home for both.
+ *
+ * Lazy loading: the real implementations pull in DB + HTTP wiring that some
+ * unit tests do not need. Each loader is an async dynamic import so the
+ * module graph stays cheap to load.
+ */
+
+import type { PrismaClient } from "../../lib/prisma";
+
+// =====================
+// Facade interfaces (union of methods used across reconciler + deleter)
+// =====================
+
+export interface VaultPolicyFacade {
+  getByName(name: string): Promise<{ id: string; displayName: string } | null>;
+  create(
+    input: {
+      name: string;
+      displayName: string;
+      description?: string;
+      draftHclBody: string;
+    },
+    userId: string,
+  ): Promise<{ id: string; displayName: string }>;
+  update(
+    id: string,
+    input: { draftHclBody?: string; displayName?: string },
+    userId: string,
+  ): Promise<{ id: string; displayName: string }>;
+  publish(id: string): Promise<{ id: string }>;
+  delete(id: string): Promise<void>;
+}
+
+export interface VaultAppRoleFacade {
+  getByName(name: string): Promise<{ id: string } | null>;
+  create(
+    input: {
+      name: string;
+      policyId: string;
+      secretIdNumUses?: number;
+      secretIdTtl?: string;
+      tokenTtl?: string;
+      tokenMaxTtl?: string;
+      tokenPeriod?: string;
+    },
+    userId: string,
+  ): Promise<{ id: string }>;
+  update(
+    id: string,
+    input: {
+      policyId?: string;
+      secretIdNumUses?: number;
+      secretIdTtl?: string;
+      tokenTtl?: string;
+      tokenMaxTtl?: string;
+      tokenPeriod?: string;
+    },
+  ): Promise<{ id: string }>;
+  apply(id: string): Promise<{ id: string }>;
+  delete(id: string): Promise<void>;
+}
+
+export interface VaultKVFacade {
+  write(path: string, data: Record<string, unknown>): Promise<void>;
+  delete(path: string, opts?: { permanent?: boolean }): Promise<void>;
+}
+
+// =====================
+// Loader injection shape — used by reconciler and deleter for testability
+// =====================
+
+export interface VaultServiceLoaders {
+  getPolicyService?: (prisma: PrismaClient) => Promise<VaultPolicyFacade>;
+  getAppRoleService?: (prisma: PrismaClient) => Promise<VaultAppRoleFacade>;
+  getKVService?: () => Promise<VaultKVFacade>;
+}
+
+// =====================
+// Default loaders
+// =====================
+
+export async function loadDefaultPolicyService(
+  prisma: PrismaClient,
+): Promise<VaultPolicyFacade> {
+  const { VaultPolicyService } = await import("../vault/vault-policy-service");
+  const { getVaultServices } = await import("../vault/vault-services");
+  return new VaultPolicyService(prisma, getVaultServices().admin);
+}
+
+export async function loadDefaultAppRoleService(
+  prisma: PrismaClient,
+): Promise<VaultAppRoleFacade> {
+  const { VaultAppRoleService } = await import("../vault/vault-approle-service");
+  const { getVaultServices } = await import("../vault/vault-services");
+  return new VaultAppRoleService(prisma, getVaultServices().admin);
+}
+
+export async function loadDefaultKVService(): Promise<VaultKVFacade> {
+  const { getVaultKVService } = await import("../vault/vault-kv-service");
+  return getVaultKVService();
+}
+
+/**
+ * Resolve all three facades, honouring caller-supplied overrides for tests.
+ * Returns null for any facade whose corresponding `present` flag is false —
+ * callers can short-circuit the import for empty phases.
+ */
+export async function resolveVaultServiceFacades(
+  prisma: PrismaClient,
+  present: { policy: boolean; appRole: boolean; kv: boolean },
+  overrides?: VaultServiceLoaders,
+): Promise<{
+  policy: VaultPolicyFacade | null;
+  appRole: VaultAppRoleFacade | null;
+  kv: VaultKVFacade | null;
+}> {
+  const policy = present.policy
+    ? await (overrides?.getPolicyService ?? loadDefaultPolicyService)(prisma)
+    : null;
+  const appRole = present.appRole
+    ? await (overrides?.getAppRoleService ?? loadDefaultAppRoleService)(prisma)
+    : null;
+  const kv = present.kv ? await (overrides?.getKVService ?? loadDefaultKVService)() : null;
+  return { policy, appRole, kv };
+}


### PR DESCRIPTION
## Summary

Cleans up duplication introduced across PRs #247–#252 in the `server/src/services/stacks/` Vault pipeline. Three high-impact wins from the architectural review:

1. **Collapsed forked reconcile path.** The load-template-version → reconcile → bind-services → commit-snapshot pipeline was duplicated in [`stacks-apply-route.ts`](https://github.com/mrgeoffrich/mini-infra/blob/main/server/src/routes/stacks/stacks-apply-route.ts) (~95 lines) and [`builtin-vault-reconcile.ts`](https://github.com/mrgeoffrich/mini-infra/blob/main/server/src/services/stacks/builtin-vault-reconcile.ts) (~100 lines). Now lives in a single `stack-vault-apply-orchestrator.ts`; both callers invoke `runStackVaultApplyPhase()` and branch only on the result status.
2. **Lifted Vault phase out of the apply route.** Route is back to ~30 lines on the vault path; orchestration moved to the service layer.
3. **Unified Vault service facades + lazy loaders.** Six narrow interfaces (`PolicyServiceFacade`/`AppRoleServiceFacade`/`KVServiceFacade` in the reconciler + `*DeleteFacade` in the deleter) and six inline `await import(...)` stubs collapsed to three broad facades + one `resolveVaultServiceFacades` helper in `vault-services-loader.ts`. Old names are kept as re-exported aliases for backward compat with existing tests.

`builtin-vault-reconcile.ts` shrinks 173 → 75 lines. Net diff in existing files is **−258 LOC** (370 removed, 112 added); two new files (~280 lines combined) replace the duplication.

## Test plan

- [x] `pnpm --filter mini-infra-server exec vitest run` for all 8 vault-pipeline test files — 84/84 pass
- [x] Full server suite: 1620/1626 (5 failures in `environment-api.test.ts` confirmed pre-existing on pristine main, unrelated)
- [x] `pnpm --filter mini-infra-server lint` — clean
- [x] `pnpm --filter mini-infra-server build` — compiles
- [x] `pnpm --filter mini-infra-client build` — compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)