### PR TITLE
feat(egress): expose egressFirewallEnabled toggle on PUT /api/environments/:id

### DIFF
--- a/lib/types/environments.ts
+++ b/lib/types/environments.ts
@@ -12,6 +12,7 @@ export interface Environment {
   networkType: EnvironmentNetworkType;
   tunnelId?: string;
   tunnelServiceUrl?: string;
+  egressFirewallEnabled: boolean;
   networks: EnvironmentNetwork[];
   stackCount: number;
   systemStackCount: number;
@@ -44,6 +45,7 @@ export interface UpdateEnvironmentRequest {
   networkType?: EnvironmentNetworkType;
   tunnelId?: string;
   tunnelServiceUrl?: string;
+  egressFirewallEnabled?: boolean;
 }
 
 // Operation result types

--- a/server/src/__tests__/environment-api.test.ts
+++ b/server/src/__tests__/environment-api.test.ts
@@ -335,6 +335,21 @@ describe('Environment API', () => {
       expect(mockEnvironmentManager.updateEnvironment).toHaveBeenCalledWith('env-1', updateRequest);
     });
 
+    it('should pass egressFirewallEnabled through to updateEnvironment', async () => {
+      const updatedEnvironment = { ...mockEnvironment, egressFirewallEnabled: true };
+      mockEnvironmentManager.updateEnvironment.mockResolvedValue(updatedEnvironment);
+
+      const updateRequest = { egressFirewallEnabled: true };
+
+      const response = await request(app)
+        .put('/api/environments/env-1')
+        .send(updateRequest)
+        .expect(200);
+
+      expect(response.body.egressFirewallEnabled).toBe(true);
+      expect(mockEnvironmentManager.updateEnvironment).toHaveBeenCalledWith('env-1', updateRequest);
+    });
+
     it('should return 404 for non-existent environment', async () => {
       mockEnvironmentManager.updateEnvironment.mockResolvedValue(null);
 

--- a/server/src/__tests__/environment-manager.test.ts
+++ b/server/src/__tests__/environment-manager.test.ts
@@ -54,6 +54,17 @@ vi.mock('../services/egress/egress-network-allocator', () => ({
   },
 }));
 
+// Mock EnvFirewallManager singleton accessor
+const mockApplyEnv = vi.fn().mockResolvedValue(undefined);
+const mockRemoveEnv = vi.fn().mockResolvedValue(undefined);
+const mockGetEnvFirewallManager = vi.fn(() => ({
+  applyEnv: mockApplyEnv,
+  removeEnv: mockRemoveEnv,
+}));
+vi.mock('../services/egress', () => ({
+  getEnvFirewallManager: () => mockGetEnvFirewallManager(),
+}));
+
 const MockDockerExecutorService = DockerExecutorService as MockedClass<typeof DockerExecutorService>;
 
 describe('EnvironmentManager', () => {
@@ -355,11 +366,13 @@ describe('EnvironmentManager', () => {
         description: 'Updated description',
         type: 'production',
         networkType: 'local',
+        egressFirewallEnabled: false,
         networks: [],
         createdAt: new Date(),
         updatedAt: new Date()
       };
 
+      mockPrisma.environment.findUnique.mockResolvedValue({ egressFirewallEnabled: false, name: 'updated-env' } as any);
       mockPrisma.environment.update.mockResolvedValue(mockUpdatedEnvironment as any);
 
       const request = {
@@ -380,6 +393,7 @@ describe('EnvironmentManager', () => {
           networkType: undefined,
           tunnelId: undefined,
           tunnelServiceUrl: undefined,
+          egressFirewallEnabled: undefined,
         },
         include: {
           networks: true,
@@ -393,6 +407,81 @@ describe('EnvironmentManager', () => {
             select: { id: true },
           },
         }
+      });
+    });
+
+    describe('egressFirewallEnabled transitions', () => {
+      const baseEnvRow = {
+        id: 'env-1',
+        name: 'test-env',
+        type: 'nonproduction',
+        networkType: 'local',
+        networks: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      it('should call applyEnv with observe mode when toggled false→true', async () => {
+        mockPrisma.environment.findUnique.mockResolvedValue({ egressFirewallEnabled: false, name: 'test-env' } as any);
+        mockPrisma.environment.update.mockResolvedValue({ ...baseEnvRow, egressFirewallEnabled: true } as any);
+
+        await environmentManager.updateEnvironment('env-1', { egressFirewallEnabled: true });
+
+        expect(mockApplyEnv).toHaveBeenCalledWith('env-1', 'observe');
+        expect(mockRemoveEnv).not.toHaveBeenCalled();
+      });
+
+      it('should call removeEnv when toggled true→false', async () => {
+        mockPrisma.environment.findUnique.mockResolvedValue({ egressFirewallEnabled: true, name: 'test-env' } as any);
+        mockPrisma.environment.update.mockResolvedValue({ ...baseEnvRow, egressFirewallEnabled: false } as any);
+
+        await environmentManager.updateEnvironment('env-1', { egressFirewallEnabled: false });
+
+        expect(mockRemoveEnv).toHaveBeenCalledWith('env-1', 'test-env');
+        expect(mockApplyEnv).not.toHaveBeenCalled();
+      });
+
+      it('should not call applyEnv or removeEnv when value is unchanged (true→true)', async () => {
+        mockPrisma.environment.findUnique.mockResolvedValue({ egressFirewallEnabled: true, name: 'test-env' } as any);
+        mockPrisma.environment.update.mockResolvedValue({ ...baseEnvRow, egressFirewallEnabled: true } as any);
+
+        await environmentManager.updateEnvironment('env-1', { egressFirewallEnabled: true });
+
+        expect(mockApplyEnv).not.toHaveBeenCalled();
+        expect(mockRemoveEnv).not.toHaveBeenCalled();
+      });
+
+      it('should not call applyEnv or removeEnv when egressFirewallEnabled is omitted from the request', async () => {
+        mockPrisma.environment.findUnique.mockResolvedValue({ egressFirewallEnabled: false, name: 'test-env' } as any);
+        mockPrisma.environment.update.mockResolvedValue({ ...baseEnvRow, egressFirewallEnabled: false } as any);
+
+        await environmentManager.updateEnvironment('env-1', { description: 'just changing desc' });
+
+        expect(mockApplyEnv).not.toHaveBeenCalled();
+        expect(mockRemoveEnv).not.toHaveBeenCalled();
+      });
+
+      it('should not throw when applyEnv fails (best-effort, DB is authoritative)', async () => {
+        mockPrisma.environment.findUnique.mockResolvedValue({ egressFirewallEnabled: false, name: 'test-env' } as any);
+        mockPrisma.environment.update.mockResolvedValue({ ...baseEnvRow, egressFirewallEnabled: true } as any);
+        mockApplyEnv.mockRejectedValueOnce(new Error('fw-agent unreachable'));
+
+        const result = await environmentManager.updateEnvironment('env-1', { egressFirewallEnabled: true });
+
+        expect(result).not.toBeNull();
+        expect(mockApplyEnv).toHaveBeenCalledWith('env-1', 'observe');
+      });
+
+      it('should skip the agent call gracefully when EnvFirewallManager is not initialised', async () => {
+        mockGetEnvFirewallManager.mockReturnValueOnce(null as any);
+        mockPrisma.environment.findUnique.mockResolvedValue({ egressFirewallEnabled: false, name: 'test-env' } as any);
+        mockPrisma.environment.update.mockResolvedValue({ ...baseEnvRow, egressFirewallEnabled: true } as any);
+
+        const result = await environmentManager.updateEnvironment('env-1', { egressFirewallEnabled: true });
+
+        expect(result).not.toBeNull();
+        expect(mockApplyEnv).not.toHaveBeenCalled();
+        expect(mockRemoveEnv).not.toHaveBeenCalled();
       });
     });
   });

--- a/server/src/services/environment/environment-manager.ts
+++ b/server/src/services/environment/environment-manager.ts
@@ -13,6 +13,7 @@ import { getLogger } from '../../lib/logger-factory';
 import { UserEventService } from '../user-events';
 import { EgressNetworkAllocator } from '../egress/egress-network-allocator';
 import { EgressPolicyLifecycleService } from '../egress/egress-policy-lifecycle';
+import { getEnvFirewallManager } from '../egress';
 import { StackReconciler } from '../stacks/stack-reconciler';
 import DockerService from '../docker';
 
@@ -230,6 +231,12 @@ export class EnvironmentManager {
 
   public async updateEnvironment(id: string, request: UpdateEnvironmentRequest): Promise<Environment | null> {
     try {
+      // Read prior firewall state so we can detect transitions after the update.
+      const prior = await this.prisma.environment.findUnique({
+        where: { id },
+        select: { egressFirewallEnabled: true, name: true },
+      });
+
       const environment = await this.prisma.environment.update({
         where: { id },
         data: {
@@ -238,6 +245,7 @@ export class EnvironmentManager {
           networkType: request.networkType,
           tunnelId: request.tunnelId,
           tunnelServiceUrl: request.tunnelServiceUrl,
+          egressFirewallEnabled: request.egressFirewallEnabled,
         },
         include: {
           networks: true,
@@ -261,11 +269,38 @@ export class EnvironmentManager {
       const egressPolicyLifecycle = new EgressPolicyLifecycleService(this.prisma);
       await egressPolicyLifecycle.refreshEnvironmentNameSnapshot(id);
 
+      // If egressFirewallEnabled transitioned, push the change to the fw-agent.
+      // Best-effort: failures are logged but don't fail the request — the DB row
+      // is the source of truth and the agent will reconcile on next boot.
+      if (prior && request.egressFirewallEnabled !== undefined && request.egressFirewallEnabled !== prior.egressFirewallEnabled) {
+        await this.applyFirewallTransition(id, prior.name, request.egressFirewallEnabled);
+      }
+
       return this.mapPrismaToEnvironment(environment);
 
     } catch (error) {
       this.logger.error({ error, environmentId: id, request }, 'Failed to update environment');
       throw error;
+    }
+  }
+
+  private async applyFirewallTransition(envId: string, envName: string, enabled: boolean): Promise<void> {
+    const manager = getEnvFirewallManager();
+    if (!manager) {
+      this.logger.warn({ envId, enabled }, 'EnvFirewallManager not initialised; firewall transition skipped (will reconcile on next boot)');
+      return;
+    }
+    try {
+      if (enabled) {
+        await manager.applyEnv(envId, 'observe');
+      } else {
+        await manager.removeEnv(envId, envName);
+      }
+    } catch (err) {
+      this.logger.warn(
+        { err: err instanceof Error ? err.message : String(err), envId, enabled },
+        'fw-agent transition failed (non-fatal — DB state is authoritative)',
+      );
     }
   }
 
@@ -787,6 +822,7 @@ export class EnvironmentManager {
       systemStackCount: prismaEnv.stacks?.length ?? 0,
       tunnelId: prismaEnv.tunnelId ?? undefined,
       tunnelServiceUrl: prismaEnv.tunnelServiceUrl ?? undefined,
+      egressFirewallEnabled: prismaEnv.egressFirewallEnabled ?? false,
       createdAt: prismaEnv.createdAt,
       updatedAt: prismaEnv.updatedAt
     };


### PR DESCRIPTION
## Summary

Egress phases 1-3 ([#272](https://github.com/mrgeoffrich/mini-infra/pull/272)) landed the `Environment.egressFirewallEnabled` column and the `EnvFirewallManager` service that reads it, but no API surface existed to flip the flag — it could only be changed by hand-editing the database. This PR closes that gap.

- Extends the existing `PUT /api/environments/:id` route to accept `egressFirewallEnabled` (no new endpoint).
- `EnvironmentManager.updateEnvironment` now reads the prior value, writes the new one, and on transition calls `EnvFirewallManager.applyEnv(id, 'observe')` (false→true) or `removeEnv(id, name)` (true→false).
- Side-effect failures are logged but never fail the request — the DB row is the source of truth and the fw-agent reconciles on next boot. Same best-effort pattern used elsewhere in `EnvFirewallManager`.

## Design notes

- **Default mode on enable: `'observe'`**, matching `_reconcileEnvRegistrations` ([env-firewall-manager.ts:387](https://github.com/mrgeoffrich/mini-infra/blob/main/server/src/services/egress/env-firewall-manager.ts#L387)). Persisting the mode is a follow-up that needs its own column / UI.
- **No new endpoint** — `tunnelId`/`tunnelServiceUrl` already ride through this PUT route despite having runtime side effects, so the precedent is set.
- **No new permission** — the existing `environments:write` is the right scope for an environment-level toggle.

## Out of scope

- Frontend toggle UI — this PR is the backend-only piece. The flag now round-trips on `Environment` so the UI can render it.
- Persisting `'observe'` vs `'enforce'` mode — schema change + UI both required; later phase.
- Socket.IO event for environment mutations — none of the existing env mutations emit one; not adding here.

## Test plan

- [x] `pnpm build:lib` — types compile
- [x] `pnpm build:server` — server compiles
- [x] `pnpm --filter mini-infra-client build` — frontend still compiles with new required field
- [x] `pnpm --filter mini-infra-server lint` — clean
- [x] `pnpm --filter mini-infra-server test` — 1842 tests pass (117 files), including 6 new unit tests covering both transition directions, no-change, omitted-field, agent failure, and not-initialised cases, plus a route-level round-trip test
- [ ] End-to-end smoke in a worktree: `curl -X PUT \$UI/api/environments/\$ENV_ID -d '{"egressFirewallEnabled":true}'`, confirm the field round-trips on GET and that mini-infra-server logs `applyEnv` (or a warning if fw-agent is down)

🤖 Generated with [Claude Code](https://claude.com/claude-code)