### PR TITLE
fix(stacks): persist vaultAppRoleRef on the HTTP draft endpoint

### DIFF
--- a/lib/types/stacks.ts
+++ b/lib/types/stacks.ts
@@ -361,6 +361,9 @@ export interface StackServiceDefinition {
   adoptedContainer?: AdoptedContainerRef;
   poolConfig?: PoolConfig;
   vaultAppRoleId?: string | null;
+  /** Symbolic reference to a vault.appRoles[].name in the owning template draft.
+   *  Resolved to a concrete vaultAppRoleId at apply time. */
+  vaultAppRoleRef?: string | null;
 }
 
 export interface StackDefinition {

--- a/server/src/__tests__/stack-template-schemas.test.ts
+++ b/server/src/__tests__/stack-template-schemas.test.ts
@@ -115,6 +115,52 @@ describe('draftVersionSchema', () => {
   });
 });
 
+describe('draftVersionSchema — vaultAppRoleRef on services', () => {
+  const draftWithVaultAndRef = {
+    networks: [],
+    volumes: [],
+    services: [{ ...baseService, vaultAppRoleRef: 'my-approle' }],
+    vault: {
+      policies: [{ name: 'my-policy', body: 'path "x" { capabilities = ["read"] }' }],
+      appRoles: [{ name: 'my-approle', policy: 'my-policy' }],
+    },
+  };
+
+  it('preserves vaultAppRoleRef on parsed services (regression: was silently stripped)', () => {
+    const r = draftVersionSchema.safeParse(draftWithVaultAndRef);
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.services[0].vaultAppRoleRef).toBe('my-approle');
+    }
+  });
+
+  it('rejects vaultAppRoleRef pointing at an undeclared appRole', () => {
+    const r = draftVersionSchema.safeParse({
+      ...draftWithVaultAndRef,
+      services: [{ ...baseService, vaultAppRoleRef: 'nonexistent-role' }],
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const messages = r.error.issues.map((i) => i.message);
+      expect(messages.some((m) => m.includes('nonexistent-role'))).toBe(true);
+      expect(messages.some((m) => m.includes("Service 'web'"))).toBe(true);
+    }
+  });
+
+  it('rejects vaultAppRoleRef when the draft has no vault section at all', () => {
+    const r = draftVersionSchema.safeParse({
+      networks: [],
+      volumes: [],
+      services: [{ ...baseService, vaultAppRoleRef: 'my-approle' }],
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const messages = r.error.issues.map((i) => i.message);
+      expect(messages.some((m) => m.includes('none defined'))).toBe(true);
+    }
+  });
+});
+
 describe('config-file mountPath safety', () => {
   const configFile = {
     serviceName: 'web',

--- a/server/src/__tests__/stack-templates-draft-route.integration.test.ts
+++ b/server/src/__tests__/stack-templates-draft-route.integration.test.ts
@@ -1,0 +1,133 @@
+/**
+ * HTTP regression test for POST /api/stack-templates/:templateId/draft.
+ *
+ * Critical regression this file guards:
+ *   `vaultAppRoleRef` on services in a draft body was being silently stripped
+ *   by Zod's default unknown-key behavior because the field was missing from
+ *   `stackServiceDefinitionSchema`. The drafted DB row ended up with
+ *   `vaultAppRoleRef = NULL`, so apply-time the vault orchestrator filtered
+ *   the service out and never bound it to its declared AppRole.
+ *
+ * These tests POST a real draft body through the route (via supertest) with
+ * a vault section + vaultAppRoleRef on a service, then assert the column is
+ * persisted in the integration DB. The unit-level test in
+ * stack-template-schemas.test.ts proves the schema preserves the field; this
+ * test proves the full HTTP → service → Prisma path persists it.
+ */
+
+import supertest from 'supertest';
+import express, { type Request, type Response, type NextFunction } from 'express';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { testPrisma } from './integration-test-helpers';
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+
+vi.mock('../middleware/auth', () => ({
+  requirePermission: () => (req: Request, _res: Response, next: NextFunction) => {
+    // Session user — bypasses the template-vault:write scope gate.
+    (req as Request & { user?: { id: string } }).user = { id: 'session-user' };
+    next();
+  },
+}));
+
+vi.mock('../lib/prisma', () => ({ default: testPrisma }));
+
+import stackTemplateRouter from '../routes/stack-templates';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/stack-templates', stackTemplateRouter);
+  return app;
+}
+
+async function createUserTemplateRow(): Promise<string> {
+  const templateId = createId();
+  await testPrisma.stackTemplate.create({
+    data: {
+      id: templateId,
+      name: `tpl-${templateId.slice(0, 6)}`,
+      displayName: 'Draft Route Test Template',
+      source: 'user',
+      scope: 'environment',
+      currentVersionId: null,
+      draftVersionId: null,
+    },
+  });
+  return templateId;
+}
+
+const baseService = {
+  serviceName: 'web',
+  serviceType: 'Stateful',
+  dockerImage: 'nginx',
+  dockerTag: 'latest',
+  containerConfig: {},
+  dependsOn: [],
+  order: 0,
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('POST /api/stack-templates/:templateId/draft — vaultAppRoleRef persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('persists vaultAppRoleRef on the StackTemplateService row (regression: was silently stripped)', async () => {
+    const templateId = await createUserTemplateRow();
+
+    const draftBody = {
+      networks: [],
+      volumes: [],
+      services: [{ ...baseService, vaultAppRoleRef: 'my-approle' }],
+      vault: {
+        policies: [{ name: 'my-policy', body: 'path "secret/*" { capabilities = ["read"] }' }],
+        appRoles: [{ name: 'my-approle', policy: 'my-policy' }],
+      },
+    };
+
+    const res = await supertest(buildApp())
+      .post(`/api/stack-templates/${templateId}/draft`)
+      .send(draftBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const tmpl = await testPrisma.stackTemplate.findUnique({ where: { id: templateId } });
+    expect(tmpl?.draftVersionId).not.toBeNull();
+
+    const row = await testPrisma.stackTemplateService.findFirst({
+      where: { versionId: tmpl!.draftVersionId! },
+    });
+    expect(row).not.toBeNull();
+    expect(row!.vaultAppRoleRef).toBe('my-approle');
+  });
+
+  it('returns 400 when vaultAppRoleRef does not resolve to a declared appRole', async () => {
+    const templateId = await createUserTemplateRow();
+
+    const draftBody = {
+      networks: [],
+      volumes: [],
+      services: [{ ...baseService, vaultAppRoleRef: 'nonexistent-role' }],
+      vault: {
+        policies: [{ name: 'my-policy', body: 'path "secret/*" { capabilities = ["read"] }' }],
+        appRoles: [{ name: 'my-approle', policy: 'my-policy' }],
+      },
+    };
+
+    const res = await supertest(buildApp())
+      .post(`/api/stack-templates/${templateId}/draft`)
+      .send(draftBody);
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toMatch(/Validation failed/);
+    const issueMessages = (res.body.issues as Array<{ message: string }>).map((i) => i.message);
+    expect(issueMessages.some((m) => m.includes('nonexistent-role'))).toBe(true);
+  });
+});

--- a/server/src/services/stacks/schemas.ts
+++ b/server/src/services/stacks/schemas.ts
@@ -302,6 +302,9 @@ export const stackServiceDefinitionSchema = z
     adoptedContainer: adoptedContainerSchema.optional(),
     poolConfig: poolConfigSchema.optional(),
     vaultAppRoleId: z.string().min(1).nullable().optional(),
+    // Symbolic reference to a vault.appRoles[].name declared in the same draft.
+    // Resolved to a concrete vaultAppRoleId at apply time by the vault apply orchestrator.
+    vaultAppRoleRef: z.string().min(1).optional(),
   })
   .refine(
     (data) => {

--- a/server/src/services/stacks/stack-template-schemas.ts
+++ b/server/src/services/stacks/stack-template-schemas.ts
@@ -147,7 +147,30 @@ export const draftVersionSchema = z.object({
   notes: z.string().max(1000).optional(),
   inputs: z.array(templateInputDeclSchema).optional(),
   vault: templateVaultSectionSchema.optional(),
+}).superRefine((data, ctx) => {
+  // Mirror templateFileSchema: every services[].vaultAppRoleRef must resolve
+  // to a vault.appRoles[].name declared in this same draft body. Otherwise
+  // the field would persist as a dangling reference and the apply-time vault
+  // orchestrator would silently fail to bind the service to any AppRole.
+  const appRoleNames = new Set((data.vault?.appRoles ?? []).map((a) => a.name));
+  for (let i = 0; i < data.services.length; i++) {
+    const svc = data.services[i];
+    if (svc.vaultAppRoleRef !== undefined && !appRoleNames.has(svc.vaultAppRoleRef)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Service '${svc.serviceName}' vaultAppRoleRef '${svc.vaultAppRoleRef}' references unknown appRole (defined: ${formatNameSet(appRoleNames)})`,
+        path: ['services', i, 'vaultAppRoleRef'],
+      });
+    }
+  }
 });
+
+function formatNameSet(set: Set<string>): string {
+  if (set.size === 0) return 'none defined';
+  return Array.from(set)
+    .map((n) => `'${n}'`)
+    .join(', ');
+}
 
 export const publishDraftSchema = z.object({
   notes: z.string().max(1000).optional(),

--- a/server/src/services/stacks/stack-template-service.ts
+++ b/server/src/services/stacks/stack-template-service.ts
@@ -1165,7 +1165,7 @@ function serializeTemplateConfigFile(cf: Prisma.StackTemplateConfigFileGetPayloa
  * Convert a StackServiceDefinition to a Prisma create input for StackTemplateService.
  */
 function toTemplateServiceCreate(
-  s: StackServiceDefinition & { vaultAppRoleRef?: string },
+  s: StackServiceDefinition,
   fallbackOrder: number
 ) {
   return {
@@ -1320,6 +1320,7 @@ function buildServiceDefinitionsFromVersion(version: {
       adoptedContainer: (svc.adoptedContainer as unknown as StackServiceDefinition['adoptedContainer']) ?? undefined,
       poolConfig: (svc.poolConfig as unknown as StackServiceDefinition['poolConfig']) ?? undefined,
       vaultAppRoleId: svc.vaultAppRoleId ?? undefined,
+      vaultAppRoleRef: svc.vaultAppRoleRef ?? undefined,
     };
   });
 }


### PR DESCRIPTION
## Summary

- `services[].vaultAppRoleRef` was being silently stripped on `POST /api/stack-templates/:id/draft` because the field was missing from `stackServiceDefinitionSchema`. Zod v4 strips unknown keys by default, so the draft persisted with `vaultAppRoleRef = NULL`.
- Apply-time, the vault orchestrator (`stack-vault-apply-orchestrator.ts:139`) filters services on `vaultAppRoleRef != null` and found nothing — the `vault.appRoles[]` were created in Vault but no service was bound. This closes that gap; the apply-time logic was already correct.
- Adds the field to the shared `StackServiceDefinition` type, drops the `& { vaultAppRoleRef?: string }` intersection workaround that was papering over the missing type, and grows a `superRefine` on `draftVersionSchema` so an unresolvable ref now fails at the HTTP boundary instead of silently writing a dangling reference.

## Test plan

- [x] `pnpm --filter mini-infra-server test` — full suite passes (1876 tests)
- [x] `pnpm --filter mini-infra-server lint` — clean
- [x] `pnpm build:server` and `pnpm --filter mini-infra-client build` — both compile
- [x] New unit cases against `draftVersionSchema`: preserves field on parse, rejects unresolvable ref, rejects ref when no vault section
- [x] New HTTP integration test posts a real draft body to `/api/stack-templates/:id/draft` and asserts the column persists in the DB — the regression test that would have caught this; existing apply-route test bypassed HTTP via Prisma fixtures
- [ ] End-to-end smoke via the slackbot installer against the rebuilt worktree (deferred to reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)