### PR TITLE
feat(worktree): per-worktree egress subnet allocation

### DIFF
--- a/deployment/development/__tests__/registry.test.ts
+++ b/deployment/development/__tests__/registry.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import {
+  allocatePorts,
+  DEFAULT_EGRESS_POOL_CIDR,
+  egressPoolForSlot,
+  EGRESS_PER_WORKTREE_SLOT_COUNT,
+  REGISTRY_YAML,
+  saveRegistry,
+  type WorktreeEntry,
+  UI_PORT_MIN,
+  REGISTRY_PORT_MIN,
+  VAULT_PORT_MIN,
+  DOCKER_PORT_MIN,
+  HAPROXY_HTTP_PORT_MIN,
+  HAPROXY_HTTPS_PORT_MIN,
+  HAPROXY_STATS_PORT_MIN,
+  HAPROXY_DATAPLANE_PORT_MIN,
+} from '../lib/registry.js';
+
+describe('egressPoolForSlot', () => {
+  it.each([
+    [0, '172.30.0.0/22'],
+    [1, '172.30.4.0/22'],
+    [3, '172.30.12.0/22'],
+    [10, '172.30.40.0/22'],
+    [63, '172.30.252.0/22'],
+  ])('slot %i → %s', (slot, cidr) => {
+    expect(egressPoolForSlot(slot)).toBe(cidr);
+  });
+
+  it('slot at boundary (= EGRESS_PER_WORKTREE_SLOT_COUNT) falls back to default', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(egressPoolForSlot(EGRESS_PER_WORKTREE_SLOT_COUNT)).toBe(DEFAULT_EGRESS_POOL_CIDR);
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain('exceeds per-worktree egress pool capacity');
+    expect(warn.mock.calls[0][0]).toContain('worktree_cleanup');
+    warn.mockRestore();
+  });
+
+  it('slot above boundary falls back to default', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(egressPoolForSlot(99)).toBe(DEFAULT_EGRESS_POOL_CIDR);
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+
+  it('negative slot falls back to default', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(egressPoolForSlot(-1)).toBe(DEFAULT_EGRESS_POOL_CIDR);
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+
+  it('non-integer slot falls back to default', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(egressPoolForSlot(1.5)).toBe(DEFAULT_EGRESS_POOL_CIDR);
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+
+  it('NaN slot falls back to default', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(egressPoolForSlot(Number.NaN)).toBe(DEFAULT_EGRESS_POOL_CIDR);
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+});
+
+describe('allocatePorts (egress_pool_cidr wiring)', () => {
+  beforeEach(() => {
+    if (fs.existsSync(REGISTRY_YAML)) fs.rmSync(REGISTRY_YAML);
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(REGISTRY_YAML)) fs.rmSync(REGISTRY_YAML);
+  });
+
+  it('first profile lands in slot 0 with 172.30.0.0/22', () => {
+    const alloc = allocatePorts('first');
+    expect(alloc.ui_port).toBe(UI_PORT_MIN);
+    expect(alloc.egress_pool_cidr).toBe('172.30.0.0/22');
+  });
+
+  it('second profile lands in slot 1 with 172.30.4.0/22 (no collision)', () => {
+    // Seed slot 0 by upserting a fully-formed entry — allocatePorts only
+    // reads ports, so this is enough to mark slot 0 as taken.
+    const slot0Entry: WorktreeEntry = {
+      profile: 'first',
+      worktree_path: '',
+      colima_vm: 'first',
+      url: '',
+      ui_port: UI_PORT_MIN,
+      registry_port: REGISTRY_PORT_MIN,
+      vault_port: VAULT_PORT_MIN,
+      docker_port: DOCKER_PORT_MIN,
+      haproxy_http_port: HAPROXY_HTTP_PORT_MIN,
+      haproxy_https_port: HAPROXY_HTTPS_PORT_MIN,
+      haproxy_stats_port: HAPROXY_STATS_PORT_MIN,
+      haproxy_dataplane_port: HAPROXY_DATAPLANE_PORT_MIN,
+      seeded: false,
+      updated_at: new Date().toISOString(),
+    };
+    saveRegistry({ first: slot0Entry });
+
+    const alloc = allocatePorts('second');
+    expect(alloc.ui_port).toBe(UI_PORT_MIN + 1);
+    expect(alloc.egress_pool_cidr).toBe('172.30.4.0/22');
+  });
+
+  it('re-allocating the same profile keeps its slot and CIDR', () => {
+    const first = allocatePorts('stable');
+    const again = allocatePorts('stable');
+    expect(again.ui_port).toBe(first.ui_port);
+    expect(again.egress_pool_cidr).toBe(first.egress_pool_cidr);
+  });
+
+  it('uses the temp registry path, not the user home', () => {
+    // Sanity check that the test setup correctly redirects MINI_INFRA_HOME.
+    // The mkdtempSync prefix 'mini-infra-test-' lands somewhere under
+    // os.tmpdir(); on Windows that's still under the user profile, so this
+    // is the strongest check we can make portably.
+    expect(REGISTRY_YAML).toContain('mini-infra-test-');
+    expect(REGISTRY_YAML).not.toMatch(/\.mini-infra[\\/]worktrees\.yaml$/);
+  });
+});

--- a/deployment/development/__tests__/setup.ts
+++ b/deployment/development/__tests__/setup.ts
@@ -1,0 +1,9 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// Redirect MINI_INFRA_HOME to a per-process temp dir before the registry
+// module captures it at import time. This isolates tests from the user's
+// real ~/.mini-infra/worktrees.yaml.
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'mini-infra-test-'));
+process.env.MINI_INFRA_HOME = tmpHome;

