### PR TITLE
fix(egress): init ConnTracker on gateway so CONNECT no longer panics

### DIFF
--- a/egress-gateway/cmd/main.go
+++ b/egress-gateway/cmd/main.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	smokescreen "github.com/stripe/smokescreen/pkg/smokescreen"
 
 	"github.com/mrgeoffrich/mini-infra/egress-gateway/internal/admin"
 	"github.com/mrgeoffrich/mini-infra/egress-gateway/internal/config"
@@ -46,35 +45,14 @@ func main() {
 	// Admin server (manages health flags for proxy + admin listeners).
 	adminSrv := admin.New(aclSwapper, containers, rulesState, logger)
 
-	// Build Smokescreen config.
-	// IMPORTANT: We call BuildProxy (not StartWithConfig) so we own our own
-	// signal handling and can run proxy + admin as separate listeners.
-	sk := smokescreen.NewConfig()
-	sk.RoleFromRequest = proxy.RoleFromRequest(containers)
-	sk.EgressACL = aclSwapper
-	sk.DenyRanges = proxy.BuiltinPrivateRanges()
-	sk.ConnectTimeout = 10 * time.Second
-	sk.Log = logger
-	// Security posture: only known managed containers (those present in the
-	// container map) may use the proxy. Unmapped source IPs must be denied
-	// deterministically. Setting AllowMissingRole=false makes this explicit —
-	// Smokescreen's default is already false, but we document it here so the
-	// intent is clear and a future config change can't accidentally allow it.
-	sk.AllowMissingRole = false
-
-	// Build the proxy handler.
-	proxyHandler := smokescreen.BuildProxy(sk)
-
-	// Wrap with a fast-fail check for unknown source IPs before handing off to
-	// Smokescreen. When RoleFromRequest returns MissingRoleError, Smokescreen
-	// logs an error and then returns an HTTP 503, but the timing is not
-	// guaranteed for all code paths. This pre-handler ensures unknown IPs
-	// receive a deterministic HTTP 403 JSON response within the request
-	// read-header timeout, never silently timing out.
-	authenticatedHandler := proxy.UnknownIPDenyHandler(proxyHandler, containers)
-
-	// Wrap with DoH gate — runs before Smokescreen ACL.
-	gatewayHandler := proxy.DoHGate(authenticatedHandler)
+	// Build the full DoH → unknown-IP-deny → Smokescreen handler chain.
+	// We use BuildGatewayHandler (rather than smokescreen.StartWithConfig) so
+	// we own our own signal handling and can run proxy + admin as separate
+	// listeners — see internal/proxy/gateway.go for the bits that StartWithConfig
+	// would have initialised for us.
+	gatewayHandler := proxy.BuildGatewayHandler(containers, aclSwapper, logger, proxy.GatewayOptions{
+		DenyRanges: proxy.BuiltinPrivateRanges(),
+	})
 
 	// Determine ports.
 	proxyPort := cfg.ProxyPort

--- a/egress-gateway/internal/proxy/gateway.go
+++ b/egress-gateway/internal/proxy/gateway.go
@@ -1,0 +1,48 @@
+package proxy
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	smokescreen "github.com/stripe/smokescreen/pkg/smokescreen"
+	"github.com/stripe/smokescreen/pkg/smokescreen/conntrack"
+
+	"github.com/mrgeoffrich/mini-infra/egress-shared/state"
+)
+
+// GatewayOptions holds the knobs callers can tune when assembling the gateway
+// handler. Production sets DenyRanges to BuiltinPrivateRanges; tests may pass
+// nil DenyRanges and an explicit AllowRanges for loopback so they can dial
+// httptest upstreams.
+type GatewayOptions struct {
+	DenyRanges  []smokescreen.RuleRange
+	AllowRanges []smokescreen.RuleRange
+}
+
+// BuildGatewayHandler assembles the full proxy handler chain used in production:
+// DoHGate → UnknownIPDenyHandler → Smokescreen. It also performs the ConnTracker
+// initialisation that BuildProxy itself omits (that init lives in
+// Smokescreen's StartWithConfig/runServer, which we don't call). Without this
+// step, the first CONNECT request panics in smokescreen.dialContext when it
+// dereferences a nil ConnTracker.
+func BuildGatewayHandler(
+	containers *state.ContainerMap,
+	aclSwapper *ACLSwapper,
+	logger *logrus.Logger,
+	opts GatewayOptions,
+) http.Handler {
+	sk := smokescreen.NewConfig()
+	sk.RoleFromRequest = RoleFromRequest(containers)
+	sk.EgressACL = aclSwapper
+	sk.DenyRanges = opts.DenyRanges
+	sk.AllowRanges = opts.AllowRanges
+	sk.ConnectTimeout = 10 * time.Second
+	sk.Log = logger
+	sk.AllowMissingRole = false
+
+	sk.ShuttingDown.Store(false)
+	sk.ConnTracker = conntrack.NewTracker(sk.IdleTimeout, sk.MetricsClient, sk.Log, sk.ShuttingDown, nil)
+
+	return DoHGate(UnknownIPDenyHandler(smokescreen.BuildProxy(sk), containers))
+}

