### PR TITLE
feat(egress): UI toggle for Environment.egressFirewallEnabled

### DIFF
--- a/client/src/__tests__/egress-tab.test.tsx
+++ b/client/src/__tests__/egress-tab.test.tsx
@@ -45,6 +45,48 @@ vi.mock("@/hooks/use-stacks", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// useEnvironment / useUpdateEnvironment mocks (firewall card)
+// ---------------------------------------------------------------------------
+
+let currentEnvironmentData: { egressFirewallEnabled: boolean } & Record<string, unknown> = {
+  id: "env-1",
+  name: "production",
+  type: "production",
+  networkType: "internet",
+  egressFirewallEnabled: false,
+  networks: [],
+  stackCount: 0,
+  systemStackCount: 0,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+const mockUpdateEnvironmentMutateAsync = vi.fn();
+let mockUpdateEnvironmentIsPending = false;
+
+vi.mock("@/hooks/use-environments", () => ({
+  useEnvironment: vi.fn(() => ({
+    data: currentEnvironmentData,
+    isLoading: false,
+    isError: false,
+  })),
+  useUpdateEnvironment: vi.fn(() => ({
+    mutateAsync: mockUpdateEnvironmentMutateAsync,
+    isPending: mockUpdateEnvironmentIsPending,
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// sonner toast mock — needed so we can assert on success/error notifications
+// ---------------------------------------------------------------------------
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
 // Mock data
 // ---------------------------------------------------------------------------
 
@@ -216,6 +258,21 @@ function renderTab(canWrite = true) {
 describe("EgressTab", () => {
   beforeEach(() => {
     currentPoliciesData = { policies: mockPolicies, total: 1, page: 1, limit: 50, totalPages: 1, hasNextPage: false, hasPreviousPage: false };
+    currentEnvironmentData = {
+      id: "env-1",
+      name: "production",
+      type: "production",
+      networkType: "internet",
+      egressFirewallEnabled: false,
+      networks: [],
+      stackCount: 0,
+      systemStackCount: 0,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mockUpdateEnvironmentIsPending = false;
+    mockUpdateEnvironmentMutateAsync.mockReset();
+    mockUpdateEnvironmentMutateAsync.mockResolvedValue(currentEnvironmentData);
     vi.clearAllMocks();
   });
 
@@ -337,5 +394,101 @@ describe("EgressTab", () => {
     currentPoliciesData = { policies: [], total: 0, page: 1, limit: 50, totalPages: 0, hasNextPage: false, hasPreviousPage: false };
     renderTab();
     expect(screen.getByText("No egress policies")).toBeTruthy();
+  });
+
+  // ---- Egress firewall card ----
+
+  describe("Egress firewall card", () => {
+    it("renders the firewall header and unchecked switch when egressFirewallEnabled=false", async () => {
+      renderTab(true);
+      await waitFor(() => {
+        expect(screen.getByText("Egress Firewall")).toBeTruthy();
+      });
+      const toggle = screen.getByLabelText("Egress firewall") as HTMLButtonElement;
+      expect(toggle.getAttribute("aria-checked")).toBe("false");
+    });
+
+    it("renders the switch as checked when egressFirewallEnabled=true", async () => {
+      currentEnvironmentData = { ...currentEnvironmentData, egressFirewallEnabled: true };
+      renderTab(true);
+      await waitFor(() => {
+        const toggle = screen.getByLabelText("Egress firewall") as HTMLButtonElement;
+        expect(toggle.getAttribute("aria-checked")).toBe("true");
+      });
+    });
+
+    it("calls mutateAsync directly when enabling (no confirm dialog)", async () => {
+      const { toast } = await import("sonner");
+      renderTab(true);
+      const toggle = await screen.findByLabelText("Egress firewall");
+      fireEvent.click(toggle);
+      await waitFor(() => {
+        expect(mockUpdateEnvironmentMutateAsync).toHaveBeenCalledWith({
+          id: "env-1",
+          request: { egressFirewallEnabled: true },
+        });
+      });
+      expect(toast.success).toHaveBeenCalledWith(
+        "Egress firewall enabled — applying to running stacks",
+      );
+      // No confirm dialog rendered
+      expect(screen.queryByText("Disable egress firewall?")).toBeNull();
+    });
+
+    it("opens the confirm dialog when disabling, calls mutateAsync only after confirm", async () => {
+      currentEnvironmentData = { ...currentEnvironmentData, egressFirewallEnabled: true };
+      const { toast } = await import("sonner");
+      renderTab(true);
+      const toggle = await screen.findByLabelText("Egress firewall");
+      fireEvent.click(toggle);
+      // Dialog opens; mutate not yet called
+      await waitFor(() => {
+        expect(screen.getByText("Disable egress firewall?")).toBeTruthy();
+      });
+      expect(mockUpdateEnvironmentMutateAsync).not.toHaveBeenCalled();
+      // Click the confirm action
+      fireEvent.click(screen.getByText("Disable firewall"));
+      await waitFor(() => {
+        expect(mockUpdateEnvironmentMutateAsync).toHaveBeenCalledWith({
+          id: "env-1",
+          request: { egressFirewallEnabled: false },
+        });
+      });
+      expect(toast.success).toHaveBeenCalledWith("Egress firewall disabled");
+    });
+
+    it("does not call mutateAsync when the disable confirm is cancelled", async () => {
+      currentEnvironmentData = { ...currentEnvironmentData, egressFirewallEnabled: true };
+      renderTab(true);
+      const toggle = await screen.findByLabelText("Egress firewall");
+      fireEvent.click(toggle);
+      await waitFor(() => {
+        expect(screen.getByText("Disable egress firewall?")).toBeTruthy();
+      });
+      fireEvent.click(screen.getByText("Cancel"));
+      expect(mockUpdateEnvironmentMutateAsync).not.toHaveBeenCalled();
+    });
+
+    it("disables the switch when canWrite=false", async () => {
+      renderTab(false);
+      await waitFor(() => {
+        expect(screen.getByText("Egress Firewall")).toBeTruthy();
+      });
+      const toggle = screen.getByLabelText("Egress firewall") as HTMLButtonElement;
+      expect(toggle.disabled).toBe(true);
+    });
+
+    it("shows toast.error when mutateAsync rejects", async () => {
+      mockUpdateEnvironmentMutateAsync.mockRejectedValueOnce(new Error("boom"));
+      const { toast } = await import("sonner");
+      renderTab(true);
+      const toggle = await screen.findByLabelText("Egress firewall");
+      fireEvent.click(toggle);
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(
+          "Failed to update egress firewall: boom",
+        );
+      });
+    });
   });
 });

--- a/client/src/components/egress/egress-tab.tsx
+++ b/client/src/components/egress/egress-tab.tsx
@@ -41,6 +41,10 @@ import {
   useDeleteEgressRule,
   usePatchEgressPolicy,
 } from "@/hooks/use-egress";
+import {
+  useEnvironment,
+  useUpdateEnvironment,
+} from "@/hooks/use-environments";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -75,6 +79,17 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Switch } from "@/components/ui/switch";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import {
   Tooltip,
@@ -269,6 +284,142 @@ function RuleSourceBadge({ source }: { source: string }) {
     >
       {source}
     </Badge>
+  );
+}
+
+// ====================
+// Egress firewall toggle (env-level master switch)
+// ====================
+
+interface EgressFirewallCardProps {
+  environmentId: string;
+  enabled: boolean;
+  isLoading: boolean;
+  canWrite: boolean;
+}
+
+// NOTE: server-side, the egressFirewallEnabled PUT is best-effort with
+// respect to the fw-agent push — the route returns 200 once the DB write
+// succeeds, even if the agent is unreachable. So today this UI cannot
+// distinguish "DB updated + agent notified" from "DB updated + agent down".
+// If/when the server adds an agentNotified flag (or a follow-up Socket.IO
+// event), surface a "pending agent reconnect" badge here.
+// See server/src/routes/environments.ts.
+function EgressFirewallCard({
+  environmentId,
+  enabled,
+  isLoading,
+  canWrite,
+}: EgressFirewallCardProps) {
+  const updateEnvironment = useUpdateEnvironment();
+  const [confirmDisableOpen, setConfirmDisableOpen] = useState(false);
+
+  const applyToggle = async (nextValue: boolean) => {
+    try {
+      await updateEnvironment.mutateAsync({
+        id: environmentId,
+        request: { egressFirewallEnabled: nextValue },
+      });
+      toast.success(
+        nextValue
+          ? "Egress firewall enabled — applying to running stacks"
+          : "Egress firewall disabled",
+      );
+    } catch (err) {
+      toast.error(
+        `Failed to update egress firewall: ${
+          err instanceof Error ? err.message : "Unknown error"
+        }`,
+      );
+    }
+  };
+
+  const handleSwitchChange = (next: boolean) => {
+    if (!next && enabled) {
+      setConfirmDisableOpen(true);
+      return;
+    }
+    void applyToggle(next);
+  };
+
+  const handleConfirmDisable = async () => {
+    setConfirmDisableOpen(false);
+    await applyToggle(false);
+  };
+
+  const switchControl = (
+    <Switch
+      checked={enabled}
+      onCheckedChange={handleSwitchChange}
+      disabled={!canWrite || updateEnvironment.isPending || isLoading}
+      data-tour="environment-egress-firewall-toggle"
+      aria-label="Egress firewall"
+    />
+  );
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-row items-start justify-between space-y-0 gap-4">
+          <div className="flex items-start gap-3">
+            <div className="p-2 rounded-md bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300">
+              <IconShield className="h-5 w-5" />
+            </div>
+            <div>
+              <CardTitle className="text-base">Egress Firewall</CardTitle>
+              <p className="text-sm text-muted-foreground mt-1">
+                Kernel-level enforcement for outbound traffic. Currently runs
+                in observe mode — events are logged, no traffic is dropped.
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center pt-1">
+            {isLoading ? (
+              <Skeleton className="h-5 w-9" />
+            ) : !canWrite ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span>{switchControl}</span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  Requires environments:write permission
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              switchControl
+            )}
+          </div>
+        </CardHeader>
+      </Card>
+
+      <AlertDialog
+        open={confirmDisableOpen}
+        onOpenChange={setConfirmDisableOpen}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Disable egress firewall?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The kernel-level enforcement layer will be torn down. Egress
+              events will stop being logged for this environment until you
+              re-enable it. This change is best-effort if the firewall agent
+              is offline.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={updateEnvironment.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmDisable}
+              disabled={updateEnvironment.isPending}
+            >
+              Disable firewall
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }
 
@@ -1184,10 +1335,23 @@ export function EgressTab({ environmentId, canWrite = true }: EgressTabProps) {
     error: policiesErr,
   } = useEgressPolicies({ query: { environmentId } });
 
+  const {
+    data: environment,
+    isLoading: environmentLoading,
+  } = useEnvironment(environmentId, { enabled: !!environmentId });
+
   const policies: EgressPolicySummary[] = policiesData?.policies ?? [];
 
   return (
     <div className="space-y-6">
+      {/* Section: Egress firewall master switch */}
+      <EgressFirewallCard
+        environmentId={environmentId}
+        enabled={environment?.egressFirewallEnabled ?? false}
+        isLoading={environmentLoading}
+        canWrite={canWrite}
+      />
+
       {/* Section: Policy summary cards */}
       <div>
         <div className="flex items-center gap-2 mb-4">

--- a/client/src/user-docs/docs-structure.yaml
+++ b/client/src/user-docs/docs-structure.yaml
@@ -156,6 +156,9 @@ sections:
           - Environment detail page — deployed applications and stacks
           - Deleting an environment — does not stop running containers
           - Color-coded environment badges
+          - Egress firewall toggle — kernel-level enforcement in observe mode
+          - Observe mode — log outbound connections without dropping traffic
+          - Best-effort firewall agent reconciliation when offline
 
   - slug: postgres-backups
     label: PostgreSQL Backups

--- a/client/src/user-docs/environments/environments.md
+++ b/client/src/user-docs/environments/environments.md
@@ -41,3 +41,13 @@ Open the dropdown menu on the environment details page and select **Edit Environ
 ## Deleting an Environment
 
 Open the dropdown menu and select **Delete Environment**. A confirmation dialog will appear. Deleting an environment removes its configuration but does not automatically stop running containers.
+
+## Egress Firewall
+
+The **Egress** tab on the environment details page has an **Egress Firewall** toggle at the top. Turning it on installs kernel-level egress rules (via the firewall agent) for stacks in this environment and starts logging outbound connections in **observe mode** --- no traffic is blocked, only recorded. Turning it off tears those rules down.
+
+Observe mode lets you see what your egress policies *would have* blocked without disrupting traffic --- useful for tuning policies before committing to enforcement. Actually dropping traffic (enforcement) is a future feature.
+
+A confirmation dialog is shown when you turn the firewall **off**, since disabling stops the event stream for this environment until you turn it back on.
+
+If the firewall agent is offline when you toggle, the change is saved immediately and the agent reconciles when it next reconnects.

--- a/client/src/user-docs/ui-elements/manifest.json
+++ b/client/src/user-docs/ui-elements/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-07",
+  "generated": "2026-04-29",
   "description": "UI element IDs (data-tour attributes) available for agent highlighting. Pass \"id\" to highlight_element and the route key to navigate_to. \"global\" elements are present on all pages.",
   "routes": {
     "/applications/new": {
@@ -9,19 +9,19 @@
           "id": "new-app-display-name-input",
           "label": "New App Display Name Input",
           "elementType": "FormItem",
-          "file": "client/src/app/applications/new/page.tsx"
+          "file": "client/src/app/applications/new/components/basics-step.tsx"
         },
         {
           "id": "new-app-environment-select",
           "label": "New App Environment Select",
           "elementType": "FormItem",
-          "file": "client/src/app/applications/new/page.tsx"
+          "file": "client/src/app/applications/new/components/basics-step.tsx"
         },
         {
           "id": "new-app-docker-image-input",
           "label": "New App Docker Image Input",
-          "elementType": "FormItem",
-          "file": "client/src/app/applications/new/page.tsx"
+          "elementType": "Input",
+          "file": "client/src/app/applications/new/components/image-step.tsx"
         },
         {
           "id": "new-app-create-button",
@@ -89,6 +89,18 @@
         {
           "id": "azure-default-container-selector",
           "label": "Azure Default Container Selector",
+          "elementType": "div",
+          "file": "client/src/app/connectivity/azure/page.tsx"
+        },
+        {
+          "id": "azure-self-backup-container-selector",
+          "label": "Azure Self Backup Container Selector",
+          "elementType": "div",
+          "file": "client/src/app/connectivity/azure/page.tsx"
+        },
+        {
+          "id": "azure-tls-container-selector",
+          "label": "Azure Tls Container Selector",
           "elementType": "div",
           "file": "client/src/app/connectivity/azure/page.tsx"
         }
@@ -240,12 +252,6 @@
       "title": "Self-Backup Settings",
       "elements": [
         {
-          "id": "backup-container-selector",
-          "label": "Backup Container Selector",
-          "elementType": "FormItem",
-          "file": "client/src/app/settings/self-backup/page.tsx"
-        },
-        {
           "id": "backup-schedule-input",
           "label": "Backup Schedule Input",
           "elementType": "FormItem",
@@ -281,18 +287,6 @@
       "title": "TLS Settings",
       "elements": [
         {
-          "id": "tls-container-selector",
-          "label": "Tls Container Selector",
-          "elementType": "div",
-          "file": "client/src/app/settings/tls/page.tsx"
-        },
-        {
-          "id": "tls-test-connection",
-          "label": "Tls Test Connection",
-          "elementType": "Button",
-          "file": "client/src/app/settings/tls/page.tsx"
-        },
-        {
           "id": "tls-acme-provider",
           "label": "Tls Acme Provider",
           "elementType": "div",
@@ -322,6 +316,123 @@
           "file": "client/src/app/tunnels/page.tsx"
         }
       ]
+    },
+    "/vault/approles": {
+      "title": "/vault/approles",
+      "elements": [
+        {
+          "id": "vault-approle-new",
+          "label": "Vault Approle New",
+          "elementType": "Button",
+          "file": "client/src/app/vault/approles/page.tsx"
+        },
+        {
+          "id": "vault-approles-list",
+          "label": "Vault Approles List",
+          "elementType": "Card",
+          "file": "client/src/app/vault/approles/page.tsx"
+        }
+      ]
+    },
+    "/vault": {
+      "title": "Vault",
+      "elements": [
+        {
+          "id": "vault-bootstrap-address",
+          "label": "Vault Bootstrap Address",
+          "elementType": "Input",
+          "file": "client/src/app/vault/components/BootstrapDialog.tsx"
+        },
+        {
+          "id": "vault-bootstrap-passphrase",
+          "label": "Vault Bootstrap Passphrase",
+          "elementType": "Input",
+          "file": "client/src/app/vault/components/BootstrapDialog.tsx"
+        },
+        {
+          "id": "vault-bootstrap-submit",
+          "label": "Vault Bootstrap Submit",
+          "elementType": "Button",
+          "file": "client/src/app/vault/components/BootstrapDialog.tsx"
+        },
+        {
+          "id": "vault-passphrase-input",
+          "label": "Vault Passphrase Input",
+          "elementType": "Input",
+          "file": "client/src/app/vault/components/PassphraseUnlockDialog.tsx"
+        },
+        {
+          "id": "vault-passphrase-submit",
+          "label": "Vault Passphrase Submit",
+          "elementType": "Button",
+          "file": "client/src/app/vault/components/PassphraseUnlockDialog.tsx"
+        },
+        {
+          "id": "vault-refresh",
+          "label": "Vault Refresh",
+          "elementType": "Button",
+          "file": "client/src/app/vault/page.tsx"
+        },
+        {
+          "id": "vault-status-card",
+          "label": "Vault Status Card",
+          "elementType": "Card",
+          "file": "client/src/app/vault/page.tsx"
+        },
+        {
+          "id": "vault-bootstrap",
+          "label": "Vault Bootstrap",
+          "elementType": "Button",
+          "file": "client/src/app/vault/page.tsx"
+        },
+        {
+          "id": "vault-unlock",
+          "label": "Vault Unlock",
+          "elementType": "Button",
+          "file": "client/src/app/vault/page.tsx"
+        },
+        {
+          "id": "vault-lock",
+          "label": "Vault Lock",
+          "elementType": "Button",
+          "file": "client/src/app/vault/page.tsx"
+        },
+        {
+          "id": "vault-unseal",
+          "label": "Vault Unseal",
+          "elementType": "Button",
+          "file": "client/src/app/vault/page.tsx"
+        },
+        {
+          "id": "vault-policies-link",
+          "label": "Vault Policies Link",
+          "elementType": "Link",
+          "file": "client/src/app/vault/page.tsx"
+        },
+        {
+          "id": "vault-approles-link",
+          "label": "Vault Approles Link",
+          "elementType": "Link",
+          "file": "client/src/app/vault/page.tsx"
+        }
+      ]
+    },
+    "/vault/policies": {
+      "title": "/vault/policies",
+      "elements": [
+        {
+          "id": "vault-policy-new",
+          "label": "Vault Policy New",
+          "elementType": "Button",
+          "file": "client/src/app/vault/policies/page.tsx"
+        },
+        {
+          "id": "vault-policies-list",
+          "label": "Vault Policies List",
+          "elementType": "Card",
+          "file": "client/src/app/vault/policies/page.tsx"
+        }
+      ]
     }
   },
   "global": [
@@ -338,6 +449,12 @@
       "file": "client/src/components/app-sidebar.tsx"
     },
     {
+      "id": "environment-egress-firewall-toggle",
+      "label": "Environment Egress Firewall Toggle",
+      "elementType": "Switch",
+      "file": "client/src/components/egress/egress-tab.tsx"
+    },
+    {
       "id": "header-backup-health",
       "label": "Header Backup Health",
       "elementType": "Link",
@@ -351,7 +468,7 @@
     },
     {
       "id": "header-assisted-setup",
-      "label": "Header Guided Setup",
+      "label": "Header Assisted Setup",
       "elementType": "div",
       "file": "client/src/components/site-header.tsx"
     },


### PR DESCRIPTION
## Summary

- Adds an **Egress Firewall** settings card at the top of the Egress tab on the environment detail page, above the policies section, wired to `PUT /api/environments/:id` via the existing `useUpdateEnvironment` hook (no new endpoint, no new hook).
- Enabling flips the switch with a toast (safe — observe mode never drops traffic). Disabling opens an `AlertDialog` since the kernel-level enforcement layer is being torn down.
- `data-tour="environment-egress-firewall-toggle"` so the AI agent's `highlight_element` tool can point users at it; ran `pnpm generate:ui-manifest` to refresh the manifest.
- Help docs: appended an **Egress Firewall** section to `user-docs/environments/environments.md` and three new topic lines to `docs-structure.yaml`.
- Tests: 6 new cases in `egress-tab.test.tsx` covering render-on/off, enable-without-dialog, disable-with-dialog, cancel, permission-disabled, and toast-on-error. 21/21 passing total.

Builds on the backend half from #277.

## Why

Operators currently have to hit the API directly to flip the per-env firewall layer. This adds a control where it logically belongs — at the top of the tab that already shows the policies it governs.

### Where it lives

The Egress tab is the right home: the toggle is the master switch above the per-stack policies. Putting it inline with the policies makes the layering obvious (firewall → policies → traffic feed). The env edit dialog is the wrong place — it's behind a click and not visible alongside the policies the toggle governs.

### Confirmation UX

Asymmetric on purpose: enabling in observe mode never drops traffic, so a single click + toast is fine. Disabling tears down the kernel rules and stops the event stream, so it gets an `AlertDialog`.

### Known constraint

The route returns 200 once the DB write succeeds, even when the fw-agent push silently fails — the UI today **cannot distinguish** "DB updated + agent notified" from "DB updated + agent unreachable". The toast copy reflects this honestly ("applying to running stacks"). A follow-up could surface a "pending agent reconnect" badge once the server returns that signal — there's a TODO comment in `EgressFirewallCard` pointing at the route.

## Out of scope

- `enforce` mode (server hard-codes `observe` today).
- API-key permission threading for `environments:write` vs `egress:write` on the egress tab — browser sessions get full access today; the existing TODO in env-detail page covers this.

## Note on the manifest diff

The UI manifest regeneration also picked up pre-existing drift from prior PRs (some `data-tour` attributes had moved file paths or been added since the last regen on 2026-04-07). Those mechanical updates are bundled in.

## Test plan

- [x] `pnpm build:lib` — clean
- [x] `pnpm --filter mini-infra-client lint` — clean
- [x] `pnpm --filter mini-infra-client exec vitest run src/__tests__/egress-tab.test.tsx` — 21/21 (15 existing + 6 new)
- [x] `pnpm --filter mini-infra-client build` — clean
- [x] `pnpm generate:ui-manifest` — manifest contains `environment-egress-firewall-toggle`
- [x] Manual end-to-end in dev (worktree on port 3101):
  - Toggle renders at top of Egress tab with title "Egress Firewall" and the observe-mode subtitle
  - Click to enable: switch flips, no dialog, server log shows `Environment updated successfully` with `request: { egressFirewallEnabled: true }`, GET confirms
  - Click to disable: AlertDialog with the right copy; **Cancel** preserves enabled on UI + DB; **Disable firewall** flips to false on UI + DB
  - Zero console errors/warnings during the flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)