### PR TITLE
test(stacks,vault): extract shared test fixtures for the vault pipeline

### DIFF
--- a/server/src/__tests__/builtin-vault-reconcile-boot-order.integration.test.ts
+++ b/server/src/__tests__/builtin-vault-reconcile-boot-order.integration.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { testPrisma } from './integration-test-helpers';
+import { makeFakeLog } from './fixtures/vault-mocks';
 
 describe('boot ordering — builtin vault reconciler runs after Vault init', () => {
   beforeEach(() => {
@@ -38,13 +39,7 @@ describe('boot ordering — builtin vault reconciler runs after Vault init', () 
 
     const reconcileMod = await import('../services/stacks/builtin-vault-reconcile');
 
-    const fakeLog = {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-      child: vi.fn().mockReturnThis(),
-    } as unknown as ReturnType<typeof import('../lib/logger-factory').getLogger>;
+    const fakeLog = makeFakeLog();
 
     const templateByName = new Map<string, { id: string; template: import('../services/stacks/template-file-loader').LoadedTemplate }>();
 
@@ -62,13 +57,7 @@ describe('boot ordering — builtin vault reconciler runs after Vault init', () 
 
     const reconcileMod = await import('../services/stacks/builtin-vault-reconcile');
 
-    const fakeLog = {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-      child: vi.fn().mockReturnThis(),
-    } as unknown as ReturnType<typeof import('../lib/logger-factory').getLogger>;
+    const fakeLog = makeFakeLog();
 
     const templateByName = new Map<string, { id: string; template: import('../services/stacks/template-file-loader').LoadedTemplate }>();
 

--- a/server/src/__tests__/builtin-vault-reconcile.integration.test.ts
+++ b/server/src/__tests__/builtin-vault-reconcile.integration.test.ts
@@ -18,118 +18,35 @@
 import { describe, it, expect, vi } from 'vitest';
 import { testPrisma } from './integration-test-helpers';
 import { createId } from '@paralleldrive/cuid2';
-import type { PolicyServiceFacade, AppRoleServiceFacade, KVServiceFacade } from '../services/stacks/stack-vault-reconciler';
+import type { PolicyServiceFacade, AppRoleServiceFacade } from '../services/stacks/stack-vault-reconciler';
 import { runStackVaultReconciler } from '../services/stacks/stack-vault-reconciler';
 import type { LoadedTemplate } from '../services/stacks/template-file-loader';
 import { runSystemStackMigrations } from '../services/stacks/system-stack-migrations';
+import { makePolicySvc, makeAppRoleSvc, makeKVSvc, makeFakeLog } from './fixtures/vault-mocks';
+type FakeLog = ReturnType<typeof makeFakeLog>;
+import { createTestEnvironment, createTestStackTemplate, createTestStack } from './fixtures/vault-test-db';
 
-// ─── Mock helpers ─────────────────────────────────────────────────────────────
-
-function makePolicySvc(): PolicyServiceFacade {
-  let n = 0;
-  return {
-    getByName: vi.fn().mockResolvedValue(null),
-    create: vi.fn().mockImplementation((input: { name: string }) => {
-      n++;
-      return Promise.resolve({ id: `pol-${n}`, displayName: input.name });
-    }),
-    update: vi.fn().mockImplementation((id: string) => Promise.resolve({ id, displayName: 'updated' })),
-    publish: vi.fn().mockImplementation((id: string) => Promise.resolve({ id })),
-    delete: vi.fn().mockResolvedValue(undefined),
-  };
+// Local naming aliases retained so the existing test bodies keep reading.
+const createEnv = createTestEnvironment;
+async function createTemplateWithVault(
+  opts: { policies?: unknown[]; appRoles?: unknown[] } = {},
+): Promise<{ templateId: string; version: number }> {
+  const { templateId, version } = await createTestStackTemplate(opts);
+  return { templateId, version };
 }
-
-function makeAppRoleSvc(): AppRoleServiceFacade {
-  let n = 0;
-  return {
-    getByName: vi.fn().mockResolvedValue(null),
-    create: vi.fn().mockImplementation((input: { name: string }) => {
-      n++;
-      return Promise.resolve({ id: `ar-${n}-${input.name}` });
-    }),
-    update: vi.fn().mockImplementation((id: string) => Promise.resolve({ id })),
-    apply: vi.fn().mockImplementation((id: string) => Promise.resolve({ id })),
-    delete: vi.fn().mockResolvedValue(undefined),
-  };
-}
-
-function makeKVSvc(): KVServiceFacade {
-  return {
-    write: vi.fn().mockResolvedValue(undefined),
-    delete: vi.fn().mockResolvedValue(undefined),
-  };
-}
-
-// ─── DB fixtures ──────────────────────────────────────────────────────────────
-
-async function createEnv(): Promise<string> {
-  const env = await testPrisma.environment.create({
-    data: {
-      id: createId(),
-      name: `test-env-${createId().slice(0, 6)}`,
-      type: 'nonproduction',
-      networkType: 'local',
-    },
-  });
-  return env.id;
-}
-
-async function createTemplateWithVault(opts: {
-  policies?: unknown[];
-  appRoles?: unknown[];
-} = {}): Promise<{ templateId: string; version: number }> {
-  const templateId = createId();
-  await testPrisma.stackTemplate.create({
-    data: {
-      id: templateId,
-      name: `tmpl-${createId().slice(0, 8)}`,
-      displayName: 'Test Template',
-      source: 'system',
-      scope: 'host',
-      currentVersionId: null,
-      draftVersionId: null,
-    },
-  });
-
-  const ver = await testPrisma.stackTemplateVersion.create({
-    data: {
-      id: createId(),
-      templateId,
-      version: 1,
-      status: 'published',
-      parameters: [],
-      defaultParameterValues: {},
-      networkTypeDefaults: {},
-      networks: [],
-      volumes: [],
-      vaultPolicies: opts.policies ?? null,
-      vaultAppRoles: opts.appRoles ?? null,
-    },
-  });
-
-  return { templateId, version: ver.version };
-}
-
 async function createBuiltinStack(opts: {
   name: string;
   templateId: string;
   templateVersion: number;
   environmentId?: string;
 }): Promise<string> {
-  const id = createId();
-  await testPrisma.stack.create({
-    data: {
-      id,
-      name: opts.name,
-      networks: JSON.stringify([]),
-      volumes: JSON.stringify([]),
-      builtinVersion: 1,
-      templateId: opts.templateId,
-      templateVersion: opts.templateVersion,
-      ...(opts.environmentId ? { environmentId: opts.environmentId } : {}),
-    },
+  return createTestStack({
+    name: opts.name,
+    templateId: opts.templateId,
+    templateVersion: opts.templateVersion,
+    environmentId: opts.environmentId,
+    builtinVersion: 1,
   });
-  return id;
 }
 
 function makeLoadedTemplate(name: string, vault?: LoadedTemplate['vault']): LoadedTemplate {
@@ -142,14 +59,6 @@ function makeLoadedTemplate(name: string, vault?: LoadedTemplate['vault']): Load
     configFiles: [],
     vault,
   };
-}
-
-type FakeLog = ReturnType<typeof import('../lib/logger-factory').getLogger>;
-function makeFakeLog(): FakeLog {
-  return {
-    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
-    child: vi.fn().mockReturnThis(),
-  } as unknown as FakeLog;
 }
 
 /**

--- a/server/src/__tests__/fixtures/vault-mocks.ts
+++ b/server/src/__tests__/fixtures/vault-mocks.ts
@@ -1,0 +1,129 @@
+/**
+ * Shared test mocks for the stack-vault test suite.
+ *
+ * Replaces the near-identical `makePolicySvc` / `makeAppRoleSvc` / `makeKVSvc`
+ * factories that lived inline in three different test files (the reconciler
+ * unit test, the reconciler integration test, and the builtin-reconcile
+ * integration test).
+ *
+ * The factories accept the union of opts every caller used:
+ *   - `existing`        — pre-seeded record returned from `getByName`
+ *   - `throwOnCreate`   — `create()` rejects (apply-failure tests)
+ *   - `throwOnPublish`  — `publish()` rejects (policy phase)
+ *   - `throwOnApply`    — `apply()` rejects (appRole phase)
+ *   - `throwOnWrite`    — `write()` rejects (kv phase)
+ *
+ * Created IDs are sequence-numbered (`pol-1`, `pol-2`, …) so multi-resource
+ * scenarios get unique IDs without further configuration.
+ */
+
+import { vi } from "vitest";
+import type {
+  PolicyServiceFacade,
+  AppRoleServiceFacade,
+  KVServiceFacade,
+} from "../../services/stacks/stack-vault-reconciler";
+
+export interface PolicySvcOpts {
+  existing?: { id: string; displayName: string } | null;
+  throwOnCreate?: boolean;
+  throwOnPublish?: boolean;
+}
+
+export function makePolicySvc(opts: PolicySvcOpts = {}): PolicyServiceFacade {
+  const existing = opts.existing !== undefined ? opts.existing : null;
+  let n = 0;
+  return {
+    getByName: vi.fn().mockResolvedValue(existing),
+    create: opts.throwOnCreate
+      ? vi.fn().mockRejectedValue(new Error("policy create failed"))
+      : vi.fn().mockImplementation((input: { name: string }) => {
+          n++;
+          return Promise.resolve({ id: `pol-${n}`, displayName: input.name });
+        }),
+    update: vi.fn().mockImplementation(
+      (id: string, input: { displayName?: string }) =>
+        Promise.resolve({ id, displayName: input.displayName ?? "updated" }),
+    ),
+    publish: opts.throwOnPublish
+      ? vi.fn().mockRejectedValue(new Error("policy publish failed"))
+      : vi.fn().mockImplementation((id: string) =>
+          Promise.resolve({ id: existing?.id ?? id }),
+        ),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+export interface AppRoleSvcOpts {
+  existing?: { id: string } | null;
+  throwOnCreate?: boolean;
+  throwOnApply?: boolean;
+}
+
+export function makeAppRoleSvc(opts: AppRoleSvcOpts = {}): AppRoleServiceFacade {
+  const existing = opts.existing !== undefined ? opts.existing : null;
+  let n = 0;
+  return {
+    getByName: vi.fn().mockResolvedValue(existing),
+    create: opts.throwOnCreate
+      ? vi.fn().mockRejectedValue(new Error("approle create failed"))
+      : vi.fn().mockImplementation(() => {
+          n++;
+          return Promise.resolve({ id: `ar-${n}` });
+        }),
+    update: vi.fn().mockImplementation((id: string) => Promise.resolve({ id })),
+    apply: opts.throwOnApply
+      ? vi.fn().mockRejectedValue(new Error("approle apply failed"))
+      : vi.fn().mockImplementation((id: string) =>
+          Promise.resolve({ id: existing?.id ?? id }),
+        ),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+export interface KVSvcOpts {
+  throwOnWrite?: boolean;
+}
+
+export function makeKVSvc(opts: KVSvcOpts = {}): KVServiceFacade {
+  return {
+    write: opts.throwOnWrite
+      ? vi.fn().mockRejectedValue(new Error("kv write failed"))
+      : vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/**
+ * Bundle the three facade mocks into the loader-shaped `services` override
+ * accepted by `runStackVaultReconciler`. Each loader is itself a `vi.fn()`
+ * spy so tests can assert "lazy load only happened for non-empty phases."
+ */
+export function makeVaultServiceLoaders(overrides: {
+  policy?: PolicyServiceFacade;
+  appRole?: AppRoleServiceFacade;
+  kv?: KVServiceFacade;
+} = {}) {
+  return {
+    getPolicyService: vi.fn().mockResolvedValue(overrides.policy ?? makePolicySvc()),
+    getAppRoleService: vi.fn().mockResolvedValue(overrides.appRole ?? makeAppRoleSvc()),
+    getKVService: vi.fn().mockResolvedValue(overrides.kv ?? makeKVSvc()),
+  };
+}
+
+// =====================
+// Logger stub
+// =====================
+
+type FakeLog = ReturnType<typeof import("../../lib/logger-factory").getLogger>;
+
+/** Plain object that satisfies the `getLogger()` return shape — pino calls become no-ops. */
+export function makeFakeLog(): FakeLog {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  } as unknown as FakeLog;
+}

--- a/server/src/__tests__/fixtures/vault-test-db.ts
+++ b/server/src/__tests__/fixtures/vault-test-db.ts
@@ -1,0 +1,171 @@
+/**
+ * Shared DB fixtures for the stack-vault integration test suite.
+ *
+ * Replaces the per-file `createEnv` / `createTestEnvironment`,
+ * `createTemplateWithVault` / `createTemplateWithService`, and
+ * `createBuiltinStack` / `createTestStack` / `createBoundStack` helpers that
+ * had drifted into 4-5 near-identical variants.
+ *
+ * All helpers use the shared `testPrisma` from `integration-test-helpers.ts`
+ * and `@paralleldrive/cuid2` for unique identifiers so parallel test runs do
+ * not collide.
+ */
+
+import { createId } from "@paralleldrive/cuid2";
+import { testPrisma } from "../integration-test-helpers";
+
+export interface CreateTestStackTemplateOpts {
+  /** Vault sections; pass `undefined` to leave the column null. */
+  policies?: unknown[];
+  appRoles?: unknown[];
+  kv?: unknown[];
+  inputs?: unknown[];
+  /** Optional template service definitions with vault refs. */
+  services?: Array<{
+    serviceName: string;
+    vaultAppRoleRef?: string;
+    /** Defaults to "Stateful" if omitted. */
+    serviceType?: string;
+    /** Defaults to "nginx" if omitted. */
+    dockerImage?: string;
+    /** Defaults to "latest" if omitted. */
+    dockerTag?: string;
+  }>;
+  /** Defaults to "system". Use "user" for user-template scenarios. */
+  source?: "system" | "user";
+}
+
+/** Create a Cloudflare-tunnel-free `local` host environment. Returns the env id. */
+export async function createTestEnvironment(): Promise<string> {
+  const env = await testPrisma.environment.create({
+    data: {
+      id: createId(),
+      name: `test-env-${createId().slice(0, 6)}`,
+      type: "nonproduction",
+      networkType: "local",
+    },
+  });
+  return env.id;
+}
+
+/**
+ * Create a stack template with a single published version. Returns
+ * `templateId`, `version` (always 1), and `versionId` so callers can attach
+ * downstream rows (e.g. `StackTemplateService`) when needed.
+ */
+export async function createTestStackTemplate(
+  opts: CreateTestStackTemplateOpts = {},
+): Promise<{ templateId: string; version: number; versionId: string }> {
+  const templateId = createId();
+  const versionId = createId();
+  const source = opts.source ?? "system";
+
+  await testPrisma.stackTemplate.create({
+    data: {
+      id: templateId,
+      name: `tmpl-${createId().slice(0, 8)}`,
+      displayName: "Test Template",
+      source,
+      scope: "host",
+      currentVersionId: null,
+      draftVersionId: null,
+    },
+  });
+
+  await testPrisma.stackTemplateVersion.create({
+    data: {
+      id: versionId,
+      templateId,
+      version: 1,
+      status: "published",
+      parameters: [],
+      defaultParameterValues: {},
+      networkTypeDefaults: {},
+      networks: [],
+      volumes: [],
+      ...(opts.inputs !== undefined ? { inputs: opts.inputs } : {}),
+      vaultPolicies: opts.policies ?? null,
+      vaultAppRoles: opts.appRoles ?? null,
+      ...(opts.kv !== undefined ? { vaultKv: opts.kv } : {}),
+    },
+  });
+
+  if (opts.services && opts.services.length > 0) {
+    for (const [i, svc] of opts.services.entries()) {
+      await testPrisma.stackTemplateService.create({
+        data: {
+          id: createId(),
+          versionId,
+          serviceName: svc.serviceName,
+          serviceType: svc.serviceType ?? "Stateful",
+          dockerImage: svc.dockerImage ?? "nginx",
+          dockerTag: svc.dockerTag ?? "latest",
+          containerConfig: { restartPolicy: "unless-stopped" },
+          dependsOn: [],
+          order: i,
+          ...(svc.vaultAppRoleRef !== undefined
+            ? { vaultAppRoleRef: svc.vaultAppRoleRef }
+            : {}),
+        },
+      });
+    }
+  }
+
+  return { templateId, version: 1, versionId };
+}
+
+export interface CreateTestStackOpts {
+  name?: string;
+  templateId?: string;
+  templateVersion?: number;
+  environmentId?: string | null;
+  encryptedInputValues?: string;
+  /** Encrypted snapshot blob (pass via `encryptSnapshot()` or omit). */
+  lastAppliedVaultSnapshot?: string | null;
+  /** Per-service rows to attach. */
+  services?: Array<{ serviceName: string; vaultAppRoleRef?: string | null }>;
+  /** Tag this stack as a system/builtin stack so the builtin reconciler picks it up. */
+  builtinVersion?: number | null;
+}
+
+/** Create a `Stack` row plus optional `StackService` rows. Returns the stack id. */
+export async function createTestStack(opts: CreateTestStackOpts = {}): Promise<string> {
+  const id = createId();
+  await testPrisma.stack.create({
+    data: {
+      id,
+      name: opts.name ?? `stack-${id.slice(0, 6)}`,
+      networks: JSON.stringify([]),
+      volumes: JSON.stringify([]),
+      ...(opts.templateId !== undefined ? { templateId: opts.templateId } : {}),
+      ...(opts.templateVersion !== undefined ? { templateVersion: opts.templateVersion } : {}),
+      ...(opts.environmentId !== undefined ? { environmentId: opts.environmentId } : {}),
+      ...(opts.encryptedInputValues !== undefined
+        ? { encryptedInputValues: opts.encryptedInputValues }
+        : {}),
+      lastAppliedVaultSnapshot: opts.lastAppliedVaultSnapshot ?? null,
+      ...(opts.builtinVersion !== undefined ? { builtinVersion: opts.builtinVersion } : {}),
+    },
+  });
+
+  if (opts.services && opts.services.length > 0) {
+    for (const [i, svc] of opts.services.entries()) {
+      await testPrisma.stackService.create({
+        data: {
+          id: createId(),
+          stackId: id,
+          serviceName: svc.serviceName,
+          serviceType: "Stateful",
+          dockerImage: "myimage",
+          dockerTag: "latest",
+          containerConfig: JSON.stringify({ restartPolicy: "unless-stopped" }),
+          dependsOn: JSON.stringify([]),
+          order: i,
+          vaultAppRoleRef: svc.vaultAppRoleRef ?? null,
+        },
+      });
+    }
+  }
+
+  return id;
+}

--- a/server/src/__tests__/stack-vault-reconciler.integration.test.ts
+++ b/server/src/__tests__/stack-vault-reconciler.integration.test.ts
@@ -26,14 +26,20 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
 import { testPrisma } from './integration-test-helpers';
 import { runStackVaultReconciler } from '../services/stacks/stack-vault-reconciler';
-import type { PolicyServiceFacade, AppRoleServiceFacade, KVServiceFacade } from '../services/stacks/stack-vault-reconciler';
 import { encryptInputValues } from '../services/stacks/stack-input-values-service';
 import { encryptSnapshot, decryptSnapshot, type SnapshotV2 } from '../services/stacks/stack-vault-snapshot';
 import { pruneOrphanedInputValues } from '../services/stacks/orphan-input-pruner';
 import type { TemplateInputDeclaration, TemplateVaultPolicy, TemplateVaultAppRole, TemplateVaultKv } from '@mini-infra/types';
-import { createId } from '@paralleldrive/cuid2';
+import {
+  makePolicySvc,
+  makeAppRoleSvc,
+  makeKVSvc,
+  makeVaultServiceLoaders as makeServices,
+} from './fixtures/vault-mocks';
+import { createTestEnvironment, createTestStack } from './fixtures/vault-test-db';
 
 // ─── Factories ────────────────────────────────────────────────────────────────
 
@@ -51,119 +57,6 @@ function ar(name: string, policy: string): TemplateVaultAppRole {
 
 function kv(path: string, fields: TemplateVaultKv['fields']): TemplateVaultKv {
   return { path, fields };
-}
-
-/** Build a mock host environment. Returns the ID. */
-async function createTestEnvironment(): Promise<string> {
-  const env = await testPrisma.environment.create({
-    data: {
-      id: createId(),
-      name: `test-env-${createId().slice(0, 6)}`,
-      type: 'nonproduction',
-      networkType: 'local',
-    },
-  });
-  return env.id;
-}
-
-/** Create a minimal Stack row suitable for vault reconciler tests. */
-async function createTestStack(opts: {
-  encryptedInputValues?: string;
-  environmentId?: string | null;
-  /** Pass an encrypted blob string directly (from encryptSnapshot()). */
-  lastAppliedVaultSnapshot?: string | null;
-  services?: Array<{ serviceName: string; vaultAppRoleRef?: string }>;
-} = {}): Promise<string> {
-  const id = createId();
-  await testPrisma.stack.create({
-    data: {
-      id,
-      name: `stack-${id.slice(0, 6)}`,
-      networks: JSON.stringify([]),
-      volumes: JSON.stringify([]),
-      encryptedInputValues: opts.encryptedInputValues ?? null,
-      ...(opts.environmentId !== undefined ? { environmentId: opts.environmentId } : {}),
-      lastAppliedVaultSnapshot: opts.lastAppliedVaultSnapshot ?? null,
-    },
-  });
-
-  if (opts.services && opts.services.length > 0) {
-    for (const [i, svc] of opts.services.entries()) {
-      await testPrisma.stackService.create({
-        data: {
-          id: createId(),
-          stackId: id,
-          serviceName: svc.serviceName,
-          serviceType: 'Stateful',
-          dockerImage: 'myimage',
-          dockerTag: 'latest',
-          containerConfig: JSON.stringify({ restartPolicy: 'unless-stopped' }),
-          dependsOn: JSON.stringify([]),
-          order: i,
-          vaultAppRoleRef: svc.vaultAppRoleRef ?? null,
-        },
-      });
-    }
-  }
-
-  return id;
-}
-
-// Mock services helpers
-
-function makePolicySvc(opts: { throwOnCreate?: boolean; throwOnPublish?: boolean } = {}): PolicyServiceFacade {
-  let callCount = 0;
-  return {
-    getByName: vi.fn().mockResolvedValue(null),
-    create: opts.throwOnCreate
-      ? vi.fn().mockRejectedValue(new Error('policy create failed'))
-      : vi.fn().mockImplementation((input: { name: string }) => {
-          callCount++;
-          return Promise.resolve({ id: `pol-${callCount}`, displayName: input.name });
-        }),
-    update: vi.fn().mockImplementation((_id: string) => Promise.resolve({ id: _id, displayName: 'updated' })),
-    publish: opts.throwOnPublish
-      ? vi.fn().mockRejectedValue(new Error('policy publish failed'))
-      : vi.fn().mockImplementation((id: string) => Promise.resolve({ id })),
-    delete: vi.fn().mockResolvedValue(undefined),
-  };
-}
-
-function makeAppRoleSvc(opts: { throwOnApply?: boolean } = {}): AppRoleServiceFacade {
-  let callCount = 0;
-  return {
-    getByName: vi.fn().mockResolvedValue(null),
-    create: vi.fn().mockImplementation((input: { name: string }) => {
-      callCount++;
-      return Promise.resolve({ id: `ar-${callCount}-${input.name}` });
-    }),
-    update: vi.fn().mockImplementation((id: string) => Promise.resolve({ id })),
-    apply: opts.throwOnApply
-      ? vi.fn().mockRejectedValue(new Error('approle apply failed'))
-      : vi.fn().mockImplementation((id: string) => Promise.resolve({ id })),
-    delete: vi.fn().mockResolvedValue(undefined),
-  };
-}
-
-function makeKVSvc(opts: { throwOnWrite?: boolean } = {}): KVServiceFacade {
-  return {
-    write: opts.throwOnWrite
-      ? vi.fn().mockRejectedValue(new Error('kv write failed'))
-      : vi.fn().mockResolvedValue(undefined),
-    delete: vi.fn().mockResolvedValue(undefined),
-  };
-}
-
-function makeServices(overrides: {
-  policy?: PolicyServiceFacade;
-  appRole?: AppRoleServiceFacade;
-  kv?: KVServiceFacade;
-} = {}) {
-  return {
-    getPolicyService: vi.fn().mockResolvedValue(overrides.policy ?? makePolicySvc()),
-    getAppRoleService: vi.fn().mockResolvedValue(overrides.appRole ?? makeAppRoleSvc()),
-    getKVService: vi.fn().mockResolvedValue(overrides.kv ?? makeKVSvc()),
-  };
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────

--- a/server/src/__tests__/stack-vault-reconciler.test.ts
+++ b/server/src/__tests__/stack-vault-reconciler.test.ts
@@ -34,11 +34,16 @@ vi.mock('../services/user-events/user-event-service', () => {
 });
 
 import { runStackVaultReconciler } from '../services/stacks/stack-vault-reconciler';
-import type { PolicyServiceFacade, AppRoleServiceFacade, KVServiceFacade } from '../services/stacks/stack-vault-reconciler';
 import { encryptInputValues } from '../services/stacks/stack-input-values-service';
 import { encryptSnapshot, emptySnapshotV2, decryptSnapshot, type SnapshotV2 } from '../services/stacks/stack-vault-snapshot';
 import type { TemplateInputDeclaration, TemplateVaultPolicy, TemplateVaultAppRole, TemplateVaultKv } from '@mini-infra/types';
 import type { PrismaClient } from '../lib/prisma';
+import {
+  makePolicySvc,
+  makeAppRoleSvc,
+  makeKVSvc,
+  makeVaultServiceLoaders as makeServices,
+} from './fixtures/vault-mocks';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -103,57 +108,6 @@ function makePrisma(opts: {
       findUnique: vi.fn().mockResolvedValue(null),
     },
   } as unknown as PrismaClient;
-}
-
-function makePolicySvc(opts: { existing?: { id: string; displayName: string } | null; throwOnCreate?: boolean; throwOnPublish?: boolean } = {}): PolicyServiceFacade {
-  const existing = opts.existing !== undefined ? opts.existing : null;
-  return {
-    getByName: vi.fn().mockResolvedValue(existing),
-    create: opts.throwOnCreate
-      ? vi.fn().mockRejectedValue(new Error('policy create failed'))
-      : vi.fn().mockResolvedValue({ id: 'pol-1', displayName: 'test policy' }),
-    update: vi.fn().mockResolvedValue({ id: existing?.id ?? 'pol-1', displayName: 'test policy' }),
-    publish: opts.throwOnPublish
-      ? vi.fn().mockRejectedValue(new Error('policy publish failed'))
-      : vi.fn().mockResolvedValue({ id: existing?.id ?? 'pol-1' }),
-    delete: vi.fn().mockResolvedValue(undefined),
-  };
-}
-
-function makeAppRoleSvc(opts: { existing?: { id: string } | null; throwOnCreate?: boolean; throwOnApply?: boolean } = {}): AppRoleServiceFacade {
-  const existing = opts.existing !== undefined ? opts.existing : null;
-  return {
-    getByName: vi.fn().mockResolvedValue(existing),
-    create: opts.throwOnCreate
-      ? vi.fn().mockRejectedValue(new Error('approle create failed'))
-      : vi.fn().mockResolvedValue({ id: 'ar-1' }),
-    update: vi.fn().mockResolvedValue({ id: existing?.id ?? 'ar-1' }),
-    apply: opts.throwOnApply
-      ? vi.fn().mockRejectedValue(new Error('approle apply failed'))
-      : vi.fn().mockResolvedValue({ id: existing?.id ?? 'ar-1' }),
-    delete: vi.fn().mockResolvedValue(undefined),
-  };
-}
-
-function makeKVSvc(opts: { throwOnWrite?: boolean } = {}): KVServiceFacade {
-  return {
-    write: opts.throwOnWrite
-      ? vi.fn().mockRejectedValue(new Error('kv write failed'))
-      : vi.fn().mockResolvedValue(undefined),
-    delete: vi.fn().mockResolvedValue(undefined),
-  };
-}
-
-function makeServices(overrides: {
-  policy?: PolicyServiceFacade;
-  appRole?: AppRoleServiceFacade;
-  kv?: KVServiceFacade;
-} = {}) {
-  return {
-    getPolicyService: vi.fn().mockResolvedValue(overrides.policy ?? makePolicySvc()),
-    getAppRoleService: vi.fn().mockResolvedValue(overrides.appRole ?? makeAppRoleSvc()),
-    getKVService: vi.fn().mockResolvedValue(overrides.kv ?? makeKVSvc()),
-  };
 }
 
 const BASE_STACK_ID = 'stack-abc123';


### PR DESCRIPTION
## Summary

Follow-up to #255 / #256. Item #7 from the architectural review — test cleanup.

The Explore-agent audit revealed that the apply-route integration test does NOT duplicate the reconciler test cases (they're complementary, not overlapping), so the savings come from **fixture extraction** rather than trimming test bodies. Extracts ~290 lines of duplicated factory code across four files into a new `server/src/__tests__/fixtures/` directory.

**New files**
- [`fixtures/vault-mocks.ts`](server/src/__tests__/fixtures/vault-mocks.ts) — `makePolicySvc` / `makeAppRoleSvc` / `makeKVSvc` (union opts, sequence-based unique IDs), `makeVaultServiceLoaders`, `makeFakeLog`.
- [`fixtures/vault-test-db.ts`](server/src/__tests__/fixtures/vault-test-db.ts) — `createTestEnvironment`, `createTestStackTemplate`, `createTestStack` (one helper each, options bag covers all prior variants).

**Files migrated**
- `stack-vault-reconciler.test.ts` (unit, mocked Prisma)
- `stack-vault-reconciler.integration.test.ts`
- `builtin-vault-reconcile.integration.test.ts` (kept local naming aliases so test bodies didn't need re-grepping)
- `builtin-vault-reconcile-boot-order.integration.test.ts` (just `makeFakeLog`)

**Out of scope (intentional)**
- `stack-vault-deleter.integration.test.ts` — uses delete-style mocks (`existing` as name→id map, `failOn` as id list); extracting them is no-win because the pattern is single-file.
- `stacks-apply-vault-route.integration.test.ts` and `stacks-delete-vault-cascade.integration.test.ts` — both use module-level `vi.mock` chains (different testing strategy).

Net: 4 existing files **−290 LOC**, 2 new fixture files **+300 LOC**. Roughly LOC-neutral, but single source of truth for vault fixtures going forward.

## Test plan

- [x] All 112 vault-pipeline tests pass (9 files)
- [x] `pnpm --filter mini-infra-server lint` — clean
- [x] `pnpm --filter mini-infra-server build` — compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)