### PR TITLE
fix(worktree): clean up orphaned Linux bridges on worktree delete

### DIFF
--- a/deployment/development/lib/wsl.ts
+++ b/deployment/development/lib/wsl.ts
@@ -59,6 +59,17 @@ export function isDistroRunning(name: string): boolean {
   return entry?.state === 'Running';
 }
 
+/**
+ * Names of every running WSL distro. Used by the orphan-bridge sweep so we
+ * know which other Docker daemons might still be claiming bridges that
+ * appear (in the shared netns) inside the distro we're about to unregister.
+ */
+export function listRunningDistros(): string[] {
+  return listDistros()
+    .filter((d) => d.state === 'Running')
+    .map((d) => d.name);
+}
+
 export interface WslImportOpts {
   name: string;
   baseTarball: string;
@@ -186,4 +197,167 @@ export function defaultBaseTarballPath(miniInfraHome: string): string {
  */
 export function defaultInstallDir(miniInfraHome: string, profile: string): string {
   return path.join(miniInfraHome, 'wsl', profile);
+}
+
+/**
+ * Run a single command inside a WSL distro and capture its UTF-8 stdout.
+ *
+ * Linux processes write UTF-8; only the `wsl -l/-v` family emits UTF-16
+ * (those are Windows-side outputs from the wsl.exe wrapper). Anything we
+ * launch with `wsl -d <distro> -- <cmd>` goes straight to the Linux pipe.
+ */
+function execInDistro(
+  distro: string,
+  cmd: string[],
+): { status: number; stdout: string; stderr: string } {
+  const res = spawnSync(WSL, ['-d', distro, '--', ...cmd], { encoding: 'utf8' });
+  return {
+    status: res.status ?? 1,
+    stdout: res.stdout ?? '',
+    stderr: res.stderr ?? '',
+  };
+}
+
+/**
+ * The 12-char hex network IDs that Docker uses as bridge name suffixes.
+ * Returns an empty set if the daemon isn't reachable (distro stopped, no
+ * dockerd, etc.) — callers should treat that as "claims nothing".
+ */
+export function listDockerNetworkIds(distro: string): Set<string> {
+  const res = execInDistro(distro, ['docker', 'network', 'ls', '-q', '--no-trunc']);
+  if (res.status !== 0) return new Set();
+  const ids = new Set<string>();
+  for (const line of res.stdout.split('\n')) {
+    const id = line.trim();
+    if (id.length >= 12) ids.add(id.slice(0, 12));
+  }
+  return ids;
+}
+
+/**
+ * Lists `br-XXXXXXXXXXXX` bridge interfaces visible from inside `distro`.
+ *
+ * NOTE: WSL2's default NAT-mode networking puts every running distro in
+ * the same kernel network namespace (verifiable via `readlink /proc/self/ns/net`
+ * — they all return the same id). So this returns bridges created by any
+ * distro's dockerd, not just the target's.
+ *
+ * The Alpine base image ships BusyBox `ip`, which doesn't accept
+ * `show type bridge`, so we use plain `ip link` and grep the names
+ * ourselves. The Docker bridge naming convention is rigid enough
+ * (`br-` + first 12 chars of the network ID) that the regex is safe.
+ */
+export function listKernelBridges(distro: string): string[] {
+  const res = execInDistro(distro, ['ip', '-o', 'link']);
+  if (res.status !== 0) return [];
+  const out: string[] = [];
+  for (const line of res.stdout.split('\n')) {
+    // `ip -o link` rows look like: `4: br-effde9cded84: <BROADCAST,...> mtu 1500 ...`
+    const m = line.match(/^\d+:\s+(br-[a-f0-9]{12}):/);
+    if (m) out.push(m[1]);
+  }
+  return out;
+}
+
+export interface OrphanBridgeSweep {
+  deleted: string[];
+  preserved: string[];
+  errors: { bridge: string; reason: string }[];
+}
+
+/**
+ * Sweep orphaned `br-XXXXXXXXXXXX` interfaces from the shared WSL2 kernel
+ * netns by running `ip link delete` from inside `targetDistro`. A bridge
+ * is preserved if its 12-char id appears in any `liveDistros[i]`'s
+ * `docker network ls -q` output; otherwise it is deleted.
+ *
+ * Background: dockerd creates each bridge as `br-` + first 12 chars of
+ * the network ID. When a Docker network is left over from a partial
+ * shutdown — the daemon DB lost track of it but the kernel still has
+ * the interface — the bridge becomes an "orphan" with a phantom subnet
+ * route that beats the legitimate route in the FIB. That's the bug
+ * `fix(worktree): clean up orphaned Linux bridges on worktree delete`
+ * is targeting.
+ *
+ * Two intended call sites:
+ *  - Pre-unregister cleanup (`worktree-delete`, `worktree-cleanup`):
+ *    pass every running mini-infra distro EXCEPT the doomed one. The
+ *    doomed distro's networks become "not live" and are swept, while
+ *    sibling worktrees' bridges are preserved.
+ *  - Defensive pre-start sweep: pass every running mini-infra distro
+ *    INCLUDING the target. Only true orphans (no dockerd claims them)
+ *    are removed.
+ *
+ * Caveat: deleting a bridge here removes it for every distro because
+ * the netns is shared. Get the `liveDistros` list right or you'll yank
+ * an active bridge out from under another worktree's daemon.
+ */
+export function cleanupOrphanBridges(
+  targetDistro: string,
+  liveDistros: string[],
+): OrphanBridgeSweep {
+  const protectedIds = new Set<string>();
+  for (const d of liveDistros) {
+    for (const id of listDockerNetworkIds(d)) protectedIds.add(id);
+  }
+
+  const result: OrphanBridgeSweep = { deleted: [], preserved: [], errors: [] };
+  for (const bridge of listKernelBridges(targetDistro)) {
+    const id = bridge.slice(3); // strip "br-"
+    if (protectedIds.has(id)) {
+      result.preserved.push(bridge);
+      continue;
+    }
+    const res = execInDistro(targetDistro, ['ip', 'link', 'delete', bridge]);
+    if (res.status === 0) {
+      result.deleted.push(bridge);
+    } else {
+      result.errors.push({ bridge, reason: res.stderr.trim() || `exit ${res.status}` });
+    }
+  }
+  return result;
+}
+
+/**
+ * Force-stop every container, then prune unused networks, in `distro`'s
+ * Docker daemon. Used as a pre-unregister cleanup so dockerd can normally
+ * remove the bridges it created — leaving `cleanupOrphanBridges` as a
+ * safety net for any that don't go quietly.
+ *
+ * Best-effort and tolerant of partial failure.
+ */
+export function forceDockerCleanup(distro: string): {
+  containersRemoved: number;
+  networksPruned: number;
+  errors: string[];
+} {
+  const errors: string[] = [];
+
+  // Force-remove every container (running or stopped) so no network has
+  // attached endpoints when we prune.
+  const ps = execInDistro(distro, ['docker', 'ps', '-aq']);
+  const containerIds = ps.status === 0
+    ? ps.stdout.split('\n').map((s) => s.trim()).filter(Boolean)
+    : [];
+  let containersRemoved = 0;
+  if (containerIds.length > 0) {
+    const rm = execInDistro(distro, ['docker', 'rm', '-f', ...containerIds]);
+    if (rm.status === 0) {
+      containersRemoved = rm.stdout.split('\n').filter(Boolean).length;
+    } else {
+      errors.push(`docker rm -f: ${rm.stderr.trim() || `exit ${rm.status}`}`);
+    }
+  }
+
+  // Prune unused networks. Counts the lines after the "Deleted Networks:" header.
+  const prune = execInDistro(distro, ['docker', 'network', 'prune', '-f']);
+  let networksPruned = 0;
+  if (prune.status === 0) {
+    const m = prune.stdout.match(/Deleted Networks:\s*\n([\s\S]*)/);
+    if (m) networksPruned = m[1].split('\n').map((s) => s.trim()).filter(Boolean).length;
+  } else {
+    errors.push(`docker network prune: ${prune.stderr.trim() || `exit ${prune.status}`}`);
+  }
+
+  return { containersRemoved, networksPruned, errors };
 }

--- a/deployment/development/worktree-cleanup.ts
+++ b/deployment/development/worktree-cleanup.ts
@@ -19,7 +19,15 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { logInfo, logOk, logWarn, logSkip, logError } from './lib/log.js';
 import { colimaExists, deleteColima } from './lib/colima.js';
-import { distroExists, distroName, unregisterDistro } from './lib/wsl.js';
+import {
+  cleanupOrphanBridges,
+  distroExists,
+  distroName,
+  forceDockerCleanup,
+  isDistroRunning,
+  listRunningDistros,
+  unregisterDistro,
+} from './lib/wsl.js';
 import { migrateFromJsonIfNeeded, removeEntry } from './lib/registry.js';
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -220,6 +228,8 @@ function main(): void {
       if (driver === 'colima') {
         console.log(`  [dry-run] colima delete ${profile} --force`);
       } else {
+        console.log(`  [dry-run] docker rm -f / network prune inside ${distro} (if running)`);
+        console.log(`  [dry-run] sweep orphan bridges from ${distro}`);
         console.log(`  [dry-run] wsl --unregister ${distro}`);
       }
       console.log(`  [dry-run] git worktree remove --force ${wt.path}  (${ageHours}h old)`);
@@ -241,6 +251,32 @@ function main(): void {
       }
     } else {
       if (distroExists(distro)) {
+        // Same orphan-bridge problem as worktree-delete: WSL2 distros share
+        // one kernel netns, so leftover `br-<id>` interfaces from a previous
+        // dockerd survive the unregister and collide with new daemons'
+        // bridges in the FIB. Sweep before unregister; preserve any bridge
+        // claimed by another running mini-infra distro.
+        if (isDistroRunning(distro)) {
+          logInfo(`Forcing Docker cleanup inside ${distro} before unregister`);
+          const fc = forceDockerCleanup(distro);
+          if (fc.containersRemoved > 0) {
+            logOk(`Removed ${fc.containersRemoved} container(s)`);
+          }
+          if (fc.networksPruned > 0) {
+            logOk(`Pruned ${fc.networksPruned} unused network(s)`);
+          }
+          for (const e of fc.errors) logWarn(`docker cleanup: ${e}`);
+
+          const siblings = listRunningDistros().filter((d) => d !== distro);
+          const sweep = cleanupOrphanBridges(distro, siblings);
+          if (sweep.deleted.length > 0) {
+            logOk(`Deleted ${sweep.deleted.length} orphan bridge(s): ${sweep.deleted.join(', ')}`);
+          }
+          for (const e of sweep.errors) {
+            logWarn(`ip link delete ${e.bridge}: ${e.reason}`);
+          }
+        }
+
         logInfo(`Unregistering WSL distro: ${distro}`);
         if (unregisterDistro(distro)) {
           logOk('WSL distro unregistered');

--- a/deployment/development/worktree-delete.ts
+++ b/deployment/development/worktree-delete.ts
@@ -20,9 +20,13 @@ import { stdin as input, stdout as output } from 'node:process';
 import { logInfo, logOk, logWarn, logSkip, logError } from './lib/log.js';
 import { colimaExists, deleteColima } from './lib/colima.js';
 import {
+  cleanupOrphanBridges,
   defaultInstallDir,
   distroExists,
   distroName,
+  forceDockerCleanup,
+  isDistroRunning,
+  listRunningDistros,
   unregisterDistro,
 } from './lib/wsl.js';
 import {
@@ -239,6 +243,40 @@ async function main(): Promise<void> {
     } else {
       const distro = distroName(profile);
       if (commandExists('wsl') && distroExists(distro)) {
+        // WSL2's default NAT-mode networking shares one kernel netns across every
+        // running distro, so dockerd-created bridges (`br-<id12>`) outlive their
+        // owning daemon if the daemon dies before the kernel cleans them up. Two
+        // bridges with the same subnet then race in the FIB and silently drop
+        // traffic. Tear them down explicitly while we still have a hand on the
+        // daemon, falling back to `ip link delete` for any that don't go quietly.
+        if (isDistroRunning(distro)) {
+          logInfo(`Forcing Docker cleanup inside '${distro}' before unregister...`);
+          const fc = forceDockerCleanup(distro);
+          if (fc.containersRemoved > 0) {
+            logOk(`Removed ${fc.containersRemoved} container(s).`);
+          }
+          if (fc.networksPruned > 0) {
+            logOk(`Pruned ${fc.networksPruned} unused network(s).`);
+          }
+          for (const e of fc.errors) logWarn(`docker cleanup: ${e}`);
+
+          // Sibling running distros' bridges must be preserved — sweep is keyed
+          // off "no live mini-infra distro claims this bridge id".
+          const siblings = listRunningDistros().filter((d) => d !== distro);
+          logInfo('Sweeping orphan bridges from shared WSL2 kernel netns...');
+          const sweep = cleanupOrphanBridges(distro, siblings);
+          if (sweep.deleted.length > 0) {
+            logOk(`Deleted ${sweep.deleted.length} orphan bridge(s): ${sweep.deleted.join(', ')}`);
+          } else {
+            logSkip('No orphan bridges found.');
+          }
+          for (const e of sweep.errors) {
+            logWarn(`ip link delete ${e.bridge}: ${e.reason}`);
+          }
+        } else {
+          logSkip(`Distro '${distro}' is not running — skipping bridge sweep.`);
+        }
+
         logInfo(`Unregistering WSL distro '${distro}'...`);
         if (unregisterDistro(distro)) {
           logOk('WSL distro unregistered.');

--- a/docs/planning/not-shipped/worktree-egress-subnet-allocation.md
+++ b/docs/planning/not-shipped/worktree-egress-subnet-allocation.md
@@ -1,0 +1,204 @@
+# Per-worktree egress subnet allocation (design)
+
+Status: **planned, not implemented**. Follow-up to [#275](https://github.com/mrgeoffrich/mini-infra/pull/275) (orphan-bridge sweep on worktree delete).
+
+## Problem
+
+Two parallel WSL2 worktrees both pick `172.30.0.0/24` for their `local-applications` Docker network and stomp on each other in the kernel's FIB. PR #275 fixes the *cleanup* failure mode (orphan bridges left behind by partial teardown). It does not fix the *concurrent* failure mode: two running worktrees can still independently pick the same subnet today.
+
+Root cause:
+
+- WSL2's default NAT networking puts every running distro in **one shared kernel network namespace** (`readlink /proc/self/ns/net` returns the same id from every distro — verified empirically).
+- Each worktree's `mini-infra-server` runs `EgressNetworkAllocator.allocateSubnet()` against its **own DB and its own Docker daemon's `network ls`**. It can't see what subnets siblings have used.
+- Each worktree therefore picks slot 0 (`172.30.0.0/24`) for its first env. Two `br-<id>` bridges with the same `/24` route end up in the FIB; the kernel picks one round-robin per lookup; half the packets disappear into an empty veth.
+
+The bridge sweep makes the problem visible at delete time. It doesn't help two daemons running side-by-side.
+
+## Goals
+
+1. Two concurrent worktrees never pick the same applications subnet — by construction, not by retry.
+2. Zero coordination at `mini-infra-server` runtime. The allocator's per-DB view stays correct because the *pool* it draws from is already disjoint.
+3. No global system config (no `.wslconfig`, no kernel modules). Mirrored mode is rejected separately on its own merits — see [#275 PR discussion](https://github.com/mrgeoffrich/mini-infra/pull/275).
+4. Backwards compatible: existing worktrees keep their already-allocated subnets when the change rolls out.
+
+## Non-goals
+
+- Cross-host coordination. This is dev-tooling only; one developer's machine.
+- Defending against malicious workloads inside the dev VM.
+- Reclaiming subnets when a worktree is deleted. Slots are reused via the existing port-slot reuse path; subnet assignments follow the slot for free.
+
+## Design
+
+Slice the existing egress pool into per-worktree pools, keyed off the same slot the port allocator already uses.
+
+```
+Pool:      172.30.0.0/16          (existing default, ~65k addresses)
+Per worktree slice: /22           (4 contiguous /24 subnets = 4 envs per worktree)
+Slots:     64                     (256 / 4)
+
+Slot 0  → 172.30.0.0/22           covers .0/.1/.2/.3 .0/24
+Slot 1  → 172.30.4.0/22           covers .4/.5/.6/.7 .0/24
+...
+Slot 63 → 172.30.252.0/22         covers .252-.255 .0/24
+```
+
+Each worktree's `mini-infra-server` is launched with `MINI_INFRA_EGRESS_POOL_CIDR` set to its own `/22`. Inside that pool, the existing per-env allocator continues to hand out `/24`s sequentially. Two worktrees in slots 0 and 1 can both ask for "the lowest free /24 in my pool" and reach for `172.30.0.0/24` and `172.30.4.0/24` respectively — disjoint, no coordination.
+
+### Why /22, not /20
+
+A /22 gives 4 envs per worktree, which covers the realistic dev case (production + staging + maybe a couple of feature envs) and lets us fit 64 worktree slots into the default `172.30.0.0/16` pool without changing the wider net. The current port allocator advertises 100 slots but in practice we've never seen more than 5–6 concurrent. 64 is a safe ceiling for dev with comfortable headroom.
+
+If we ever do need more than 64 concurrent worktrees with > 4 envs each, expand the pool (see [Future expansion](#future-expansion)).
+
+### Why slot-keyed, not random
+
+- **Stable across re-runs.** A worktree keeps the same slot across `worktree_start.ps1` re-runs (the registry already enforces this for ports), so it keeps the same subnet pool. No DB migration churn each run.
+- **Trivial to reason about.** "Slot 3 → ports 3103/5103/8203/2503 → subnet `172.30.12.0/22`" is mechanical. Operators can spot-check from `worktree_list.ps1` output.
+- **No global allocator state needed.** The slot is already in `~/.mini-infra/worktrees.yaml`. We just compute the CIDR from it on each start.
+
+### Worktree registry
+
+Add one field to `WorktreeEntry`:
+
+```ts
+export interface WorktreeEntry {
+  // ...existing fields...
+
+  /**
+   * Per-worktree slice of the egress pool, derived from the worktree's
+   * port slot. Empty until the worktree is started under a build that
+   * supports per-worktree pool slicing — older entries fall through to
+   * the default 172.30.0.0/16 pool and behave as today.
+   */
+  egress_pool_cidr?: string;
+}
+```
+
+It's stored for visibility (operator can see "this worktree owns 172.30.12.0/22" in `worktree_list`) and forensics, not as the source of truth. The source of truth is the slot.
+
+### Allocator behavior
+
+`PortAllocation` gains one field; the existing `allocatePorts(profile)` returns it alongside the ports:
+
+```ts
+export interface PortAllocation {
+  // ...existing port fields...
+  egress_pool_cidr: string; // e.g. "172.30.12.0/22" for slot 3
+}
+```
+
+Math:
+
+```
+const slot = ...; // existing slot derivation
+const baseInt = (172 << 24) | (30 << 16);
+const sliceInt = (baseInt + slot * 4 * 256) >>> 0; // 4 /24s = 1024 addresses
+const o2 = (sliceInt >> 8) & 0xff;
+const o3 = sliceInt & 0xff;
+const cidr = `172.30.${o2}.${o3}/22`;
+```
+
+If a profile is in slot `>= 64`, throw — pool exhausted, document the override.
+
+### Server side
+
+`server/src/services/egress/egress-network-allocator.ts` already reads the pool from `MINI_INFRA_EGRESS_POOL_CIDR`. No code change there.
+
+### Compose plumbing
+
+`deployment/development/docker-compose.worktree.yaml` adds the env var to the `mini-infra` service:
+
+```yaml
+environment:
+  - LOG_LEVEL=debug
+  - ALLOW_INSECURE=true
+  - ENABLE_DEV_API_KEY_ENDPOINT=true
+  - BUNDLES_DRIVE_BUILTIN=true
+  - MINI_INFRA_EGRESS_POOL_CIDR=${EGRESS_POOL_CIDR}
+```
+
+`deployment/development/worktree-start.ts` adds it to `stackEnv` so the substitution resolves:
+
+```ts
+const stackEnv: NodeJS.ProcessEnv = {
+  // ...existing vars...
+  EGRESS_POOL_CIDR: egressPoolCidr,
+};
+```
+
+### environment-details.xml
+
+Add an `<egressPool>` field to the generated XML so test/CI scripts can read the assigned pool the same way they read ports.
+
+## Implementation checklist
+
+1. [ ] `lib/registry.ts`: extend `PortAllocation` with `egress_pool_cidr`, compute it from slot in `allocatePorts`, throw on slot ≥ 64.
+2. [ ] `lib/registry.ts`: add `egress_pool_cidr?: string` to `WorktreeEntry`, persist via `upsertEntry`.
+3. [ ] `worktree-start.ts`: pass `EGRESS_POOL_CIDR=<allocated>` into `stackEnv`.
+4. [ ] `docker-compose.worktree.yaml`: add `MINI_INFRA_EGRESS_POOL_CIDR=${EGRESS_POOL_CIDR}` to the mini-infra service env.
+5. [ ] `lib/env-details.ts`: emit `<egressPool>` in `environment-details.xml`.
+6. [ ] `worktree-list.ts`: surface the pool in `--wide` output.
+7. [ ] `wsl2-reference.md`: replace the sweep-remediation note with a "subnets are slot-allocated, no manual override needed" note.
+8. [ ] Tests: a small unit test in `deployment/development/__tests__/registry.test.ts` (need to create the test setup; the dev scripts have none today) that asserts `slot N → 172.30.(4N).0/22`.
+
+## Migration
+
+- Worktrees existing at upgrade time keep running on their already-allocated app networks. The next time they're started, they'll get a `MINI_INFRA_EGRESS_POOL_CIDR` set to their slot's slice.
+- The server-side allocator reuses the existing `local-applications` subnet if the network already exists (see `provisionEgressGateway` step 1 in `environment-manager.ts`). So an already-provisioned env won't churn its subnet — the new pool only governs *new* envs the worktree creates after the upgrade.
+- For a clean cutover, a user can `worktree_start.ps1 --reset` to wipe the DB and let the env be re-created in the new pool. Optional, not required.
+
+## Future expansion
+
+If 64 worktrees × 4 envs is ever insufficient:
+
+1. **Wider base, smaller slice.** Switch the default to `10.96.0.0/12` and allocate a /20 per slot. That's 4096 slots × 16 envs each. Painless to flip — `MINI_INFRA_EGRESS_POOL_CIDR` already controls the base; the slot→CIDR math swaps.
+2. **Two-tier pool.** Reserve `172.30.0.0/16` for the first 64 worktrees (no env override needed; default just works), spill into a configured `MINI_INFRA_EGRESS_POOL_OVERFLOW_CIDR` for slots 64+.
+
+Both are safely deferred. Not needed for shipping this.
+
+## Alternatives considered
+
+### A. Switch WSL2 to `networkingMode=mirrored`
+
+Mirrored mode is documented as bridging WSL↔Windows, not isolating distro↔distro. Microsoft's docs use "shared network space" language consistently and the community has hit Docker compatibility issues with mirrored mode (TCP stalls — moby/moby#48201, port-forward breakage — microsoft/WSL#10494, local DNS interference). It also requires editing `~\.wslconfig`, which is a global change affecting every distro the user has, not just mini-infra. Rejected — solving a local problem with a global config change with known Docker incompatibilities is the wrong trade.
+
+### B. Run dockerd inside its own netns per distro
+
+`unshare -n` the dockerd inside each distro so its bridges live in a private netns. Genuinely isolates, but:
+
+- Has to thread netns visibility through every `docker exec`, every container start, every tool that runs against the daemon. Compose, the registry, mini-infra itself.
+- Loses `localhostForwarding` from Windows for free — we'd need to set up portmap/socat plumbing inside each isolated netns to make `localhost:<port>` work again on Windows.
+- Future-fragile against WSL2 networking changes.
+
+Rejected — high implementation cost, large surface area, fragile.
+
+### C. Coordinate via an additional global lock file
+
+`~/.mini-infra/subnets.yaml` records every active `(profile → cidr)`. Each `mini-infra-server` reads it at start and avoids subnets in use. Works, but:
+
+- Creates a runtime dependency the server doesn't have today (reading host-side config from inside the container).
+- Adds a coordination point that can drift from reality (file says X is in use, but the worktree was force-killed and never cleaned up).
+- The slot-keyed approach gets the same outcome with strictly less moving state.
+
+Rejected — overkill.
+
+### D. Detect collision at server start, fail loudly, ask user to re-run
+
+Cheap to build, terrible UX — bites the user every time they start a second worktree.
+
+### E. Random subnet picker with retry
+
+Allocator picks a random /24 not already in `docker network ls`, retries up to N times. Avoids slot bookkeeping but reintroduces the race: worktree A picks `.5.0/24`, worktree B independently picks `.5.0/24` between A's check and A's create. Rejected.
+
+## Risks
+
+- **Slot ≥ 64 panic.** A user with > 64 lifetime worktrees in `worktrees.yaml` (even if mostly inactive) could hit the throw. The existing port allocator caps at 100 slots, so the registry already grows to that ceiling. Mitigation: in `allocatePorts`, when computing the egress CIDR, if slot >= 64 fall back to the default pool *and* log a loud warning ("worktree N at slot ≥ 64 falls back to shared default pool — collision risk; clean up old worktrees with `worktree_cleanup`"). Deferred; document for now.
+- **Dev users with VPN/LAN on `172.30.0.0/16`.** If their corporate VPN allocates from `172.30.x.x`, all dev worktrees will collide with the VPN regardless of slicing. Mitigation: doc the `MINI_INFRA_EGRESS_POOL_CIDR` override; same as today.
+- **The /22 size assumption.** If a single dev needs >4 envs in one worktree, they hit `Egress subnet pool exhausted` from the per-worktree allocator. Realistic? Unclear. Mitigation: revisit when it bites; meanwhile a user can override via `MINI_INFRA_EGRESS_POOL_CIDR` to a wider slice.
+
+## Test plan
+
+- Unit: slot N → CIDR mapping. `n=0 → 172.30.0.0/22`, `n=3 → 172.30.12.0/22`, `n=63 → 172.30.252.0/22`, `n=64 → throws`.
+- Integration: spin two worktrees in parallel, verify `local-applications` networks have non-overlapping subnets via `wsl -d <distro> -- docker network inspect local-applications`.
+- Regression: existing worktree at slot 0 with already-provisioned `172.30.0.0/24` keeps working — re-running `worktree_start.ps1` doesn't migrate it, and inter-container connectivity is intact.
+- Cross-test against #275 sweep: with two worktrees up and disjoint subnets, deleting one should sweep only its own bridges and leave the other's intact (the sweep already does this; this just confirms the math).

--- a/docs/user/wsl2-reference.md
+++ b/docs/user/wsl2-reference.md
@@ -4,7 +4,7 @@ Reference notes for using WSL2 to run multiple isolated Docker daemons on Window
 
 ## What WSL2 Is
 
-The Windows Subsystem for Linux v2 runs a real Linux kernel in a managed lightweight VM. Each "distro" is a registered Linux installation with its own filesystem (a VHDX disk file). All distros share a single Hyper-V utility VM, but each has its own filesystem, network namespace, and processes.
+The Windows Subsystem for Linux v2 runs a real Linux kernel in a managed lightweight VM. Each "distro" is a registered Linux installation with its own filesystem (a VHDX disk file). All distros share a single Hyper-V utility VM and (in the default NAT networking mode) a single kernel network namespace — verifiable via `readlink /proc/self/ns/net`, which returns the same id from every running distro. Each distro has its own filesystem, mount, pid, ipc, and user namespaces; only the network namespace is shared. (`networkingMode=mirrored` in `~\.wslconfig` changes this, but Mini Infra assumes the default.)
 
 For our use case:
 
@@ -176,3 +176,32 @@ The orchestrator triggers a start when needed. If it consistently misdetects sta
 
 **"docker.exe is not recognized."**
 Install the static Docker CLI binary (see [Installation](#installation)). Don't install Docker Desktop unless you've intentionally chosen that path — it'll fight with the per-worktree daemon.
+
+**Containers on the same env's applications network can't reach each other.**
+Symptom: TCP connects time out and ICMP fails between two containers that `docker network inspect <env>-applications` confirms are on the same network. `iptables -L DOCKER-USER` is just `RETURN` and doesn't drop anything. Likely cause: an orphaned `br-<id>` bridge is shadowing the real one in the kernel's FIB. Because every WSL2 distro shares one network namespace, a previous worktree's leftover bridge (or a sibling distro's live bridge) can win the route lookup for the same subnet, sending packets out via empty veths.
+
+Diagnose:
+
+```powershell
+# 1. Two routes for the same subnet = orphan bridge problem
+wsl -d mini-infra-<profile> -- ip route show 172.30.0.0/24
+
+# 2. Cross-check the kernel's bridge list against what dockerd thinks it has
+wsl -d mini-infra-<profile> -- sh -c 'ip -o link | grep -oE "br-[a-f0-9]{12}" | sort > /tmp/k; docker network ls -q --no-trunc | cut -c1-12 | sort > /tmp/d; comm -23 /tmp/k /tmp/d'
+# Anything printed here is a bridge in the kernel that this distro's
+# dockerd doesn't claim — it may belong to a sibling distro (fine) or
+# be a true orphan from a partial cleanup (bug).
+
+# 3. List bridges claimed by every other running mini-infra distro
+wsl -l -v | findstr mini-infra-
+# then for each running one:
+wsl -d mini-infra-<other> -- docker network ls -q --no-trunc | cut -c1-12
+```
+
+`worktree_delete.ps1` and `worktree_cleanup.ps1` now sweep these orphans automatically before unregistering. To clean an orphan that survived a previous failed teardown without losing the distro:
+
+```powershell
+wsl -d mini-infra-<profile> -- ip link delete br-<id>
+```
+
+Only delete bridges that no running distro's `docker network ls -q` claims. Yanking a sibling distro's bridge will break that worktree's networking until its dockerd recreates it.


### PR DESCRIPTION
## Summary

Fix a silent connectivity bug for WSL2 worktrees where containers on the same Docker network can't reach each other because an orphaned Linux bridge in the kernel's FIB shadows the legitimate one.

## What was wrong

While debugging a worktree where containers on `local-applications` (subnet `172.30.0.0/24`) couldn't TCP-connect or ICMP each other, I found two bridges with the same subnet route inside the WSL2 distro:

```
$ wsl -d mini-infra-<profile> -- ip route show 172.30.0.0/24
172.30.0.0/24 dev br-c9cbd000f70d scope link  src 172.30.0.1
172.30.0.0/24 dev br-f49e238a6218 scope link  src 172.30.0.1
```

`br-c9cbd000f70d` was not in this distro's `docker network ls`, but it had a /24 route the kernel was using to send packets onto an empty veth pair. `ip link delete br-c9cbd000f70d` immediately fixed the bug.

The deeper finding while building the fix:

> **WSL2's default NAT networking puts every distro in a single shared kernel network namespace.** `readlink /proc/self/ns/net` returns the same id from every running distro (`net:[4026531840]` on the host I tested on). The wsl2-reference doc claimed each distro had its own netns; that was wrong and is fixed in this PR.

That means a `br-<id>` from any distro's dockerd is visible to every distro, and the orphan I saw was actually the live bridge of a *sibling* worktree — its 12-char id (`c9cbd000f70d`) matched another running distro's `local-applications` network. Two distros allocated the same `172.30.0.0/24` subnet because each distro's egress allocator only consults its own DB and its own dockerd, not its siblings'.

## What this PR does

`worktree-delete` and `worktree-cleanup` now run a force-cleanup + orphan-bridge sweep inside the doomed distro before `wsl --unregister`:

1. `docker rm -f $(docker ps -aq)` — kill any app-stack containers compose down doesn't manage.
2. `docker network prune -f` — let dockerd clean up the bridges it still claims.
3. `cleanupOrphanBridges` — for each `br-<id12>` still in `ip link`, delete it unless its id is claimed by *another* running mini-infra distro's `docker network ls -q`. Sibling worktrees stay untouched; the doomed distro's own bridges (now unclaimed) plus any true leftovers are removed.

The keep-vm path skips the sweep — its whole point is to leave the daemon up.

The helper lives in `deployment/development/lib/wsl.ts` and is shared between `worktree-delete.ts` and `worktree-cleanup.ts`. It's also designed to support a defensive pre-start sweep (pass the target distro itself in `liveDistros`, only true orphans get pulled), which a follow-up could wire into `worktree-start.ts` if drift continues to bite.

## What this PR does *not* fix

The deeper subnet-collision problem remains — two parallel worktrees can still both pick `172.30.0.0/24` and step on each other while *both* are running, because subnet allocation is per-distro and the netns is shared. A proper fix would either:

- Coordinate subnet allocation across distros (e.g. derive the egress pool offset from the `~/.mini-infra/worktrees.yaml` slot the worktree is allocated, so each gets a unique `/16` slice), or
- Switch WSL to `networkingMode=mirrored` so each distro gets its own netns.

Neither is in scope here. This PR fixes the cleanup-orphans flavor of the bug, which was the immediate symptom, and documents the diagnostic so the next person who hits the deeper version knows what they're looking at.

## Reproduction / verification

Reproducing the orphan-leftover variant cleanly is hard (it requires a partial daemon shutdown), but I verified the fix end-to-end against a live state that had it: my host had a `br-d4a22fe348b5` bridge marked DOWN with no Docker network claiming it. Running `cleanupOrphanBridges` in defensive-sweep mode deleted exactly that bridge and preserved the 8 live ones. The sibling-aware logic was also exercised — bridges claimed by a parallel running mini-infra distro were correctly preserved.

## Test plan

- [ ] On Windows: `worktree_start.ps1` a fresh worktree, then `worktree_delete.ps1 <profile>` — confirm the new ` Sweeping orphan bridges...` log line appears and that `wsl -d <other-mini-infra> -- ip link | grep br-` is unchanged for sibling worktrees.
- [ ] On Windows with two parallel worktrees up: `worktree_delete.ps1 <one>` — confirm the other worktree's containers stay healthy (no bridges of theirs were swept).
- [ ] On macOS: confirm Colima path is untouched (the sweep only fires under the `wsl` driver branch).
- [ ] `worktree_cleanup.ps1 --dry-run` shows the new dry-run lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)