### PR TITLE
fix(egress): use TARGETARCH for gateway/fw-agent builds

### DIFF
--- a/egress-gateway/Dockerfile
+++ b/egress-gateway/Dockerfile
@@ -19,11 +19,16 @@ RUN go mod download
 # Copy source.
 COPY . .
 
+# TARGETARCH is set automatically by buildx (and by classic `docker build`
+# from the host arch). Targets the runtime image's arch by default; override
+# with `docker buildx build --platform=linux/amd64` etc. for cross-builds.
+ARG TARGETARCH
+
 # Build both binaries (CGO disabled — go-nflog uses pure Go netlink).
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
     go build -ldflags="-s -w" -o /out/egress-gateway ./cmd/gateway
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
     go build -ldflags="-s -w" -o /out/egress-fw-agent ./cmd/fw-agent
 
 # ============================================================


### PR DESCRIPTION
## Summary
- Drop hardcoded `GOARCH=amd64` in `egress-gateway/Dockerfile`; switch to `ARG TARGETARCH` so binary arch matches the runtime image.
- Fixes a real (silent) bug on Apple Silicon: amd64-on-arm64 forced QEMU emulation, and QEMU's netfilter-netlink translation is incomplete — `fw-agent` started but its NFLOG reader failed with `setnonblock: bad file descriptor`, so `fw_drop` event observability never worked on Mac dev VMs. The "kernel module may be unavailable on WSL2" warning was misleading you about the cause.
- Buildx sets `TARGETARCH` automatically; classic `docker build` derives it from the host. amd64 CI builds keep working via `docker buildx build --platform=linux/amd64`.

## Test plan
- [x] `docker build` in arm64 Colima → binaries are `ARM aarch64`
- [x] `egress-fw-agent` starts; NFLOG reader logs `NFLOG reader started, group 1` (was `stopped` before)
- [x] Admin API socket `/var/run/mini-infra/fw.sock` returns `{"status":"ok"}`
- [x] `egress-gateway` Go test suite still passes (`go test ./...` in `egress-gateway/`)
- [ ] Verify amd64 build via `docker buildx build --platform=linux/amd64 ./egress-gateway` (left to CI / amd64 host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)