### PR TITLE
fix(platform): re-provision sidecars after Docker reconnect

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -136,6 +136,32 @@ const initializeServices = async () => {
     await dockerService.initialize();
     console.log("[STARTUP] ✓ Docker service initialized");
 
+    // Re-provision sidecars after Docker reconnects. On a fresh-boot worktree
+    // the DB has no docker host yet, so initialize() lands in degraded mode
+    // and the inline ensureXxx calls below fail. Once the seeder posts the
+    // docker host and DockerConfigService.set triggers refreshConnection(),
+    // this callback fires and the sidecars come up without manual restart.
+    // Both ensureXxx are idempotent — safe if they already succeeded inline.
+    dockerService.onConnect(async () => {
+      logger.info("Docker connected, re-provisioning sidecars");
+      try {
+        await ensureFwAgent({ checkAutoStart: true });
+      } catch (err) {
+        logger.warn(
+          { err },
+          "Egress fw-agent re-provisioning after Docker reconnect failed (non-fatal)",
+        );
+      }
+      try {
+        await ensureAgentSidecar({ checkAutoStart: true });
+      } catch (err) {
+        logger.warn(
+          { err },
+          "Agent sidecar re-provisioning after Docker reconnect failed (non-fatal)",
+        );
+      }
+    });
+
     // Wire up container state changes to Socket.IO
     setupContainerSocketEmitter();
     console.log("[STARTUP] ✓ Container socket emitter initialized");

--- a/server/src/services/__tests__/docker-onconnect.test.ts
+++ b/server/src/services/__tests__/docker-onconnect.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const { mockDocker, mockCache, mockLogger, mockDockerConfigService, mockPrisma, MockDockerConstructor } = vi.hoisted(() => {
+  const _mockDocker = {
+    ping: vi.fn(),
+    listContainers: vi.fn(),
+    getContainer: vi.fn(),
+    getEvents: vi.fn(),
+  };
+  const _MockDockerConstructor = vi.fn().mockImplementation(function () { return _mockDocker; });
+  return {
+    mockDocker: _mockDocker,
+    MockDockerConstructor: _MockDockerConstructor,
+    mockCache: {
+      get: vi.fn(),
+      set: vi.fn(),
+      flushAll: vi.fn(),
+      keys: vi.fn().mockReturnValue([]),
+      getStats: vi
+        .fn()
+        .mockReturnValue({ hits: 0, misses: 0, keys: 0, ksize: 0, vsize: 0 }),
+    },
+    mockLogger: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+    mockDockerConfigService: {
+      get: vi.fn(),
+      recordConnectivityStatus: vi.fn(),
+    },
+    mockPrisma: {},
+  };
+});
+
+vi.mock("dockerode", () => ({
+  default: MockDockerConstructor,
+}));
+
+vi.mock("node-cache", () => ({
+  default: vi.fn().mockImplementation(function () { return mockCache; }),
+}));
+
+vi.mock("../../lib/logger-factory", () => ({
+  getLogger: vi.fn(function () { return mockLogger; }),
+  clearLoggerCache: vi.fn(),
+  createChildLogger: vi.fn(function () { return mockLogger; }),
+  selfBackupLogger: vi.fn(function () { return mockLogger; }),
+  serializeError: (e: unknown) => e,
+  appLogger: vi.fn(function () { return mockLogger; }),
+  servicesLogger: vi.fn(function () { return mockLogger; }),
+  httpLogger: vi.fn(function () { return mockLogger; }),
+  prismaLogger: vi.fn(function () { return mockLogger; }),
+  default: vi.fn(function () { return mockLogger; }),
+}));
+
+vi.mock("../../lib/config-new", () => ({
+  dockerConfig: {
+    containerCacheTtl: 3000,
+    containerPollInterval: 5000,
+  },
+}));
+
+vi.mock("../docker-config", () => ({
+  DockerConfigService: vi
+    .fn()
+    .mockImplementation(function () { return mockDockerConfigService; }),
+}));
+
+vi.mock("../../lib/prisma", () => ({ default: mockPrisma }));
+
+import DockerService from "../docker";
+
+describe("DockerService.onConnect", () => {
+  let dockerService: DockerService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (DockerService as unknown as { instance?: DockerService }).instance = undefined;
+    mockDocker.getEvents.mockImplementation((_options, callback: (err: Error | null, stream: { on: () => void } | null) => void) => {
+      callback(null, { on: vi.fn() });
+    });
+    MockDockerConstructor.mockClear();
+    mockDockerConfigService.get.mockImplementation((key: string) => {
+      if (key === "host") {
+        return Promise.resolve("/var/run/docker.sock");
+      }
+      if (key === "apiVersion") return Promise.resolve("1.41");
+      return Promise.resolve(null);
+    });
+    mockDockerConfigService.recordConnectivityStatus.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    if ((dockerService as unknown as { reconnectInterval?: NodeJS.Timeout })?.reconnectInterval) {
+      clearInterval((dockerService as unknown as { reconnectInterval: NodeJS.Timeout }).reconnectInterval);
+    }
+  });
+
+  it("fires onConnect callbacks on the disconnected → connected transition", async () => {
+    mockDocker.ping.mockResolvedValue(true);
+
+    dockerService = DockerService.getInstance();
+    const callback = vi.fn();
+    dockerService.onConnect(callback);
+
+    await dockerService.initialize();
+
+    expect(dockerService.isConnected()).toBe(true);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire onConnect when ping succeeds while already connected", async () => {
+    mockDocker.ping.mockResolvedValue(true);
+
+    dockerService = DockerService.getInstance();
+    const callback = vi.fn();
+    dockerService.onConnect(callback);
+
+    // First connect: disconnected → connected, callback fires once.
+    await dockerService.initialize();
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // refreshConnection's connect call: already connected, so no transition.
+    await dockerService.refreshConnection();
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onConnect again after a disconnected → connected reconnect cycle", async () => {
+    dockerService = DockerService.getInstance();
+    const callback = vi.fn();
+    dockerService.onConnect(callback);
+
+    // First boot: connect succeeds → callback fires.
+    mockDocker.ping.mockResolvedValueOnce(true);
+    await dockerService.initialize();
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // Drop the connection (simulating a Docker daemon disconnect).
+    (dockerService as unknown as { connected: boolean }).connected = false;
+
+    // Reconnect: false → true transition fires the callback again.
+    mockDocker.ping.mockResolvedValueOnce(true);
+    await dockerService.refreshConnection();
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it("fires onConnect on the cold-boot reconnect path (initial connect failed, later succeeded)", async () => {
+    dockerService = DockerService.getInstance();
+    const callback = vi.fn();
+    dockerService.onConnect(callback);
+
+    // Cold boot: ping fails — server stays in degraded mode, no callback.
+    mockDocker.ping.mockRejectedValueOnce(new Error("Docker host not reachable"));
+    await dockerService.initialize();
+    expect(dockerService.isConnected()).toBe(false);
+    expect(callback).not.toHaveBeenCalled();
+
+    // Seeder posts host setting → refreshConnection → ping succeeds.
+    // false → true transition fires the callback.
+    mockDocker.ping.mockResolvedValueOnce(true);
+    await dockerService.refreshConnection();
+    expect(dockerService.isConnected()).toBe(true);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let a throwing callback break the connect path", async () => {
+    mockDocker.ping.mockResolvedValue(true);
+
+    dockerService = DockerService.getInstance();
+    const throwing = vi.fn().mockRejectedValue(new Error("boom"));
+    const ok = vi.fn();
+    dockerService.onConnect(throwing);
+    dockerService.onConnect(ok);
+
+    await dockerService.initialize();
+
+    expect(dockerService.isConnected()).toBe(true);
+    expect(throwing).toHaveBeenCalledTimes(1);
+    expect(ok).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      { error: expect.any(Error) },
+      "Docker onConnect callback failed",
+    );
+  });
+});

