### PR TITLE
feat(egress): add Stack and Service filters to traffic feed

### DIFF
--- a/client/src/api/egress.ts
+++ b/client/src/api/egress.ts
@@ -66,6 +66,7 @@ export interface ListEgressEventsQuery {
   environmentId?: string;
   stackId?: string;
   policyId?: string;
+  sourceServiceName?: string;
   action?: "allowed" | "blocked" | "observed";
   since?: string;
   until?: string;
@@ -151,6 +152,8 @@ export async function listEgressEvents(
   if (query.environmentId) url.searchParams.set("environmentId", query.environmentId);
   if (query.stackId) url.searchParams.set("stackId", query.stackId);
   if (query.policyId) url.searchParams.set("policyId", query.policyId);
+  if (query.sourceServiceName)
+    url.searchParams.set("sourceServiceName", query.sourceServiceName);
   if (query.action) url.searchParams.set("action", query.action);
   if (query.since) url.searchParams.set("since", query.since);
   if (query.until) url.searchParams.set("until", query.until);
@@ -193,6 +196,8 @@ export async function listEgressEventsForPolicy(
   );
 
   if (query.action) url.searchParams.set("action", query.action);
+  if (query.sourceServiceName)
+    url.searchParams.set("sourceServiceName", query.sourceServiceName);
   if (query.since) url.searchParams.set("since", query.since);
   if (query.until) url.searchParams.set("until", query.until);
   if (query.page !== undefined) url.searchParams.set("page", String(query.page));

--- a/client/src/components/egress/egress-traffic-feed.tsx
+++ b/client/src/components/egress/egress-traffic-feed.tsx
@@ -30,9 +30,13 @@ import {
 import {
   useEgressEvents,
   useEgressEventFilters,
+  useEgressPolicies,
 } from "@/hooks/use-egress";
+import { useStack } from "@/hooks/use-stacks";
 import { useFormattedDate } from "@/hooks/use-formatted-date";
 import type { EgressEventBroadcast } from "@mini-infra/types";
+
+const ALL_VALUE = "__all__";
 
 function EventActionBadge({ action }: { action: string }) {
   if (action === "blocked") {
@@ -154,20 +158,61 @@ export function EgressTrafficFeed({ environmentId }: EgressTrafficFeedProps) {
 
   const { filters, updateFilter, resetFilters } = useEgressEventFilters();
 
-  // Reset pagination when the env filter flips so we don't request a page that no longer exists.
+  // Stack dropdown source — same query the parent Egress page already issues, so
+  // TanStack Query dedupes by key (no extra HTTP request).
+  const policiesQuery = useEgressPolicies({
+    query: { environmentId, page: 1, limit: 200 },
+  });
+
+  // Service dropdown source — only enabled when a stack is selected.
+  const stackQuery = useStack(filters.stackId ?? "");
+
+  const stackOptions = useMemo(() => {
+    const seen = new Map<string, string>(); // stackId -> stackName
+    for (const p of policiesQuery.data?.policies ?? []) {
+      if (p.stackId && !seen.has(p.stackId)) {
+        seen.set(p.stackId, p.stackNameSnapshot);
+      }
+    }
+    return Array.from(seen, ([id, name]) => ({ id, name })).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
+  }, [policiesQuery.data?.policies]);
+
+  const serviceOptions = useMemo(
+    () => (stackQuery.data?.data?.services ?? []).map((s) => s.serviceName),
+    [stackQuery.data?.data?.services],
+  );
+
+  // Switching environments invalidates any stack/service filter (a stack from
+  // another env wouldn't match anything). The stack→service cascade is handled
+  // inline in the Stack dropdown's onValueChange so both updates batch into a
+  // single render — no wasted fetch with a stale service filter.
+  // updateFilter resets page to 1 on every call, so pagination is implicit.
   useEffect(() => {
-    updateFilter("page", 1);
+    updateFilter("stackId", undefined);
+    updateFilter("sourceServiceName", undefined);
   }, [environmentId, updateFilter]);
 
   const query = useMemo(
     () => ({
       environmentId,
+      stackId: filters.stackId,
+      sourceServiceName: filters.sourceServiceName,
       action: filters.action,
       since: sinceFromRange(timeRange),
       page: filters.page,
       limit: filters.limit,
     }),
-    [environmentId, filters.action, timeRange, filters.page, filters.limit],
+    [
+      environmentId,
+      filters.stackId,
+      filters.sourceServiceName,
+      filters.action,
+      timeRange,
+      filters.page,
+      filters.limit,
+    ],
   );
 
   const { data, isLoading, isError, error, liveEvents } = useEgressEvents({
@@ -236,6 +281,59 @@ export function EgressTrafficFeed({ environmentId }: EgressTrafficFeedProps) {
             <SelectItem value="observed">Observed</SelectItem>
           </SelectContent>
         </Select>
+
+        {stackOptions.length > 0 && (
+          <Select
+            value={filters.stackId ?? ALL_VALUE}
+            onValueChange={(v) => {
+              updateFilter("stackId", v === ALL_VALUE ? undefined : v);
+              // Service names aren't unique across stacks, so clear the service
+              // filter whenever the stack selection changes.
+              updateFilter("sourceServiceName", undefined);
+            }}
+            disabled={policiesQuery.isLoading}
+          >
+            <SelectTrigger className="w-44 h-8 text-xs">
+              <SelectValue placeholder="Stack" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL_VALUE}>All stacks</SelectItem>
+              {stackOptions.map((s) => (
+                <SelectItem key={s.id} value={s.id}>
+                  {s.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+
+        {filters.stackId && (
+          <Select
+            value={filters.sourceServiceName ?? ALL_VALUE}
+            onValueChange={(v) =>
+              updateFilter("sourceServiceName", v === ALL_VALUE ? undefined : v)
+            }
+            disabled={stackQuery.isLoading}
+          >
+            <SelectTrigger className="w-40 h-8 text-xs">
+              <SelectValue placeholder="Service" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL_VALUE}>All services</SelectItem>
+              {serviceOptions.length === 0 ? (
+                <div className="px-2 py-1.5 text-xs text-muted-foreground italic">
+                  No services found
+                </div>
+              ) : (
+                serviceOptions.map((name) => (
+                  <SelectItem key={name} value={name}>
+                    {name}
+                  </SelectItem>
+                ))
+              )}
+            </SelectContent>
+          </Select>
+        )}
 
         <Select
           value={timeRange}

--- a/client/src/hooks/use-egress.ts
+++ b/client/src/hooks/use-egress.ts
@@ -273,6 +273,12 @@ export function useEgressEvents(options: UseEgressEventsOptions = {}) {
     ServerEvent.EGRESS_EVENT,
     (data) => {
       if (query.environmentId && data.environmentId !== query.environmentId) return;
+      if (query.stackId && data.sourceStackId !== query.stackId) return;
+      if (
+        query.sourceServiceName &&
+        data.sourceServiceName !== query.sourceServiceName
+      )
+        return;
       if (query.policyId && data.policyId !== query.policyId) return;
       if (query.action && data.action !== query.action) return;
 
@@ -358,6 +364,8 @@ export function useEgressGatewayHealth(environmentId: string | null | undefined)
 
 export interface EgressEventFiltersState {
   action?: "allowed" | "blocked" | "observed";
+  stackId?: string;
+  sourceServiceName?: string;
   since?: string; // ISO string
   until?: string; // ISO string
   destination?: string; // free-text search

--- a/server/src/__tests__/egress-routes.test.ts
+++ b/server/src/__tests__/egress-routes.test.ts
@@ -705,6 +705,23 @@ describe('Egress Routes', () => {
       expect(res.status).toBe(400);
     });
 
+    it('applies sourceServiceName filter', async () => {
+      const policy = makePolicy();
+      mockPrisma.egressPolicy.findUnique.mockResolvedValue(policy);
+      mockPrisma.egressEvent.findMany.mockResolvedValue([]);
+      mockPrisma.egressEvent.count.mockResolvedValue(0);
+
+      await request(app).get(
+        `/api/egress/policies/${policy.id}/events?sourceServiceName=api`,
+      );
+
+      expect(mockPrisma.egressEvent.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ sourceServiceName: 'api' }),
+        }),
+      );
+    });
+
     it('returns 404 when policy not found', async () => {
       mockPrisma.egressPolicy.findUnique.mockResolvedValue(null);
 
@@ -758,6 +775,38 @@ describe('Egress Routes', () => {
         expect.objectContaining({
           where: expect.objectContaining({
             policy: { stackId },
+          }),
+        }),
+      );
+    });
+
+    it('filters by sourceServiceName as a top-level where clause', async () => {
+      mockPrisma.egressEvent.findMany.mockResolvedValue([]);
+      mockPrisma.egressEvent.count.mockResolvedValue(0);
+
+      await request(app).get('/api/egress/events?sourceServiceName=worker');
+
+      expect(mockPrisma.egressEvent.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ sourceServiceName: 'worker' }),
+        }),
+      );
+    });
+
+    it('combines stackId and sourceServiceName filters', async () => {
+      const stackId = createId();
+      mockPrisma.egressEvent.findMany.mockResolvedValue([]);
+      mockPrisma.egressEvent.count.mockResolvedValue(0);
+
+      await request(app).get(
+        `/api/egress/events?stackId=${stackId}&sourceServiceName=api`,
+      );
+
+      expect(mockPrisma.egressEvent.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            policy: { stackId },
+            sourceServiceName: 'api',
           }),
         }),
       );

--- a/server/src/routes/egress.ts
+++ b/server/src/routes/egress.ts
@@ -540,6 +540,7 @@ const eventQuerySchema = z.object({
   until: z.string().datetime({ offset: true }).optional(),
   environmentId: z.string().optional(),
   stackId: z.string().optional(),
+  sourceServiceName: z.string().optional(),
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(200).default(50),
 });
@@ -568,11 +569,12 @@ router.get(
       });
     }
 
-    const { action, since, until, page, limit } = parsed.data;
+    const { action, since, until, sourceServiceName, page, limit } = parsed.data;
 
     const where = {
       policyId: policy.id,
       ...(action ? { action } : {}),
+      ...(sourceServiceName ? { sourceServiceName } : {}),
       ...(since || until
         ? {
             occurredAt: {
@@ -621,7 +623,8 @@ router.get(
       });
     }
 
-    const { action, since, until, environmentId, stackId, page, limit } = parsed.data;
+    const { action, since, until, environmentId, stackId, sourceServiceName, page, limit } =
+      parsed.data;
 
     // If filtering by environmentId or stackId, filter via the nested policy
     const hasPolicyFilter = !!(environmentId || stackId);
@@ -633,6 +636,7 @@ router.get(
     const where = {
       ...(hasPolicyFilter ? { policy: policyWhere } : {}),
       ...(action ? { action } : {}),
+      ...(sourceServiceName ? { sourceServiceName } : {}),
       ...(since || until
         ? {
             occurredAt: {


### PR DESCRIPTION
## Summary
- Adds two new dropdowns to the Egress Traffic Feed: **Stack** (rendered when policies exist for the selected env) and **Service** (rendered when a Stack is selected). Both narrow the paginated history *and* the live socket feed.
- Backend: extends the events query schema (`server/src/routes/egress.ts`) with `sourceServiceName` on both the cross-policy `/events` endpoint and the per-policy `/policies/:policyId/events` endpoint. `stackId` was already supported; `sourceServiceName` is wired into the Prisma `where` clause.
- Frontend: extends `ListEgressEventsQuery`, `EgressEventFiltersState`, and the live-event socket predicate. Stack list comes from `useEgressPolicies` (TanStack dedupes against the parent page's existing call); Service list comes from `useStack(stackId).data.data.services`.
- Cascade behavior: switching environments clears both new filters via `useEffect`; switching stacks clears the service filter inline in the dropdown handler so React 18 batches the two state updates into a single render — no wasted fetch with a stale service name.

## Validation
- Server tests: `pnpm --filter mini-infra-server test` — 1868/1868 pass, including 3 new tests for `sourceServiceName` filtering on both event endpoints and a combined `stackId + sourceServiceName` test.
- Lint + typecheck: `pnpm --filter mini-infra-client lint`, `pnpm --filter mini-infra-server lint`, `pnpm --filter mini-infra-client build`, `pnpm build:server` — all clean.
- End-to-end (playwright-cli against the worktree dev environment): logged in, navigated to `/egress`, verified the Stack dropdown enumerates both `egress-gateway` and `haproxy-local`, that the Service dropdown only appears once a stack is selected and lists that stack's services, and that the network calls flow through the right query string (`?stackId=...&sourceServiceName=haproxy`). Switching stacks correctly resets the service filter.
  - Note: the cascade-into-handler optimization (the late refinement) was not re-tested in the browser — the prior `useEffect`-based cascade was the version validated in the dev env, and the post-edit version compiles + lints clean. Functional behavior is identical.

## Test plan
- [ ] Pick an env with multiple stacks; verify the Stack dropdown lists them alphabetically.
- [ ] Pick a stack; verify the Service dropdown appears and lists that stack's services.
- [ ] Pick a service; verify both Stack and Service narrow the history table and any live rows.
- [ ] Switch to a different stack; verify the Service filter resets to "All services".
- [ ] Switch environments via the page-level filter; verify both Stack and Service reset.
- [ ] Reset button clears all filters.
- [ ] "All environments" view: Stack dropdown lists stacks across every env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)