### PR TITLE
fix(volumes): return 200 with null when no inspection exists

### DIFF
--- a/client/src/hooks/use-volumes.ts
+++ b/client/src/hooks/use-volumes.ts
@@ -222,7 +222,7 @@ async function startVolumeInspection(volumeName: string): Promise<VolumeInspecti
 async function fetchVolumeInspection(
   volumeName: string,
   correlationId: string
-): Promise<VolumeInspection> {
+): Promise<VolumeInspection | null> {
   const response = await fetch(
     `/api/docker/volumes/${encodeURIComponent(volumeName)}/inspect`,
     {
@@ -235,10 +235,6 @@ async function fetchVolumeInspection(
   );
 
   if (!response.ok) {
-    if (response.status === 404) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.message || "Inspection not found");
-    }
     throw new Error(`Failed to fetch inspection: ${response.statusText}`);
   }
 
@@ -248,6 +244,9 @@ async function fetchVolumeInspection(
     throw new Error(data.message || "Failed to fetch inspection");
   }
 
+  // `data.data` is null when the volume has never been inspected. The list
+  // view probes this on every row mount, so the route returns 200 with null
+  // rather than 404.
   return data.data;
 }
 
@@ -344,14 +343,7 @@ export function useVolumeInspection(options: UseVolumeInspectionOptions) {
     queryKey: ["volume-inspection", volumeName],
     queryFn: () => fetchVolumeInspection(volumeName, correlationId),
     enabled: enabled && !!volumeName,
-    retry: (failureCount: number, error: Error) => {
-      // Don't retry on 404 (inspection doesn't exist yet)
-      if (error.message.includes("Inspection not found")) {
-        return false;
-      }
-      // Retry up to 3 times for other errors
-      return failureCount < 3;
-    },
+    retry: (failureCount: number) => failureCount < 3,
     retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),
     staleTime: 1000,
     gcTime: 5 * 60 * 1000,

--- a/lib/types/docker.ts
+++ b/lib/types/docker.ts
@@ -138,7 +138,13 @@ export interface VolumeInspection {
 
 export interface VolumeInspectionResponse {
   success: boolean;
-  data: VolumeInspection;
+  /**
+   * The inspection record, or `null` when no inspection has been started for
+   * this volume yet. The route returns 200 with `data: null` rather than 404
+   * so list views that probe inspection state on every render don't generate
+   * noise.
+   */
+  data: VolumeInspection | null;
   message?: string;
 }
 

--- a/server/src/routes/docker.ts
+++ b/server/src/routes/docker.ts
@@ -342,33 +342,31 @@ router.get(
       await inspectorService.initialize();
       const inspection = await inspectorService.getInspection(name);
 
-      if (!inspection) {
-        return res.status(404).json({
-          success: false,
-          message: `No inspection found for volume '${name}'`,
-        });
-      }
-
-      // Convert inspection data to API response format
-      const response: VolumeInspectionResponse = {
-        success: true,
-        data: {
-          id: inspection.id,
-          volumeName: inspection.volumeName,
-          status: inspection.status,
-          inspectedAt: inspection.inspectedAt.toISOString(),
-          completedAt: inspection.completedAt?.toISOString() || null,
-          durationMs: inspection.durationMs,
-          fileCount: inspection.fileCount,
-          totalSize: inspection.totalSize ? Number(inspection.totalSize) : null,
-          files: inspection.files,
-          stdout: inspection.stdout,
-          stderr: inspection.stderr,
-          errorMessage: inspection.errorMessage,
-          createdAt: inspection.createdAt.toISOString(),
-          updatedAt: inspection.updatedAt.toISOString(),
-        },
-      };
+      // "No inspection yet" is a valid state for any volume the user hasn't
+      // explicitly inspected, so we surface it as 200 with data: null rather
+      // than 404 — list views call this for every row and 4xx responses
+      // create persistent console noise even when the UI handles it gracefully.
+      const response: VolumeInspectionResponse = inspection
+        ? {
+            success: true,
+            data: {
+              id: inspection.id,
+              volumeName: inspection.volumeName,
+              status: inspection.status,
+              inspectedAt: inspection.inspectedAt.toISOString(),
+              completedAt: inspection.completedAt?.toISOString() || null,
+              durationMs: inspection.durationMs,
+              fileCount: inspection.fileCount,
+              totalSize: inspection.totalSize ? Number(inspection.totalSize) : null,
+              files: inspection.files,
+              stdout: inspection.stdout,
+              stderr: inspection.stderr,
+              errorMessage: inspection.errorMessage,
+              createdAt: inspection.createdAt.toISOString(),
+              updatedAt: inspection.updatedAt.toISOString(),
+            },
+          }
+        : { success: true, data: null };
 
       res.json(response);
     } catch (error) {


### PR DESCRIPTION
## Summary

The volumes list polls `GET /api/docker/volumes/:name/inspect` for every row to decide whether to show the **View results** button, but most volumes have never been inspected — so each list render produced one **404** per row. The browser captures these as `[ERROR] Failed to load resource` console lines (32 of them on a fresh dev seed), even though the UI handles the absence cleanly.

\"No inspection yet\" is a valid state for any volume, not a missing resource. The route now returns **200 with `data: null`** for that case, the frontend hook treats `null` as the absent state, and the noisy 404-skip retry branch goes away.

## Changes

### Server — `server/src/routes/docker.ts`
- `GET /api/docker/volumes/:name/inspect` now returns `{ success: true, data: null }` instead of a 404 when no inspection record exists.

### Type — `lib/types/docker.ts`
- `VolumeInspectionResponse.data` widened to `VolumeInspection | null` with a comment explaining the contract.

### Frontend — `client/src/hooks/use-volumes.ts`
- `fetchVolumeInspection` returns `VolumeInspection | null`; the 404 branch and the `Inspection not found` retry-skip both removed (no longer reachable).
- All existing UI sites already null-check `inspection` (`inspection?.status`, `if (!inspection?.files)…`, `{inspection && …}`), so no consumer changes are required.

## Verification

- `pnpm build:lib`, `pnpm --filter mini-infra-server build`, `pnpm --filter mini-infra-client exec tsc -b` — all green
- `pnpm --filter mini-infra-server lint`, `pnpm --filter mini-infra-client lint` — 0 errors, 0 warnings
- `pnpm --filter mini-infra-server test` — 1626/1626 pass
- Smoke-tested in dev:
  - `/containers` → Volumes tab: **0 console errors** (was 32 × 404), 11 `/inspect` requests all return **200 OK**
  - Inspect a volume → \"View results\" appears → detail page loads with COMPLETED status, files, search input — full flow still works

## Test plan

- [x] No 4xx responses for routine list polling
- [x] First-time-inspecting a volume still works
- [x] Re-inspecting a previously-inspected volume still works
- [x] Lint, typecheck, server tests all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)