--- a/server/src/services/docker.ts
+++ b/server/src/services/docker.ts
@@ -18,6 +18,7 @@ class DockerService {
   private dockerConfigService: DockerConfigService;
   private containerChangeCallbacks: Array<() => void> = [];
   private containerEventCallbacks: Array<(event: DockerContainerEvent) => void> = [];
+  private connectCallbacks: Array<() => void | Promise<void>> = [];
 
   private constructor() {
     // Initialize cache with 3-second TTL
@@ -155,11 +156,18 @@ class DockerService {
       await this.docker.ping();
       const responseTimeMs = Date.now() - startTime;
 
+      const wasConnected = this.connected;
       this.connected = true;
       getLogger("docker", "docker").info(
         { responseTimeMs },
         "Docker service connected successfully",
       );
+
+      // Fire onConnect callbacks only on transitions from disconnected to
+      // connected — not on every ping in scheduleReconnect's poll loop.
+      if (!wasConnected) {
+        await this.fireConnectCallbacks();
+      }
 
       // Record successful connection
       try {
@@ -796,6 +804,32 @@ class DockerService {
    */
   public onContainerEvent(callback: (event: DockerContainerEvent) => void): void {
     this.containerEventCallbacks.push(callback);
+  }
+
+  /**
+   * Register a callback to be invoked once each time DockerService transitions
+   * from disconnected to connected. Used by boot-time consumers (e.g. the
+   * agent sidecar and egress fw-agent) that need to retry their auto-start
+   * path after Docker reconnects on a fresh-boot worktree where the host
+   * setting wasn't in the DB at server startup.
+   *
+   * Callbacks must not throw — exceptions are caught and logged.
+   */
+  public onConnect(callback: () => void | Promise<void>): void {
+    this.connectCallbacks.push(callback);
+  }
+
+  private async fireConnectCallbacks(): Promise<void> {
+    for (const cb of this.connectCallbacks) {
+      try {
+        await cb();
+      } catch (err) {
+        getLogger("docker", "docker").error(
+          { error: err },
+          "Docker onConnect callback failed",
+        );
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- `DockerService` now exposes `onConnect(cb)` and fires registered callbacks on disconnected → connected transitions only — not on every ping inside `scheduleReconnect`'s poll loop.
- Server bootstrap registers one combined callback that idempotently re-runs `ensureFwAgent({ checkAutoStart: true })` + `ensureAgentSidecar({ checkAutoStart: true })`, so a fresh-boot worktree (empty DB, no Docker host yet) auto-provisions both sidecars once the seeder posts the host setting — no manual Restart from the UI.
- Each callback in the chain is wrapped in try/catch so failures never break the connect path.

## Test plan
- [x] `pnpm build:lib && pnpm --filter mini-infra-server build` — clean
- [x] `pnpm --filter mini-infra-server test` — 1863 passed (1858 baseline + 5 new)
- [x] New `docker-onconnect.test.ts` covers: first-boot transition fires, no fire when already connected (refreshConnection on warm boot), reconnect cycle re-fires, cold-boot reconnect path fires, throwing callback is logged and doesn't break the chain
- [x] Smoke test on fresh worktree (compassionate-neumann-eed901): both `mini-infra-agent-sidecar` (healthy) and `mini-infra-egress-fw-agent` came up automatically once `worktree_start.sh` reported healthy. Server log shows the full sequence: inline `ensureXxx` fail at `11:16:25` ("Docker service not connected"), seeder posts host, "Docker connected, re-provisioning sidecars" fires at `11:16:26.568`, fw-agent container started at `11:16:26.654`, agent sidecar started at `11:16:28.304` — all via the new onConnect callback.
- [x] `GET /api/egress-fw-agent/status` returns `{ available: true, containerRunning: true, healthStatus: "ok" }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)