### PR TITLE
docs: add matklad-style ARCHITECTURE.md for repo, server, and client

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,233 @@
+# Architecture
+
+This document is the bird's-eye view of Mini Infra. Read it first if you're new to the codebase. It explains what the major pieces are, where they live, and how they fit together. Subsystem-level depth lives in [server/ARCHITECTURE.md](server/ARCHITECTURE.md) and [client/ARCHITECTURE.md](client/ARCHITECTURE.md).
+
+This file is meant to be hand-maintained. When the shape of the system changes — a new sidecar, a new top-level package, a new external dependency — update it.
+
+## What Mini Infra is
+
+Mini Infra is a self-hosted control plane for a single Docker host. It manages the host's containers, networks, and volumes; deploys multi-container applications with zero-downtime blue-green rollouts; runs scheduled PostgreSQL backups to Azure Blob Storage; provisions TLS certificates via Let's Encrypt; routes public traffic through HAProxy and optionally Cloudflare tunnels; enforces per-environment egress firewall policy; and exposes an optional AI assistant.
+
+The mental model that holds the codebase together is **stacks**. A stack is a versioned, declarative bundle of services, networks, volumes, and config files with plan/apply semantics. Almost every higher-level concept — *applications*, the built-in HAProxy/Vault/Postgres/monitoring/egress services, the Cloudflare tunnel — is a stack underneath. The stack reconciler is the single chokepoint that brings desired state into being. If you understand stacks, you understand the system.
+
+## Entry points
+
+When you open the repo cold, these are the files to read first.
+
+- **Server boot** — [server/src/server.ts](server/src/server.ts). The boot sequence is documented in [server/ARCHITECTURE.md](server/ARCHITECTURE.md#boot-sequence).
+- **Server HTTP** — [server/src/app-factory.ts](server/src/app-factory.ts). Middleware order, route registration table, dev-vs-prod static serving.
+- **Client boot** — [client/src/main.tsx](client/src/main.tsx) → [client/src/App.tsx](client/src/App.tsx) → [client/src/lib/routes.tsx](client/src/lib/routes.tsx). The router is statically defined; that file is the source of truth for what URLs exist.
+- **The cross-process contract** — [lib/types/socket-events.ts](lib/types/socket-events.ts) (channels and events) and [lib/types/permissions.ts](lib/types/permissions.ts) (RBAC scopes). When client and server need to agree on something, it lives here.
+- **Stack reconciliation** — [server/src/services/stacks/stack-reconciler.ts](server/src/services/stacks/stack-reconciler.ts). The chokepoint that brings every stack — built-in or user-defined — to its desired state.
+- **Dev workflow** — [deployment/development/worktree_start.sh](deployment/development/worktree_start.sh) (`.ps1` on Windows). Spins up a per-worktree Mini Infra instance.
+
+## Code map
+
+### `client/`
+
+Vite + React 19 frontend. File-based routing, TanStack Query for server state, Socket.IO for real-time pushes, Radix-based component library. See [client/ARCHITECTURE.md](client/ARCHITECTURE.md).
+
+**Invariant:** there is no other store. TanStack Query owns server state; React state owns UI state. No Redux, no Zustand.
+
+### `server/`
+
+Express 5 + Prisma backend. A single Node process that owns the Docker socket, talks to Postgres, Vault, Azure, Cloudflare, and the host's HAProxy data-plane API, and serves both the REST API and the Socket.IO event stream. Built TypeScript. See [server/ARCHITECTURE.md](server/ARCHITECTURE.md).
+
+**Invariant:** exactly one process owns the Docker socket — this one. Sidecars and stack containers don't dial Docker directly; they ask the server.
+
+### `lib/` — `@mini-infra/types` — **API Boundary**
+
+The shared TypeScript types package consumed by both client and server. This is the only place where the two halves of the application meet at a typed contract — touch carefully. The most load-bearing files are [lib/types/socket-events.ts](lib/types/socket-events.ts) (channel and event constants — the contract for everything real-time) and [lib/types/permissions.ts](lib/types/permissions.ts) (RBAC scopes). Must be built before client or server.
+
+**Invariant:** all real-time channel and event names live in `socket-events.ts`. There are no raw event-name strings anywhere else in the codebase.
+
+### `acme/` — `@mini-infra/acme`
+
+Standalone Let's Encrypt ACME client. Implements the DNS-01 challenge flow used by [server/src/services/tls/](server/src/services/tls/). Built before server.
+
+### `update-sidecar/`
+
+Standalone npm package built into a separate container image. Drives in-place self-update: pulls the new server image, validates it via a health-check pattern, swaps containers, and rolls back on failure. Launched by the server when an update is requested.
+
+**Invariant:** sidecars are launched by, and only by, the server. Operators don't run them directly — that's how their lifecycle and credentials stay coherent across self-updates.
+
+### `agent-sidecar/`
+
+Standalone npm package built into a separate container image. Optional AI assistant — a Claude Agent SDK runtime with tools for Docker, the Mini Infra API, and the user docs. Per-user conversations stream over SSE. Launched by the server when the agent is enabled.
+
+### `egress-gateway/`
+
+Go service. The egress data plane. Container traffic that should be governed flows through the gateway, which enforces per-environment allow/deny rules and emits a traffic feed.
+
+### `egress-fw-agent/`
+
+Go sidecar. Runs alongside the gateway and applies firewall rules at the host level. Communicates with the server over a local transport — see [server/src/services/egress/fw-agent-transport.ts](server/src/services/egress/fw-agent-transport.ts).
+
+### `egress-shared/`
+
+Shared Go module imported by both `egress-gateway/` and `egress-fw-agent/`. Wired into the workspace via [go.work](go.work). Not part of the pnpm workspace.
+
+### `pg-az-backup/`
+
+Container image (Alpine + shell) that performs a single PostgreSQL backup to Azure Blob Storage. Invoked by the server's backup scheduler as a one-shot container.
+
+### `deployment/`
+
+Operator-facing scripts and compose files. The main entry point for development is [deployment/development/worktree_start.sh](deployment/development/worktree_start.sh), which spins up a per-worktree isolated VM. Production deployment artifacts also live here.
+
+### `scripts/`
+
+Repo utilities. Notable: [scripts/generate-ui-manifest.mjs](scripts/generate-ui-manifest.mjs) (scans the client for `data-tour` attributes so the agent's `highlight_element` tool can point users at UI elements) and [scripts/top-files-by-lines.sh](scripts/top-files-by-lines.sh) (refactor target finder).
+
+### `docs/`
+
+User-facing operator documentation and design specs. Distinct from `client/src/user-docs/`, which is the in-app help shipped to end users.
+
+### `claude-guidance/`
+
+Notes and prompts for Claude Code; not consumed by the running application.
+
+## Runtime topology
+
+In production a Mini Infra installation looks like this:
+
+```
+                ┌─────────────────────────────┐
+   browser ───▶ │       HAProxy (stack)       │ ◀── public traffic via Cloudflare tunnel (optional)
+                └────────────────┬────────────┘
+                                 │
+              ┌──────────────────┴──────────────────┐
+              ▼                                     ▼
+     ┌──────────────────┐                  ┌─────────────────┐
+     │  Mini Infra      │ ──── /var/run/docker.sock ────────┐│
+     │  server (Express)│ ──── HAProxy data-plane socket ──┐││
+     │  + Socket.IO     │                                  │││
+     └──┬──────┬──────┬─┘                                  │││
+        │      │      │                                    │││
+        │      │      ▼                                    │││
+        │      │   Postgres (stack)  ◀── pg-az-backup ─▶ Azure Blob
+        │      │                                           │││
+        │      ▼                                           │││
+        │   Vault (stack)                                  │││
+        │                                                  │││
+        ▼                                                  │││
+   sidecars (launched by server, share docker.sock):       │││
+     ┌────────────────────┐                                │││
+     │ agent-sidecar      │ ◀── SSE proxy                  │││
+     │ update-sidecar     │ ◀── only during self-update    │││
+     │ egress-fw-agent    │ ◀── firewall rule transport    │││
+     └────────────────────┘                                │││
+                                                          ▼▼▼
+                                       managed Docker host containers
+                                       (egress-gateway, monitoring,
+                                        Cloudflare tunnel, user apps…)
+```
+
+Everything drawn as a "stack" — HAProxy, Postgres, Vault, monitoring (Prometheus + Grafana), the egress gateway, the Cloudflare tunnel — is reconciled through the same code path as user-deployed applications. The server is the only long-lived bespoke process; sidecars are short-lived or optional.
+
+### External boundaries
+
+| Boundary | What it is | Where it's wrapped |
+|---|---|---|
+| Docker socket | `/var/run/docker.sock` via dockerode | [server/src/services/docker.ts](server/src/services/docker.ts) (`DockerService` singleton) |
+| Postgres | App database (Prisma) | [server/src/lib/prisma.ts](server/src/lib/prisma.ts) |
+| Vault | HashiCorp Vault for secrets | [server/src/services/vault/](server/src/services/vault/) |
+| Cloudflare API | DNS zones, tunnels | [server/src/services/cloudflare/](server/src/services/cloudflare/) |
+| Azure Blob Storage | Backups + certificates | [server/src/services/azure-storage-service.ts](server/src/services/azure-storage-service.ts) |
+| Container registries | Image pulls (Hub, GHCR, etc.) | [server/src/services/registry-credential.ts](server/src/services/registry-credential.ts) + [server/src/services/docker-executor/](server/src/services/docker-executor/) |
+| HAProxy data-plane | Live config without reload | [server/src/services/haproxy/haproxy-dataplane-client.ts](server/src/services/haproxy/haproxy-dataplane-client.ts) |
+| ACME servers | Let's Encrypt (or staging) | [server/src/services/tls/acme-client-manager.ts](server/src/services/tls/acme-client-manager.ts) via `@mini-infra/acme` |
+| GitHub | Bug reports + GitHub App auth | [server/src/services/github-service.ts](server/src/services/github-service.ts) |
+| Agent sidecar | SSE proxy for chat | [server/src/services/agent-service.ts](server/src/services/agent-service.ts) |
+| Egress firewall agent | Per-env rule push | [server/src/services/egress/fw-agent-transport.ts](server/src/services/egress/fw-agent-transport.ts) |
+
+## Architectural invariants — digest
+
+The repo-wide invariants in one place, for quick reference. Each one is restated where it applies in the code map and in the per-project docs. Breaking one is a signal that the change needs more thought, not a workaround.
+
+- One Docker socket owner: the server. (See `server/`.)
+- All Docker access through `DockerService.getInstance()`; image pulls through `DockerExecutorService.pullImageWithAutoAuth()`.
+- Stacks are the only orchestration primitive. Built-in services and user apps share one code path.
+- All Socket.IO channel and event names are constants in [lib/types/socket-events.ts](lib/types/socket-events.ts). No raw strings.
+- All long-running operations emit `*_STARTED → *_STEP → *_COMPLETED`.
+- Configuration is database-backed and audited; mutations require `userId`. No runtime env-var settings.
+- Permissions are `resource:action` scopes, not roles. New code never branches on a role name.
+- Client never polls when the socket is connected. `refetchOnReconnect: true` covers gaps.
+- Sidecars are launched by the server, not operators.
+
+## Cross-cutting concerns
+
+These show up in nearly every feature. Skim them before making changes that touch more than one file.
+
+### Socket.IO is the real-time backbone
+
+Channels and event names are constants in [lib/types/socket-events.ts](lib/types/socket-events.ts). Use `Channel.*` and `ServerEvent.*` — never raw strings. The server emits via `emitToChannel()`; the client subscribes per-room via `useSocketChannel()` and listens via `useSocketEvent()`. Long-running operations follow a **started → step → completed** triplet; see the patterns sections of [server/ARCHITECTURE.md](server/ARCHITECTURE.md) and [client/ARCHITECTURE.md](client/ARCHITECTURE.md).
+
+### Task tracker for long-running ops
+
+Operations like certificate issuance, stack apply, container connect, and HAProxy migrations report progress through a single registry-driven UI. Server emits `*_STARTED`, `*_STEP`, `*_COMPLETED`. The client maps task types to that triplet in [client/src/lib/task-type-registry.ts](client/src/lib/task-type-registry.ts), and components register tasks with `trackTask()` so progress is visible from anywhere in the app.
+
+### Audit events
+
+`UserEventService` ([server/src/services/user-events/](server/src/services/user-events/)) is the persistent audit log. Every user-initiated mutation that's worth showing in the events page goes through it. It also emits `EVENT_CREATED` / `EVENT_UPDATED` so the events list updates live.
+
+### RBAC
+
+Permissions are scope strings of the form `resource:action` defined in [lib/types/permissions.ts](lib/types/permissions.ts). API keys and users are granted scopes (or one of the Reader/Editor/Admin presets). Server middleware in [server/src/lib/permission-middleware.ts](server/src/lib/permission-middleware.ts) gates routes; the client reads the user's scopes from auth context and gates UI accordingly.
+
+### Logging
+
+`getLogger(component, subcomponent)` from [server/src/lib/logger-factory.ts](server/src/lib/logger-factory.ts) is the only entry point. All output is NDJSON to a single rotating file. Long-running operations carry an `operationId`; HTTP requests carry a `requestId` injected by middleware. Components are a fixed set: `http`, `auth`, `db`, `docker`, `stacks`, `deploy`, `haproxy`, `tls`, `backup`, `integrations`, `agent`, `platform`. See [server/ARCHITECTURE.md](server/ARCHITECTURE.md) for the full conventions.
+
+### Configuration is database-backed and audited
+
+Settings for Docker, Cloudflare, Azure, Postgres, and TLS aren't environment variables — they're rows in the database, managed through services created by `ConfigurationServiceFactory`. Every mutation requires a `userId` for the audit trail. `validate()` records connectivity status and metadata so the UI can show "Last checked 2m ago — connected".
+
+## Build and dev topology
+
+### Workspaces
+
+`pnpm-workspace.yaml` declares four packages: `client`, `server`, `lib`, `acme`. The sidecars (`update-sidecar/`, `agent-sidecar/`) and Go services (`egress-gateway/`, `egress-fw-agent/`, `pg-az-backup/`) are **not** in the workspace — they're standalone packages with their own lockfiles. Don't `cd` into client/server/lib at the workspace root; use `pnpm --filter <name>`.
+
+### Build order
+
+`lib` (types) and `acme` compile independently, then `client` and `server` build in parallel against them. The server's production Docker image is multi-stage: types → acme → client (bundled into `server/public/`) → server → runtime image. The two npm sidecars and the Go services are built as separate images.
+
+### Development
+
+Each git worktree gets its own isolated Mini Infra instance running on its own VM (Colima on macOS, WSL2 on Windows), with its own ports allocated from `~/.mini-infra/worktrees.yaml`. Spin up via [deployment/development/worktree_start.sh](deployment/development/worktree_start.sh). The worktree's URL, vault URL, and seeded credentials are written to `environment-details.xml` at the worktree root — read from there instead of hard-coding ports. See the root [CLAUDE.md](CLAUDE.md) for the worktree workflow.
+
+In dev, Vite serves the client and proxies `/api`, `/auth`, and `/socket.io` to the backend. In production, Express serves the pre-built client bundle out of `server/public/`.
+
+## Vocabulary
+
+Mini Infra has a precise vocabulary. Get the words right and the code reads itself; mix them up and confusion compounds.
+
+- **Container** — a Docker container on the managed host. Status: Running, Stopped, Paused, Exited, Restarting.
+- **Application** — a logical UX layer over a stack. The application screens collect user inputs (image, ports, env, volumes, routing) and produce a stack definition. There is no "application" object underneath — it's always a stack.
+- **Stack** — the unit of orchestration. A collection of containers, networks, volumes, and config files managed together with plan/apply semantics. Can be host-level or environment-scoped. Status: Synced, Drifted, Pending, Undeployed, Error, Removed.
+- **Stack Definition** — a versioned snapshot of a stack's desired state. The reconciler diffs the latest definition against the running state to detect drift and produce a plan.
+- **Stack Template** — a reusable blueprint with draft-and-publish versioning. Scoped to Host or Environment. Source: System (built-in) or User (custom).
+- **Service** — an individual container definition inside a stack. Type: Stateful (stop/start replacement) or StatelessWeb (zero-downtime blue-green via HAProxy).
+- **Deployment (Blue-Green)** — the release strategy for StatelessWeb services. Phases: deploy green → health check → switch traffic → drain blue → remove blue. Auto-rollback on failure.
+- **Environment** — a named grouping (e.g. `production`, `staging`) with a type (production/nonproduction) and a network type: Local (Docker host only) or Internet (publicly routable via Cloudflare tunnel). Local environments still get real Let's Encrypt certificates and public DNS — don't gate TLS by network type.
+- **HAProxy** — the load balancer, configured live via the Data Plane API (no reload). Key objects: Instance (running process), Frontend (listener — Manual or Shared with routes), Backend (server group with balance algorithm), Server (container endpoint).
+- **PostgreSQL Backup** — scheduled or manual encrypted dumps stored in Azure Blob. Configurable cron, retention, format (custom/sql), and compression.
+- **TLS Certificate** — automated SSL/TLS via ACME (Let's Encrypt). DNS-01 challenge through Cloudflare. Stored in Azure Blob. Auto-renewed 30 days before expiry.
+- **Cloudflare Tunnel** — Argo Tunnel that gives an Internet-network environment public reachability without opening firewall ports.
+- **Connected Service** — an external integration (Docker, Azure, Cloudflare, GitHub) with tracked connectivity status and response time.
+- **DNS Zone** — a Cloudflare-managed domain. Records auto-created for ACME challenges and tunnel config.
+- **Volume** — a Docker volume. Inspectable: an Alpine sidecar can scan the filesystem and serve content up to 1 MB.
+- **API Key** — programmatic access token with permission scopes. Presets: Reader, Editor, Admin. Supports rotation and last-used tracking.
+- **Event** — an entry in the audit log. Tracks type, status progression, trigger source, progress, user, and duration. Streams via Socket.IO.
+- **Self-Update** — in-place upgrade via the update sidecar's health-check pattern. Pulls new image, validates, swaps containers. Auto-rollback on failure. Data on mounted volumes is preserved.
+- **Agent Sidecar** — the optional AI assistant. Per-user conversations, SSE streaming, has tools for Docker, the Mini Infra API, and the user docs.
+
+## Where to next
+
+- [server/ARCHITECTURE.md](server/ARCHITECTURE.md) — server subsystems, service patterns, boot sequence, "adding a feature" walkthrough.
+- [client/ARCHITECTURE.md](client/ARCHITECTURE.md) — client layout, data fetching, socket integration, task tracker, "adding a page" walkthrough.
+- [CLAUDE.md](CLAUDE.md) — project-wide instructions for Claude (and a useful reference for humans).
+- [server/CLAUDE.md](server/CLAUDE.md) — the canonical service-pattern cheat-sheet. The server architecture doc summarises this; the cheat-sheet has all the do/don't tables.
+- [client/CLAUDE.md](client/CLAUDE.md) — the task-tracker and data-fetching pattern reference.
+- [docs/](docs/) — operator and design docs.

--- a/client/ARCHITECTURE.md
+++ b/client/ARCHITECTURE.md
@@ -1,0 +1,319 @@
+# Client architecture
+
+The client is a Vite + React 19 single-page app served from the same origin as the API. This document is the orientation guide for frontend contributors. It covers the layout, the routing model, the data and real-time layers, and the patterns that hold the app together.
+
+For repo-wide context, start at the root [ARCHITECTURE.md](../ARCHITECTURE.md). For Claude-facing pattern reference, see [CLAUDE.md](CLAUDE.md) — this doc summarises and links into it.
+
+## Entry points
+
+When you read the client cold, these are the files to open in order.
+
+- [src/main.tsx](src/main.tsx) — mounts `<App/>` into `#root`. Almost trivial; the only side-effect is a `MutationObserver` that strips password-manager-injected DOM nodes (which would otherwise re-inject after every render).
+- [src/App.tsx](src/App.tsx) — the provider stack: `AuthProvider` → `RouterProvider` → `Toaster`. Read this once to understand what's globally available.
+- [src/lib/routes.tsx](src/lib/routes.tsx) — `createBrowserRouter()`. The static, hand-edited list of every URL the app knows about. If a route isn't here, it doesn't exist.
+- [src/hooks/use-socket.ts](src/hooks/use-socket.ts) — the socket primitives every resource hook builds on.
+- [src/hooks/useContainers.ts](src/hooks/useContainers.ts) — the canonical resource-hook pattern. Copy this shape when adding a new resource.
+
+## Layout
+
+```
+client/
+├── public/                       static assets served as-is
+├── src/
+│   ├── main.tsx                  entry — mounts <App/> into #root
+│   ├── App.tsx                   AuthProvider → RouterProvider → Toaster
+│   ├── index.css                 global styles, Tailwind layer config
+│   ├── api/                      raw fetch helpers (when not behind a hook)
+│   ├── app/                      page components, one folder per route
+│   ├── components/               feature-scoped UI + shared primitives
+│   ├── hooks/                    data and behaviour hooks (TanStack Query, sockets)
+│   ├── lib/                      router, contexts, utilities, registries
+│   ├── user-docs/                in-app help, served as MDX/MD
+│   ├── user-docs-structure/      meta files describing docs hierarchy
+│   ├── assets/                   images, icons, static files
+│   └── __tests__/                tests
+├── vite.config.ts                dev server, proxy, build output
+└── package.json
+```
+
+Entry chain: [src/main.tsx](src/main.tsx) → [src/App.tsx](src/App.tsx) (`AuthProvider` + `RouterProvider` + `Toaster`) → [src/lib/routes.tsx](src/lib/routes.tsx) (`createBrowserRouter`).
+
+### `src/app/` — page components
+
+One folder per route. Bracketed segments map to URL params (`app/containers/[id]/page.tsx` → `/containers/:id`). Pages are thin: they assemble components from `src/components/<feature>/` and pull data from hooks in `src/hooks/`.
+
+**Invariant:** logic does not live in page files. If a `page.tsx` grows past assembly, factor it into the corresponding `components/<feature>/` folder. (We've been burned by re-using "page" code when the same UI gets dropped into a dialog elsewhere.)
+
+### `src/components/` — feature-scoped UI
+
+Each feature has its own folder (e.g. `containers/`, `stacks/`, `haproxy/`, `egress/`, `certificates/`, `agent/`, `task-tracker/`). The shared design-system primitives — buttons, dialogs, inputs, sheets — live in [src/components/ui/](src/components/ui/) and wrap [Radix UI](https://www.radix-ui.com/) primitives.
+
+**Invariant:** the design system is one folder. New primitives are added to `components/ui/` (wrapping Radix). We don't import a second component library.
+
+### `src/hooks/` — data + behaviour
+
+This is where API access happens. Every server resource has a hook (`useContainers`, `useStacks`, `useApplications`, `useEgress`, etc.) that wraps fetch + TanStack Query + Socket.IO subscriptions. The reference pattern lives in [src/hooks/useContainers.ts](src/hooks/useContainers.ts) — copy from it when adding a new resource.
+
+**Invariant:** server state lives in TanStack Query, not React state and not a third-party store. Components read via hooks; mutations go through `useMutation`. There is no other store on the client.
+
+### `src/lib/` — wiring
+
+| File | What it owns |
+|---|---|
+| [routes.tsx](src/lib/routes.tsx) | `createBrowserRouter()` configuration |
+| [route-config.ts](src/lib/route-config.ts) | route metadata (title, icon, breadcrumb parent, nav group, help doc) |
+| [auth-context.tsx](src/lib/auth-context.tsx) | `AuthProvider`, `useAuth()` |
+| [task-tracker-context.ts](src/lib/task-tracker-context.ts), [task-type-registry.ts](src/lib/task-type-registry.ts), [task-tracker-types.ts](src/lib/task-tracker-types.ts) | global task tracker |
+| [agent-chat-context.ts](src/lib/agent-chat-context.ts) | agent sidecar chat |
+| [doc-loader.ts](src/lib/doc-loader.ts), [doc-search.ts](src/lib/doc-search.ts) | in-app help docs |
+| [date-utils.ts](src/lib/date-utils.ts), [ansi-to-html.ts](src/lib/ansi-to-html.ts), [parse-dotenv.ts](src/lib/parse-dotenv.ts), [utils.ts](src/lib/utils.ts) | leaf utilities |
+
+### `src/user-docs/` — in-app help
+
+Markdown/MDX organised by feature (`containers/`, `applications/`, `connectivity/`, etc.). Loaded at runtime by [doc-loader.ts](src/lib/doc-loader.ts). The help system is hosted at `/help/:category/:slug`. Pages opt in to contextual help by setting `helpDoc` in [route-config.ts](src/lib/route-config.ts).
+
+UI elements that the agent's `highlight_element` tool should be able to point at carry `data-tour="<id>"` attributes. [scripts/generate-ui-manifest.mjs](../scripts/generate-ui-manifest.mjs) scans the codebase and writes `src/user-docs/ui-elements/manifest.json`. Run `pnpm generate:ui-manifest` after adding or renaming `data-tour` IDs.
+
+## Routing
+
+Routes are statically defined in [src/lib/routes.tsx](src/lib/routes.tsx) using `createBrowserRouter()` from `react-router-dom`. Adding a route means editing this file.
+
+**Invariant:** routes are static. There is no dynamic route generation — and every authenticated route has a matching entry in [src/lib/route-config.ts](src/lib/route-config.ts) so navigation, breadcrumbs, page titles, and contextual help all work. (We tried meta-driven routing once; nav and breadcrumbs drifted out of sync within a sprint.)
+
+The structure has three concentric layers:
+
+1. **`AuthErrorBoundary`** — catches auth errors anywhere in the tree and forces a redirect to login.
+2. **`PublicRoute` / `ProtectedRoute`** — `PublicRoute` is for `/login`, `/setup`, `/recover`; `ProtectedRoute` ensures a valid session before rendering.
+3. **`AppLayout`** — the nav + main shell that wraps every authenticated page. Rendered as the layout child of the `/` route, so all in-app pages inherit it.
+
+A few special cases to know:
+
+- `/logs/fullscreen` is a top-level protected route that bypasses `AppLayout` so the logs viewer can take the whole window.
+- The help pages (`/help`, `/help/:category/:slug`) are **lazy-loaded** via `lazy: async () => ...` to keep the help bundle out of the main route chunk.
+- Dev-only routes (`/design/icons`) are gated behind `import.meta.env.VITE_SHOW_DEV_MENU === 'true'`.
+
+Every route should also have an entry in [src/lib/route-config.ts](src/lib/route-config.ts) so navigation, breadcrumbs, page titles, and contextual help work. The metadata fields are documented inline.
+
+## Client invariants — digest
+
+Most of these are also stated inline at the spot they apply. This is the consolidated list.
+
+- **State:** TanStack Query owns server state; React state owns UI state. Auth and the task tracker are the only other contexts. No Redux, no Zustand.
+- **Polling:** `refetchInterval: false` when connected; fast poll only when disconnected. Always `refetchOnReconnect: true`.
+- **Socket:** singleton from `useSocket()`. `io()` is never constructed in feature code.
+- **Channels:** ref-counted via `useSocketChannel()`. Manual `socket.emit("subscribe")` is not used.
+- **Real-time names:** `Channel.*` / `ServerEvent.*` from `@mini-infra/types`. No raw strings.
+- **Routing:** static in `lib/routes.tsx`. Every authed route has a `route-config.ts` entry.
+- **Pages:** thin. Logic lives in `components/<feature>/` and `hooks/`.
+- **UI library:** one — `components/ui/` wrapping Radix.
+- **Permissions:** scopes from auth context, not role names. UI gate is for UX only; server enforces.
+- **Long-running ops:** through the task tracker (`trackTask()` / `useOperationProgress`). No one-off socket listeners for progress.
+
+## Data layer (TanStack Query + sockets)
+
+The combination of TanStack Query and Socket.IO is the data layer. There is no Redux, no Zustand, no other store. Server state lives in TanStack Query's cache; UI state lives in React state and a small number of contexts (auth, task tracker, agent chat).
+
+### Anatomy of a resource hook
+
+The reference is [src/hooks/useContainers.ts](src/hooks/useContainers.ts). Every resource hook should follow the same shape:
+
+```ts
+export function useContainers(options: UseContainersOptions = {}) {
+  const { connected } = useSocket();
+
+  // 1. Polling falls back to a fast interval only when the socket is disconnected.
+  const refetchInterval = connected ? false : POLL_INTERVAL_DISCONNECTED;
+
+  // 2. Subscribe to the room while this hook is mounted.
+  useSocketChannel(Channel.CONTAINERS, enabled);
+
+  // 3. Listen to events and either invalidate or surgically patch the cache.
+  useSocketEvent(ServerEvent.CONTAINERS_LIST, () => {
+    queryClient.invalidateQueries({ queryKey: ["containers"] });
+  }, enabled);
+  useSocketEvent(ServerEvent.CONTAINER_STATUS, (data) => {
+    queryClient.setQueriesData<ContainerListResponse>(/* surgical patch */);
+  }, enabled);
+
+  // 4. The query itself.
+  return useQuery({
+    queryKey: ["containers", queryParams],
+    queryFn: () => fetchContainers(queryParams, correlationId),
+    refetchInterval,
+    refetchOnReconnect: true,    // recover events missed during disconnect
+    refetchOnWindowFocus: true,
+    staleTime: 2000,
+    gcTime: 5 * 60 * 1000,
+    retry: /* don't retry 401s or "Docker unavailable"; backoff on others */,
+  });
+}
+```
+
+The four invariants that every hook must respect:
+
+1. **No polling when the socket is connected.** Set `refetchInterval: false` when `connected` is true.
+2. **Always set `refetchOnReconnect: true`.** It backfills any events missed while the socket was down.
+3. **Use `Channel.*` and `ServerEvent.*` constants** from `@mini-infra/types`. Never raw strings.
+4. **Use `useSocketChannel()`** rather than emitting `subscribe` manually. The hook ref-counts subscribers, so two components on the same channel don't unsubscribe each other on unmount.
+
+### The socket primitives
+
+[src/hooks/use-socket.ts](src/hooks/use-socket.ts) exports four hooks:
+
+| Hook | Purpose |
+|---|---|
+| `useSocket()` | Access the singleton socket and the `connected` flag (via `useSyncExternalStore`). |
+| `useSocketEvent(event, handler, enabled?)` | Listen to a typed `ServerToClientEvents` event for the lifetime of the component. Handler is held by ref so updates don't re-subscribe. |
+| `useSocketChannel(channel, enabled?)` | Join a Socket.IO room on mount, leave on unmount. Ref-counted so multiple subscribers coexist; only emits `SUBSCRIBE`/`UNSUBSCRIBE` at the boundaries. |
+| `useSocketQueryBridge(event, queryKey, transform, enabled?)` | One-liner for "when this event fires, set this query data." |
+
+The socket is a singleton. Don't construct your own `io()` instance. The connection auto-starts on first mount.
+
+### Cache patching strategy
+
+There are two modes:
+
+- **Invalidate** (`queryClient.invalidateQueries`) when the server pushes "the list changed" — TanStack Query refetches with the current filters/sorts. Use this for list-level updates.
+- **Surgical patch** (`queryClient.setQueriesData`) when you have the exact delta — single-row status changes, removals. Use this for high-frequency events to avoid refetch storms.
+
+`useContainers` does both: `CONTAINERS_LIST` invalidates; `CONTAINER_STATUS` and `CONTAINER_REMOVED` patch in place.
+
+## Long-running operations: the task tracker
+
+Operations like certificate issuance, stack apply, container connect, and HAProxy migrations report progress through a single registry-driven UI. The architecture:
+
+```
+TaskTrackerProvider (root context, persisted to sessionStorage)
+  └─ TaskEventListener subscribes to Socket.IO
+       └─ matches events using Task Type Registry
+            └─ updates TrackedTask state (phase, steps, errors)
+                 ├─ TaskTrackerPopover  (top-nav badge + list)
+                 └─ TaskDetailDialog    (step-by-step detail view)
+```
+
+### Task Type Registry — [src/lib/task-type-registry.ts](src/lib/task-type-registry.ts)
+
+A static map: `TaskType` → Socket.IO bindings + payload normalisers. Every tracked operation needs an entry. Each entry has:
+
+- `channel` — the Socket.IO channel to subscribe to (a `Channel.*` constant).
+- `startedEvent`, `stepEvent`, `completedEvent` — the three events. `stepEvent` is `null` for operations that emit no intermediate steps.
+- `failedEvent` (optional) — when success and failure are split across two events (e.g. pool spawn). When omitted, the completed handler must produce both outcomes from one payload (the stack-apply pattern).
+- `getId(payload)` — extracts the task ID from the started event.
+- `normalizeStarted(payload)` → `{ totalSteps, plannedStepNames }`.
+- `normalizeStep(payload)` → `OperationStep`.
+- `normalizeCompleted(payload)` → `{ success, steps, errors }`.
+- `invalidateKeys(taskId)` (optional) — TanStack Query keys to invalidate when the task completes.
+
+Entries are built with `defineTaskTypeConfig()`, which infers the event-key generics so TypeScript validates each normaliser against the actual payload shape. The runtime registry erases those generics so `TaskEventListener` can iterate polymorphically.
+
+### Adding a tracked operation
+
+1. **Server side:** add channel + `*_STARTED` / `*_STEP` / `*_COMPLETED` constants to [lib/types/socket-events.ts](../lib/types/socket-events.ts) and emit them. See [server/ARCHITECTURE.md](../server/ARCHITECTURE.md#long-running-operations).
+2. **Registry entry:** add an entry to [task-type-registry.ts](src/lib/task-type-registry.ts).
+3. **Trigger:** in the component that starts the operation, call `trackTask({ id, type, label })` from `useTaskTracker()`. The tracker handles channel subscription, event matching, persistence, and UI rendering automatically.
+
+### Local progress UI: `useOperationProgress`
+
+When a dialog needs its own live step list (e.g. the certificate issuance dialog showing each ACME step), use [src/hooks/use-operation-progress.ts](src/hooks/use-operation-progress.ts) instead of writing one-off socket listeners:
+
+```ts
+const progress = useOperationProgress({
+  channel: Channel.TLS,
+  startedEvent: ServerEvent.CERT_ISSUANCE_STARTED,
+  stepEvent: ServerEvent.CERT_ISSUANCE_STEP,
+  completedEvent: ServerEvent.CERT_ISSUANCE_COMPLETED,
+  operationId,
+  getOperationId: (p) => p.operationId,
+  getTotalSteps: (p) => p.totalSteps,
+  getStep: (p) => p.step,
+  getResult: (p) => ({ success: p.success, steps: p.steps, errors: p.errors }),
+  tracker: { type: "cert-issuance", label: "Issuing certificate" }, // optional global tracking
+  invalidateKeys: [["certificates"]],
+  toasts: { success: "Certificate issued", error: "Issuance failed" },
+  timeoutMs: 300_000,
+});
+```
+
+It returns `{ phase, steps, totalSteps, errors, completedCount }` and handles subscription, cleanup, timeout, query invalidation, and toasts.
+
+### Task tracker behaviours
+
+- Active tasks are persisted to `sessionStorage` and survive page reloads.
+- Completed tasks auto-dismiss after 5 minutes.
+- Tasks restored from `sessionStorage` time out after 30 seconds if no events arrive (the operation likely finished while the tab was closed).
+- `useOperationProgress` defaults to a 5-minute operation timeout.
+
+## Cross-cutting concerns
+
+### Cancellation
+
+There are two flavours of cancellation, and only one of them is supported.
+
+**In-flight queries** are cancellable via `queryClient.cancelQueries(...)`. We use this implicitly when a query refetches with new params — TanStack Query aborts the stale request. We don't expose user-driven query cancellation; it's not a UX we've needed.
+
+**Long-running server operations** (stack apply, certificate issuance, etc.) **cannot be cancelled** from the UI. The reasoning is the same as the server's: each step has external state that a partial cancel would corrupt. The right pattern is to let the operation finish and then trigger a corrective action. `useOperationProgress` does enforce a timeout (default 5 minutes); on timeout the local UI gives up and shows an error, but the server-side work continues.
+
+### Testing
+
+Tests live in [src/__tests__/](src/__tests__/) and (sometimes) alongside the code. The toolchain is vitest. Component tests use [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/).
+
+The most useful tests are around resource hooks — they exercise the TanStack Query + Socket.IO interaction that's hard to verify by inspection. Form schemas (Zod) are also valuable test targets because they double as runtime validation.
+
+### Error handling
+
+Three principles, in order:
+
+1. **Network failures surface to the user.** TanStack Query's `error` state propagates to the component, which renders an error UI. We use sonner toasts ([@/components/ui/sonner](src/components/ui/sonner.tsx)) for transient errors and inline error states for in-page failures.
+2. **Auth errors redirect.** [src/components/auth-error-boundary.tsx](src/components/auth-error-boundary.tsx) wraps every route and catches auth-shaped errors anywhere in the tree, forcing a clean redirect to `/login`. Don't catch 401s manually — let them bubble.
+3. **Operation failures appear in the task tracker.** Long-running ops emit `*_COMPLETED` with `success: false` and `errors[]`. The tracker surfaces them in the popover and the detail dialog. Local progress dialogs (via `useOperationProgress`) get the same data and can render their own error UI.
+
+### Observability
+
+The client doesn't have a metrics or telemetry layer beyond the browser's devtools. The mental model:
+
+- **Network panel** for HTTP traffic. Every request sets an `X-Correlation-ID` header so server logs can be tied back to a specific UI action.
+- **Console** for client-side errors. We don't ship a Sentry-like crash reporter today.
+- **Server logs** are the source of truth for any cross-cutting issue. The `requestId` and `operationId` machinery on the server side does the heavy lifting; the client's job is to make sure each request carries enough context.
+
+For agent-related debugging, the agent sidecar's container logs are accessible from the Logs page in the app.
+
+## Forms
+
+Forms use [React Hook Form](https://react-hook-form.com/) + [Zod](https://zod.dev/) for schema validation. The Zod schemas often live next to the form (`src/lib/application-schemas.ts` is a representative example). When a server route validates the same shape, prefer sharing the schema via [@mini-infra/types](../lib/types/) so client and server can't drift.
+
+## Auth and permissions
+
+`AuthProvider` ([src/lib/auth-context.tsx](src/lib/auth-context.tsx)) wraps the router and exposes `useAuth()`. The auth context holds the current user, their permission scopes, and helpers for login/logout/refresh.
+
+Permissions are scope strings of the form `resource:action`, defined in [@mini-infra/types/permissions](../lib/types/permissions.ts). Gate UI by checking scopes from auth context — never assume role names. The same scopes are enforced server-side, so the UI gate is for UX (hide/disable rather than silently fail).
+
+## Vite and dev topology
+
+[vite.config.ts](vite.config.ts) configures the build:
+
+- **Dev server:** `0.0.0.0:3005`. Proxies `/api`, `/auth`, and `/socket.io` to `http://localhost:5005`. WebSocket proxying is enabled for `/socket.io` (and `/api` so SSE through `/api/.../logs/stream` works).
+- **Aliases:** `@` → `./src`, `@mini-infra/types` → `../lib/types`. The types package is `optimizeDeps.exclude`d so Vite reads it directly from source instead of pre-bundling.
+- **YAML import plugin:** lets `.yaml`/`.yml` files be imported as default JSON exports.
+- **Build output:** `../server/public/`. The Express server statics-serves this directory in production, so `pnpm build` produces a deployable bundle without further wiring.
+
+Worktree dev: each git worktree has its own VM, its own port allocation, and its own `environment-details.xml` at the worktree root. Read the UI URL from there rather than hard-coding `localhost:3005`. See the root [CLAUDE.md](../CLAUDE.md) for the worktree workflow.
+
+## Adding a page
+
+A typical end-to-end change:
+
+1. **Route definition:** add to `createBrowserRouter()` in [src/lib/routes.tsx](src/lib/routes.tsx). Match the path style of nearby routes; nested params follow `[id]` folders under [src/app/](src/app/).
+2. **Route metadata:** add an entry to [src/lib/route-config.ts](src/lib/route-config.ts) with `title`, `icon`, `parent` (for breadcrumbs), `showInNav` + `navGroup`/`navSection`, and `helpDoc` if relevant.
+3. **Page component:** `src/app/<path>/page.tsx`. Keep it thin — assemble components and hooks.
+4. **Feature components:** in [src/components/<feature>/](src/components/). Co-locate dialogs, tables, forms.
+5. **Data hooks:** in [src/hooks/](src/hooks/). Follow the [useContainers.ts](src/hooks/useContainers.ts) pattern: TanStack Query + `useSocketChannel` + `useSocketEvent`, no polling when connected, `refetchOnReconnect: true`.
+6. **User docs:** add a Markdown file under [src/user-docs/](src/user-docs/) and reference it via `helpDoc` in `route-config.ts`.
+7. **`data-tour` IDs:** add them to interactive elements that the agent should be able to point at, then run `pnpm generate:ui-manifest`.
+8. **Lint:** `pnpm --filter mini-infra-client lint` before opening a PR.
+
+## Where to next
+
+- [CLAUDE.md](CLAUDE.md) — task tracker and data-fetching pattern reference.
+- [../ARCHITECTURE.md](../ARCHITECTURE.md) — repo-wide context.
+- [../server/ARCHITECTURE.md](../server/ARCHITECTURE.md) — the API and Socket.IO contracts the client consumes.
+- [../lib/types/](../lib/types/) — shared types, event constants, permission scopes.

--- a/server/ARCHITECTURE.md
+++ b/server/ARCHITECTURE.md
@@ -1,0 +1,333 @@
+# Server architecture
+
+The server is a single Node process that owns the Docker socket, talks to the database, drives the HAProxy data plane, and brokers everything else. This document is the orientation guide for backend contributors. It covers the layout, the major subsystems, the cross-cutting patterns you must follow, and the boot sequence.
+
+For repo-wide context, start at the root [ARCHITECTURE.md](../ARCHITECTURE.md). For Claude-facing service rules and exhaustive do/don't tables, see [CLAUDE.md](CLAUDE.md) — this doc summarises and links into it.
+
+## Entry points
+
+When you read the server cold, these are the files to open in order.
+
+- [src/server.ts](src/server.ts) — the process entry. Boots logging, security secrets, Docker, schedulers, sidecars, then attaches Socket.IO and binds the HTTP listener. The full sequence is documented in [Boot sequence](#boot-sequence) below.
+- [src/app-factory.ts](src/app-factory.ts) — builds the Express app. The `getRouteDefinitions()` table is the canonical list of every route family and where it mounts. Middleware order, dev-vs-prod static serving, and the route-metadata drift check all live here.
+- [src/app.ts](src/app.ts) — re-exports the configured app. Test code can call `createApp({ includeRouteIds, routeOverrides })` to spin up a slice of the app in isolation.
+- [src/services/stacks/stack-reconciler.ts](src/services/stacks/stack-reconciler.ts) — the heart of the system. Read this once you understand the boot path; everything orchestration-related routes through here.
+- [prisma/schema.prisma](prisma/schema.prisma) — the data model. Skim it to learn the nouns.
+
+## Layout
+
+```
+server/
+├── prisma/                       schema + migrations (sqlite in dev, postgres in prod)
+├── src/
+│   ├── server.ts                 process entry — boot sequence
+│   ├── app.ts                    re-exports the configured Express app
+│   ├── app-factory.ts            wires middleware, mounts routes, returns the app
+│   ├── routes/                   HTTP handlers, one file per resource family
+│   ├── middleware/               auth, request context, validation, gates
+│   ├── services/                 the business logic — see "Subsystem map" below
+│   ├── lib/                      cross-cutting utilities (logger, prisma, http, jwt)
+│   ├── types/                    server-only type augmentations (e.g. express.d.ts)
+│   ├── scripts/                  one-off DB tools
+│   ├── test-support/             shared fixtures for vitest
+│   └── __tests__/                top-level integration tests
+└── public/                       built client bundle (production only, served by Express)
+```
+
+Entry chain: [src/server.ts](src/server.ts) → [src/app.ts](src/app.ts) → [src/app-factory.ts](src/app-factory.ts) → `src/routes/*`.
+
+Tests live next to the code they test (`src/services/.../__tests__/`) plus a top-level [src/__tests__/](src/__tests__/) for integration.
+
+Compose templates for the built-in stacks (HAProxy, Postgres, Vault, monitoring, egress, Cloudflare tunnel) are loaded from disk by the stack reconciler — see [src/services/stacks/template-file-loader.ts](src/services/stacks/template-file-loader.ts).
+
+## Subsystem map
+
+Each row is one paragraph of "what this is and where to start reading."
+
+### Docker management — [services/docker.ts](src/services/docker.ts), [services/docker-executor/](src/services/docker-executor/)
+
+`DockerService.getInstance()` is the singleton that wraps dockerode. It holds the connection, streams Docker events, invalidates an in-memory container cache (3s TTL), redacts sensitive labels, and exposes typed callbacks (`onContainerChange`, `onContainerEvent`) used by the socket emitter. `DockerExecutorService` is the layer on top: container lifecycle (`ContainerExecutor`, `LongRunningContainer`), network/volume creation (`InfrastructureManager`), multi-container projects (`ProjectManager`), and authenticated image pulls (`pullImageWithAutoAuth`).
+
+**Invariant:** every Docker API call goes through `DockerService.getInstance()`. `new Dockerode()` does not appear in feature code. Direct dockerode calls bypass the cache, the event stream, the timeout protection, and the sensitive-label redaction.
+
+**Invariant:** image pulls always go through `DockerExecutorService.pullImageWithAutoAuth()`. `docker.pull()` is never called directly. The wrapper handles registry detection, credential lookup, and token refresh — without it, private-registry pulls fail unpredictably.
+
+### Stack orchestration — [services/stacks/](src/services/stacks/)
+
+The heart of the system. [stack-reconciler.ts](src/services/stacks/stack-reconciler.ts) drives plan/apply: it computes a diff between the latest stack definition and the running state, runs the plan through a state machine ([state-machine-runner.ts](src/services/stacks/state-machine-runner.ts) + the per-phase machines in `services/haproxy/`), and updates the applied snapshot on success. [template-engine.ts](src/services/stacks/template-engine.ts) handles parameter substitution; [stack-template-service.ts](src/services/stacks/stack-template-service.ts) owns templates with draft-and-publish versioning; [stack-vault-reconciler.ts](src/services/stacks/stack-vault-reconciler.ts) wires Vault-backed inputs into stack containers; [builtin-stack-sync.ts](src/services/stacks/builtin-stack-sync.ts) is what installs the built-in stacks at boot.
+
+**Invariant:** there is one orchestration code path. Built-in services (HAProxy, Postgres, Vault, monitoring, egress, Cloudflare tunnel) and user-deployed applications all reconcile through this reconciler. Avoid the temptation to add a parallel "system services" layer.
+
+### HAProxy — [services/haproxy/](src/services/haproxy/)
+
+[haproxy-service.ts](src/services/haproxy/haproxy-service.ts) is the lifecycle owner. Live config goes through the HAProxy Data Plane API (HTTP) — [haproxy-dataplane-client.ts](src/services/haproxy/haproxy-dataplane-client.ts) re-exports the modular client in [dataplane/](src/services/haproxy/dataplane/), which is split into a base + per-resource mixins (ACL, backend, frontend, HTTP rules, server, SSL, stats, switching rules). No reload, no downtime. The blue-green and initial/removal deployment state machines (`*-state-machine.ts` in this folder) orchestrate green-deploy → health-check → traffic-switch → drain → remove. Frontend management (Manual vs Shared) splits across [haproxy-frontend-manager.ts](src/services/haproxy/haproxy-frontend-manager.ts) and the per-mode managers in `frontend-manager/`.
+
+### TLS / ACME — [services/tls/](src/services/tls/)
+
+[certificate-lifecycle-manager.ts](src/services/tls/certificate-lifecycle-manager.ts) coordinates issuance and renewal. Underneath: [acme-client-manager.ts](src/services/tls/acme-client-manager.ts) (wraps `@mini-infra/acme`), [dns-challenge-provider.ts](src/services/tls/dns-challenge-provider.ts) (DNS-01 via Cloudflare), [azure-storage-certificate-store.ts](src/services/tls/azure-storage-certificate-store.ts) (cert persistence), [certificate-distributor.ts](src/services/tls/certificate-distributor.ts) (push to HAProxy via the data-plane). [certificate-renewal-scheduler.ts](src/services/tls/certificate-renewal-scheduler.ts) runs on a timer and renews 30 days before expiry.
+
+### Backups — [services/backup/](src/services/backup/), [services/restore-executor/](src/services/restore-executor/)
+
+[backup-scheduler.ts](src/services/backup/backup-scheduler.ts) drives cron; [backup-executor.ts](src/services/backup/backup-executor.ts) launches the `pg-az-backup` container as a one-shot. Self-backups (the Mini Infra DB itself) have parallel scheduler/executor. Restores stream through [services/restore-executor/](src/services/restore-executor/). Long-running progress goes through [services/progress-tracker.ts](src/services/progress-tracker.ts), which is the *only* subsystem still on the database-backed `BackupOperation` / `RestoreOperation` model — everything else uses the unified Socket.IO pattern.
+
+**Invariant:** `ProgressTrackerService` is a historical exception, not a template. New tracked operations use the Socket.IO `*_STARTED` / `*_STEP` / `*_COMPLETED` triplet — see [Long-running operations](#long-running-operations) below.
+
+### Vault — [services/vault/](src/services/vault/)
+
+[vault-services.ts](src/services/vault/vault-services.ts) is the entry point used at boot. [vault-seed.ts](src/services/vault/vault-seed.ts) creates baseline policies. AppRole, KV, policy, admin, and credential injection are split across the `vault-*-service.ts` files. [vault-health-watcher.ts](src/services/vault/vault-health-watcher.ts) handles the unseal loop.
+
+### Egress — [services/egress/](src/services/egress/)
+
+Per-environment egress firewall. [egress-policy-lifecycle.ts](src/services/egress/egress-policy-lifecycle.ts) manages rule sets; [egress-gateway-client.ts](src/services/egress/egress-gateway-client.ts) talks to the gateway container; [fw-agent-transport.ts](src/services/egress/fw-agent-transport.ts) is the host-side firewall agent transport; [egress-rule-pusher.ts](src/services/egress/egress-rule-pusher.ts) and [egress-container-map-pusher.ts](src/services/egress/egress-container-map-pusher.ts) keep state synchronised; [egress-log-ingester.ts](src/services/egress/egress-log-ingester.ts) and [egress-event-pruner.ts](src/services/egress/egress-event-pruner.ts) consume the gateway's traffic feed.
+
+### Agent sidecar — [services/agent-service.ts](src/services/agent-service.ts), [services/agent-sidecar.ts](src/services/agent-sidecar.ts)
+
+`agent-sidecar.ts` owns the container's lifecycle (ensure, remove). `agent-service.ts` is the SSE proxy used by the chat UI; conversations are persisted via [services/agent-conversation-service.ts](src/services/agent-conversation-service.ts).
+
+### Self-update — [services/self-update.ts](src/services/self-update.ts)
+
+Health-check-based rolling update. The server launches the update sidecar, which pulls the new image, runs it as a "candidate", health-checks it, and either swaps containers or rolls back. `cleanupOrphanedSidecars()` and `finalizeLastUpdate()` run at boot to recover from interrupted updates.
+
+### Monitoring & DNS — [services/monitoring/](src/services/monitoring/), [services/dns/](src/services/dns/)
+
+`MonitoringService` runs Prometheus + Grafana as a built-in stack and exposes summary endpoints. The DNS cache scheduler ([services/dns/](src/services/dns/)) periodically refreshes Cloudflare zone data so route lookups don't hit the API on every request.
+
+### Audit events — [services/user-events/](src/services/user-events/)
+
+`UserEventService` is the audit log. Every user-initiated mutation that's worth surfacing emits one. Records carry type, status, progress %, metadata, logs, and duration; updates emit `EVENT_UPDATED` on the `EVENTS` channel.
+
+### Connectivity & socket emitters — [services/container-socket-emitter.ts](src/services/container-socket-emitter.ts), [services/connectivity-socket-emitter.ts](src/services/connectivity-socket-emitter.ts), [services/haproxy-socket-emitter.ts](src/services/haproxy-socket-emitter.ts), [services/backup/backup-health-socket-emitter.ts](src/services/backup/backup-health-socket-emitter.ts), [services/egress/egress-socket-emitter.ts](src/services/egress/egress-socket-emitter.ts), [services/stacks/stack-socket-emitter.ts](src/services/stacks/stack-socket-emitter.ts)
+
+Standalone emitter functions (no class wrappers). Each one queries the DB or computes state and calls `emitToChannel()`. Health calculations are extracted into shared modules so REST routes and emitters reuse them.
+
+**Invariant:** every `emitToChannel()` call is wrapped in try/catch by the caller. Schedulers, executors, and route handlers continue working even if no client is listening or Socket.IO is down. Emission failures must never break the caller.
+
+**Invariant:** all channel and event names come from constants in [lib/types/socket-events.ts](../lib/types/socket-events.ts). `Channel.*` and `ServerEvent.*` are the only acceptable values — raw strings are not allowed.
+
+## Server invariants — digest
+
+Most of these are also stated inline in the subsystem map at the spot they apply. This is the consolidated list.
+
+- **Docker:** all access through `DockerService.getInstance()`; image pulls through `DockerExecutorService.pullImageWithAutoAuth()`.
+- **Configuration:** mutations require `userId`. Settings are never env vars — they're database rows served by `ConfigurationServiceFactory`.
+- **Real-time:** `Channel.*` and `ServerEvent.*` constants only. Every `emitToChannel()` is wrapped in try/catch.
+- **Long-running ops:** `*_STARTED → *_STEP → *_COMPLETED`. `ProgressTrackerService` is grandfathered for backup/restore only.
+- **Logging:** one entry point — `getLogger(component, subcomponent)`. Components are a fixed set. `console.*` is reserved for the pre-logger boot path.
+- **`pino-http`:** receives options from `buildPinoHttpOptions()`, never a pre-built pino instance. (pino-http bundles its own pino copy with mismatched internal Symbols.)
+- **External integrations:** wrapping service class with retries, error mapping, and a `validate()` method. Circuit breakers and backoff at flaky boundaries.
+- **Boot:** the HTTP listener is the *last* thing to come up. Every singleton, scheduler, and sidecar runs before the port binds.
+
+## Coding patterns
+
+These are the patterns every contributor must follow. [CLAUDE.md](CLAUDE.md) has the full do/don't tables; this section explains the *why*.
+
+### Singletons and factories
+
+| Service | Why a singleton | Anti-pattern |
+|---|---|---|
+| `DockerService.getInstance()` | One Docker connection, shared event stream, in-memory cache | `new Dockerode(...)` |
+| `DockerExecutorService.getInstance()` | Reuses the Docker connection; image-pull queue and progress tracking | Calling `docker.pull()` directly |
+| `ApplicationServiceFactory.getInstance()` | Tracks running app services; supports stop-by-label fallback | Stopping containers by ID outside the factory |
+
+`ConfigurationServiceFactory` ([services/configuration-factory.ts](src/services/configuration-factory.ts)) creates per-category config services (`docker`, `cloudflare`, `azure`, `postgres`, `tls`). Always go through the factory; never `new DockerConfigService()`. Check `factory.isSupported(category)` before creating.
+
+### Image pulls always use `pullImageWithAutoAuth()`
+
+[services/docker-executor/](src/services/docker-executor/) handles registry detection, credential lookup via `RegistryCredentialService`, token refresh (5 minutes before expiry), and progress streaming. Calling `docker.pull()` skips all of that, so image pulls fail unpredictably for private registries.
+
+### Configuration mutations require `userId`
+
+`set()`, `delete()`, and `create()` on every configuration service take a `userId` for the audit trail (`createdBy`, `updatedBy`). If you find yourself wanting to omit it, that's a sign the call is happening outside a request scope where it shouldn't be — propagate `userId` through, or use a system actor constant if it's truly system-driven.
+
+### Socket emission
+
+Standalone functions in `*-socket-emitter.ts` files. The pattern:
+
+```ts
+export async function emitConnectivityStatus() {
+  try {
+    const state = await computeConnectivityState();
+    emitToChannel(Channel.CONNECTIVITY, ServerEvent.CONNECTIVITY_STATUS, state);
+  } catch (err) {
+    log.error({ err }, "failed to emit connectivity status");
+  }
+}
+```
+
+Rules:
+1. **Use `Channel.*` and `ServerEvent.*` constants** from [lib/types/socket-events.ts](../lib/types/socket-events.ts). Never raw strings.
+2. **Wrap in try/catch.** Emission failures must never break the caller (a scheduler, an executor, a route handler).
+3. **Extract shared logic** (e.g. health calculators) into modules that REST routes and emitters both import. Don't duplicate.
+
+### Long-running operations
+
+Every tracked operation emits a triplet:
+
+- `*_STARTED` — once, with `operationId`, `totalSteps`, `stepNames[]`
+- `*_STEP` — per step, with `step`, `status` (`completed` | `failed` | `skipped`), `completedCount`, `totalSteps`
+- `*_COMPLETED` — once, with `success`, `steps[]`, `errors[]`
+
+The service signature accepts an `onStep` callback rather than emitting directly:
+
+```ts
+async issueCertificate(req, onStep?: IssuanceStepCallback) {
+  onStep?.({ step: "Create ACME order", status: "completed" }, 1, totalSteps);
+}
+```
+
+The route handler wires `onStep` to `emitToChannel()`. This keeps services decoupled from Socket.IO and makes them unit-testable.
+
+When adding a new tracked operation:
+1. Add channel + `*_STARTED` / `*_STEP` / `*_COMPLETED` constants to [lib/types/socket-events.ts](../lib/types/socket-events.ts).
+2. Implement the service with an `onStep` parameter.
+3. Wire `onStep` → `emitToChannel()` in the route handler.
+4. Register the task type on the client in [client/src/lib/task-type-registry.ts](../client/src/lib/task-type-registry.ts).
+5. Optionally create a `UserEvent` record for persistent audit.
+
+[services/progress-tracker.ts](src/services/progress-tracker.ts) is the *exception*: backup and restore use a database-backed progress model with EventEmitter (not Socket.IO). Don't extend it to new operation types — use the Socket.IO pattern.
+
+### Auth and permissions
+
+- JWT extraction lives in [lib/jwt-middleware.ts](src/lib/jwt-middleware.ts); API key validation in [lib/api-key-service.ts](src/lib/api-key-service.ts) and [lib/api-key-middleware.ts](src/lib/api-key-middleware.ts).
+- Permission checks go through [lib/permission-middleware.ts](src/lib/permission-middleware.ts). Scopes are `resource:action` strings from [lib/types/permissions.ts](../lib/types/permissions.ts). Presets (Reader/Editor/Admin) are seeded by `seedDefaultPresets()` at boot.
+- The internal auth secret used for JWT signing and API-key HMAC is loaded by [lib/security-config.ts](src/lib/security-config.ts) **before any other service initialises** (see boot sequence below). It's never exposed via API, env var, or UI.
+
+### Logging
+
+`getLogger(component, subcomponent)` is the only entry point. One NDJSON file rotated by `pino-roll`. Components are a fixed set: `http`, `auth`, `db`, `docker`, `stacks`, `deploy`, `haproxy`, `tls`, `backup`, `integrations`, `agent`, `platform`. Subcomponent is kebab-case, usually the filename.
+
+Every line carries `component`, `subcomponent`, and (when in scope) `requestId` (from request middleware) or `operationId` (from `withOperation()` / `runWithContext()` in [lib/logging-context.ts](src/lib/logging-context.ts)).
+
+`pino-http` builds its own logger from `buildPinoHttpOptions()` exported by the factory — don't pass it a pre-built pino instance. See [CLAUDE.md](CLAUDE.md) for grep patterns and the per-component levels in `config/logging.json`.
+
+`console.*` is reserved for the pre-logger boot path (`server.ts`, `app-factory.ts`, `prisma.ts`, `config-new.ts`, `logging-config.ts` fallback) and tests/scripts. Don't add new console calls outside those.
+
+### Database
+
+A single Prisma client instance lives in [lib/prisma.ts](src/lib/prisma.ts). Use transactions for multi-step writes that must be atomic. Migrations are created with `prisma migrate dev --name <description>` from the repo root via the `mini-infra-server` filter. The schema lives at [prisma/schema.prisma](prisma/schema.prisma).
+
+### External calls
+
+External boundaries get defensive wrappers, not raw SDK calls:
+
+- **Azure Blob** ([services/azure-storage-service.ts](src/services/azure-storage-service.ts)) — exponential backoff, error mapping (`AuthenticationFailed`, `ENOTFOUND`, etc. → typed codes), 5-minute success cache / 1–2-minute failure cache, metadata sanitisation for Azure's 8 KB key limit.
+- **GitHub** ([services/github-service.ts](src/services/github-service.ts)) — circuit breaker (5 failures → 5-minute cooldown), token redaction in logs, 1-second deduplication window.
+- **Cloudflare** ([services/cloudflare/](src/services/cloudflare/)) — rate-limit aware, DNS cache feeds via the DNS scheduler.
+- **Container registries** — go through `RegistryCredentialService` + `pullImageWithAutoAuth()` (above).
+
+If you're adding a new external service, follow this pattern: a wrapping service class with retries, error mapping, and a `validate()` method that records connectivity status.
+
+### TypeScript discipline
+
+No `any` in new code. Existing `any`s are tech debt to be cleaned up. Prefer narrow types from `@mini-infra/types`; if you need a new shared type, add it to [lib/types/](../lib/types/) and rebuild the types package.
+
+## Cross-cutting concerns
+
+The system-level concerns that don't belong to any single subsystem.
+
+### Cancellation
+
+Long-running operations are not cancellable mid-step today. The reasoning: every step (Docker network create, ACME order, HAProxy server bind) is either fast enough that "wait for it" is acceptable, or has external state that a half-applied cancel would corrupt. If you need to abandon an operation, the right path is to let the step finish and rely on the next reconcile pass to drift back to desired state.
+
+The two places where pre-emptive abort is needed are timeouts and shutdown. Timeouts are handled per-call in the relevant wrapper (`DockerService` adds a 5-second container-lookup timeout; `AzureStorageService` has its own retry/timeout policy). Shutdown is handled by the `gracefulShutdown` handler in [src/server.ts](src/server.ts), which stops schedulers in deterministic order before the process exits — schedulers don't share state, so a single missed iteration on shutdown isn't a correctness problem.
+
+If a future operation genuinely needs cancellation, hook a cancellation token into the `onStep` callback and check it between steps, not within them.
+
+### Testing
+
+Tests live in two places: alongside the code they test (`src/services/<area>/__tests__/`) for unit and per-service integration, and at the top level in [src/__tests__/](src/__tests__/) for cross-service integration. Both use vitest.
+
+**Invariant:** integration tests run against a real database, never a mock. The previous incident the team learned from is mocked tests passing while the production migration broke. The trade-off is that `pnpm build:lib` must run before the test suite, since type imports break if the types package isn't compiled.
+
+`src/test-support/` holds shared fixtures so tests can share the boilerplate of spinning up a Prisma client, a fake Docker, etc.
+
+### Error handling
+
+Three rough categories:
+
+1. **Boundary IO** (Docker, Azure, Vault, Cloudflare, ACME) — the wrapper service catches the SDK error, maps it to a typed code where useful, and either retries (transient) or rethrows (terminal). Boundary errors are the things most likely to break, so they're the things most defended.
+2. **Business logic** — throws on unexpected state. Express's `errorHandler` middleware catches and serialises. Don't swallow errors and return a partial result; the route should fail loudly so the client can react.
+3. **Background work** (schedulers, emitters, listeners) — wraps every call in try/catch and logs. The principle: a backup that failed yesterday must not stop the scheduler from running today; an emitter with no listener must not bring down the route that triggered it.
+
+`UserEvent` records carry their own `errors[]` for terminal failure detail. The route's response is a summary; the audit log has the full story.
+
+### Observability
+
+The story is structured logs, not metrics. Every line carries `component`, `subcomponent`, and (in scope) `requestId` or `operationId`. The `lib/logging-context.ts` async-local-storage hook propagates context through async boundaries automatically, so a log line emitted three layers down inside a stack apply still ties back to the operation.
+
+Practical recipes (run against `logs/app.*.log` to cover rotation):
+
+```sh
+# One HTTP request, end-to-end:
+grep -h '"requestId":"<id>"' logs/app.*.log | jq -c .
+
+# One long-running operation, end-to-end:
+grep -h '"operationId":"stack-apply-<id>"' logs/app.*.log | jq -c .
+
+# Live tail, projected to the fields that matter:
+tail -f $(ls -t logs/app.*.log | head -1) | \
+  jq -c '{t:.time, lvl:.level, c:.component, s:.subcomponent, m:.msg, r:.requestId, op:.operationId}'
+```
+
+Per-component levels live in `config/logging.json`. There is no runtime log-level UI — change the JSON and restart.
+
+For external-process visibility, the monitoring stack (Prometheus + Grafana, deployed as a built-in stack) is the place to look. Loki ingests the rotated log files.
+
+## Boot sequence
+
+[src/server.ts](src/server.ts) calls `initializeServices()` and then `startServer()` in this exact order. Knowing it matters when adding a new service that depends on another. The HTTP listener is the *last* thing to come up — every scheduler, sidecar, and singleton is already running by the time the first request arrives.
+
+`initializeServices()`:
+
+1. **Logging config** — `loadLoggingConfig()` runs before any service module is imported, so transitive imports build component loggers at the correct level.
+2. **Internal auth secret** — `loadOrCreateInternalAuthSecret()` from [lib/security-config.ts](src/lib/security-config.ts). Required before anything that signs JWTs or hashes API keys.
+3. **Public URL migration** — one-time migration of a legacy `PUBLIC_URL` env var into the DB.
+4. **Docker service** — `DockerService.getInstance().initialize()` connects to the daemon and starts the event stream. A `dockerService.onConnect()` callback re-provisions the agent and fw-agent sidecars after a reconnect (covers the fresh-boot case where the seeder posts the docker host *after* boot).
+5. **Container socket emitter** — `setupContainerSocketEmitter()` registers callbacks on `DockerService` so container changes broadcast over Socket.IO.
+6. **HAProxy crash-loop watcher** — `setupHAProxyCrashLoopWatcher()` watches for repeated HAProxy crashes and triggers remediation.
+7. **Egress fw-agent** — `ensureFwAgent()` provisions the host-singleton firewall agent sidecar before egress background services start, so `EnvFirewallManager` can reach the admin socket on its first reconcile pass.
+8. **Egress background services** — `startEgressBackgroundServices()` (rule pushers, log ingester, event pruner).
+9. **Self-update cleanup** — `finalizeLastUpdate()` then `cleanupOrphanedSidecars()` recover from interrupted updates.
+10. **Agent sidecar** — load Anthropic API key from DB, `initializeAgentApiKey()` (sidecar needs the Mini Infra API key), then `ensureAgentSidecar()`.
+11. **Connectivity scheduler** — periodic external-service checks.
+12. **Pool instance reaper** — stops idle pool instances on a 60s cadence; force-fails spawns stuck `starting` for >5 min.
+13. **Backup scheduler** + **restore executor service** + **PostgreSQL database health scheduler**.
+14. **`ApplicationServiceFactory.setDockerService()`** — wires the factory so it can stop containers by label as a fallback.
+15. **`syncBuiltinStacks()`** — sync built-in stack definitions (HAProxy, Postgres, Vault, monitoring, egress-gateway, Cloudflare tunnel).
+16. **Vault services** — `initVaultServices()` + `seedVaultPolicies()`; if a Vault address is configured, re-authenticate the admin client. `vaultServices.healthWatcher.start()` (no-op when Vault isn't configured).
+17. **Builtin vault reconcile** — `runBuiltinVaultReconcile()` when `BUNDLES_DRIVE_BUILTIN=true`.
+18. **Monitoring network attach** — connect the server container to the monitoring network so it can proxy to Prometheus / Loki by container name.
+19. **Self-backup scheduler**, **user-event cleanup scheduler**, **PostgreSQL server health scheduler**.
+20. **TLS renewal scheduler** — only if a certificate blob container is configured. Wires up `AzureStorageCertificateStore` → `AcmeClientManager` → `DnsChallenge01Provider` → `CertificateLifecycleManager` → `CertificateRenewalScheduler`.
+21. **DNS cache scheduler** — `DnsCacheService` periodically refreshes Cloudflare zone data.
+22. **Permission presets** — `seedDefaultPresets()` ensures Reader/Editor/Admin presets exist.
+23. **Development API key** — `initializeDevApiKey()` (only when enabled in dev).
+24. **Agent proxy service** — if an Anthropic API key is configured, instantiate `AgentProxyService`.
+
+`startServer()`:
+
+25. **HTTP server** — `createServer(app)` from the configured Express app.
+26. **Socket.IO** — `initializeSocketIO(httpServer)` attaches Socket.IO to the same HTTP server with JWT + API-key auth middleware.
+27. **`httpServer.listen()`** — bind to the configured port. The `/health` endpoint becomes reachable here.
+
+Adding a new initialisation step belongs in `initializeServices()`. If it depends on Docker, put it after step 4. If it needs Vault, put it after step 17.
+
+## Adding a new feature
+
+A typical end-to-end change touches these things in order:
+
+1. **Schema** — add or modify a model in [prisma/schema.prisma](prisma/schema.prisma). Run `pnpm --filter mini-infra-server exec prisma migrate dev --name <description>` from the repo root.
+2. **Types** — add or update shared types in [../lib/types/](../lib/types/). Rebuild with `pnpm build:lib`.
+3. **Service** — add the business logic to `src/services/<area>/`. Use existing wrappers (`DockerService`, `DockerExecutorService`, `ConfigurationServiceFactory`, etc.); don't reach for raw SDKs. If it's a new external integration, write a service class that wraps the SDK with retries and error mapping.
+4. **Route** — add or extend a file in `src/routes/`. Use `describeRoute` from [lib/describe-route.ts](src/lib/describe-route.ts) to register OpenAPI metadata, validation middleware from [middleware/validation.ts](src/middleware/validation.ts) for input schemas, and permission middleware for scope checks.
+5. **Real-time updates** — if state changes belong on a Socket.IO channel, write a `*-socket-emitter.ts` function and call it from the service or route handler. If the operation is long-running, follow the started/step/completed pattern.
+6. **Audit** — if it's a user-initiated mutation that should appear in the events page, create a `UserEvent` record via `userEventService.create()`.
+7. **Tests** — vitest under `src/__tests__/` (integration) or alongside the service (`<area>/__tests__/`). The shared types package must be built first (`pnpm build:lib`) or test imports fail.
+8. **Lint** — `pnpm --filter mini-infra-server lint` before opening a PR.
+
+## Where to next
+
+- [CLAUDE.md](CLAUDE.md) — exhaustive service-pattern do/don't tables, logging grep recipes.
+- [../ARCHITECTURE.md](../ARCHITECTURE.md) — repo-wide context.
+- [../client/ARCHITECTURE.md](../client/ARCHITECTURE.md) — the other half of the application.
+- [../docs/](../docs/) — operator and design docs.


### PR DESCRIPTION
## Summary

Three new orientation docs aimed at new contributors:

- [ARCHITECTURE.md](ARCHITECTURE.md) — repo-wide bird's-eye view: code map, runtime topology with ASCII diagram, external-boundaries table, architectural-invariants digest, vocabulary glossary, build/dev topology.
- [server/ARCHITECTURE.md](server/ARCHITECTURE.md) — server layout, subsystem map with inline `**Invariant:**` callouts, coding patterns (singletons, factories, image pulls, socket emission, long-running ops, auth, logging, DB, external calls), cross-cutting concerns (cancellation, testing, error handling, observability), full boot sequence in actual order, "adding a feature" walkthrough.
- [client/ARCHITECTURE.md](client/ARCHITECTURE.md) — client layout, routing model, data layer (TanStack Query + Socket.IO + the canonical `useContainers` pattern), task tracker, cross-cutting concerns, "adding a page" walkthrough.

## Why

`CLAUDE.md` files are written as instructions to Claude, not as architecture documentation. Mini Infra has grown to a multi-package repo (server, client, lib, acme, four sidecars, Go egress data plane) and new contributors — human or agentic — currently have to reverse-engineer the shape of the system. These docs externalise the mental map maintainers carry.

## Style

Modelled on matklad's [ARCHITECTURE.md](https://matklad.github.io/2021/02/06/ARCHITECTURE.md.html) and rust-analyzer's [doc](https://github.com/rust-lang/rust-analyzer/blob/master/docs/book/src/contributing/architecture.md):

- Explicit **Entry points** sections — "open these files first."
- Inline `**Invariant:**` callouts in the subsystem maps where they apply, plus a short invariants digest.
- `lib/types/` is flagged as the **API Boundary** between client and server.
- Pedagogical asides explain *why* a few non-obvious rules exist.
- File-path links are kept (modern editors and GitHub resolve them) — the trade-off matklad warned about ("links go stale") is mitigated by editors making them clickable.

`CLAUDE.md` files are unchanged; they remain the Claude-facing imperative cheat-sheet.

## Test plan

- [ ] Render each doc in GitHub's preview and skim — links resolve, no broken anchors.
- [ ] Spot-check claims by clicking through file path links to confirm they exist and match the description.
- [ ] No code changes; lint should be a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)