### PR TITLE
fix(egress): promote wizard hits per-policy events endpoint

### DIFF
--- a/client/src/api/egress.ts
+++ b/client/src/api/egress.ts
@@ -172,6 +172,47 @@ export async function listEgressEvents(
   return response.json();
 }
 
+/**
+ * Per-policy events list. Use this instead of listEgressEvents() when you
+ * want events for one specific policy — the cross-policy /events endpoint
+ * silently ignores its policyId param.
+ */
+export type ListEgressEventsForPolicyQuery = Omit<
+  ListEgressEventsQuery,
+  "environmentId" | "stackId" | "policyId"
+>;
+
+export async function listEgressEventsForPolicy(
+  policyId: string,
+  query: ListEgressEventsForPolicyQuery = {},
+): Promise<EgressEventListResponse> {
+  const correlationId = generateCorrelationId();
+  const url = new URL(
+    `/api/egress/policies/${policyId}/events`,
+    window.location.origin,
+  );
+
+  if (query.action) url.searchParams.set("action", query.action);
+  if (query.since) url.searchParams.set("since", query.since);
+  if (query.until) url.searchParams.set("until", query.until);
+  if (query.page !== undefined) url.searchParams.set("page", String(query.page));
+  if (query.limit !== undefined) url.searchParams.set("limit", String(query.limit));
+
+  const response = await fetch(url.toString(), {
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Correlation-ID": correlationId,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch egress events for policy: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
 // ====================
 // Mutation endpoint stubs (UI not wired in v1 — next slice)
 // ====================

--- a/client/src/components/egress/egress-promote-wizard.tsx
+++ b/client/src/components/egress/egress-promote-wizard.tsx
@@ -35,7 +35,7 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useCreateEgressRule, usePatchEgressPolicy } from "@/hooks/use-egress";
-import { listEgressEvents } from "@/api/egress";
+import { listEgressEventsForPolicy } from "@/api/egress";
 import {
   computeWildcardSuggestions,
   type WildcardSuggestion,
@@ -439,11 +439,14 @@ export function EgressPromoteWizard({
   const createRule = useCreateEgressRule();
   const patchPolicy = usePatchEgressPolicy();
 
-  // Fetch last 7 days of events for this policy
+  // Fetch last 7 days of events for this policy. 200 is the server's
+  // hard cap on `limit`; events are deduplicated server-side per
+  // (destination, pattern) with mergedHits, so 200 rows comfortably
+  // covers the unique destinations a wizard run needs to consider.
   const eventsQuery = useQuery({
     queryKey: ["egressEvents", "wizard", policyId],
     queryFn: () =>
-      listEgressEvents({ policyId, since: since7d(), limit: 500 }),
+      listEgressEventsForPolicy(policyId, { since: since7d(), limit: 200 }),
     enabled: open,
     staleTime: 30000,
   });


### PR DESCRIPTION
## Summary

Fixes the Detect → Enforce promote wizard, which has been broken since the cross-policy events endpoint landed: every open showed "Failed to load traffic events" and `400 Bad Request` in DevTools.

## Root cause

[`egress-promote-wizard.tsx`](client/src/components/egress/egress-promote-wizard.tsx) called `listEgressEvents({ policyId, since, limit: 500 })`. Two latent bugs in that one line:

1. **`limit` rejected by the server.** [`/api/egress/events`](server/src/routes/egress.ts:611) shares `eventQuerySchema` with the per-policy endpoint, and that schema caps `limit` at 200 ([routes/egress.ts:544](server/src/routes/egress.ts:544)). `500` failed Zod validation → 400 → wizard alert.
2. **`policyId` silently ignored even at a valid limit.** The cross-policy `/events` route destructures only `{ action, since, until, environmentId, stackId, page, limit }` ([routes/egress.ts:624](server/src/routes/egress.ts:624)) — `policyId` is dropped on the floor. As soon as an env had more than one policy, the wizard would have started computing rule suggestions from cross-policy traffic without anyone noticing.

The per-policy endpoint `GET /api/egress/policies/:policyId/events` already exists and correctly scopes by policyId, but the wizard wasn't using it.

## Fix

- Add `listEgressEventsForPolicy(policyId, query)` to [client/src/api/egress.ts](client/src/api/egress.ts) — hits the per-policy endpoint, takes a query type that omits the now-irrelevant `environmentId`/`stackId`/`policyId` fields.
- Switch the wizard to it. Drop `limit` from 500 → 200 to match the server cap. Events are server-side deduplicated per `(destination, pattern)` with `mergedHits`, so 200 rows is plenty for a wizard run on any realistic stack.

## Test plan

- [x] `pnpm build:lib` + `pnpm --filter mini-infra-client build` — clean
- [x] `pnpm --filter mini-infra-client lint` — clean
- [x] Reproduced the bug pre-fix on the dev env: wizard showed `Failed to load traffic events`, network log had two `400 Bad Request`s on `/api/egress/events?policyId=...&limit=500`.
- [x] Post-fix on the dev env: wizard opens cleanly. With no observed traffic in the empty dev env it correctly renders "No observed traffic in the last 7 days." Step 1 → 2 → 3 all advance, Step 3 shows the Promote summary with default-action picker, no console errors. Network log shows `GET /api/egress/policies/<id>/events?since=...&limit=200` returning `200 OK`.
