### PR TITLE
feat(dev): WSL2 driver so worktree dev runs natively on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Force LF for shell scripts and Dockerfiles regardless of host OS.
+# Without this, `core.autocrlf=true` (the Git-for-Windows default) silently
+# rewrites these to CRLF on checkout — which breaks `set -e` in any script
+# COPYed into a Linux container ("set: line 2: illegal option -" because
+# the shell parses the trailing \r as part of the flag name).
+
+*.sh        text eol=lf
+*.bash      text eol=lf
+Dockerfile  text eol=lf
+Dockerfile.* text eol=lf
+
+# Windows wrappers stay CRLF — cmd.exe handles either, but consistency.
+*.cmd       text eol=crlf
+*.bat       text eol=crlf
+*.ps1       text eol=crlf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,25 +12,27 @@ When designing the solution make sure you pick a DRY and well though out solutio
 
 ## Worktree Development Workflow
 
-For parallel dev work, each git worktree runs its own fully isolated Mini Infra instance on its own Colima VM. This is the default flow — use it instead of fighting over a single dev daemon when you have multiple WIPs in flight.
+For parallel dev work, each git worktree runs its own fully isolated Mini Infra instance on its own VM. This is the default flow — use it instead of fighting over a single dev daemon when you have multiple WIPs in flight. The VM driver is auto-selected per platform: **Colima** on macOS, **WSL2** on Windows. Override via the `MINI_INFRA_DRIVER` env var (`colima` or `wsl`).
 
-1. **Spin up.** From the worktree root, run `deployment/development/worktree_start.sh --description "<short summary of what this worktree is for>"`. The `--description` flag (≤10 words) is required on the first run for a new worktree — without it the script drops into an interactive prompt. Optionally also pass `--long-description "<≤50 words>"`. Subsequent re-runs reuse the stored description, so the flag is only needed once. This creates (or reuses) a Colima profile named after the worktree directory, allocates stable UI/registry ports from `~/.mini-infra/worktrees.yaml`, builds + starts the stack, then seeds credentials from `~/.mini-infra/dev.env` so the onboarding wizard is skipped.
+**Windows users:** before your first run, build the cached Alpine + dockerd base tarball with `.\scripts\build-wsl-base.ps1` (one-time). Then use the `.cmd` wrappers wherever the steps below mention `.sh` (`worktree_start.cmd`, `worktree_list.cmd`, `worktree_cleanup.cmd`). See [docs/user/wsl2-reference.md](docs/user/wsl2-reference.md) for full detail.
 
-2. **Find the URL.** The script writes `environment-details.xml` at the worktree root with the UI URL, Vault URL, Docker host, seeded resource IDs, and connected-service status. Read from it instead of assuming a port (see Browser Automation below for the one-liner). Worktree-unique ports are allocated for the UI (3100-3199), local registry (5100-5199), and Vault (8200-8299) — every parallel instance gets its own slot so multiple Vaults don't collide on `localhost:8200`.
+1. **Spin up.** From the worktree root, run `deployment/development/worktree_start.sh --description "<short summary of what this worktree is for>"` (or `worktree_start.cmd` on Windows). The `--description` flag (≤10 words) is required on the first run for a new worktree — without it the script drops into an interactive prompt. Optionally also pass `--long-description "<≤50 words>"`. Subsequent re-runs reuse the stored description, so the flag is only needed once. This creates (or reuses) a Colima profile / WSL2 distro named after the worktree directory, allocates stable UI/registry/vault/docker ports from `~/.mini-infra/worktrees.yaml`, builds + starts the stack, then seeds credentials from `~/.mini-infra/dev.env` so the onboarding wizard is skipped.
+
+2. **Find the URL.** The script writes `environment-details.xml` at the worktree root with the UI URL, Vault URL, Docker host, seeded resource IDs, and connected-service status. Read from it instead of assuming a port (see Browser Automation below for the one-liner). Worktree-unique ports are allocated for the UI (3100-3199), local registry (5100-5199), Vault (8200-8299), and dockerd over TCP on the WSL2 driver (2500-2599) — every parallel instance gets its own slot so multiple Vaults don't collide on `localhost:8200`.
 
 3. **Edit code normally.** The `server/` / `client/` / `lib/` layout and workspace rules below still apply.
 
-4. **Rebuild after changes.** Re-run `deployment/development/worktree_start.sh`. It's idempotent — profile stays up, image rebuilds, container recreates, seeder skips already-seeded steps.
+4. **Rebuild after changes.** Re-run `deployment/development/worktree_start.sh` (or `.cmd`). It's idempotent — VM stays up, image rebuilds, container recreates, seeder skips already-seeded steps.
 
 5. **Test.** Use the `test-dev` or `diagnose-dev` skills; both resolve the URL from `environment-details.xml` automatically.
 
-6. **List everything.** Run `deployment/development/worktree_list.sh` from anywhere to see every registered environment (URL, admin login, path, seed status) in a table. `--wide` also prints the API key and admin password; `--json` emits the raw registry.
+6. **List everything.** Run `deployment/development/worktree_list.sh` (or `.cmd`) from anywhere to see every registered environment (URL, admin login, path, seed status) in a table. `--wide` also prints the API key and admin password; `--json` emits the raw registry.
 
-7. **Tear down.** `colima delete <profile> --data --force` removes the entire VM for that worktree. The profile name is the worktree directory basename (lowercased, sanitised to `[a-z0-9-]`).
+7. **Tear down.** On macOS: `colima delete <profile> --data --force`. On Windows: `wsl --unregister mini-infra-<profile>`. Either removes the entire VM/distro for that worktree. The profile name is the worktree directory basename (lowercased, sanitised to `[a-z0-9-]`).
 
 Run `git` commands from inside the worktree directory, not the main checkout — mixing shells between the two is the main way commits land on the wrong branch.
 
-See [docs/user/colima-reference.md](docs/user/colima-reference.md) for Colima command/config detail and gotchas.
+See [docs/user/colima-reference.md](docs/user/colima-reference.md) for Colima detail (macOS) or [docs/user/wsl2-reference.md](docs/user/wsl2-reference.md) for WSL2 detail (Windows).
 
 ## Browser Automation & Testing
 

--- a/deployment/development/lib/registry.ts
+++ b/deployment/development/lib/registry.ts
@@ -17,6 +17,18 @@ export const VAULT_PORT_MIN = 8200;
 export const VAULT_PORT_MAX = 8299;
 export const DOCKER_PORT_MIN = 2500;
 export const DOCKER_PORT_MAX = 2599;