--- a/egress-gateway/internal/proxy/gateway_test.go
+++ b/egress-gateway/internal/proxy/gateway_test.go
@@ -1,0 +1,95 @@
+package proxy
+
+import (
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	smokescreen "github.com/stripe/smokescreen/pkg/smokescreen"
+
+	"github.com/mrgeoffrich/mini-infra/egress-shared/state"
+)
+
+// TestBuildGatewayHandler_ConnectDoesNotPanic is the regression test for the
+// nil-pointer panic in smokescreen.dialContext that fired on every CONNECT
+// because BuildProxy never initialises ConnTracker. Before the fix this test
+// panicked on the first CONNECT; after the fix the tunnel completes and the
+// upstream HTTPS request returns 200.
+func TestBuildGatewayHandler_ConnectDoesNotPanic(t *testing.T) {
+	// Real HTTPS upstream the proxy will tunnel us to.
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "hello")
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream url: %v", err)
+	}
+
+	// Listener for the gateway proxy.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	// Map the loopback client IP to a stack so RoleFromRequest succeeds.
+	containers := state.NewContainerMap()
+	containers.Replace(map[string]*state.ContainerAttr{
+		"127.0.0.1": {StackID: "stk_test", ServiceName: "web"},
+	})
+	aclSwapper := NewACLSwapper() // permissive default — Report policy on every host
+
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	// DenyRanges is empty and AllowRanges explicitly allows loopback so the
+	// proxy can dial the httptest upstream — the regression we're guarding
+	// against fires on the happy path through dialContext, which only runs
+	// once IP classification allows the connection.
+	_, loopbackNet, _ := net.ParseCIDR("127.0.0.0/8")
+	srv := &http.Server{
+		Handler: BuildGatewayHandler(containers, aclSwapper, logger, GatewayOptions{
+			AllowRanges: []smokescreen.RuleRange{{Net: *loopbackNet}},
+		}),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() { _ = srv.Serve(ln) }()
+	defer srv.Close()
+
+	// Client that goes via the proxy. Skip TLS verify on the upstream test cert.
+	proxyURL := &url.URL{Scheme: "http", Host: ln.Addr().String()}
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			Proxy:           http.ProxyURL(proxyURL),
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	// Smokescreen ACLs match on hostname, so connect via "localhost" (the cert
+	// is for 127.0.0.1, hence InsecureSkipVerify).
+	target := "https://localhost:" + upstreamURL.Port()
+	resp, err := client.Get(target)
+	if err != nil {
+		t.Fatalf("CONNECT through gateway failed (was the panic reintroduced?): %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("want 200, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "hello") {
+		t.Errorf("unexpected body: %q", body)
+	}
+}

--- a/scripts/egress-e2e.sh
+++ b/scripts/egress-e2e.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+#
+# egress-e2e.sh — black-box smoke test for the per-environment egress firewall.
+#
+# Drives a running worktree's Mini Infra instance via its REST API:
+#   1. Reads connection details from environment-details.xml
+#   2. Enables egress firewall on env "local" (idempotent)
+#   3. Deploys a single-container "alpine + curl" workload joining the
+#      `applications` resource network
+#   4. Runs two curls inside the workload via `docker exec`:
+#        - https://example.com         → expect 200. This is the regression
+#          test for the ConnTracker nil-deref panic — detect mode's default
+#          Report policy was the exact trigger.
+#        - https://dns.google/dns-query → expect 403 from the DoH gate.
+#   5. Verifies the example.com request appears in /api/egress/events.
+#   6. Greps the egress-gateway container's docker logs for `panic serving`
+#      and fails loudly if any are present.
+#   7. Always tears down the test stack on exit.
+#
+# Usage:  scripts/egress-e2e.sh
+# Requires: xmllint, jq, curl, docker — all present on a normal dev machine.
+
+set -euo pipefail
+
+# ---- locate worktree root (script lives in scripts/) -----------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_XML="$ROOT/environment-details.xml"
+
+if [[ ! -f "$ENV_XML" ]]; then
+  echo "error: environment-details.xml not found at $ENV_XML" >&2
+  echo "       run deployment/development/worktree_start.sh first" >&2
+  exit 1
+fi
+
+xq() { xmllint --xpath "string($1)" "$ENV_XML"; }
+
+UI_URL="$(xq '//environment/endpoints/ui')"
+API_KEY="$(xq '//environment/admin/apiKey')"
+LOCAL_ENV_ID="$(xq '//environment/localEnvironment/id')"
+LOCAL_ENV_NAME="$(xq '//environment/localEnvironment/name')"
+COMPOSE_PROJECT="$(xq '//environment/worktree/composeProject')"
+
+if [[ -z "$UI_URL" || -z "$API_KEY" || -z "$LOCAL_ENV_ID" ]]; then
+  echo "error: environment-details.xml is missing required fields" >&2
+  exit 1
+fi
+
+API="$UI_URL/api"
+AUTH=(-H "x-api-key: $API_KEY")
+
+STACK_NAME="egress-e2e-$$"
+SERVICE_NAME="workload"
+WORKLOAD_CONTAINER="${LOCAL_ENV_NAME}-${STACK_NAME}-${SERVICE_NAME}"
+GATEWAY_CONTAINER="${LOCAL_ENV_NAME}-egress-gateway-egress-gateway"
+
+STACK_ID=""
+TEST_START_ISO=""
+
+# ---- helpers ---------------------------------------------------------------
+
+step() { printf '\n\033[1;34m▸ %s\033[0m\n' "$*"; }
+ok()   { printf '\033[0;32m  ✓ %s\033[0m\n' "$*"; }
+fail() { printf '\033[0;31m  ✗ %s\033[0m\n' "$*" >&2; exit 1; }
+
+api_call() {
+  local method="$1" path="$2" body="${3:-}"
+  if [[ -n "$body" ]]; then
+    curl -fsS -X "$method" "${AUTH[@]}" \
+      -H "content-type: application/json" \
+      -d "$body" "$API$path"
+  else
+    curl -fsS -X "$method" "${AUTH[@]}" "$API$path"
+  fi
+}
+
+cleanup() {
+  local exit_code=$?
+  if [[ -n "$STACK_ID" ]]; then
+    step "Cleanup: removing test stack $STACK_NAME"
+    api_call DELETE "/stacks/$STACK_ID" >/dev/null 2>&1 || true
+    ok "stack delete requested"
+  fi
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+# ---- 1. enable firewall on env --------------------------------------------
+
+step "Ensuring egress firewall is enabled on env '$LOCAL_ENV_NAME'"
+api_call PUT "/environments/$LOCAL_ENV_ID" '{"egressFirewallEnabled":true}' >/dev/null
+ok "firewall flag set"
+
+# ---- 2. confirm gateway container is running ------------------------------
+
+step "Locating gateway container"
+gateway_id="$(docker ps --filter "name=^${GATEWAY_CONTAINER}" --format '{{.ID}}' | head -n 1)"
+[[ -n "$gateway_id" ]] || fail "gateway container '$GATEWAY_CONTAINER' is not running"
+ok "gateway container $gateway_id"
+
+# ---- 3. deploy the test workload stack ------------------------------------
+
+step "Creating test stack $STACK_NAME"
+TEST_START_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+create_payload=$(cat <<JSON
+{
+  "name": "$STACK_NAME",
+  "environmentId": "$LOCAL_ENV_ID",
+  "description": "egress-e2e smoke test workload",
+  "networks": [],
+  "volumes": [],
+  "resourceInputs": [{"type":"docker-network","purpose":"applications"}],
+  "services": [{
+    "serviceName": "$SERVICE_NAME",
+    "serviceType": "Stateful",
+    "dockerImage": "curlimages/curl",
+    "dockerTag": "latest",
+    "order": 0,
+    "dependsOn": [],
+    "containerConfig": {
+      "entrypoint": ["sh"],
+      "command": ["-c","sleep infinity"],
+      "joinResourceNetworks": ["applications"],
+      "restartPolicy": "no"
+    }
+  }]
+}
+JSON
+)
+create_response="$(api_call POST "/stacks" "$create_payload")"
+STACK_ID="$(echo "$create_response" | jq -r '.data.id // .id')"
+[[ -n "$STACK_ID" && "$STACK_ID" != "null" ]] || fail "could not parse stack id from create response: $create_response"
+ok "stack id $STACK_ID"
+
+step "Applying stack"
+api_call POST "/stacks/$STACK_ID/apply" '{}' >/dev/null
+ok "apply requested"
+
+step "Waiting for stack to reach 'synced'"
+for _ in $(seq 1 60); do
+  status="$(api_call GET "/stacks/$STACK_ID" | jq -r '.data.status // .status')"
+  if [[ "$status" == "synced" ]]; then ok "stack status=synced"; break; fi
+  if [[ "$status" == "error" ]]; then fail "stack apply failed (status=error)"; fi
+  sleep 2
+done
+if [[ "$status" != "synced" ]]; then fail "stack did not reach 'synced' (last status=$status)"; fi
+
+step "Waiting for workload container to be running"
+for _ in $(seq 1 30); do
+  state="$(docker inspect -f '{{.State.Status}}' "$WORKLOAD_CONTAINER" 2>/dev/null || echo missing)"
+  case "$state" in
+    running)
+      if docker exec "$WORKLOAD_CONTAINER" sh -c 'command -v curl >/dev/null' 2>/dev/null; then
+        ok "curl available in $WORKLOAD_CONTAINER"
+        break
+      fi
+      ;;
+    exited|dead)
+      echo "  ✗ container is $state — last 30 lines of logs:" >&2
+      docker logs --tail 30 "$WORKLOAD_CONTAINER" 2>&1 | sed 's/^/    /' >&2
+      fail "workload container exited before we could exec into it"
+      ;;
+  esac
+  sleep 2
+done
+docker exec "$WORKLOAD_CONTAINER" sh -c 'command -v curl >/dev/null' \
+  || fail "curl never became available in $WORKLOAD_CONTAINER (state=$state)"
+
+# Default auto-created policy is detect mode with allow-default — no rules
+# needed. Detect mode means the default Report policy is applied to every
+# request, which is exactly the state that triggered the panic
+# (`decision_reason: "rule has allow and report policy"`).
+
+# ---- 4. run the curls inside the workload --------------------------------
+
+run_curl() {
+  # Returns the *effective* HTTP status from the request:
+  #   - on success: %{http_code} from curl (the upstream's response)
+  #   - on a CONNECT-tunnel failure: the code the proxy returned in its 4xx
+  #     CONNECT response, parsed from stderr ("CONNECT tunnel failed, response NNN")
+  #   - "000" if neither was available (DNS/network failure, panic, etc.)
+  local url="$2"
+  local out
+  out="$(docker exec "$WORKLOAD_CONTAINER" \
+    curl -sS -k --connect-timeout 5 -m 10 \
+      -o /dev/null -w '%{http_code}' "$url" 2>&1)" || true
+  # The trailing line is the curl `-w` output (3-digit code or "000").
+  local last_line http_code proxy_code
+  last_line="$(printf '%s' "$out" | tail -n1)"
+  http_code="$(printf '%s' "$last_line" | grep -oE '^[0-9]{3}$' | head -n1)"
+  if [[ -n "$http_code" && "$http_code" != "000" ]]; then
+    echo "$http_code"
+    return
+  fi
+  proxy_code="$(printf '%s' "$out" | grep -oE 'response [0-9]{3}' | tail -n1 | awk '{print $2}')"
+  if [[ -n "$proxy_code" ]]; then
+    echo "$proxy_code"
+    return
+  fi
+  echo "000"
+}
+
+step "Waiting for gateway container-map to register workload (curl example.com)"
+# The container-map pusher debounces ~500ms after the workload starts. Poll
+# the first curl until we get a non-403 — that proves our IP is in the map.
+code=""
+for i in $(seq 1 15); do
+  code="$(run_curl example "https://example.com")"
+  if [[ "$code" == "200" ]]; then
+    ok "got $code (after ${i} attempt(s))"
+    break
+  fi
+  sleep 1
+done
+[[ "$code" == "200" ]] || fail "want 200 from example.com, got $code after retries — gateway map likely never synced our IP"
+
+step "Curl: https://dns.google/dns-query (expect 403 from DoH gate)"
+code="$(run_curl doh "https://dns.google/dns-query")"
+[[ "$code" == "403" ]] && ok "got 403" || fail "want 403 from DoH gate, got $code"
+
+# ---- 5. verify the example.com request landed in /api/egress/events -------
+
+step "Verifying egress events landed in /api/egress/events"
+events="$(api_call GET "/egress/events?stackId=$STACK_ID&since=$TEST_START_ISO&limit=50")"
+example_seen="$(echo "$events" | jq -r '[.events[]?, .data.events[]?] | map(select(.destination|test("example\\.com"))) | length')"
+[[ "$example_seen" -ge 1 ]] && ok "example.com event present" || fail "no example.com event recorded"
+
+# ---- 6. grep gateway logs for panics --------------------------------------
+
+step "Grepping gateway logs for 'panic serving'"
+if docker logs "$gateway_id" 2>&1 | grep -F -q 'panic serving'; then
+  echo "--- panic excerpt ---" >&2
+  docker logs "$gateway_id" 2>&1 | grep -A 8 'panic serving' >&2 || true
+  fail "FOUND panic in egress-gateway logs — regression of the ConnTracker nil-deref"
+fi
+ok "no panics in gateway logs"
+
+step "ALL CHECKS PASSED"


