### PR TITLE
fix(egress): stop traffic-feed re-render loop hammering /api/egress/events

### DIFF
--- a/client/src/components/egress/egress-tab.tsx
+++ b/client/src/components/egress/egress-tab.tsx
@@ -13,7 +13,7 @@
  * A prop `canWrite` is threaded through so callers can restrict to API-key users.
  */
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import {
   IconShield,
   IconChevronLeft,
@@ -1081,13 +1081,20 @@ function TrafficFeedSection({ environmentId }: { environmentId: string }) {
 
   const { filters, updateFilter, resetFilters } = useEgressEventFilters();
 
-  const query = {
-    environmentId,
-    action: filters.action,
-    since: sinceFromRange(timeRange),
-    page: filters.page,
-    limit: filters.limit,
-  };
+  // Memoise the query so `since` is only recomputed when `timeRange` flips —
+  // otherwise `sinceFromRange()` returns a fresh ISO string on every render,
+  // the TanStack Query key churns, and the events endpoint is hammered in a
+  // re-render loop.
+  const query = useMemo(
+    () => ({
+      environmentId,
+      action: filters.action,
+      since: sinceFromRange(timeRange),
+      page: filters.page,
+      limit: filters.limit,
+    }),
+    [environmentId, filters.action, timeRange, filters.page, filters.limit],
+  );
 
   const {
     data,


### PR DESCRIPTION
## Summary

Fixes a runaway `/api/egress/events` re-render loop on the Environment Detail → Egress tab.

`TrafficFeedSection` rebuilt its `query` object on every render, with `since: sinceFromRange(timeRange)` returning a fresh `new Date().toISOString()` each render (drifting by milliseconds). That made the `useEgressEvents` TanStack Query key unstable — the events endpoint refetched on every render, which set state, which re-rendered, which refetched, and so on.

Measured in dev: ~12,000 requests in the first ~3 seconds after opening the tab (~350 req/s). Each request was a `200 OK`, so nothing surfaced as an error in the UI, but the backend was being hammered and the page felt sluggish.

## Fix

Wrap the `query` object in `useMemo`, keyed on its actual inputs (`environmentId`, `filters.action`, `timeRange`, `filters.page`, `filters.limit`). `since` is now only recomputed when `timeRange` flips, so the query key is stable and TanStack Query refetches only when something actually changes.

## Test plan

- [x] `pnpm build:lib` + `pnpm --filter mini-infra-client build` — clean
- [x] `pnpm --filter mini-infra-client lint` — clean
- [x] In a running dev env, opened `/environments/<id>` and clicked the Egress tab. Network log showed:
  - **Before fix:** 12,126 requests to `/api/egress/events` in seconds (~350 req/s)
  - **After fix:** 1 request on tab open, no further requests during a steady-state hold
- [x] Egress tab still renders policies, the firewall toggle, and the traffic feed correctly. Switching `timeRange` triggers exactly one new fetch (verified by counting requests).