+// HAProxy gets its host ports overridden per-worktree (rather than using the
+// template's 80/443/8404/5555 defaults) so two concurrent worktrees can both
+// run an HAProxy without colliding — and so a Windows box with Docker Desktop
+// also running doesn't lose to Docker Desktop on port 80.
+export const HAPROXY_HTTP_PORT_MIN = 8100;
+export const HAPROXY_HTTP_PORT_MAX = 8199;
+export const HAPROXY_HTTPS_PORT_MIN = 8500;
+export const HAPROXY_HTTPS_PORT_MAX = 8599;
+export const HAPROXY_STATS_PORT_MIN = 8400;
+export const HAPROXY_STATS_PORT_MAX = 8499;
+export const HAPROXY_DATAPLANE_PORT_MIN = 5500;
+export const HAPROXY_DATAPLANE_PORT_MAX = 5599;
 
 export interface WorktreeEntry {
   profile: string;
@@ -32,6 +44,12 @@ export interface WorktreeEntry {
   // (dockerd is reached via a unix socket there) but allocated regardless
   // so a registry file is portable across drivers.
   docker_port: number;
+  // Per-worktree HAProxy host ports — passed as parameterValues when the
+  // seeder instantiates the haproxy stack template.
+  haproxy_http_port: number;
+  haproxy_https_port: number;
+  haproxy_stats_port: number;
+  haproxy_dataplane_port: number;
   admin_email?: string;
   admin_password?: string;
   api_key?: string;
@@ -78,6 +96,10 @@ export function upsertEntry(
     registry_port: partial.registry_port ?? existing?.registry_port ?? 0,
     vault_port: partial.vault_port ?? existing?.vault_port ?? 0,
     docker_port: partial.docker_port ?? existing?.docker_port ?? 0,
+    haproxy_http_port: partial.haproxy_http_port ?? existing?.haproxy_http_port ?? 0,
+    haproxy_https_port: partial.haproxy_https_port ?? existing?.haproxy_https_port ?? 0,
+    haproxy_stats_port: partial.haproxy_stats_port ?? existing?.haproxy_stats_port ?? 0,
+    haproxy_dataplane_port: partial.haproxy_dataplane_port ?? existing?.haproxy_dataplane_port ?? 0,
     admin_email: partial.admin_email ?? existing?.admin_email,
     admin_password: partial.admin_password ?? existing?.admin_password,
     api_key: partial.api_key ?? existing?.api_key,
@@ -106,9 +128,18 @@ export function removeEntry(profile: string): boolean {
  * worktree's slot. Existing entries' ui_port wins as the source of truth
  * for the slot.
  */
-export function allocatePorts(
-  profile: string,
-): { ui_port: number; registry_port: number; vault_port: number; docker_port: number } {
+export interface PortAllocation {
+  ui_port: number;
+  registry_port: number;
+  vault_port: number;
+  docker_port: number;
+  haproxy_http_port: number;
+  haproxy_https_port: number;
+  haproxy_stats_port: number;
+  haproxy_dataplane_port: number;
+}
+
+export function allocatePorts(profile: string): PortAllocation {
   const SLOT_COUNT = UI_PORT_MAX - UI_PORT_MIN + 1;
   const entries = loadRegistry();
   const existing = entries[profile];
@@ -125,6 +156,13 @@ export function allocatePorts(
     }
     if (e.docker_port && e.docker_port >= DOCKER_PORT_MIN && e.docker_port <= DOCKER_PORT_MAX) {
       return e.docker_port - DOCKER_PORT_MIN;
+    }
+    if (
+      e.haproxy_http_port &&
+      e.haproxy_http_port >= HAPROXY_HTTP_PORT_MIN &&
+      e.haproxy_http_port <= HAPROXY_HTTP_PORT_MAX
+    ) {
+      return e.haproxy_http_port - HAPROXY_HTTP_PORT_MIN;
     }
     return undefined;
   };
@@ -155,6 +193,10 @@ export function allocatePorts(
     registry_port: REGISTRY_PORT_MIN + slot,
     vault_port: VAULT_PORT_MIN + slot,
     docker_port: DOCKER_PORT_MIN + slot,
+    haproxy_http_port: HAPROXY_HTTP_PORT_MIN + slot,
+    haproxy_https_port: HAPROXY_HTTPS_PORT_MIN + slot,
+    haproxy_stats_port: HAPROXY_STATS_PORT_MIN + slot,
+    haproxy_dataplane_port: HAPROXY_DATAPLANE_PORT_MIN + slot,
   };
 }
 
@@ -177,8 +219,8 @@ export function migrateFromJsonIfNeeded(): void {
   const now = new Date().toISOString();
   for (const [profile, e] of Object.entries(legacy)) {
     const uiPort = e.ui_port || 0;
-    // docker_port wasn't tracked before — derive it from the slot index of
-    // ui_port so a migrated entry stays slot-aligned.
+    // docker_port and haproxy_* weren't tracked before — derive from the
+    // slot index of ui_port so migrated entries stay slot-aligned.
     const slot = uiPort >= UI_PORT_MIN && uiPort <= UI_PORT_MAX ? uiPort - UI_PORT_MIN : 0;
     entries[profile] = {
       profile,
@@ -189,6 +231,10 @@ export function migrateFromJsonIfNeeded(): void {
       registry_port: e.registry_port || 0,
       vault_port: e.vault_port || 0,
       docker_port: uiPort ? DOCKER_PORT_MIN + slot : 0,
+      haproxy_http_port: uiPort ? HAPROXY_HTTP_PORT_MIN + slot : 0,
+      haproxy_https_port: uiPort ? HAPROXY_HTTPS_PORT_MIN + slot : 0,
+      haproxy_stats_port: uiPort ? HAPROXY_STATS_PORT_MIN + slot : 0,
+      haproxy_dataplane_port: uiPort ? HAPROXY_DATAPLANE_PORT_MIN + slot : 0,
       seeded: false,
       updated_at: now,
     };

--- a/deployment/development/lib/registry.ts
+++ b/deployment/development/lib/registry.ts
@@ -15,15 +15,23 @@ export const REGISTRY_PORT_MIN = 5100;
 export const REGISTRY_PORT_MAX = 5199;
 export const VAULT_PORT_MIN = 8200;
 export const VAULT_PORT_MAX = 8299;
+export const DOCKER_PORT_MIN = 2500;
+export const DOCKER_PORT_MAX = 2599;
 
 export interface WorktreeEntry {
   profile: string;
   worktree_path: string;
+  // VM identifier — colima profile name on macOS, WSL2 distro name on Windows.
+  // Kept named `colima_vm` for backwards compatibility with existing yaml files.
   colima_vm: string;
   url: string;
   ui_port: number;
   registry_port: number;
   vault_port: number;
+  // dockerd TCP port inside the WSL2 distro. Unused by the colima driver
+  // (dockerd is reached via a unix socket there) but allocated regardless
+  // so a registry file is portable across drivers.
+  docker_port: number;
   admin_email?: string;
   admin_password?: string;
   api_key?: string;
@@ -69,6 +77,7 @@ export function upsertEntry(
     ui_port: partial.ui_port ?? existing?.ui_port ?? 0,
     registry_port: partial.registry_port ?? existing?.registry_port ?? 0,
     vault_port: partial.vault_port ?? existing?.vault_port ?? 0,
+    docker_port: partial.docker_port ?? existing?.docker_port ?? 0,
     admin_email: partial.admin_email ?? existing?.admin_email,
     admin_password: partial.admin_password ?? existing?.admin_password,
     api_key: partial.api_key ?? existing?.api_key,
@@ -99,7 +108,7 @@ export function removeEntry(profile: string): boolean {
  */
 export function allocatePorts(
   profile: string,
-): { ui_port: number; registry_port: number; vault_port: number } {
+): { ui_port: number; registry_port: number; vault_port: number; docker_port: number } {
   const SLOT_COUNT = UI_PORT_MAX - UI_PORT_MIN + 1;
   const entries = loadRegistry();
   const existing = entries[profile];
@@ -113,6 +122,9 @@ export function allocatePorts(
     }
     if (e.vault_port && e.vault_port >= VAULT_PORT_MIN && e.vault_port <= VAULT_PORT_MAX) {
       return e.vault_port - VAULT_PORT_MIN;
+    }
+    if (e.docker_port && e.docker_port >= DOCKER_PORT_MIN && e.docker_port <= DOCKER_PORT_MAX) {
+      return e.docker_port - DOCKER_PORT_MIN;
     }
     return undefined;
   };
@@ -142,6 +154,7 @@ export function allocatePorts(
     ui_port: UI_PORT_MIN + slot,
     registry_port: REGISTRY_PORT_MIN + slot,
     vault_port: VAULT_PORT_MIN + slot,
+    docker_port: DOCKER_PORT_MIN + slot,
   };
 }
 
@@ -164,6 +177,9 @@ export function migrateFromJsonIfNeeded(): void {
   const now = new Date().toISOString();
   for (const [profile, e] of Object.entries(legacy)) {
     const uiPort = e.ui_port || 0;
+    // docker_port wasn't tracked before — derive it from the slot index of
+    // ui_port so a migrated entry stays slot-aligned.
+    const slot = uiPort >= UI_PORT_MIN && uiPort <= UI_PORT_MAX ? uiPort - UI_PORT_MIN : 0;
     entries[profile] = {
       profile,
       worktree_path: '',
@@ -172,6 +188,7 @@ export function migrateFromJsonIfNeeded(): void {
       ui_port: uiPort,
       registry_port: e.registry_port || 0,
       vault_port: e.vault_port || 0,
+      docker_port: uiPort ? DOCKER_PORT_MIN + slot : 0,
       seeded: false,
       updated_at: now,
     };

--- a/deployment/development/lib/seeder.ts
+++ b/deployment/development/lib/seeder.ts
@@ -29,6 +29,13 @@ export interface SeederInput {
   uiPort: number;
   registryPort: number;
   vaultPort: number;
+  // Per-worktree HAProxy host ports — passed as parameterValues to the
+  // haproxy stack template so two worktrees (or any other process binding
+  // 80/443) don't collide.
+  haproxyHttpPort: number;
+  haproxyHttpsPort: number;
+  haproxyStatsPort: number;
+  haproxyDataplanePort: number;
   profile: string;
   projectRoot: string;
   dockerHost: string;
@@ -403,7 +410,18 @@ async function findTemplate(
   return match?.id || null;
 }
 
-async function ensureHaproxyStack(api: ApiClient, envId: string): Promise<string | null> {
+interface HaproxyPorts {
+  http: number;
+  https: number;
+  stats: number;
+  dataplane: number;
+}
+
+async function ensureHaproxyStack(
+  api: ApiClient,
+  envId: string,
+  ports: HaproxyPorts,
+): Promise<string | null> {
   const stackName = 'haproxy-local';
   logInfo(`Looking for existing ${stackName} stack in local env`);
   const list = await api.get<unknown>(`/api/stacks?environmentId=${envId}`);
@@ -421,9 +439,22 @@ async function ensureHaproxyStack(api: ApiClient, envId: string): Promise<string
     logSkip('HAProxy template not found — skipping HAProxy setup');
     return null;
   }
+  // Override host-ports per worktree. Defaults are 80/443/8404/5555 which
+  // collide between worktrees and lose to anything else on the box already
+  // binding those (Docker Desktop on Windows, an existing HTTP server on
+  // macOS). Slot-aligned with the rest of the per-worktree port assignment.
   const res = await api.post<unknown>(
     `/api/stack-templates/${templateId}/instantiate`,
-    { environmentId: envId, name: stackName },
+    {
+      environmentId: envId,
+      name: stackName,
+      parameterValues: {
+        'http-port': ports.http,
+        'https-port': ports.https,
+        'stats-port': ports.stats,
+        'dataplane-port': ports.dataplane,
+      },
+    },
   );
   if (res.status !== 201) {
     logError(`HAProxy instantiate returned ${res.status}: ${res.bodyText}`);
@@ -435,7 +466,9 @@ async function ensureHaproxyStack(api: ApiClient, envId: string): Promise<string
     logError(`HAProxy instantiate response missing id: ${res.bodyText}`);
     return null;
   }
-  logOk(`HAProxy stack created (id=${id})`);
+  logOk(
+    `HAProxy stack created (id=${id}, ports: http=${ports.http} https=${ports.https} stats=${ports.stats} dataplane=${ports.dataplane})`,
+  );
   return id;
 }
 
@@ -720,7 +753,12 @@ export async function seed(input: SeederInput): Promise<SeederOutput> {
   await configureServices(api, env);
 
   const localEnvId = await ensureLocalEnvironment(api, env);
-  const haproxyStackId = await ensureHaproxyStack(api, localEnvId);
+  const haproxyStackId = await ensureHaproxyStack(api, localEnvId, {
+    http: input.haproxyHttpPort,
+    https: input.haproxyHttpsPort,
+    stats: input.haproxyStatsPort,
+    dataplane: input.haproxyDataplanePort,
+  });
   if (haproxyStackId) {
     await applyAndWaitForSynced(api, haproxyStackId, 'HAProxy');
   }

--- a/deployment/development/lib/wsl.ts
+++ b/deployment/development/lib/wsl.ts
@@ -1,0 +1,189 @@
+// WSL2 driver — Windows analog of lib/colima.ts.
+//
+// Each worktree gets its own WSL2 distro named `mini-infra-<profile>` cloned
+// from the cached Alpine + dockerd tarball at `~/.mini-infra/wsl-base.tar`
+// (produced by scripts/build-wsl-base.ps1). The distro hosts dockerd on
+// `tcp://0.0.0.0:<docker_port>` plus `unix:///var/run/docker.sock`. WSL2's
+// localhostForwarding makes `tcp://localhost:<docker_port>` reachable from
+// Windows; the unix socket is what the mini-infra container bind-mounts.
+//
+// Distro names are namespaced (`mini-infra-` prefix) so they never collide
+// with a user-installed Ubuntu or whatever else they have.
+
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const DISTRO_PREFIX = 'mini-infra-';
+const WSL = 'wsl.exe';
+
+export function distroName(profile: string): string {
+  return `${DISTRO_PREFIX}${profile}`;
+}
+
+interface WslListEntry {
+  name: string;
+  state: string;
+  version: string;
+}
+
+/**
+ * `wsl -l -v` emits UTF-16 little-endian. Node's spawnSync with `encoding`
+ * decodes as UTF-8 by default, which produces strings full of nulls. Reading
+ * the buffer raw and decoding manually avoids that.
+ */
+function listDistros(): WslListEntry[] {
+  const res = spawnSync(WSL, ['-l', '-v'], { encoding: 'buffer' });
+  if (res.status !== 0) return [];
+  // wsl emits BOM-prefixed UTF-16 LE on the Windows side.
+  const text = res.stdout.toString('utf16le').replace(/^﻿/, '');
+  const lines = text.split(/\r?\n/).filter(Boolean);
+  if (lines.length === 0) return [];
+  // First line is a header. Strip the leading `*` marker on the default distro.
+  const out: WslListEntry[] = [];
+  for (const raw of lines.slice(1)) {
+    const line = raw.replace(/^\s*\*?\s*/, '').trimEnd();
+    const cols = line.split(/\s+/);
+    if (cols.length < 3) continue;
+    out.push({ name: cols[0], state: cols[1], version: cols[2] });
+  }
+  return out;
+}
+
+export function distroExists(name: string): boolean {
+  return listDistros().some((d) => d.name === name);
+}
+
+export function isDistroRunning(name: string): boolean {
+  const entry = listDistros().find((d) => d.name === name);
+  return entry?.state === 'Running';
+}
+
+export interface WslImportOpts {
+  name: string;
+  baseTarball: string;
+  installDir: string;
+}
+
+export function importDistro(opts: WslImportOpts): void {
+  if (!fs.existsSync(opts.baseTarball)) {
+    throw new Error(
+      `Base tarball not found at ${opts.baseTarball}. ` +
+        'Run scripts\\build-wsl-base.ps1 first.',
+    );
+  }
+  fs.mkdirSync(opts.installDir, { recursive: true });
+  const res = spawnSync(WSL, ['--import', opts.name, opts.installDir, opts.baseTarball], {
+    stdio: 'inherit',
+  });
+  if (res.status !== 0) {
+    throw new Error(`wsl --import failed for distro ${opts.name}`);
+  }
+}
+
+export function unregisterDistro(name: string): boolean {
+  const res = spawnSync(WSL, ['--unregister', name], { stdio: 'inherit' });
+  return res.status === 0;
+}
+
+export interface WslStartDockerOpts {
+  name: string;
+  dockerPort: number;
+}
+
+/**
+ * Ensure dockerd is running on the requested TCP port inside the distro.
+ *
+ * Calls the baked-in `/etc/mini-infra/start-dockerd.sh <port>` which uses
+ * `setsid -f` to detach dockerd from the wsl-session shell. Without setsid,
+ * the daemon dies when the invoking shell exits — WSL kills children of an
+ * exiting session even when nohup'd. setsid moves it into a new session
+ * parented to init.
+ *
+ * Idempotent — the helper script no-ops if dockerd is already running.
+ * dockerd's TLS-warning startup pause means the listener takes ~15-20s to
+ * bind even after this returns; pair with `ensureDockerReady`.
+ */
+export function startDocker(opts: WslStartDockerOpts): void {
+  const res = spawnSync(
+    WSL,
+    ['-d', opts.name, '--', '/etc/mini-infra/start-dockerd.sh', String(opts.dockerPort)],
+    { stdio: 'inherit' },
+  );
+  if (res.status !== 0) {
+    throw new Error(`Failed to start dockerd in distro ${opts.name}`);
+  }
+}
+
+/**
+ * Poll the dockerd TCP listener until it responds or attempts run out.
+ * Resolves true on success, false on timeout. Uses fetch against the
+ * dockerd ping endpoint (`/_ping`) which all dockerd versions expose.
+ *
+ * Default of 60 attempts is set high because dockerd intentionally pauses
+ * ~15 s on startup when binding to a TCP host without --tlsverify (a foot-
+ * gun warning baked into recent dockerd builds). On a cold boot of the
+ * distro, expect the first probe success around the 18–25 s mark.
+ */
+export async function ensureDockerReady(
+  dockerPort: number,
+  attempts = 60,
+): Promise<boolean> {
+  const url = `http://localhost:${dockerPort}/_ping`;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return true;
+    } catch {
+      // dockerd not up yet
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  return false;
+}
+
+/**
+ * Resolve a Windows path (like `C:\Users\...`) to its WSL2 mount path
+ * (like `/mnt/c/Users/...`). Handy for translating `PROJECT_ROOT` for
+ * commands run inside the distro. Returns null if wslpath isn't usable
+ * (e.g. distro not running). Currently unused by the orchestrator but
+ * exposed for future use — bind-mounts in compose are daemon-side, so
+ * we don't need this on the hot path.
+ */
+export function wslPath(distro: string, windowsPath: string): string | null {
+  const res = spawnSync(WSL, ['-d', distro, '--', 'wslpath', '-u', windowsPath], {
+    encoding: 'utf8',
+  });
+  if (res.status !== 0) return null;
+  const out = res.stdout.trim();
+  return out || null;
+}
+
+/**
+ * Best-effort: ensure WSL2 is installed and at least one feature-enabled
+ * distro can run. Throws with a friendly message otherwise.
+ */
+export function assertWslAvailable(): void {
+  const res = spawnSync(WSL, ['--status'], { encoding: 'buffer' });
+  if (res.status !== 0) {
+    throw new Error(
+      'WSL2 is not available on this host. Run `wsl --install` from an admin PowerShell and reboot.',
+    );
+  }
+}
+
+/**
+ * The cached base tarball location. Mirrors the path
+ * scripts/build-wsl-base.ps1 writes to.
+ */
+export function defaultBaseTarballPath(miniInfraHome: string): string {
+  return path.join(miniInfraHome, 'wsl-base.tar');
+}
+
+/**
+ * The per-distro install directory under MINI_INFRA_HOME. WSL stores the
+ * VHDX disk file under here.
+ */
+export function defaultInstallDir(miniInfraHome: string, profile: string): string {
+  return path.join(miniInfraHome, 'wsl', profile);
+}

--- a/deployment/development/worktree-cleanup.ts
+++ b/deployment/development/worktree-cleanup.ts
@@ -16,12 +16,22 @@ import { parseArgs } from 'node:util';
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { logInfo, logOk, logWarn, logSkip, logError } from './lib/log.js';
 import { colimaExists, deleteColima } from './lib/colima.js';
+import { distroExists, distroName, unregisterDistro } from './lib/wsl.js';
 import { migrateFromJsonIfNeeded, removeEntry } from './lib/registry.js';
 
-const SCRIPT_DIR = path.dirname(new URL(import.meta.url).pathname);
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, '..', '..');
+
+type Driver = 'colima' | 'wsl';
+
+function pickDriver(): Driver {
+  const env = process.env.MINI_INFRA_DRIVER;
+  if (env === 'colima' || env === 'wsl') return env;
+  return process.platform === 'darwin' ? 'colima' : 'wsl';
+}
 
 function exec(
   cmd: string,
@@ -37,6 +47,9 @@ function exec(
 }
 
 function commandExists(cmd: string): boolean {
+  if (process.platform === 'win32') {
+    return spawnSync('where', [cmd]).status === 0;
+  }
   return spawnSync('command', ['-v', cmd], { shell: '/bin/bash' }).status === 0;
 }
 
@@ -108,17 +121,25 @@ function parseCliArgs(): Args {
 
 function main(): void {
   const args = parseCliArgs();
+  const driver = pickDriver();
 
   if (args.dryRun) {
     logWarn('DRY RUN — no changes will be made');
   }
 
   if (!commandExists('gh')) {
-    logError('gh CLI is not installed. Install with: brew install gh');
+    const hint = process.platform === 'win32'
+      ? 'Install from https://cli.github.com/ or `winget install GitHub.cli`'
+      : 'Install with: brew install gh';
+    logError(`gh CLI is not installed. ${hint}`);
     process.exit(1);
   }
-  if (!commandExists('colima')) {
+  if (driver === 'colima' && !commandExists('colima')) {
     logError('colima is not installed. Install with: brew install colima');
+    process.exit(1);
+  }
+  if (driver === 'wsl' && !commandExists('wsl')) {
+    logError('wsl.exe not found on PATH — WSL2 must be enabled on this host.');
     process.exit(1);
   }
 
@@ -193,23 +214,42 @@ function main(): void {
 
     logOk(`${name} — PR merged, folder ${ageHours}h old — cleaning up`);
 
+    const distro = distroName(profile);
+
     if (args.dryRun) {
-      console.log(`  [dry-run] colima delete ${profile} --force`);
+      if (driver === 'colima') {
+        console.log(`  [dry-run] colima delete ${profile} --force`);
+      } else {
+        console.log(`  [dry-run] wsl --unregister ${distro}`);
+      }
       console.log(`  [dry-run] git worktree remove --force ${wt.path}  (${ageHours}h old)`);
       console.log(`  [dry-run] remove '${profile}' from ~/.mini-infra/worktrees.yaml`);
       cleaned++;
       continue;
     }
 
-    if (colimaExists(profile)) {
-      logInfo(`Deleting Colima VM: ${profile}`);
-      if (deleteColima(profile)) {
-        logOk('Colima VM deleted');
+    if (driver === 'colima') {
+      if (colimaExists(profile)) {
+        logInfo(`Deleting Colima VM: ${profile}`);
+        if (deleteColima(profile)) {
+          logOk('Colima VM deleted');
+        } else {
+          logWarn('Colima delete returned non-zero (continuing)');
+        }
       } else {
-        logWarn('Colima delete returned non-zero (continuing)');
+        logSkip(`No Colima VM for ${profile}`);
       }
     } else {
-      logSkip(`No Colima VM for ${profile}`);
+      if (distroExists(distro)) {
+        logInfo(`Unregistering WSL distro: ${distro}`);
+        if (unregisterDistro(distro)) {
+          logOk('WSL distro unregistered');
+        } else {
+          logWarn('wsl --unregister returned non-zero (continuing)');
+        }
+      } else {
+        logSkip(`No WSL distro for ${distro}`);
+      }
     }
 
     logInfo(`Removing git worktree: ${wt.path}`);

--- a/deployment/development/worktree-list.ts
+++ b/deployment/development/worktree-list.ts
@@ -76,7 +76,8 @@ function main(): void {
       'UI',
       'REG',
       'VAULT',
-      'COLIMA VM',
+      'HAPROXY',
+      'VM',
       'ADMIN EMAIL',
       'ADMIN PASSWORD',
       'API KEY',
@@ -84,6 +85,9 @@ function main(): void {
       'PATH',
     ]);
     for (const e of values) {
+      const haproxy = e.haproxy_http_port
+        ? `${e.haproxy_http_port}/${e.haproxy_https_port}`
+        : '-';
       rows.push([
         e.profile,
         dash(e.description),
@@ -91,6 +95,7 @@ function main(): void {
         e.ui_port ? String(e.ui_port) : '-',
         e.registry_port ? String(e.registry_port) : '-',
         e.vault_port ? String(e.vault_port) : '-',
+        haproxy,
         dash(e.colima_vm),
         dash(e.admin_email),
         dash(e.admin_password),

--- a/deployment/development/worktree-start.ts
+++ b/deployment/development/worktree-start.ts
@@ -291,6 +291,10 @@ async function main(): Promise<void> {
     registry_port: registryPort,
     vault_port: vaultPort,
     docker_port: dockerPort,
+    haproxy_http_port: haproxyHttpPort,
+    haproxy_https_port: haproxyHttpsPort,
+    haproxy_stats_port: haproxyStatsPort,
+    haproxy_dataplane_port: haproxyDataplanePort,
   } = allocatePorts(profile);
   // Persist early so the entry exists even if later steps fail
   upsertEntry({
@@ -301,12 +305,17 @@ async function main(): Promise<void> {
     registry_port: registryPort,
     vault_port: vaultPort,
     docker_port: dockerPort,
+    haproxy_http_port: haproxyHttpPort,
+    haproxy_https_port: haproxyHttpsPort,
+    haproxy_stats_port: haproxyStatsPort,
+    haproxy_dataplane_port: haproxyDataplanePort,
     url: `http://localhost:${uiPort}`,
     description: shortDesc,
   });
   logInfo(
     `Ports: UI=${uiPort}, registry=${registryPort}, vault=${vaultPort}` +
-      (driver === 'wsl' ? `, docker=${dockerPort}` : ''),
+      (driver === 'wsl' ? `, docker=${dockerPort}` : '') +
+      `, haproxy(http/https/stats/dataplane)=${haproxyHttpPort}/${haproxyHttpsPort}/${haproxyStatsPort}/${haproxyDataplanePort}`,
   );
 
   // Bring the VM up via the selected driver. For environment-details.xml,
@@ -569,6 +578,10 @@ async function main(): Promise<void> {
         uiPort,
         registryPort,
         vaultPort,
+        haproxyHttpPort,
+        haproxyHttpsPort,
+        haproxyStatsPort,
+        haproxyDataplanePort,
         profile,
         projectRoot: PROJECT_ROOT,
         dockerHost,
@@ -587,6 +600,10 @@ async function main(): Promise<void> {
         registry_port: registryPort,
         vault_port: vaultPort,
         docker_port: dockerPort,
+        haproxy_http_port: haproxyHttpPort,
+        haproxy_https_port: haproxyHttpsPort,
+        haproxy_stats_port: haproxyStatsPort,
+        haproxy_dataplane_port: haproxyDataplanePort,
         url: `http://localhost:${uiPort}`,
         admin_email: result.adminEmail,
         admin_password: result.adminPassword,
@@ -615,6 +632,10 @@ async function main(): Promise<void> {
       registry_port: registryPort,
       vault_port: vaultPort,
       docker_port: dockerPort,
+      haproxy_http_port: haproxyHttpPort,
+      haproxy_https_port: haproxyHttpsPort,
+      haproxy_stats_port: haproxyStatsPort,
+      haproxy_dataplane_port: haproxyDataplanePort,
       url: `http://localhost:${uiPort}`,
       seeded: details?.seeded ?? false,
       admin_email: details?.admin.email,
@@ -645,6 +666,7 @@ async function main(): Promise<void> {
   console.log(`  URL:         http://localhost:${uiPort}`);
   console.log(`  Registry:    localhost:${registryPort}`);
   console.log(`  Vault:       http://localhost:${vaultPort}`);
+  console.log(`  HAProxy:     http://localhost:${haproxyHttpPort}  (https=${haproxyHttpsPort}, stats=${haproxyStatsPort}, dataplane=${haproxyDataplanePort})`);
   console.log(`  DOCKER_HOST: ${dockerHost}`);
   console.log('');
   console.log(`  Logs:   DOCKER_HOST=${dockerHost} docker compose -f ${COMPOSE_FILE} -p ${composeProjectName} logs -f`);

--- a/deployment/development/worktree-start.ts
+++ b/deployment/development/worktree-start.ts
@@ -99,6 +99,11 @@ function commandExists(cmd: string): boolean {
   return spawnSync(probe, args, opts).status === 0;
 }
 
+// On Windows, spawnSync without `shell:true` only resolves .exe — it can't
+// find .cmd shims like corepack.cmd or pnpm.cmd. Enabling shell on Windows
+// routes through cmd.exe which respects PATHEXT.
+const NEEDS_SHELL = process.platform === 'win32';
+
 function exec(
   cmd: string,
   args: string[],
@@ -109,6 +114,7 @@ function exec(
     env: { ...process.env, ...(opts.env || {}) },
     cwd: opts.cwd,
     stdio: opts.stdio || 'pipe',
+    shell: NEEDS_SHELL,
   });
   return {
     status: res.status ?? 1,
@@ -121,6 +127,7 @@ function compose(args: string[], env: NodeJS.ProcessEnv, stdio: 'inherit' | 'pip
   const res = spawnSync('docker', ['compose', '-f', COMPOSE_FILE, ...args], {
     env: { ...process.env, ...env },
     stdio,
+    shell: NEEDS_SHELL,
   });
   return res.status ?? 1;
 }
@@ -302,8 +309,11 @@ async function main(): Promise<void> {
       (driver === 'wsl' ? `, docker=${dockerPort}` : ''),
   );
 
-  // Bring the VM up via the selected driver.
+  // Bring the VM up via the selected driver. For environment-details.xml,
+  // colima exposes a host-side unix socket path; wsl exposes only TCP, so
+  // the socket field is empty there.
   let dockerHost: string;
+  let dockerSockPath = '';
   if (driver === 'colima') {
     if (!isColimaRunning(profile)) {
       logInfo(`Starting Colima profile '${profile}' (vz, ${COLIMA_CPUS} CPU, ${COLIMA_MEMORY_GIB}G RAM)...`);
@@ -312,7 +322,7 @@ async function main(): Promise<void> {
     } else {
       logInfo(`Colima profile '${profile}' already running`);
     }
-    const dockerSockPath = path.join(process.env.HOME || '', '.colima', profile, 'docker.sock');
+    dockerSockPath = path.join(process.env.HOME || '', '.colima', profile, 'docker.sock');
     if (!fs.existsSync(dockerSockPath)) {
       logError(`Expected Colima socket not found at ${dockerSockPath}`);
       process.exit(1);

--- a/deployment/development/worktree-start.ts
+++ b/deployment/development/worktree-start.ts
@@ -16,6 +16,7 @@ import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as readline from 'node:readline/promises';
+import { fileURLToPath } from 'node:url';
 import { stdin as input, stdout as output } from 'node:process';
 import { logInfo, logOk, logWarn, logError } from './lib/log.js';
 import {
@@ -28,15 +29,37 @@ import {
 } from './lib/registry.js';
 import { readEnvironmentDetails, writeMinimalEnvironmentDetails } from './lib/env-details.js';
 import { isColimaRunning, startColima } from './lib/colima.js';
+import {
+  assertWslAvailable,
+  defaultBaseTarballPath,
+  defaultInstallDir,
+  distroExists,
+  distroName,
+  ensureDockerReady,
+  importDistro,
+  isDistroRunning,
+  startDocker as startWslDocker,
+} from './lib/wsl.js';
 import { seed, ensureVaultUnlocked } from './lib/seeder.js';
 import { ApiClient } from './lib/api.js';
 
-const SCRIPT_DIR = path.dirname(new URL(import.meta.url).pathname);
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = path.resolve(SCRIPT_DIR, '..', '..');
 const COMPOSE_FILE = path.join(SCRIPT_DIR, 'docker-compose.worktree.yaml');
 
 const COLIMA_CPUS = 2;
 const COLIMA_MEMORY_GIB = 8;
+
+type Driver = 'colima' | 'wsl';
+
+function pickDriver(): Driver {
+  const env = process.env.MINI_INFRA_DRIVER;
+  if (env === 'colima' || env === 'wsl') return env;
+  if (env) {
+    logWarn(`Unknown MINI_INFRA_DRIVER='${env}' — falling back to platform default`);
+  }
+  return process.platform === 'darwin' ? 'colima' : 'wsl';
+}
 
 function usage(): void {
   const lines = fs.readFileSync(new URL(import.meta.url), 'utf8').split('\n');
@@ -70,8 +93,10 @@ async function waitForHttp(url: string, attempts: number, label: string): Promis
 }
 
 function commandExists(cmd: string): boolean {
-  const res = spawnSync('command', ['-v', cmd], { shell: '/bin/bash' });
-  return res.status === 0;
+  const probe = process.platform === 'win32' ? 'where' : 'command';
+  const args = process.platform === 'win32' ? [cmd] : ['-v', cmd];
+  const opts = process.platform === 'win32' ? {} : { shell: '/bin/bash' };
+  return spawnSync(probe, args, opts).status === 0;
 }
 
 function exec(
@@ -158,6 +183,8 @@ async function confirm(prompt: string): Promise<boolean> {
 
 async function main(): Promise<void> {
   const args = parseCliArgs();
+  const driver = pickDriver();
+  logInfo(`VM driver: ${driver}`);
 
   let profile = args.profile;
   if (!profile) {
@@ -170,12 +197,26 @@ async function main(): Promise<void> {
   }
   logInfo(`Worktree profile: ${profile}`);
 
-  // Prereqs
-  for (const tool of ['colima', 'docker']) {
-    if (!commandExists(tool)) {
-      logError(`${tool} is not installed. Install with: brew install ${tool}`);
+  // Prereqs — driver-specific tools first, then the always-required ones.
+  if (driver === 'colima' && !commandExists('colima')) {
+    logError('colima is not installed. Install with: brew install colima');
+    process.exit(1);
+  }
+  if (driver === 'wsl') {
+    try {
+      assertWslAvailable();
+    } catch (err) {
+      logError(err instanceof Error ? err.message : String(err));
       process.exit(1);
     }
+  }
+  if (!commandExists('docker')) {
+    const hint =
+      driver === 'wsl'
+        ? 'Install the Docker CLI: https://download.docker.com/win/static/stable/'
+        : 'Install with: brew install docker';
+    logError(`docker CLI is not installed. ${hint}`);
+    process.exit(1);
   }
   if (!commandExists('corepack')) {
     logError('corepack is not available. Install a recent Node.js (>=16.9) or run: npm install -g corepack');
@@ -242,35 +283,74 @@ async function main(): Promise<void> {
     ui_port: uiPort,
     registry_port: registryPort,
     vault_port: vaultPort,
+    docker_port: dockerPort,
   } = allocatePorts(profile);
   // Persist early so the entry exists even if later steps fail
   upsertEntry({
     profile,
     worktree_path: PROJECT_ROOT,
-    colima_vm: profile,
+    colima_vm: driver === 'wsl' ? distroName(profile) : profile,
     ui_port: uiPort,
     registry_port: registryPort,
     vault_port: vaultPort,
+    docker_port: dockerPort,
     url: `http://localhost:${uiPort}`,
     description: shortDesc,
   });
-  logInfo(`Ports: UI=${uiPort}, registry=${registryPort}, vault=${vaultPort}`);
+  logInfo(
+    `Ports: UI=${uiPort}, registry=${registryPort}, vault=${vaultPort}` +
+      (driver === 'wsl' ? `, docker=${dockerPort}` : ''),
+  );
 
-  // Colima
-  if (!isColimaRunning(profile)) {
-    logInfo(`Starting Colima profile '${profile}' (vz, ${COLIMA_CPUS} CPU, ${COLIMA_MEMORY_GIB}G RAM)...`);
-    startColima({ profile, cpus: COLIMA_CPUS, memoryGib: COLIMA_MEMORY_GIB });
-    logOk(`Colima profile '${profile}' started`);
+  // Bring the VM up via the selected driver.
+  let dockerHost: string;
+  if (driver === 'colima') {
+    if (!isColimaRunning(profile)) {
+      logInfo(`Starting Colima profile '${profile}' (vz, ${COLIMA_CPUS} CPU, ${COLIMA_MEMORY_GIB}G RAM)...`);
+      startColima({ profile, cpus: COLIMA_CPUS, memoryGib: COLIMA_MEMORY_GIB });
+      logOk(`Colima profile '${profile}' started`);
+    } else {
+      logInfo(`Colima profile '${profile}' already running`);
+    }
+    const dockerSockPath = path.join(process.env.HOME || '', '.colima', profile, 'docker.sock');
+    if (!fs.existsSync(dockerSockPath)) {
+      logError(`Expected Colima socket not found at ${dockerSockPath}`);
+      process.exit(1);
+    }
+    dockerHost = `unix://${dockerSockPath}`;
   } else {
-    logInfo(`Colima profile '${profile}' already running`);
+    const distro = distroName(profile);
+    if (!distroExists(distro)) {
+      const baseTar = defaultBaseTarballPath(MINI_INFRA_HOME);
+      if (!fs.existsSync(baseTar)) {
+        logError(`Base tarball not found at ${baseTar}.`);
+        logError('Run scripts\\build-wsl-base.ps1 from the project root first.');
+        process.exit(1);
+      }
+      logInfo(`Importing WSL distro '${distro}' from ${baseTar}...`);
+      importDistro({
+        name: distro,
+        baseTarball: baseTar,
+        installDir: defaultInstallDir(MINI_INFRA_HOME, profile),
+      });
+      logOk(`WSL distro '${distro}' imported`);
+    } else {
+      logInfo(`WSL distro '${distro}' already exists`);
+    }
+    if (!isDistroRunning(distro)) {
+      logInfo(`Starting dockerd inside '${distro}' on tcp port ${dockerPort}...`);
+    }
+    startWslDocker({ name: distro, dockerPort });
+    const ready = await ensureDockerReady(dockerPort, 60);
+    if (!ready) {
+      logError(`dockerd in '${distro}' did not become ready on port ${dockerPort} within 60s`);
+      logError(`Check the daemon log: wsl -d ${distro} -- cat /var/log/mini-infra/dockerd.log`);
+      process.exit(1);
+    }
+    logOk(`dockerd ready at tcp://localhost:${dockerPort}`);
+    dockerHost = `tcp://localhost:${dockerPort}`;
   }
 
-  const dockerSockPath = path.join(process.env.HOME || '', '.colima', profile, 'docker.sock');
-  if (!fs.existsSync(dockerSockPath)) {
-    logError(`Expected Colima socket not found at ${dockerSockPath}`);
-    process.exit(1);
-  }
-  const dockerHost = `unix://${dockerSockPath}`;
   const composeProjectName = `mini-infra-${profile}`;
   const agentSidecarImageTag = `localhost:${registryPort}/mini-infra-agent-sidecar:latest`;
 
@@ -492,10 +572,11 @@ async function main(): Promise<void> {
       upsertEntry({
         profile,
         worktree_path: PROJECT_ROOT,
-        colima_vm: profile,
+        colima_vm: driver === 'wsl' ? distroName(profile) : profile,
         ui_port: uiPort,
         registry_port: registryPort,
         vault_port: vaultPort,
+        docker_port: dockerPort,
         url: `http://localhost:${uiPort}`,
         admin_email: result.adminEmail,
         admin_password: result.adminPassword,
@@ -519,10 +600,11 @@ async function main(): Promise<void> {
     upsertEntry({
       profile,
       worktree_path: PROJECT_ROOT,
-      colima_vm: profile,
+      colima_vm: driver === 'wsl' ? distroName(profile) : profile,
       ui_port: uiPort,
       registry_port: registryPort,
       vault_port: vaultPort,
+      docker_port: dockerPort,
       url: `http://localhost:${uiPort}`,
       seeded: details?.seeded ?? false,
       admin_email: details?.admin.email,
@@ -557,9 +639,11 @@ async function main(): Promise<void> {
   console.log('');
   console.log(`  Logs:   DOCKER_HOST=${dockerHost} docker compose -f ${COMPOSE_FILE} -p ${composeProjectName} logs -f`);
   console.log(`  Stop:   DOCKER_HOST=${dockerHost} docker compose -f ${COMPOSE_FILE} -p ${composeProjectName} down`);
-  console.log(`  Re-seed: ${path.join(SCRIPT_DIR, 'worktree_start.sh')} --seed --profile ${profile}`);
-  console.log(`  Nuke:    ${path.join(SCRIPT_DIR, 'worktree_start.sh')} --reset --profile ${profile}`);
-  console.log(`  List all: ${path.join(SCRIPT_DIR, 'worktree_list.sh')}`);
+  const startWrapper = process.platform === 'win32' ? 'worktree_start.cmd' : 'worktree_start.sh';
+  const listWrapper = process.platform === 'win32' ? 'worktree_list.cmd' : 'worktree_list.sh';
+  console.log(`  Re-seed: ${path.join(SCRIPT_DIR, startWrapper)} --seed --profile ${profile}`);
+  console.log(`  Nuke:    ${path.join(SCRIPT_DIR, startWrapper)} --reset --profile ${profile}`);
+  console.log(`  List all: ${path.join(SCRIPT_DIR, listWrapper)}`);
   console.log('');
 }
 

--- a/deployment/development/worktree_cleanup.cmd
+++ b/deployment/development/worktree_cleanup.cmd
@@ -1,0 +1,8 @@
+@echo off
+setlocal
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%..\.."
+call pnpm dlx tsx@4.21.0 "%SCRIPT_DIR%worktree-cleanup.ts" %*
+set "RC=%ERRORLEVEL%"
+popd
+exit /b %RC%

--- a/deployment/development/worktree_list.cmd
+++ b/deployment/development/worktree_list.cmd
@@ -1,0 +1,8 @@
+@echo off
+setlocal
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%..\.."
+call pnpm dlx tsx@4.21.0 "%SCRIPT_DIR%worktree-list.ts" %*
+set "RC=%ERRORLEVEL%"
+popd
+exit /b %RC%

--- a/deployment/development/worktree_start.cmd
+++ b/deployment/development/worktree_start.cmd
@@ -1,0 +1,8 @@
+@echo off
+setlocal
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%..\.."
+call pnpm dlx tsx@4.21.0 "%SCRIPT_DIR%worktree-start.ts" %*
+set "RC=%ERRORLEVEL%"
+popd
+exit /b %RC%

--- a/docs/planning/not-shipped/wsl2-driver-plan.md
+++ b/docs/planning/not-shipped/wsl2-driver-plan.md
@@ -1,0 +1,242 @@
+# Worktree dev — WSL2 driver for Windows hosts
+
+Adds a second VM driver for `worktree_start` so the per-worktree dev flow runs on Windows. macOS keeps using Colima; Windows uses one Alpine WSL2 distro per worktree as the dockerd carrier. Linux is left as-is for now (existing flow assumes a remote Docker host or system dockerd).
+
+## Goal
+
+`pnpm dlx tsx deployment/development/worktree-start.ts --description "..."` on a Windows host produces the same end state as it does on macOS today:
+
+- One isolated dockerd per worktree
+- A registered entry in `~/.mini-infra/worktrees.yaml` with stable ports
+- A healthy mini-infra at `http://localhost:<ui_port>`
+- A seeded `environment-details.xml` at the worktree root
+- `worktree_list` and cleanup work the same way
+
+The bash wrappers (`worktree_start.sh`, `worktree_list.sh`) keep working on macOS unchanged. New `.cmd` siblings handle Windows.
+
+## Why Option B (per-worktree WSL2 distro)
+
+Rejected during exploration: dropping per-worktree isolation in favour of one shared Docker Desktop / Rancher Desktop daemon. That works but loses the "one stuck container can't blast-radius into other worktrees" property that the colima-per-worktree model gives today. With Alpine WSL2 distros being ~250 MB on disk and ~60 MB idle RAM each, the per-worktree model is cheap enough on Windows that there's no good reason not to keep it.
+
+## Architecture mapping
+
+| Colima concept | WSL2 equivalent |
+|---|---|
+| `colima start <profile>` | `wsl --import mini-infra-<profile> <install-dir> <base.tar>` |
+| `colima status <profile>` | `wsl -l -v` parsed |
+| `colima delete <profile> --data --force` | `wsl --unregister mini-infra-<profile>` |
+| `~/.colima/<profile>/docker.sock` (host-side socket) | dockerd in distro on `tcp://0.0.0.0:<docker_port>` + `unix:///var/run/docker.sock` |
+| `DOCKER_HOST=unix://...sock` | `DOCKER_HOST=tcp://localhost:<docker_port>` (WSL2 localhostForwarding) |
+| Per-VM CPU/RAM (`--cpu 2 --memory 8`) | Global `.wslconfig` (shared pool — see Tradeoffs) |
+
+## What stays unchanged
+
+- [docker-compose.worktree.yaml](../../../deployment/development/docker-compose.worktree.yaml) — no source bind-mounts, only managed volumes + `/var/run/docker.sock`. Daemon-agnostic.
+- [lib/seeder.ts](../../../deployment/development/lib/seeder.ts) — pure HTTP against `localhost:<ui_port>`. Verified portable: only `dgram`, `fetch`, `fs.readFileSync` for `dev.env`. The `dockerHost: 'unix:///var/run/docker.sock'` POSTed at line 218 is the *container's* view of the bind-mounted socket — works as long as dockerd in the distro listens on the unix socket (it will).
+- [lib/registry.ts](../../../deployment/development/lib/registry.ts) — port-slot allocation logic. Extended (not rewritten) to cover `docker_port`.
+- [lib/dev-env.ts](../../../deployment/development/lib/dev-env.ts), [lib/api.ts](../../../deployment/development/lib/api.ts), [lib/env-details.ts](../../../deployment/development/lib/env-details.ts) — pure file/HTTP, no platform assumptions.
+
+## What changes
+
+### Phase 1 — Alpine WSL2 base tarball pipeline
+
+**Deliverable:** `scripts/build-wsl-base.ps1` that produces `~\.mini-infra\wsl-base.tar` (~250 MB).
+
+Steps the script performs:
+
+1. Download Alpine Mini Root Filesystem (`alpine-minirootfs-3.x-x86_64.tar.gz`, ~3 MB) from `https://dl-cdn.alpinelinux.org/alpine/v3.x/releases/x86_64/`. Hash-verify against the published checksum.
+2. `wsl --import mini-infra-builder <temp-dir> <minirootfs.tar.gz>`.
+3. Inside the builder distro, run an inline provisioning script:
+   - `apk add --no-cache docker iptables ip6tables ca-certificates`
+   - **iptables-legacy symlink** — Alpine 3.18+ defaults to nf_tables. dockerd needs `iptables-legacy` available; create the symlinks: `update-alternatives` or direct `ln -sf /usr/sbin/iptables-legacy /usr/sbin/iptables`. (Bake into base so per-worktree imports don't repeat.)
+   - Drop in `/etc/mini-infra/start-dockerd.sh`:
+     ```sh
+     #!/bin/sh
+     set -e
+     PORT="${1:?docker port required}"
+     mkdir -p /var/run /var/log/mini-infra
+     # Idempotent: skip if already up
+     if pgrep -x dockerd >/dev/null; then exit 0; fi
+     nohup dockerd \
+       -H tcp://0.0.0.0:"$PORT" \
+       -H unix:///var/run/docker.sock \
+       --iptables=true \
+       >/var/log/mini-infra/dockerd.log 2>&1 &
+     ```
+     Made executable.
+   - Add a probe helper `/etc/mini-infra/dockerd-ready.sh` that returns 0 once `docker info` succeeds against the unix socket.
+4. `wsl --export mini-infra-builder <output-tar>`.
+5. `wsl --unregister mini-infra-builder`.
+
+Re-run any time we want to bump Alpine or dockerd versions. Checked-in `scripts/build-wsl-base.ps1` is the source of truth.
+
+**Acceptance:** running `scripts/build-wsl-base.ps1` on a fresh Windows box produces a tarball; `wsl --import test ... <tarball>` + `wsl -d test -- /etc/mini-infra/start-dockerd.sh 2500` + `docker -H tcp://localhost:2500 info` succeeds.
+
+### Phase 2 — `lib/wsl.ts` driver
+
+**Deliverable:** new file mirroring [lib/colima.ts](../../../deployment/development/lib/colima.ts) contract.
+
+Public surface:
+
+```ts
+export function isDistroRunning(name: string): boolean;
+export function distroExists(name: string): boolean;
+export interface WslImportOpts { name: string; baseTarball: string; installDir: string; }
+export function importDistro(opts: WslImportOpts): void;
+export function unregisterDistro(name: string): boolean;
+export interface WslStartOpts { name: string; dockerPort: number; }
+export function startDocker(opts: WslStartOpts): void;  // calls /etc/mini-infra/start-dockerd.sh
+export function ensureDockerReady(name: string, dockerPort: number, attempts: number): Promise<boolean>;
+```
+
+All shell-out via `spawnSync('wsl', [...args])`. Distro names are `mini-infra-<profile>` to namespace and avoid collision with user-installed distros.
+
+**Acceptance:** unit-style scripts in `deployment/development/lib/__tests__/wsl.test.ts` covering the parsing of `wsl -l -v` output. Integration coverage falls under Phase 8.
+
+### Phase 3 — `lib/registry.ts` extension
+
+**Deliverable:** add `docker_port` to `WorktreeEntry`, port range `2500–2599`, slot-aligned with the existing `ui_port`/`registry_port`/`vault_port` triple.
+
+Changes:
+
+- New constants: `DOCKER_PORT_MIN = 2500`, `DOCKER_PORT_MAX = 2599`.
+- `WorktreeEntry.docker_port: number`.
+- `allocatePorts(profile)` returns `{ ui_port, registry_port, vault_port, docker_port }`. Slot indexing already exists; add docker to the same slot.
+- `migrateFromJsonIfNeeded` and existing entries: if `docker_port` is missing, fill it from the slot index of `ui_port`.
+
+Backwards-compatible: macOS users with existing `worktrees.yaml` get `docker_port` populated on next run but never used (Colima driver ignores it).
+
+### Phase 4 — Driver abstraction in `worktree-start.ts`
+
+**Deliverable:** swap the colima block at [worktree-start.ts:260-273](../../../deployment/development/worktree-start.ts:260) for a driver dispatch.
+
+Sketch:
+
+```ts
+type Driver = 'colima' | 'wsl';
+
+function pickDriver(): Driver {
+  if (process.env.MINI_INFRA_DRIVER === 'colima' || process.env.MINI_INFRA_DRIVER === 'wsl') {
+    return process.env.MINI_INFRA_DRIVER;
+  }
+  return process.platform === 'darwin' ? 'colima' : 'wsl';
+}
+
+interface DriverHandle { dockerHost: string; }
+
+async function ensureDriver(driver: Driver, profile: string, ports: PortAllocation): Promise<DriverHandle> {
+  if (driver === 'colima') { /* existing logic */ }
+  if (driver === 'wsl') {
+    const distro = `mini-infra-${profile}`;
+    if (!distroExists(distro)) {
+      const baseTar = path.join(MINI_INFRA_HOME, 'wsl-base.tar');
+      if (!fs.existsSync(baseTar)) throw new Error('Run scripts/build-wsl-base.ps1 first');
+      importDistro({ name: distro, baseTarball: baseTar, installDir: path.join(MINI_INFRA_HOME, 'wsl', profile) });
+    }
+    if (!isDistroRunning(distro)) startDocker({ name: distro, dockerPort: ports.docker_port });
+    const ok = await ensureDockerReady(distro, ports.docker_port, 30);
+    if (!ok) throw new Error('dockerd did not come up in WSL distro');
+    return { dockerHost: `tcp://localhost:${ports.docker_port}` };
+  }
+}
+```
+
+Prereq check at [worktree-start.ts:174-179](../../../deployment/development/worktree-start.ts:174) becomes driver-aware: `colima` only required when driver is `colima`; `wsl` only required when driver is `wsl`. `docker` is always required (it's the Windows-side CLI talking to whichever daemon).
+
+The `dockerSockPath` existence check at [worktree-start.ts:268-272](../../../deployment/development/worktree-start.ts:268) becomes a `dockerHost` reachability probe (already covered by `ensureDockerReady`).
+
+The `colima_vm` field on `WorktreeEntry` is repurposed to "VM identifier" — for WSL it stores the distro name. Not renaming yet to keep diffs small; add a one-line comment.
+
+### Phase 5 — Windows entrypoints
+
+**Deliverable:** three `.cmd` files matching the existing `.sh` files.
+
+```
+deployment/development/worktree_start.cmd
+deployment/development/worktree_list.cmd
+deployment/development/worktree_cleanup.cmd
+```
+
+Each is one line, e.g.:
+
+```cmd
+@echo off
+pushd "%~dp0..\.."
+pnpm dlx tsx@^4.21.0 deployment\development\worktree-start.ts %*
+popd
+```
+
+The `.sh` versions stay for macOS users.
+
+CLAUDE.md gets a sentence: "On Windows, use `deployment\development\worktree_start.cmd`".
+
+### Phase 6 — Cleanup parity
+
+**Deliverable:** [worktree-cleanup.ts](../../../deployment/development/worktree-cleanup.ts) updated to dispatch on driver.
+
+When tearing down a worktree:
+
+- macOS: `colima delete <profile> --data --force` (existing).
+- Windows: `wsl --unregister mini-infra-<profile>` (drops the VHDX, equivalent of `--data --force`).
+
+The orphan-detection logic (worktree directory gone but registry entry remains) becomes driver-aware too.
+
+`worktree_cleanup.plist` (macOS launchd) has no Windows analog. Adding a Task Scheduler equivalent is out of scope — Windows users run cleanup manually.
+
+### Phase 7 — Documentation
+
+**Deliverables:**
+
+- [CLAUDE.md](../../../CLAUDE.md) — update the Worktree Development Workflow section with a Windows note: "On Windows, run `worktree_start.cmd` instead of `worktree_start.sh`. First-time setup also requires `scripts\build-wsl-base.ps1`."
+- New `docs/user/wsl2-reference.md` mirroring [docs/user/colima-reference.md](../../../docs/user/colima-reference.md). Cover: prereqs (`wsl --install`), base tarball build, listing distros (`wsl -l -v`), inspecting (`wsl -d <name>`), nuking, `.wslconfig` global memory cap, the `localhostForwarding` requirement.
+- README mention if there is one.
+
+### Phase 8 — Test passes on real Windows hardware
+
+Cannot be done in CI today — needs a Windows box with WSL2 enabled. Manual checklist:
+
+1. **Cold-start.** Fresh box, no `~\.mini-infra\`, no distros. Run `scripts\build-wsl-base.ps1` then `worktree_start.cmd --description "test"`. Expect: tarball produced, distro imported, dockerd up, registry container, mini-infra image built and pushed, app healthy, seeder runs, `environment-details.xml` written.
+2. **Second worktree.** From a second worktree path, `worktree_start.cmd --description "test 2"`. Expect: distinct slot allocated (e.g. 3101 / 5101 / 8201 / 2501), no port collision, both UIs reachable.
+3. **`--reset` path.** Wipes volumes, keeps distro, re-seeds.
+4. **Re-run idempotency.** Re-run with no flags; existing distro reused, image rebuilt, no re-seed.
+5. **`worktree_list.cmd`.** Lists both entries.
+6. **Cleanup.** `worktree_cleanup.cmd` removes a deleted worktree's distro and registry entry.
+7. **Cross-driver coexistence.** macOS user with existing `worktrees.yaml` from before this change: `docker_port` backfilled, no behavioural change.
+
+## Tradeoffs
+
+1. **Global memory budget.** `.wslconfig` controls RAM/CPU for *all* WSL distros combined. Can't say "worktree A gets 8 GB, B gets 4 GB" the way Colima does. For 1–3 concurrent worktrees the dynamic shared pool is actually friendlier than colima's static per-VM cap; for heavy users with many worktrees we document the `[wsl2] memory=16GB` knob.
+2. **Build context streaming over loopback TCP.** `docker.exe` on Windows tars `PROJECT_ROOT` and streams to dockerd in WSL. Loopback throughput is high enough that a few-hundred-MB context is fine, but a multi-GB context will be noticeably slower than the macOS virtiofs mount. Mitigation: existing `.dockerignore` is already tight.
+3. **TCP dockerd is unauthenticated.** Bound to `0.0.0.0` *inside the distro* (not on the LAN), and Windows' `localhostForwarding` exposes it only on `127.0.0.1`. For a single-user dev box, fine. Multi-user Windows boxes should disable port forwarding or add TLS — out of scope.
+4. **No systemd in the distro.** dockerd runs under `nohup`. Distro shutdown (`wsl --shutdown`) kills it cleanly; on next `wsl -d` the start script re-launches. Lifecycle is more "one-shot script" than "service manager"; that's fine for our use.
+5. **`docker.exe` is a separate prereq on Windows.** Users need the Docker CLI on PATH. We can ship instructions to install just the static binary from `https://download.docker.com/win/static/stable/` (~50 MB) — no Docker Desktop subscription required.
+
+## Open questions
+
+- **Should we also support Linux hosts?** Today the script assumes macOS via colima. Linux users are presumably running their own dockerd already and could use a third driver (`local-daemon`, no VM). Out of scope here, but the `pickDriver()` function leaves room for it.
+- **Cleanup timer on Windows.** The macOS launchd job runs `worktree_cleanup.sh` periodically. Should we add a Task Scheduler analog, or leave it as a manual command?
+- **`--cpu` / `--memory` flags.** Currently hardcoded to 2 CPU / 8 GB for colima. WSL2 driver ignores them. Worth surfacing in the help output that they're macOS-only?
+- **`environment-details.xml` schema.** Currently writes `dockerHost` as a string. With WSL2 it'll be `tcp://localhost:<port>` instead of `unix://...`. Verify no consumer of this file (including the `diagnose-dev` skill, `test-dev`, etc.) parses the value as a unix path.
+
+## Effort estimate
+
+| Phase | Estimated effort |
+|---|---|
+| 1 — Base tarball pipeline | ~½ day |
+| 2 — `lib/wsl.ts` | ~½ day |
+| 3 — Registry extension | ~2 hours |
+| 4 — Driver abstraction in `worktree-start.ts` | ~½ day |
+| 5 — Windows entrypoints | ~1 hour |
+| 6 — Cleanup parity | ~3 hours |
+| 7 — Docs | ~3 hours |
+| 8 — Test passes | ~1 day |
+
+Total: ~3 days of focused work for a mergeable PR. Most risk is in phase 8 — getting iptables, dockerd, and `localhostForwarding` to play nicely on a real Windows box always surfaces something the design didn't anticipate.
+
+## Out of scope
+
+- **Linux host driver** — explicit.
+- **Docker Desktop / Rancher Desktop fallback** — explicit. Could be added later as a third driver if a Windows user objects to managing their own dockerd.
+- **Per-distro CPU/RAM caps** — not possible without WSL2 changes upstream.
+- **TLS for dockerd TCP listener** — out of scope for single-user dev boxes.
+- **Migrating the Linux-on-macOS-via-colima path away from colima** — colima stays the default on macOS.

--- a/docs/user/wsl2-reference.md
+++ b/docs/user/wsl2-reference.md
@@ -1,0 +1,166 @@
+# WSL2 Reference
+
+Reference notes for using WSL2 to run multiple isolated Docker daemons on Windows — one per Mini Infra worktree. The Windows analog of [colima-reference.md](colima-reference.md).
+
+## What WSL2 Is
+
+The Windows Subsystem for Linux v2 runs a real Linux kernel in a managed lightweight VM. Each "distro" is a registered Linux installation with its own filesystem (a VHDX disk file). All distros share a single Hyper-V utility VM, but each has its own filesystem, network namespace, and processes.
+
+For our use case:
+
+- Mini Infra creates one distro per worktree, namespaced `mini-infra-<profile>`.
+- The distro is cloned from a cached Alpine + dockerd tarball at `~\.mini-infra\wsl-base.tar`.
+- ~250 MB on disk per worktree (Alpine + dockerd installed).
+- ~60 MB idle RAM per worktree (shared kernel keeps overhead low).
+- Each distro hosts dockerd on a dedicated TCP port (range 2500–2599) plus a unix socket inside the distro.
+
+## Installation
+
+One-time, on a fresh box, from an admin PowerShell:
+
+```powershell
+wsl --install
+```
+
+This enables the WSL2 feature and reboots. After reboot, run `wsl --status` from a normal PowerShell to confirm it works.
+
+You also need the Docker CLI on Windows PATH (no daemon — that runs inside the distro). Smallest install is the static Docker binary:
+
+1. Download from <https://download.docker.com/win/static/stable/x86_64/> (pick the latest `docker-XX.YY.ZZ.zip`).
+2. Extract `docker.exe` to a folder on PATH (e.g. `C:\Tools\docker\`).
+3. Verify: `docker --version` from a new shell.
+
+Docker Desktop is **not** required and **not** recommended — it would conflict with the per-worktree dockerd model.
+
+## Building the Base Tarball
+
+One-time, before your first `worktree_start.cmd`:
+
+```powershell
+.\scripts\build-wsl-base.ps1
+```
+
+The script downloads Alpine Mini Root Filesystem, imports it as a builder distro, installs dockerd + iptables, exports the result to `~\.mini-infra\wsl-base.tar`, and unregisters the builder.
+
+Re-run with `-Force` to refresh after Alpine or dockerd updates. Pass `-AlpineVersion 3.22.1` to pin a specific version.
+
+## Per-Worktree Workflow
+
+Same as the macOS flow — see [CLAUDE.md](../../CLAUDE.md), but use the `.cmd` wrappers:
+
+```powershell
+deployment\development\worktree_start.cmd --description "auth refactor"
+deployment\development\worktree_list.cmd
+deployment\development\worktree_cleanup.cmd --dry-run
+```
+
+The orchestrator auto-detects driver: `wsl` on Windows, `colima` on macOS. Override with `MINI_INFRA_DRIVER=wsl` (or `colima`) if you need to.
+
+## Core Commands
+
+```powershell
+wsl --list --verbose                      # list all distros + state
+wsl --list --running                      # only running distros
+wsl -d mini-infra-<profile>               # open a shell in a distro
+wsl -d mini-infra-<profile> -- <cmd>      # run one command and exit
+wsl --terminate mini-infra-<profile>      # stop a distro (data preserved)
+wsl --shutdown                            # stop ALL distros + the utility VM
+wsl --unregister mini-infra-<profile>     # delete a distro and its disk
+wsl --export mini-infra-<profile> out.tar # snapshot
+wsl --import <name> <dir> <tar>           # restore / clone
+```
+
+## Inspecting a Worktree's Daemon
+
+```powershell
+# What's running inside the worktree's distro?
+wsl -d mini-infra-strange-ride-7c8285 -- ps aux | findstr dockerd
+
+# dockerd logs
+wsl -d mini-infra-strange-ride-7c8285 -- cat /var/log/mini-infra/dockerd.log
+
+# Docker info via the TCP listener (from Windows)
+$env:DOCKER_HOST = "tcp://localhost:2500"
+docker info
+```
+
+## Resource Limits
+
+WSL2 uses a single global memory budget shared across all distros. Configure it via `~\.wslconfig`:
+
+```ini
+[wsl2]
+memory=16GB
+processors=8
+swap=4GB
+```
+
+Apply with `wsl --shutdown` then start a distro again. Unlike Colima, you cannot give individual distros different caps — all distros share the pool dynamically. For 1–3 concurrent worktrees this is usually friendlier than Colima's per-VM allocation.
+
+## Networking — How `localhost:<port>` Reaches the Distro
+
+WSL2's `localhostForwarding` feature (default on) automatically forwards `127.0.0.1:<port>` from Windows to whichever distro is binding that port. That's how `http://localhost:3100` reaches the mini-infra container, how `tcp://localhost:2500` reaches dockerd, and so on. If forwarding ever breaks, check `~\.wslconfig`:
+
+```ini
+[wsl2]
+localhostForwarding=true
+```
+
+## Common Tasks
+
+### Wipe and rebuild a worktree
+
+```powershell
+wsl --unregister mini-infra-<profile>
+deployment\development\worktree_start.cmd --description "..."
+```
+
+### Reset only data (keep distro)
+
+```powershell
+deployment\development\worktree_start.cmd --reset --profile <profile>
+```
+
+### Stop everything quickly
+
+```powershell
+wsl --shutdown
+```
+
+Restarts on the next `worktree_start.cmd`.
+
+### List all Mini Infra distros
+
+```powershell
+wsl --list --verbose | findstr mini-infra-
+```
+
+## Tradeoffs vs Colima
+
+| Property | Colima (macOS) | WSL2 (Windows) |
+|---|---|---|
+| Disk / worktree | ~3–8 GB VHDX | ~250 MB VHDX |
+| Idle RAM / worktree | ~400 MB | ~60 MB |
+| Per-worktree CPU/RAM caps | Yes (`--cpu` / `--memory`) | No (global only) |
+| Cold-start time | ~30–60 s | ~5–10 s |
+| Source-mount perf | virtiofs (excellent) | TCP build context (fine) |
+| Init system | systemd in VM | none — dockerd via `nohup` |
+
+Net: WSL2 is lighter per-instance and faster to spin up, but coarser on resource isolation.
+
+## Troubleshooting
+
+**`wsl --import` fails with "There is not enough space on the disk."**
+WSL stores VHDX files under `~\.mini-infra\wsl\<profile>\`. Free up space on that drive or symlink the directory elsewhere before re-running.
+
+**dockerd doesn't start.**
+Check `wsl -d mini-infra-<profile> -- cat /var/log/mini-infra/dockerd.log`. Most common cause: iptables nftables/legacy mismatch — re-run `scripts\build-wsl-base.ps1 -Force` to rebuild the base tarball with the correct iptables symlinks.
+
+**`localhost:<port>` doesn't reach the distro.**
+Ensure `localhostForwarding=true` in `~\.wslconfig`, then `wsl --shutdown` and try again.
+
+**Distro shows status `Stopped` but `worktree_start.cmd` says it's running.**
+The orchestrator triggers a start when needed. If it consistently misdetects state, manually `wsl --terminate` the distro and re-run.
+
+**"docker.exe is not recognized."**
+Install the static Docker CLI binary (see [Installation](#installation)). Don't install Docker Desktop unless you've intentionally chosen that path — it'll fight with the per-worktree daemon.

--- a/scripts/build-wsl-base.ps1
+++ b/scripts/build-wsl-base.ps1
@@ -1,0 +1,195 @@
+# Build the cached Alpine + dockerd WSL2 base tarball used by the
+# per-worktree dev flow on Windows. Produces ~\.mini-infra\wsl-base.tar.
+#
+# Re-run any time you want to refresh Alpine/dockerd versions.
+#
+# Usage:
+#   .\scripts\build-wsl-base.ps1                       # default Alpine version
+#   .\scripts\build-wsl-base.ps1 -AlpineVersion 3.22.1
+#   .\scripts\build-wsl-base.ps1 -Force                # rebuild even if cached
+#
+# Requires: WSL2 enabled (`wsl --status`), internet access.
+
+[CmdletBinding()]
+param(
+    [string]$AlpineVersion = '3.21.0',
+    [string]$Architecture = 'x86_64',
+    [switch]$Force
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Step  { param($Msg) Write-Host "[base] $Msg" -ForegroundColor Cyan }
+function Write-Ok    { param($Msg) Write-Host "[base] $Msg" -ForegroundColor Green }
+function Write-WarnX { param($Msg) Write-Host "[base] $Msg" -ForegroundColor Yellow }
+
+$MiniInfraHome = if ($env:MINI_INFRA_HOME) { $env:MINI_INFRA_HOME } else { Join-Path $env:USERPROFILE '.mini-infra' }
+$BaseTarball   = Join-Path $MiniInfraHome 'wsl-base.tar'
+$WorkDir       = Join-Path $env:TEMP "mini-infra-wsl-base-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+$BuilderName   = 'mini-infra-builder'
+
+if ((Test-Path $BaseTarball) -and -not $Force) {
+    Write-WarnX "Base tarball already exists at $BaseTarball"
+    Write-WarnX 'Pass -Force to rebuild.'
+    exit 0
+}
+
+# Sanity check WSL is available
+try {
+    $wslVersion = & wsl.exe --version 2>$null
+    if ($LASTEXITCODE -ne 0) { throw 'wsl --version returned non-zero' }
+} catch {
+    Write-Error 'WSL2 is not available. Run `wsl --install` (admin) and reboot, then re-run this script.'
+    exit 1
+}
+
+# `wsl --list --quiet` writes UTF-16 LE on Windows. Decode it ourselves so
+# regex matches don't get tripped up by interleaved null bytes.
+function Get-WslDistroNames {
+    $proc = Start-Process -FilePath 'wsl.exe' -ArgumentList '--list', '--quiet' `
+        -RedirectStandardOutput "$env:TEMP\wsl-list.tmp" -NoNewWindow -Wait -PassThru
+    $bytes = [System.IO.File]::ReadAllBytes("$env:TEMP\wsl-list.tmp")
+    Remove-Item "$env:TEMP\wsl-list.tmp" -Force -ErrorAction SilentlyContinue
+    $text = [System.Text.Encoding]::Unicode.GetString($bytes)
+    return $text -split "[`r`n]+" | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+}
+
+# Clean up any stale builder distro from a previous failed run
+if (Get-WslDistroNames | Where-Object { $_ -eq $BuilderName }) {
+    Write-WarnX "Stale builder distro '$BuilderName' found — unregistering"
+    & wsl.exe --unregister $BuilderName | Out-Null
+}
+
+New-Item -ItemType Directory -Path $MiniInfraHome -Force | Out-Null
+New-Item -ItemType Directory -Path $WorkDir -Force | Out-Null
+
+try {
+    # 1. Download minirootfs + checksum
+    $base = "https://dl-cdn.alpinelinux.org/alpine/v$($AlpineVersion.Substring(0, $AlpineVersion.LastIndexOf('.')))/releases/$Architecture"
+    $rootfsName = "alpine-minirootfs-$AlpineVersion-$Architecture.tar.gz"
+    $rootfsUrl  = "$base/$rootfsName"
+    $shaUrl     = "$rootfsUrl.sha256"
+    $rootfsPath = Join-Path $WorkDir $rootfsName
+    $shaPath    = "$rootfsPath.sha256"
+
+    Write-Step "Downloading $rootfsUrl"
+    Invoke-WebRequest -Uri $rootfsUrl -OutFile $rootfsPath -UseBasicParsing
+    Invoke-WebRequest -Uri $shaUrl    -OutFile $shaPath    -UseBasicParsing
+
+    $expectedHash = (Get-Content $shaPath -Raw).Split()[0].Trim().ToLower()
+    $actualHash   = (Get-FileHash -Algorithm SHA256 $rootfsPath).Hash.ToLower()
+    if ($expectedHash -ne $actualHash) {
+        throw "SHA256 mismatch — expected $expectedHash, got $actualHash. Refusing to import a tampered rootfs."
+    }
+    Write-Ok 'Rootfs checksum verified'
+
+    # 2. Import as builder distro
+    $builderInstallDir = Join-Path $WorkDir 'builder-vhdx'
+    New-Item -ItemType Directory -Path $builderInstallDir -Force | Out-Null
+
+    Write-Step "Importing $BuilderName"
+    & wsl.exe --import $BuilderName $builderInstallDir $rootfsPath
+    if ($LASTEXITCODE -ne 0) { throw 'wsl --import failed' }
+
+    # 3. Provision: write script to a host-side path and run it inside the distro.
+    # Uses a heredoc-style here-string with literal markers so $-vars in the
+    # script aren't expanded by PowerShell.
+    $provisioning = @'
+#!/bin/sh
+set -eu
+
+apk update
+apk add --no-cache docker iptables ip6tables ca-certificates procps util-linux
+
+# Alpine 3.18+ ships nf_tables-backed iptables by default; dockerd's bridge
+# networking needs the legacy backend. Symlink it as the default iptables.
+if [ -e /sbin/iptables-legacy ]; then
+  ln -sf /sbin/iptables-legacy  /sbin/iptables
+  ln -sf /sbin/ip6tables-legacy /sbin/ip6tables
+fi
+
+mkdir -p /etc/mini-infra /var/log/mini-infra
+
+# dockerd starter, called by lib/wsl.ts via `wsl -d <distro> -- /etc/mini-infra/start-dockerd.sh <port>`.
+# Uses `setsid -f` (from util-linux) to reparent dockerd to init so it
+# survives after the wsl-session shell exits. Idempotent — re-running while
+# dockerd is already up is a no-op.
+cat > /etc/mini-infra/start-dockerd.sh <<'STARTEOF'
+#!/bin/sh
+set -eu
+PORT="${1:?docker port required}"
+mkdir -p /var/run /var/log/mini-infra
+if pgrep -x dockerd >/dev/null 2>&1; then
+  exit 0
+fi
+: > /var/log/mini-infra/dockerd.log
+setsid -f sh -c "dockerd -H tcp://0.0.0.0:${PORT} -H unix:///var/run/docker.sock --iptables=true >/var/log/mini-infra/dockerd.log 2>&1"
+STARTEOF
+chmod +x /etc/mini-infra/start-dockerd.sh
+
+cat > /etc/mini-infra/dockerd-ready.sh <<'READYEOF'
+#!/bin/sh
+docker -H unix:///var/run/docker.sock info >/dev/null 2>&1
+READYEOF
+chmod +x /etc/mini-infra/dockerd-ready.sh
+
+# /etc/wsl.conf — disable automount (we never need /mnt/c from a per-worktree
+# distro) and Windows-PATH appending (otherwise WSL spams "Failed to translate"
+# warnings for every Windows PATH entry on every wsl invocation).
+cat > /etc/wsl.conf <<'WSLEOF'
+[automount]
+enabled = false
+
+[interop]
+enabled = false
+appendWindowsPath = false
+
+[network]
+generateResolvConf = true
+WSLEOF
+
+dockerd --version
+docker --version
+echo '[base] provisioning complete'
+'@
+
+    $provisioningPath = Join-Path $WorkDir 'provision.sh'
+    # UTF-8 without BOM, LF line endings — the distro is Linux.
+    $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+    [System.IO.File]::WriteAllText($provisioningPath, ($provisioning -replace "`r`n", "`n"), $utf8NoBom)
+
+    # Translate the Windows path to its WSL2 mount path (`C:\foo\bar` →
+    # `/mnt/c/foo/bar`). Doing this in PS avoids quoting headaches that
+    # come up when relaying backslashed paths through wsl.exe to wslpath.
+    $linuxPath = '/mnt/' + $provisioningPath.Substring(0,1).ToLower() + ($provisioningPath.Substring(2) -replace '\\','/')
+
+    Write-Step "Running provisioning script inside builder distro ($linuxPath)"
+    & wsl.exe -d $BuilderName -- sh $linuxPath
+    if ($LASTEXITCODE -ne 0) { throw 'Provisioning script failed inside builder distro' }
+    Write-Ok 'Builder distro provisioned'
+
+    # 4. Shut the distro down cleanly so the export is consistent.
+    Write-Step "Shutting down $BuilderName"
+    & wsl.exe --terminate $BuilderName | Out-Null
+
+    # 5. Export to the cache location.
+    Write-Step "Exporting to $BaseTarball"
+    if (Test-Path $BaseTarball) { Remove-Item $BaseTarball -Force }
+    & wsl.exe --export $BuilderName $BaseTarball
+    if ($LASTEXITCODE -ne 0) { throw 'wsl --export failed' }
+
+    $sizeMb = [math]::Round((Get-Item $BaseTarball).Length / 1MB, 1)
+    Write-Ok "Base tarball: $BaseTarball ($sizeMb MB)"
+}
+finally {
+    # 6. Clean up the builder regardless of success.
+    if (Get-WslDistroNames | Where-Object { $_ -eq $BuilderName }) {
+        Write-Step "Unregistering builder distro"
+        & wsl.exe --unregister $BuilderName | Out-Null
+    }
+    if (Test-Path $WorkDir) {
+        Remove-Item -Recurse -Force $WorkDir -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Ok 'Done. Run deployment\development\worktree_start.cmd next.'


### PR DESCRIPTION
## Summary

- Adds a WSL2 driver mirroring the existing Colima driver so the per-worktree dev flow (`worktree_start`) works on Windows, not just macOS
- Each worktree gets its own Alpine + dockerd WSL2 distro (`mini-infra-<profile>`), cloned from a cached base tarball at `~/.mini-infra/wsl-base.tar`
- Driver auto-picks by platform (`darwin` → colima, else → wsl); override with `MINI_INFRA_DRIVER=colima|wsl`
- Mac users see no behavior change

## What's in the box

- `scripts/build-wsl-base.ps1` — one-time builder for the cached base tarball (~270 MB; Alpine 3.21 + Docker 27.3.1, hash-verified rootfs, iptables-legacy symlinks, `setsid -f` daemonisation helper)
- `deployment/development/lib/wsl.ts` — driver: import / unregister / start dockerd / readiness probe
- `deployment/development/worktree_*.cmd` — Windows entrypoints (siblings to the existing `.sh` wrappers)
- `lib/registry.ts` — `docker_port` slot allocation in range 2500–2599 (slot-aligned with the existing UI/registry/vault triple); transparently backfilled for existing entries
- `worktree-start.ts` / `worktree-cleanup.ts` — driver dispatch; also fixes two latent Windows bugs (`URL.pathname` returning `/C:/...`, `commandExists` shelling out to bash)
- `docs/user/wsl2-reference.md` — user-facing reference, sibling to `colima-reference.md`
- `docs/planning/not-shipped/wsl2-driver-plan.md` — design doc capturing the tradeoffs and three real bugs caught during implementation (nohup-vs-setsid, `[boot]`-too-early, dockerd's TLS-warning slowdown)

## Verified locally on Windows 11 + WSL2

- `build-wsl-base.ps1` produces a working tarball end-to-end
- `lib/wsl.ts` exercised via temp distro: import → start dockerd → `/_ping` returns 200 in ~19s → cleanup
- `MINI_INFRA_DRIVER=colima` on Windows fails the prereq check cleanly
- `worktree_list.cmd` reads the registry without error
- All `.cmd` wrappers parse cleanly under cmd.exe
- PowerShell syntax check passes

## Test plan

- [ ] Run `scripts\build-wsl-base.ps1` on a fresh Windows box
- [ ] Run `worktree_start.cmd --description "..."` end-to-end and confirm mini-infra is healthy at the assigned port
- [ ] Spin up a second worktree and confirm distinct slot allocation (no port collision)
- [ ] `--reset` path
- [ ] `worktree_cleanup.cmd --dry-run` lists the right thing
- [ ] On macOS, confirm `worktree_start.sh` still behaves identically (driver auto-picks colima, no docker_port collisions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)