### PR TITLE
fix(stacks): always verify Docker state before deleting a stack row

### DIFF
--- a/server/src/__tests__/stacks/stacks-delete-vault-cascade.integration.test.ts
+++ b/server/src/__tests__/stacks/stacks-delete-vault-cascade.integration.test.ts
@@ -12,6 +12,10 @@
  *   E. Stack with running containers → 400 (existing behaviour preserved)
  *   F. Vault cascade failure → stack row still removed (non-fatal)
  *   G. Idempotent re-DELETE (already-deleted stack) → 404
+ *   H. status=undeployed but containers still labelled → 400 (regression
+ *      guard: status field used to short-circuit the docker check, leading
+ *      to silent partial-deletes that orphaned the Docker resources)
+ *   I. Docker unreachable → 400 (cannot verify container state)
  */
 
 import supertest from 'supertest';
@@ -270,5 +274,35 @@ describe('DELETE /api/stacks/:stackId — Vault cascade', () => {
 
     const res = await supertest(makeApp()).delete(`/api/stacks/${stackId}`);
     expect(res.status).toBe(404);
+  });
+
+  it('H. status=undeployed but containers still labelled → 400 (no silent orphan)', async () => {
+    // Regression: a partial /destroy can flip status to "undeployed" while
+    // leaving labelled containers behind. The DELETE handler used to skip
+    // the docker check whenever status was "undeployed" or "pending", so
+    // this exact state would tombstone the DB row and orphan the containers.
+    const stackId = await createStack({ status: 'undeployed' });
+    mockDockerClient.listContainers.mockResolvedValue([{ Id: 'orphan-1' }]);
+
+    const res = await supertest(makeApp()).delete(`/api/stacks/${stackId}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toMatch(/labelled with this stack ID|containers/i);
+    // The stack row must still exist — silent partial delete was the bug.
+    const still = await testPrisma.stack.findUnique({ where: { id: stackId } });
+    expect(still).not.toBeNull();
+  });
+
+  it('I. Docker unreachable → 400 (cannot verify, even for undeployed stacks)', async () => {
+    const stackId = await createStack({ status: 'undeployed' });
+    mockDockerClient.listContainers.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const res = await supertest(makeApp()).delete(`/api/stacks/${stackId}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/Cannot verify|Docker/i);
+    const still = await testPrisma.stack.findUnique({ where: { id: stackId } });
+    expect(still).not.toBeNull();
   });
 });

--- a/server/src/routes/stacks/stacks-crud-routes.ts
+++ b/server/src/routes/stacks/stacks-crud-routes.ts
@@ -411,29 +411,36 @@ router.delete(
       return res.status(404).json({ success: false, message: 'Stack not found' });
     }
 
-    if (stack.status !== 'undeployed' && stack.status !== 'pending') {
-      try {
-        const dockerExecutor = new DockerExecutorService();
-        await dockerExecutor.initialize();
-        const docker = dockerExecutor.getDockerClient();
-        const containers = await docker.listContainers({
-          filters: { label: [`mini-infra.stack-id=${stackId}`] },
-        });
+    // Always verify there are no labelled containers before tombstoning the
+    // DB row — the `status` field can lie. A partial /destroy (or any failure
+    // that flipped status to `undeployed` but left containers up) would
+    // otherwise let DELETE silently succeed and leave orphaned Docker
+    // resources running. Confirmed regression: customer repro showed two
+    // back-to-back DELETEs where the second returned 200 because status was
+    // `undeployed`, even though the containers from the first reject were
+    // still up.
+    try {
+      const dockerExecutor = new DockerExecutorService();
+      await dockerExecutor.initialize();
+      const docker = dockerExecutor.getDockerClient();
+      const containers = await docker.listContainers({
+        all: true,
+        filters: { label: [`mini-infra.stack-id=${stackId}`] },
+      });
 
-        if (containers.length > 0) {
-          return res.status(400).json({
-            success: false,
-            message:
-              'Cannot delete stack with running containers. Remove containers first or set status to undeployed.',
-          });
-        }
-      } catch {
+      if (containers.length > 0) {
         return res.status(400).json({
           success: false,
           message:
-            'Cannot verify container state. Stack status must be "undeployed" to delete without Docker access.',
+            'Cannot delete stack while Docker still has containers labelled with this stack ID. Run /destroy to remove them first, or remove the containers manually.',
         });
       }
+    } catch {
+      return res.status(400).json({
+        success: false,
+        message:
+          'Cannot verify container state — Docker is unreachable. Restore Docker connectivity and retry, or remove the containers manually before deleting.',
+      });
     }
 
     const userId = getUserId(req);


### PR DESCRIPTION
## Summary

- `DELETE /api/stacks/:id` used to skip the labelled-container check whenever `stack.status` was `undeployed` or `pending`. A partial `/destroy` that flipped status to `undeployed` but left containers up would let a follow-up `DELETE` silently succeed and tombstone the DB row — orphaning the Docker resources. Customer hit this exact path and reported it.
- Fix: always run the docker check, regardless of status. If Docker is unreachable, `DELETE` refuses for every status now (was: only refused when status != undeployed/pending) — better to fail loudly than silently delete a row whose containers we can't see.
- `listContainers` is called with `all: true` so stopped-but-labelled containers also block the delete; they still belong to the stack and would conflict on a future re-apply.
- Error message no longer says "status must be undeployed to delete" — that phrasing was the trap. Points at `/destroy` as the canonical teardown path.

## Test plan

- [x] `pnpm --filter mini-infra-server test` — full suite passes (1873 tests)
- [x] `pnpm --filter mini-infra-server lint` — clean
- [x] `pnpm build:server` — clean
- [x] Two new integration scenarios on the existing DELETE test:
  - **H**: status=undeployed but containers still labelled → 400, row preserved (the regression)
  - **I**: Docker unreachable → 400, row preserved
- [x] Live smoke against the dev worktree: DELETE on a synced+running stack returns 400 with the new error message (existing behaviour preserved, confirms the changed handler is on the wire)

🤖 Generated with [Claude Code](https://claude.com/claude-code)