### PR DESCRIPTION
## Summary

Fixes the nil-pointer panic in `smokescreen.dialContext` that fired on every CONNECT request through the egress-gateway:

```
runtime error: invalid memory address or nil pointer dereference
github.com/stripe/smokescreen/pkg/smokescreen.dialContext(...) smokescreen.go:544
```

Root cause: `smokescreen.BuildProxy` does not initialise `Config.ConnTracker` — that init lives inside `StartWithConfig`/`runServer`, which the gateway doesn't call (we own our own listener so we can run proxy + admin separately). The first CONNECT nil-derefs at `ConnTracker.RecordAttempt`.

With #296 having just landed the env-prefixed container-map naming, this panic now surfaces on **every** CONNECT once the gateway actually accepts a real workload's request — previously masked by `UnknownIPDenyHandler` 403'ing first.

## What's in the PR

- **`egress-gateway/internal/proxy/gateway.go`** — new `BuildGatewayHandler` helper. Builds the DoH → unknown-IP-deny → Smokescreen chain and initialises `ConnTracker` (and `ShuttingDown`) the same way `runServer` would, before calling `BuildProxy`.
- **`egress-gateway/cmd/main.go`** — uses the helper instead of inline config.
- **`egress-gateway/internal/proxy/gateway_test.go`** — Go-level regression test that drives a real CONNECT (`http.Client{Proxy: ...}`) through the full handler chain against an `httptest.NewTLSServer` upstream. Without the fix this test panics on the first request.
- **`scripts/egress-e2e.sh`** — black-box smoke test for the whole flow:
  - reads `environment-details.xml`
  - enables egress firewall on env "local"
  - deploys a `curlimages/curl` workload joining the `applications` resource network
  - retries until the gateway's container map registers the workload
  - asserts `https://example.com` → 200 (panic regression)
  - asserts `https://dns.google/dns-query` → 403 (DoH gate hard-block)
  - verifies the example.com request appears in `/api/egress/events`
  - greps gateway logs for `panic serving`
  - tears down the test stack on exit

## Test plan

- [x] `cd egress-gateway && go test ./...` — green, including new `TestBuildGatewayHandler_ConnectDoesNotPanic`
- [x] `scripts/egress-e2e.sh` against a live worktree — all checks pass, no panics in gateway logs

## Reviewer notes

- `BuildGatewayHandler` takes a `GatewayOptions` struct with `DenyRanges`/`AllowRanges` so the regression test can dial the loopback `httptest` upstream without gutting the production SSRF defence (production passes `BuiltinPrivateRanges()`; the test passes a custom `AllowRanges` for `127.0.0.0/8`).
- `cmd/main.go` is now noticeably shorter — all the smokescreen wiring moved into the helper. No behaviour change beyond the ConnTracker init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)