--- a/deployment/development/docker-compose.worktree.yaml
+++ b/deployment/development/docker-compose.worktree.yaml
@@ -42,6 +42,7 @@ services:
       - ALLOW_INSECURE=true
       - ENABLE_DEV_API_KEY_ENDPOINT=true
       - BUNDLES_DRIVE_BUILTIN=true
+      - MINI_INFRA_EGRESS_POOL_CIDR=${EGRESS_POOL_CIDR}
     healthcheck:
       test:
         [

--- a/deployment/development/lib/env-details.ts
+++ b/deployment/development/lib/env-details.ts
@@ -71,6 +71,7 @@ export interface MinimalEnvironmentDetailsInput {
   uiPort: number;
   registryPort: number;
   vaultPort: number;
+  egressPool: string;
   agentSidecarImageTag: string;
   egressSidecarImageTag: string;
   shortDescription?: string;
@@ -113,6 +114,7 @@ ${descBlock}  <seeded>false</seeded>
     <registry>localhost:${input.registryPort}</registry>
     <vault>http://localhost:${input.vaultPort}</vault>
   </endpoints>
+  <egressPool>${xmlEscape(input.egressPool)}</egressPool>
   <images>
     <agentSidecar>${xmlEscape(input.agentSidecarImageTag)}</agentSidecar>
     <egressSidecar>${xmlEscape(input.egressSidecarImageTag)}</egressSidecar>
@@ -144,6 +146,7 @@ export interface FullEnvironmentDetailsInput {
   uiPort: number;
   registryPort: number;
   vaultPort: number;
+  egressPool: string;
   agentSidecarImageTag: string;
   egressSidecarImageTag: string;
   adminEmail: string;
@@ -205,6 +208,7 @@ ${descBlock}  <seeded>true</seeded>
     <registry>localhost:${input.registryPort}</registry>
     <vault>http://localhost:${input.vaultPort}</vault>
   </endpoints>
+  <egressPool>${t(input.egressPool)}</egressPool>
   <images>
     <agentSidecar>${t(input.agentSidecarImageTag)}</agentSidecar>
     <egressSidecar>${t(input.egressSidecarImageTag)}</egressSidecar>

--- a/deployment/development/lib/registry.ts
+++ b/deployment/development/lib/registry.ts
@@ -30,6 +30,17 @@ export const HAPROXY_STATS_PORT_MAX = 8499;
 export const HAPROXY_DATAPLANE_PORT_MIN = 5500;
 export const HAPROXY_DATAPLANE_PORT_MAX = 5599;
 
+// Per-worktree egress pool slicing: each worktree gets a /22 carved out of
+// 172.30.0.0/16, keyed off the same slot the port allocator already uses.
+// Slot 0 → 172.30.0.0/22, slot 1 → 172.30.4.0/22, …, slot 63 → 172.30.252.0/22.
+// Slots ≥ 64 fall back to the shared default pool with a warning. The server's
+// egress-network-allocator reads MINI_INFRA_EGRESS_POOL_CIDR and is size-agnostic,
+// so handing it a /22 produces 4 /24 slots; two worktrees in different slots
+// reach disjoint /24s by construction with no coordination.
+export const DEFAULT_EGRESS_POOL_CIDR = '172.30.0.0/16';
+export const EGRESS_PER_WORKTREE_PREFIX = 22;
+export const EGRESS_PER_WORKTREE_SLOT_COUNT = 64;
+
 export interface WorktreeEntry {
   profile: string;
   worktree_path: string;
@@ -54,6 +65,11 @@ export interface WorktreeEntry {
   admin_password?: string;
   api_key?: string;
   description?: string;
+  // Per-worktree egress pool slice (e.g. "172.30.12.0/22" for slot 3).
+  // Stored for visibility in worktree_list output and forensics — the source
+  // of truth at runtime is the slot, not this field. Optional so legacy
+  // entries written before this rolled out continue to load.
+  egress_pool_cidr?: string;
   seeded: boolean;
   updated_at: string;
 }
@@ -104,6 +120,7 @@ export function upsertEntry(
     admin_password: partial.admin_password ?? existing?.admin_password,
     api_key: partial.api_key ?? existing?.api_key,
     description: partial.description ?? existing?.description,
+    egress_pool_cidr: partial.egress_pool_cidr ?? existing?.egress_pool_cidr,
     seeded: partial.seeded ?? existing?.seeded ?? false,
     updated_at: new Date().toISOString(),
   };
@@ -137,35 +154,67 @@ export interface PortAllocation {
   haproxy_https_port: number;
   haproxy_stats_port: number;
   haproxy_dataplane_port: number;
+  egress_pool_cidr: string;
+}
+
+/**
+ * Compute the per-worktree egress pool CIDR for a given slot. Each worktree
+ * gets a /22 (4 contiguous /24s) carved out of 172.30.0.0/16:
+ *   slot 0  → 172.30.0.0/22
+ *   slot 1  → 172.30.4.0/22
+ *   slot 63 → 172.30.252.0/22
+ *
+ * Slot ≥ EGRESS_PER_WORKTREE_SLOT_COUNT (or < 0) falls back to the shared
+ * default pool with a console warning. This keeps the existing 100-slot
+ * port ceiling working for slots 64–99 at the cost of reintroducing the
+ * original cross-worktree /24 collision risk for that case only — clean up
+ * old worktrees with worktree_cleanup if you see this warning.
+ */
+export function egressPoolForSlot(slot: number): string {
+  if (!Number.isInteger(slot) || slot < 0 || slot >= EGRESS_PER_WORKTREE_SLOT_COUNT) {
+    console.warn(
+      `Worktree slot ${slot} exceeds per-worktree egress pool capacity ` +
+        `(0–${EGRESS_PER_WORKTREE_SLOT_COUNT - 1}); falling back to shared ` +
+        `${DEFAULT_EGRESS_POOL_CIDR}. Two concurrent worktrees in this state ` +
+        `can collide on /24s — clean up old worktrees with worktree_cleanup.`,
+    );
+    return DEFAULT_EGRESS_POOL_CIDR;
+  }
+  return `172.30.${slot * 4}.0/${EGRESS_PER_WORKTREE_PREFIX}`;
+}
+
+/**
+ * Derive the slot index of a worktree entry by inspecting whichever known
+ * port field falls inside its allocator range. Returns undefined for legacy
+ * entries with no recognisable port.
+ */
+export function slotOf(e: WorktreeEntry): number | undefined {
+  if (e.ui_port && e.ui_port >= UI_PORT_MIN && e.ui_port <= UI_PORT_MAX) {
+    return e.ui_port - UI_PORT_MIN;
+  }
+  if (e.registry_port && e.registry_port >= REGISTRY_PORT_MIN && e.registry_port <= REGISTRY_PORT_MAX) {
+    return e.registry_port - REGISTRY_PORT_MIN;
+  }
+  if (e.vault_port && e.vault_port >= VAULT_PORT_MIN && e.vault_port <= VAULT_PORT_MAX) {
+    return e.vault_port - VAULT_PORT_MIN;
+  }
+  if (e.docker_port && e.docker_port >= DOCKER_PORT_MIN && e.docker_port <= DOCKER_PORT_MAX) {
+    return e.docker_port - DOCKER_PORT_MIN;
+  }
+  if (
+    e.haproxy_http_port &&
+    e.haproxy_http_port >= HAPROXY_HTTP_PORT_MIN &&
+    e.haproxy_http_port <= HAPROXY_HTTP_PORT_MAX
+  ) {
+    return e.haproxy_http_port - HAPROXY_HTTP_PORT_MIN;
+  }
+  return undefined;
 }
 
 export function allocatePorts(profile: string): PortAllocation {
   const SLOT_COUNT = UI_PORT_MAX - UI_PORT_MIN + 1;
   const entries = loadRegistry();
   const existing = entries[profile];
-
-  const slotOf = (e: WorktreeEntry): number | undefined => {
-    if (e.ui_port && e.ui_port >= UI_PORT_MIN && e.ui_port <= UI_PORT_MAX) {
-      return e.ui_port - UI_PORT_MIN;
-    }
-    if (e.registry_port && e.registry_port >= REGISTRY_PORT_MIN && e.registry_port <= REGISTRY_PORT_MAX) {
-      return e.registry_port - REGISTRY_PORT_MIN;
-    }
-    if (e.vault_port && e.vault_port >= VAULT_PORT_MIN && e.vault_port <= VAULT_PORT_MAX) {
-      return e.vault_port - VAULT_PORT_MIN;
-    }
-    if (e.docker_port && e.docker_port >= DOCKER_PORT_MIN && e.docker_port <= DOCKER_PORT_MAX) {
-      return e.docker_port - DOCKER_PORT_MIN;
-    }
-    if (
-      e.haproxy_http_port &&
-      e.haproxy_http_port >= HAPROXY_HTTP_PORT_MIN &&
-      e.haproxy_http_port <= HAPROXY_HTTP_PORT_MAX
-    ) {
-      return e.haproxy_http_port - HAPROXY_HTTP_PORT_MIN;
-    }
-    return undefined;
-  };
 
   const usedSlots = new Set<number>();
   for (const e of Object.values(entries)) {
@@ -197,6 +246,7 @@ export function allocatePorts(profile: string): PortAllocation {
     haproxy_https_port: HAPROXY_HTTPS_PORT_MIN + slot,
     haproxy_stats_port: HAPROXY_STATS_PORT_MIN + slot,
     haproxy_dataplane_port: HAPROXY_DATAPLANE_PORT_MIN + slot,
+    egress_pool_cidr: egressPoolForSlot(slot),
   };
 }
 

--- a/deployment/development/lib/seeder.ts
+++ b/deployment/development/lib/seeder.ts
@@ -42,6 +42,8 @@ export interface SeederInput {
   composeProject: string;
   agentSidecarImageTag: string;
   egressSidecarImageTag: string;
+  // /22 slice of 172.30.0.0/16 allocated for this worktree's slot.
+  egressPoolCidr: string;
   devEnvPath: string;
   detailsFile: string;
   shortDescription?: string;
@@ -782,6 +784,7 @@ export async function seed(input: SeederInput): Promise<SeederOutput> {
     uiPort: input.uiPort,
     registryPort: input.registryPort,
     vaultPort: input.vaultPort,
+    egressPool: input.egressPoolCidr,
     agentSidecarImageTag: input.agentSidecarImageTag,
     egressSidecarImageTag: input.egressSidecarImageTag,
     adminEmail: env.ADMIN_EMAIL,

--- a/deployment/development/package-lock.json
+++ b/deployment/development/package-lock.json
@@ -1,0 +1,1313 @@
+{
+  "name": "mini-infra-dev-scripts",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mini-infra-dev-scripts",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "^24.12.2",
+        "js-yaml": "^4.1.1",
+        "vitest": "^4.1.3"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/deployment/development/package.json
+++ b/deployment/development/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mini-infra-dev-scripts",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^24.12.2",
+    "js-yaml": "^4.1.1",
+    "vitest": "^4.1.3"
+  }
+}

--- a/deployment/development/vitest.config.ts
+++ b/deployment/development/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['__tests__/**/*.test.ts'],
+    setupFiles: ['./__tests__/setup.ts'],
+  },
+});

--- a/deployment/development/worktree-list.ts
+++ b/deployment/development/worktree-list.ts
@@ -9,8 +9,27 @@
 //   --json   Emit the registry as JSON instead of a table
 
 import { parseArgs } from 'node:util';
-import { loadRegistry, REGISTRY_YAML } from './lib/registry.js';
+import {
+  DEFAULT_EGRESS_POOL_CIDR,
+  EGRESS_PER_WORKTREE_PREFIX,
+  EGRESS_PER_WORKTREE_SLOT_COUNT,
+  loadRegistry,
+  REGISTRY_YAML,
+  slotOf,
+  type WorktreeEntry,
+} from './lib/registry.js';
 import { logError } from './lib/log.js';
+
+// Resolve the egress pool for an entry without triggering the warn side-effect
+// in egressPoolForSlot (which we don't want spamming the listing output).
+// Prefer the persisted field; otherwise compute from slot; otherwise show '-'.
+function egressPoolFor(e: WorktreeEntry): string {
+  if (e.egress_pool_cidr) return e.egress_pool_cidr;
+  const slot = slotOf(e);
+  if (slot === undefined) return '-';
+  if (slot < 0 || slot >= EGRESS_PER_WORKTREE_SLOT_COUNT) return DEFAULT_EGRESS_POOL_CIDR;
+  return `172.30.${slot * 4}.0/${EGRESS_PER_WORKTREE_PREFIX}`;
+}
 
 interface Args {
   wide: boolean;
@@ -77,6 +96,7 @@ function main(): void {
       'REG',
       'VAULT',
       'HAPROXY',
+      'EGRESS POOL',
       'VM',
       'ADMIN EMAIL',
       'ADMIN PASSWORD',
@@ -96,6 +116,7 @@ function main(): void {
         e.registry_port ? String(e.registry_port) : '-',
         e.vault_port ? String(e.vault_port) : '-',
         haproxy,
+        egressPoolFor(e),
         dash(e.colima_vm),
         dash(e.admin_email),
         dash(e.admin_password),

--- a/deployment/development/worktree-start.ts
+++ b/deployment/development/worktree-start.ts
@@ -295,6 +295,7 @@ async function main(): Promise<void> {
     haproxy_https_port: haproxyHttpsPort,
     haproxy_stats_port: haproxyStatsPort,
     haproxy_dataplane_port: haproxyDataplanePort,
+    egress_pool_cidr: egressPoolCidr,
   } = allocatePorts(profile);
   // Persist early so the entry exists even if later steps fail
   upsertEntry({
@@ -309,6 +310,7 @@ async function main(): Promise<void> {
     haproxy_https_port: haproxyHttpsPort,
     haproxy_stats_port: haproxyStatsPort,
     haproxy_dataplane_port: haproxyDataplanePort,
+    egress_pool_cidr: egressPoolCidr,
     url: `http://localhost:${uiPort}`,
     description: shortDesc,
   });
@@ -317,6 +319,7 @@ async function main(): Promise<void> {
       (driver === 'wsl' ? `, docker=${dockerPort}` : '') +
       `, haproxy(http/https/stats/dataplane)=${haproxyHttpPort}/${haproxyHttpsPort}/${haproxyStatsPort}/${haproxyDataplanePort}`,
   );
+  logInfo(`Egress pool: ${egressPoolCidr}`);
 
   // Bring the VM up via the selected driver. For environment-details.xml,
   // colima exposes a host-side unix socket path; wsl exposes only TCP, so
@@ -391,6 +394,7 @@ async function main(): Promise<void> {
     AGENT_SIDECAR_IMAGE_TAG: agentSidecarImageTag,
     EGRESS_SIDECAR_IMAGE_TAG: egressSidecarImageTag,
     EGRESS_GATEWAY_IMAGE_TAG: egressGatewayImageTag,
+    EGRESS_POOL_CIDR: egressPoolCidr,
     PROJECT_ROOT,
     PROFILE: profile,
   };
@@ -616,6 +620,7 @@ async function main(): Promise<void> {
     uiPort,
     registryPort,
     vaultPort,
+    egressPool: egressPoolCidr,
     agentSidecarImageTag,
     egressSidecarImageTag,
     shortDescription: shortDesc,
@@ -649,6 +654,7 @@ async function main(): Promise<void> {
         composeProject: composeProjectName,
         agentSidecarImageTag,
         egressSidecarImageTag,
+        egressPoolCidr,
         devEnvPath: DEV_ENV_FILE,
         detailsFile,
         shortDescription: shortDesc,

--- a/docs/user/wsl2-reference.md
+++ b/docs/user/wsl2-reference.md
@@ -178,9 +178,15 @@ The orchestrator triggers a start when needed. If it consistently misdetects sta
 Install the static Docker CLI binary (see [Installation](#installation)). Don't install Docker Desktop unless you've intentionally chosen that path — it'll fight with the per-worktree daemon.
 
 **Containers on the same env's applications network can't reach each other.**
-Symptom: TCP connects time out and ICMP fails between two containers that `docker network inspect <env>-applications` confirms are on the same network. `iptables -L DOCKER-USER` is just `RETURN` and doesn't drop anything. Likely cause: an orphaned `br-<id>` bridge is shadowing the real one in the kernel's FIB. Because every WSL2 distro shares one network namespace, a previous worktree's leftover bridge (or a sibling distro's live bridge) can win the route lookup for the same subnet, sending packets out via empty veths.
+Symptom: TCP connects time out and ICMP fails between two containers that `docker network inspect <env>-applications` confirms are on the same network. `iptables -L DOCKER-USER` is just `RETURN` and doesn't drop anything. Likely cause: an orphaned `br-<id>` bridge is shadowing the real one in the kernel's FIB. Because every WSL2 distro shares one network namespace, a previous worktree's leftover bridge can win the route lookup for the same subnet, sending packets out via empty veths.
 
-Diagnose:
+This used to happen routinely between *running* sibling worktrees because two daemons could independently pick the same `/24` for their `local-applications` network. That class of collision is now prevented by construction: each worktree is given its own `/22` slice of `172.30.0.0/16`, keyed off the same slot as its ports. Slot 0 → `172.30.0.0/22`, slot 1 → `172.30.4.0/22`, …, slot 63 → `172.30.252.0/22`. The slice is passed into the container as `MINI_INFRA_EGRESS_POOL_CIDR` and the server allocates `/24`s only from inside it. You can verify the assignment with `worktree_list.ps1 --wide` (look at the `EGRESS POOL` column) or `xmllint --xpath 'string(//environment/egressPool)' environment-details.xml`.
+
+If a worktree ends up at slot ≥ 64 (more than 64 lifetime worktrees in `~/.mini-infra/worktrees.yaml`), the start-up script logs a `Worktree slot N exceeds per-worktree egress pool capacity` warning and falls back to the shared `172.30.0.0/16` default — collisions with siblings become possible again. Run `worktree_cleanup.ps1` to reclaim old slots and clear the warning.
+
+Migration corner case: existing worktrees keep their already-allocated `local-applications` subnets across restarts (the server reuses the network's IPAM config rather than reallocating). If an old subnet sits *outside* the new pool for that worktree's slot, the worktree itself keeps working but a *different* worktree may later pick the same `/24` for a fresh env. Re-run `worktree_start.ps1 --reset` for a clean cutover.
+
+Diagnose a suspected orphan-bridge case:
 
 ```powershell
 # 1. Two routes for the same subnet = orphan bridge problem
@@ -198,7 +204,7 @@ wsl -l -v | findstr mini-infra-
 wsl -d mini-infra-<other> -- docker network ls -q --no-trunc | cut -c1-12
 ```
 
-`worktree_delete.ps1` and `worktree_cleanup.ps1` now sweep these orphans automatically before unregistering. To clean an orphan that survived a previous failed teardown without losing the distro:
+`worktree_delete.ps1` and `worktree_cleanup.ps1` already sweep orphans automatically before unregistering. As a last-resort manual recovery for a bridge that survived a partial teardown:
 
 ```powershell
 wsl -d mini-infra-<profile> -- ip link delete br-<id>


### PR DESCRIPTION
## Summary

- Slice `172.30.0.0/16` into per-worktree `/22`s keyed off the existing port slot, so two parallel WSL2 worktrees never pick the same `/24` for their `local-applications` network. Slot 0 → `172.30.0.0/22`, slot 1 → `172.30.4.0/22`, …, slot 63 → `172.30.252.0/22`.
- Slot ≥ 64 falls back to the shared `/16` default with a `console.warn` (the port allocator's 100-slot ceiling stays unchanged).
- All changes are dev-scripts and docs — the server-side allocator at `server/src/services/egress/egress-network-allocator.ts` already reads `MINI_INFRA_EGRESS_POOL_CIDR` and the slot-counting math is size-agnostic, so handing it a `/22` produces 4 `/24` slots without any server code change.

Follow-up to #275, which fixed the orphan-bridge cleanup failure but not the concurrent-pick failure two running worktrees could still hit.

Design doc: [docs/planning/not-shipped/worktree-egress-subnet-allocation.md](https://github.com/mrgeoffrich/mini-infra/blob/claude/infallible-pare-dbac4c/docs/planning/not-shipped/worktree-egress-subnet-allocation.md).

## What changed

- `deployment/development/lib/registry.ts` — new `egressPoolForSlot(slot)` helper (warns and falls back to default for slot ≥ 64), `slotOf()` extracted as exported, `egress_pool_cidr` added to `PortAllocation` and `WorktreeEntry`.
- `deployment/development/lib/env-details.ts` — `<egressPool>` element added to both minimal and full XML writers; `egressPool` field on both input interfaces.
- `deployment/development/lib/seeder.ts` — accepts `egressPoolCidr` and threads it into `writeFullEnvironmentDetails`.
- `deployment/development/worktree-start.ts` — destructures `egress_pool_cidr` from `allocatePorts`, injects `EGRESS_POOL_CIDR` into `stackEnv`, persists via `upsertEntry`, threads through to seeder and minimal env-details.
- `deployment/development/docker-compose.worktree.yaml` — `MINI_INFRA_EGRESS_POOL_CIDR=${EGRESS_POOL_CIDR}` substitution on the `mini-infra` service.
- `deployment/development/worktree-list.ts` — `EGRESS POOL` column in `--wide` output (computes from slot for legacy entries; suppresses the warn-side-effect to avoid spamming the listing).
- `docs/user/wsl2-reference.md` — replaced the orphan-bridge troubleshooting note with the slot-allocation explanation, slot-≥-64 guidance, and migration corner case.
- New: `deployment/development/{package.json,package-lock.json,vitest.config.ts,__tests__/}` — standalone vitest setup mirroring `update-sidecar`/`agent-sidecar`/`egress-sidecar` (the dev scripts had no test infrastructure before).

## Migration notes

- Already-running worktrees keep their existing `local-applications` subnets — `provisionEgressGateway` reuses the IPAM config of any pre-existing network rather than reallocating.
- New envs created **after** the upgrade go through the per-worktree `/22`.
- Edge case: if an old worktree had an env in a `/24` that now sits outside its slot's `/22`, a *different* worktree could later pick the same `/24` for a fresh env. Run `worktree_start.ps1 --reset` for a clean cutover. Documented in `wsl2-reference.md`.

## Test plan

- [x] `cd deployment/development && npm install && npm test` — 14/14 tests pass (`egressPoolForSlot` cases for slots 0/1/3/10/63, fallback for slot 64, slot 99, -1, 1.5, NaN; `allocatePorts` returns matching CIDR for first-slot/second-slot/stable-profile cases).
- [x] `docker compose config` substitutes `MINI_INFRA_EGRESS_POOL_CIDR: 172.30.0.0/22` correctly when `EGRESS_POOL_CIDR` is set.
- [x] `worktree-list.ts --wide` against the real registry: legacy slot 0/1/2 entries display `172.30.0.0/22`, `172.30.4.0/22`, `172.30.8.0/22` as computed from slot.
- [ ] **Integration (reviewer, on a Windows dev box)**: spin two parallel worktrees, verify `wsl -d <distro> -- docker network inspect local-applications` shows non-overlapping `IPAM.Config[0].Subnet` values inside each worktree's `/22`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)