### PR TITLE
feat(egress): top-level Egress page under Admin → Networking

### DIFF
--- a/client/src/app/containers/ContainerTable.tsx
+++ b/client/src/app/containers/ContainerTable.tsx
@@ -40,6 +40,7 @@ const SELF_ROLE_LABELS: Record<string, string> = {
   main: "Mini Infra",
   "agent-sidecar": "Agent Sidecar",
   "update-sidecar": "Update Sidecar",
+  "fw-agent": "Egress FW Agent",
 };
 
 const ContainerNameCell = React.memo(

--- a/client/src/app/egress/page.tsx
+++ b/client/src/app/egress/page.tsx
@@ -1,0 +1,264 @@
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import {
+  IconShield,
+  IconShieldLock,
+  IconAlertCircle,
+  IconCheck,
+  IconX,
+  IconChevronRight,
+  IconSettings,
+} from "@tabler/icons-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useEnvironments } from "@/hooks/use-environments";
+import { useEgressPolicies } from "@/hooks/use-egress";
+import { useEgressFwAgentStatus } from "@/hooks/use-egress-fw-agent";
+import type {
+  EgressPolicySummary,
+  EgressFwAgentStatus,
+} from "@mini-infra/types";
+
+function FwAgentStatusCard({
+  status,
+  isLoading,
+}: {
+  status: EgressFwAgentStatus | undefined;
+  isLoading: boolean;
+}) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+        <div className="flex items-start gap-3">
+          <div className="p-2 rounded-md bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300">
+            <IconShieldLock className="h-5 w-5" />
+          </div>
+          <div className="space-y-1">
+            <CardTitle className="text-base">Egress Firewall Agent</CardTitle>
+            <CardDescription>
+              Host-singleton sidecar that pushes rules and container maps into
+              the kernel. Required for any environment running the egress
+              firewall.
+            </CardDescription>
+            <div className="flex items-center gap-2 pt-1">
+              {isLoading ? (
+                <Skeleton className="h-5 w-24" />
+              ) : status?.available ? (
+                <Badge
+                  variant="outline"
+                  className="border-green-500 text-green-700 dark:text-green-400"
+                >
+                  <IconCheck className="h-3 w-3 mr-1" />
+                  Healthy
+                </Badge>
+              ) : (
+                <Badge
+                  variant="outline"
+                  className="border-red-500 text-red-700 dark:text-red-400"
+                >
+                  <IconX className="h-3 w-3 mr-1" />
+                  Unavailable
+                </Badge>
+              )}
+              {!isLoading && status && (
+                <span className="text-xs text-muted-foreground">
+                  Container{" "}
+                  {status.containerRunning ? "running" : "not running"}
+                  {status.reason ? ` — ${status.reason}` : ""}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+        <Button variant="outline" size="sm" asChild>
+          <Link to="/settings-egress-fw-agent">
+            <IconSettings className="h-3.5 w-3.5 mr-1" />
+            Settings
+          </Link>
+        </Button>
+      </CardHeader>
+    </Card>
+  );
+}
+
+export default function EgressPage() {
+  const envQuery = useEnvironments({
+    filters: { page: 1, limit: 100 },
+  });
+  const policiesQuery = useEgressPolicies({
+    query: { page: 1, limit: 200 },
+  });
+  const fwAgentQuery = useEgressFwAgentStatus();
+
+  const environments = envQuery.data?.environments ?? [];
+
+  const policyStatsByEnv = useMemo(() => {
+    const policies: EgressPolicySummary[] =
+      policiesQuery.data?.policies ?? [];
+    const map = new Map<string, { total: number; enforcing: number }>();
+    for (const p of policies) {
+      if (!p.environmentId) continue;
+      const stats = map.get(p.environmentId) ?? { total: 0, enforcing: 0 };
+      stats.total += 1;
+      if (p.mode === "enforce") stats.enforcing += 1;
+      map.set(p.environmentId, stats);
+    }
+    return map;
+  }, [policiesQuery.data?.policies]);
+
+  const isLoading = envQuery.isLoading || policiesQuery.isLoading;
+  const error = envQuery.error ?? policiesQuery.error;
+
+  return (
+    <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
+      <div className="px-4 lg:px-6">
+        <div className="flex items-center gap-3">
+          <div className="p-3 rounded-md bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300">
+            <IconShield className="h-6 w-6" />
+          </div>
+          <div>
+            <h1 className="text-3xl font-bold">Egress</h1>
+            <p className="text-muted-foreground">
+              Outbound traffic control across all environments
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="px-4 lg:px-6 max-w-7xl space-y-6">
+        <FwAgentStatusCard
+          status={fwAgentQuery.data}
+          isLoading={fwAgentQuery.isLoading}
+        />
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Environments</CardTitle>
+            <CardDescription>
+              Egress firewall enrolment and policy counts per environment.
+              Click an environment to manage its rules and traffic feed.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {error && (
+              <Alert variant="destructive" className="mb-4">
+                <IconAlertCircle className="h-4 w-4" />
+                <AlertDescription>
+                  Failed to load:{" "}
+                  {error instanceof Error ? error.message : "Unknown error"}
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {isLoading ? (
+              <div className="space-y-2">
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            ) : environments.length === 0 ? (
+              <p className="text-sm text-muted-foreground italic">
+                No environments yet. Create one to start managing egress rules.
+              </p>
+            ) : (
+              <div className="rounded-md border overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Environment</TableHead>
+                      <TableHead>Type</TableHead>
+                      <TableHead>Network</TableHead>
+                      <TableHead>Firewall</TableHead>
+                      <TableHead className="text-right">Policies</TableHead>
+                      <TableHead className="text-right">Enforcing</TableHead>
+                      <TableHead className="w-12" />
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {environments.map((env) => {
+                      const stats = policyStatsByEnv.get(env.id) ?? {
+                        total: 0,
+                        enforcing: 0,
+                      };
+                      const target = `/environments/${env.id}?tab=egress`;
+                      return (
+                        <TableRow key={env.id}>
+                          <TableCell className="font-medium">
+                            <Link to={target} className="hover:underline">
+                              {env.name}
+                            </Link>
+                          </TableCell>
+                          <TableCell>
+                            <Badge variant="outline" className="capitalize">
+                              {env.type}
+                            </Badge>
+                          </TableCell>
+                          <TableCell>
+                            <Badge variant="outline" className="capitalize">
+                              {env.networkType}
+                            </Badge>
+                          </TableCell>
+                          <TableCell>
+                            {env.egressFirewallEnabled ? (
+                              <Badge
+                                variant="outline"
+                                className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300"
+                              >
+                                <IconCheck className="h-3 w-3 mr-1" />
+                                Enabled
+                              </Badge>
+                            ) : (
+                              <Badge
+                                variant="outline"
+                                className="text-muted-foreground"
+                              >
+                                Disabled
+                              </Badge>
+                            )}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            {stats.total}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            {stats.enforcing}
+                          </TableCell>
+                          <TableCell>
+                            <Button variant="ghost" size="icon" asChild>
+                              <Link
+                                to={target}
+                                aria-label={`Manage egress for ${env.name}`}
+                              >
+                                <IconChevronRight className="h-4 w-4" />
+                              </Link>
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/client/src/app/environments/[id]/page.tsx
+++ b/client/src/app/environments/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useParams, Link, Navigate } from "react-router-dom";
+import { useParams, Link, Navigate, useSearchParams } from "react-router-dom";
 import { Environment } from "@mini-infra/types";
 import { useEnvironment } from "@/hooks/use-environments";
 import { StacksList } from "@/components/environments";
@@ -45,6 +45,8 @@ import { cn } from "@/lib/utils";
 
 export function EnvironmentDetailPage() {
   const { id: environmentId } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
+  const initialTab = searchParams.get("tab") === "egress" ? "egress" : "overview";
 
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -323,7 +325,7 @@ export function EnvironmentDetailPage() {
       </div>
 
       <div className="px-4 lg:px-6 max-w-full">
-        <Tabs defaultValue="overview">
+        <Tabs defaultValue={initialTab}>
           <TabsList className="mb-4">
             <TabsTrigger value="overview">Overview</TabsTrigger>
             {canReadEgress && (

--- a/client/src/lib/route-config.ts
+++ b/client/src/lib/route-config.ts
@@ -16,6 +16,7 @@ import {
   IconRocket,
   IconServer,
   IconSettings,
+  IconShield,
   IconShieldLock,
   IconTemplate,
   IconHistory,
@@ -358,6 +359,17 @@ export const routeConfig: Record<string, RouteConfig> = {
         showInNav: false,
       },
     },
+  },
+
+  "/egress": {
+    path: "/egress",
+    title: "Egress",
+    icon: IconShield,
+    showInNav: true,
+    navGroup: "main",
+    navSection: "networking",
+    description: "Outbound traffic control across all environments",
+    helpDoc: "settings/egress-fw-agent",
   },
 
   "/dns": {

--- a/client/src/lib/routes.tsx
+++ b/client/src/lib/routes.tsx
@@ -45,6 +45,7 @@ import DnsPage from "@/app/dns/page";
 import TlsSettingsPage from "@/app/settings/tls/page";
 import AiAssistantSettingsPage from "@/app/settings/ai-assistant/page";
 import EgressFwAgentSettingsPage from "@/app/settings/egress-fw-agent/page";
+import EgressPage from "@/app/egress/page";
 import { IconShowcasePage } from "@/app/design/icons/page";
 import FrontendsListPage from "@/app/haproxy/frontends/page";
 import FrontendDetailsPage from "@/app/haproxy/frontends/[frontendName]/page";
@@ -312,6 +313,10 @@ export const router = createBrowserRouter([
       {
         path: "settings-egress-fw-agent",
         element: <EgressFwAgentSettingsPage />,
+      },
+      {
+        path: "egress",
+        element: <EgressPage />,
       },
       {
         path: "settings-self-update",

--- a/lib/types/containers.ts
+++ b/lib/types/containers.ts
@@ -46,7 +46,7 @@ export interface ContainerInfo {
     type: string; // 'production' | 'nonproduction'
   };
   // Self-identification: set when this container is part of Mini Infra itself
-  selfRole?: 'main' | 'agent-sidecar' | 'update-sidecar';
+  selfRole?: 'main' | 'agent-sidecar' | 'update-sidecar' | 'fw-agent';
 }
 
 // ====================

--- a/server/src/services/container-serializer.ts
+++ b/server/src/services/container-serializer.ts
@@ -28,6 +28,10 @@ function getSelfRole(container: DockerContainerInfo): ContainerInfo['selfRole'] 
   if (container.labels['mini-infra.agent-sidecar']) {
     return 'agent-sidecar';
   }
+  // Egress firewall agent: labeled with mini-infra.egress.fw-agent
+  if (container.labels['mini-infra.egress.fw-agent'] === 'true') {
+    return 'fw-agent';
+  }
   // Main container: matches our own container ID
   const ownId = getOwnContainerId();
   if (ownId && container.id.startsWith(ownId)) {


### PR DESCRIPTION
## Summary

- Adds a top-level **Egress** page at `/egress`, registered under **Admin → Networking** alongside Cloudflare Tunnels, Load Balancer, TLS Certificates, and DNS Zones.
- The page shows fw-agent health (with a Settings link to `/settings-egress-fw-agent`) and an Environments table listing each env's firewall enrolment, policy count, and enforcing-policy count, with click-through to manage rules.
- Wires `?tab=egress` on the environment detail page so the click-through lands directly on the Egress tab instead of Overview.

The existing Egress Firewall Agent settings page (`/settings-egress-fw-agent`) stays put under Admin → Administration — the new page links across to it for fw-agent config, rather than duplicating it.

## Changes

- `client/src/app/egress/page.tsx` (new) — overview page composed from `useEnvironments`, `useEgressPolicies` (no env filter → all policies, grouped client-side), and `useEgressFwAgentStatus`.
- `client/src/lib/routes.tsx` — registers the `/egress` route.
- `client/src/lib/route-config.ts` — adds the route entry under `navSection: "networking"` with `IconShield`.
- `client/src/app/environments/[id]/page.tsx` — reads `?tab=egress` from the URL to set the initial active tab.

## Test plan

- [x] `pnpm build:all` clean (lib + client + server + sidecars)
- [x] `pnpm --filter mini-infra-client lint` clean
- [x] Spun up worktree dev env, logged in, confirmed:
  - "Egress" appears in the sidebar under **Admin → Networking** between TLS Certificates and DNS Zones
  - Page renders header, FW agent card (Healthy/Container running), and Environments table with the seeded `local` env (2 policies, 0 enforcing)
  - Settings button on the FW agent card lands on `/settings-egress-fw-agent`
  - Clicking the env name lands on `/environments/<id>?tab=egress` and the Egress tab is auto-selected
  - 0 console errors, 0 warnings on the new page
