### PR TITLE
feat(dev): preinstall ipset in WSL2 base for egress gateway v3

### DIFF
--- a/scripts/build-wsl-base.ps1
+++ b/scripts/build-wsl-base.ps1
@@ -99,7 +99,7 @@ try {
 set -eu
 
 apk update
-apk add --no-cache docker iptables ip6tables ca-certificates procps util-linux
+apk add --no-cache docker iptables ip6tables ipset ca-certificates procps util-linux
 
 # Alpine 3.18+ ships nf_tables-backed iptables by default; dockerd's bridge
 # networking needs the legacy backend. Symlink it as the default iptables.


### PR DESCRIPTION
## Summary

- Adds `ipset` to the Alpine `apk add` line in `scripts/build-wsl-base.ps1` so the cached WSL2 base tarball used by per-worktree dev distros ships with the userspace binary preinstalled.
- Prep work for the [egress gateway v3 design](docs/planning/not-shipped/egress-gateway-v3-design.md), which tracks managed and bypass containers via named ipsets and matches DOCKER-USER drop rules with `iptables -m set --match-set ...`.
- The WSL2 kernel (`6.6.x-microsoft-standard-WSL2`) already provides `ip_set`, `xt_set`, and `ip_set_hash_ip` modules and autoloads them on first use — only the userspace `ipset` package was missing.

## Validation

Validated end-to-end on Windows:

1. Rebuilt the base tarball with `-Force` — `ipset (7.22-r1)` installs cleanly alongside the existing packages, tarball exports at 270.9 MB.
2. Imported a fresh disposable distro from the new tarball — `which ipset` resolves to `/usr/sbin/ipset` v7.22 with no `apk add` step.
3. Repeated against the actual `worktree_start.ps1` flow on this branch — `mini-infra-eloquent-antonelli-4a947f` distro imported from the new tarball, confirmed `ipset` preinstalled, `hash:ip` set creation works, and `iptables -I FORWARD -m set --match-set <set> src -j RETURN` is accepted (the rule shape v3 needs).
4. After ipset operations, `lsmod` shows `ip_set`, `ip_set_hash_ip`, and `xt_set` autoloaded.

Tested only with `hash:ip` family `inet` (IPv4) — that's all the v3 design currently calls for.

## Rollout note

Existing worktrees won't pick this up automatically — `worktree_start` reuses an existing distro. Anyone on v3-aware branches will need to run `.\scripts\build-wsl-base.ps1 -Force` once to refresh the cached tarball before creating a fresh worktree, and existing worktrees that need v3 firewall rules will need to be torn down and recreated (`worktree_delete.ps1 <profile>`).

Colima (macOS) was already validated separately and is fine.

## Test plan

- [x] Base tarball rebuild succeeds with `ipset` in the apk line
- [x] Fresh `wsl --import` from new tarball has `ipset` preinstalled
- [x] `worktree_start.ps1` end-to-end build + healthy container with new tarball
- [x] `iptables -m set --match-set` rule accepted in worktree distro
- [x] Kernel modules autoload (`ip_set`, `ip_set_hash_ip`, `xt_set`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)