### PR TITLE
fix(egress): use env-prefixed container names in container-map lookup

### DIFF
--- a/server/src/services/egress/__tests__/egress-container-map-pusher.test.ts
+++ b/server/src/services/egress/__tests__/egress-container-map-pusher.test.ts
@@ -143,18 +143,19 @@ describe('EgressContainerMapPusher', () => {
       ],
     });
 
-    // Docker has both containers running on the applications network
+    // Docker has both containers running on the applications network.
+    // Names follow `${env}-${stack}-${service}` (StackContainerManager convention).
     mockDockerInstance.listContainers.mockResolvedValue([
       {
         Id: 'c1',
-        Names: ['/myapp-web'],
+        Names: ['/staging-myapp-web'],
         NetworkSettings: {
           Networks: { 'staging-applications': { IPAddress: '172.30.0.10' } },
         },
       },
       {
         Id: 'c2',
-        Names: ['/myapp-egress-gateway'],
+        Names: ['/staging-myapp-egress-gateway'],
         NetworkSettings: {
           Networks: { 'staging-applications': { IPAddress: '172.30.0.2' } },
         },
@@ -171,6 +172,51 @@ describe('EgressContainerMapPusher', () => {
     // egressBypass service should NOT appear
     expect(entryServiceNames).not.toContain('egress-gateway');
     expect(entryServiceNames).toContain('web');
+
+    pusher.stop();
+  });
+
+  // -------------------------------------------------------------------------
+  // Map computation: looks up containers by env-prefixed name
+  // -------------------------------------------------------------------------
+
+  it('matches containers using ${env.name}-${stack.name}-${serviceName}', async () => {
+    const prisma = makePrisma({
+      environments: [{ id: 'env-local', name: 'local', egressGatewayIp: '172.30.0.2' }],
+      stacks: [
+        {
+          id: 'stk-egress-test',
+          name: 'egress-test',
+          services: [{ serviceName: 'alpine', containerConfig: {} }],
+        },
+      ],
+    });
+
+    // StackContainerManager names this `local-egress-test-alpine` (env + stack + service).
+    // The pusher must look up that exact name — not `egress-test-alpine`.
+    mockDockerInstance.listContainers.mockResolvedValue([
+      {
+        Id: 'c-alpine',
+        Names: ['/local-egress-test-alpine'],
+        NetworkSettings: {
+          Networks: { 'local-applications': { IPAddress: '172.30.0.10' } },
+        },
+      },
+    ]);
+
+    const pusher = new EgressContainerMapPusher(prisma);
+    pusher.start();
+    await vi.runAllTimersAsync();
+
+    expect(pushCalls.length).toBeGreaterThan(0);
+    const { entries } = pushCalls[pushCalls.length - 1];
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({
+      ip: '172.30.0.10',
+      stackId: 'stk-egress-test',
+      serviceName: 'alpine',
+      containerId: 'c-alpine',
+    });
 
     pusher.stop();
   });

--- a/server/src/services/egress/egress-container-map-pusher.ts
+++ b/server/src/services/egress/egress-container-map-pusher.ts
@@ -280,15 +280,16 @@ export class EgressContainerMapPusher {
 
     const entries: ContainerMapEntry[] = [];
 
+    // Project name matches StackContainerManager: `${env.name}-${stack.name}` for env-scoped stacks.
+    // Container name: `${projectName}-${serviceName}` → `${env.name}-${stack.name}-${serviceName}`.
     for (const stack of stacks) {
+      const projectName = `${env.name}-${stack.name}`;
       for (const service of stack.services) {
         // Skip services with egressBypass (e.g. the egress-gateway itself)
         const cfg = service.containerConfig as Record<string, unknown> | null;
         if (cfg?.egressBypass === true) continue;
 
-        // Container name convention matches what StackContainerManager creates:
-        // {stackName}-{serviceName}
-        const containerName = `${stack.name}-${service.serviceName}`;
+        const containerName = `${projectName}-${service.serviceName}`;
         const ip = ipByName.get(containerName);
         if (!ip) continue; // Container not running or not on this network
 


### PR DESCRIPTION
## Summary

- The container-map pusher was looking up Docker containers by `${stack.name}-${service.serviceName}` but `StackContainerManager` creates them as `${env.name}-${stack.name}-${serviceName}`, so the gateway always received an empty map and proxied requests came back 403.
- Switched the lookup to the full env-prefixed name (matching the `${projectName}-${serviceName}` convention used everywhere else in `services/stacks/`).
- Added a regression test mirroring the local-env scenario from the bug (alpine container named `local-egress-test-alpine`); also fixed the existing fixture which used the wrong name shape.

## Test plan

- [x] `pnpm --filter mini-infra-server test` — 1868/1868 pass, including the new regression test
- [x] `pnpm build:server` — clean
- [x] `pnpm --filter mini-infra-server lint src/services/egress/` — clean
- [x] **End-to-end validated** in a worktree:
  - Enabled firewall on env `local`, deployed an `egress-test` stack with `joinResourceNetworks: ['applications']`, container created as `local-egress-test-alpine` on `local-applications` at `172.30.4.5`.
  - Gateway container map went from `entryCount:1` (haproxy only — also affected by the bug, but here it was the sole entry surviving by coincidence of name shape) to `entryCount:2` once alpine joined.
  - Gateway log shows source IP correctly mapped to stack: `inbound_remote_addr:"172.30.4.5", role:"<egress-test stackId>", allow:true, decision_reason:"rule has allow and report policy"`. Without this fix the request would have been rejected by `UnknownIPDenyHandler` because the container map didn't know `172.30.4.5`.
  - Two `EgressEvent` rows landed in the DB (`destination: example.com:443`, `sourceStackId: <egress-test>`, `action: allowed`) and are visible at `/egress`.
  - Note: a separate nil-pointer panic in `smokescreen.dialContext` (in the egress-gateway image) prevents the curl response from reaching the client, but the policy decision and event emission both fire correctly before the panic — so the fix is fully exercised. Spawned a follow-up task to chase that panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)