### PR TITLE
feat(stacks): accept inputs + vault on POST /api/stack-templates

### DIFF
--- a/lib/types/stack-templates.ts
+++ b/lib/types/stack-templates.ts
@@ -246,6 +246,13 @@ export interface CreateStackTemplateRequest {
   volumes: StackVolume[];
   services: StackServiceDefinition[];
   configFiles?: StackTemplateConfigFileInput[];
+  /** Optional input declarations persisted on the initial v0 draft. Matches
+   *  DraftVersionInput.inputs — submit a complete spec in one request. */
+  inputs?: TemplateInputDeclaration[];
+  /** Optional vault section persisted on the initial v0 draft. Matches
+   *  DraftVersionInput.vault. Triggers the template-vault:write permission
+   *  gate at the route layer when non-empty. */
+  vault?: TemplateVaultSection;
 }
 
 export interface StackTemplateConfigFileInput {

--- a/server/src/__tests__/stack-template-schemas.test.ts
+++ b/server/src/__tests__/stack-template-schemas.test.ts
@@ -92,6 +92,68 @@ describe('createTemplateSchema — empty services', () => {
   });
 });
 
+describe('createTemplateSchema — inputs and vault (single-call create)', () => {
+  it('accepts inputs[] alongside services and round-trips defaults', () => {
+    const r = createTemplateSchema.safeParse({
+      ...baseCreate,
+      inputs: [{ name: 'apiKey' }, { name: 'dbPassword', sensitive: true, required: false }],
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.inputs).toHaveLength(2);
+      // Default sensitive=true, required=true, rotateOnUpgrade=false
+      expect(r.data.inputs![0].sensitive).toBe(true);
+      expect(r.data.inputs![0].required).toBe(true);
+      expect(r.data.inputs![0].rotateOnUpgrade).toBe(false);
+    }
+  });
+
+  it('accepts a complete vault section with policies, appRoles, and kv', () => {
+    const r = createTemplateSchema.safeParse({
+      ...baseCreate,
+      inputs: [{ name: 'token' }],
+      vault: {
+        policies: [{ name: 'p1', body: 'path "secret/*" { capabilities = ["read"] }' }],
+        appRoles: [{ name: 'r1', policy: 'p1' }],
+        kv: [{ path: 'shared/cfg', fields: { token: { fromInput: 'token' } } }],
+      },
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.vault?.policies).toHaveLength(1);
+      expect(r.data.vault?.appRoles).toHaveLength(1);
+      expect(r.data.vault?.kv).toHaveLength(1);
+    }
+  });
+
+  it('accepts an empty vault object (treated as no vault section)', () => {
+    const r = createTemplateSchema.safeParse({ ...baseCreate, vault: {} });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects an invalid vault.kv path', () => {
+    const r = createTemplateSchema.safeParse({
+      ...baseCreate,
+      vault: {
+        kv: [{ path: '/leading-slash', fields: { k: { value: 'v' } } }],
+      },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects duplicate input names via Zod default uniqueness — schema accepts dupes; cross-validator catches them at the loader level', () => {
+    // The Zod schema itself does NOT enforce input-name uniqueness at the
+    // create-template layer (mirrors draftVersionSchema). Loader/runtime
+    // catches duplicates. This test pins that contract so a future
+    // refactor that adds uniqueness here is intentional.
+    const r = createTemplateSchema.safeParse({
+      ...baseCreate,
+      inputs: [{ name: 'dup' }, { name: 'dup' }],
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
 describe('draftVersionSchema', () => {
   const baseDraft = { networks: [], volumes: [], services: [baseService] };
 

--- a/server/src/__tests__/stack-templates-create-vault.integration.test.ts
+++ b/server/src/__tests__/stack-templates-create-vault.integration.test.ts
@@ -1,0 +1,221 @@
+/**
+ * HTTP integration test for POST /api/stack-templates accepting `inputs`
+ * and `vault` directly on create.
+ *
+ * Why this exists:
+ *   The previous flow was create-template (no vault/inputs) → POST draft
+ *   (with vault/inputs) → publish — three round-trips and a no-op stub
+ *   draft. This route now collapses to a single create-with-spec call.
+ *   The test posts a complete spec through the real route, then queries
+ *   the DB to verify the v0 draft persists every input + vault column.
+ *
+ * Also guards the template-vault:write permission gate added on the
+ * create endpoint to mirror the draft endpoint.
+ */
+
+import supertest from 'supertest';
+import express, { type Request, type Response, type NextFunction } from 'express';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { testPrisma } from './integration-test-helpers';
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockApiKeyRef, mockIsSessionRef } = vi.hoisted(() => {
+  const mockApiKeyRef = { permissions: ['stacks:write'] as string[] | null };
+  const mockIsSessionRef = { value: false };
+  return { mockApiKeyRef, mockIsSessionRef };
+});
+
+vi.mock('../middleware/auth', () => ({
+  requirePermission: () => (req: Request, _res: Response, next: NextFunction) => {
+    if (mockIsSessionRef.value) {
+      (req as Request & { user?: { id: string } }).user = { id: 'session-user' };
+    } else {
+      (req as Request & {
+        user?: { id: string };
+        apiKey?: { id: string; permissions: string[] | null };
+      }).user = { id: 'api-user' };
+      (req as Request & { apiKey?: { id: string; permissions: string[] | null } }).apiKey = {
+        id: 'test-key',
+        permissions: mockApiKeyRef.permissions,
+      };
+    }
+    next();
+  },
+}));
+
+vi.mock('../lib/prisma', () => ({ default: testPrisma }));
+
+import stackTemplateRouter from '../routes/stack-templates';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/stack-templates', stackTemplateRouter);
+  return app;
+}
+
+const baseService = {
+  serviceName: 'web',
+  serviceType: 'Stateful',
+  dockerImage: 'nginx',
+  dockerTag: 'latest',
+  containerConfig: {},
+  dependsOn: [],
+  order: 0,
+};
+
+function uniqueName(): string {
+  return `tpl-create-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function createBody(extra: Record<string, unknown> = {}) {
+  return {
+    name: uniqueName(),
+    displayName: 'Create-with-Spec Test',
+    scope: 'environment' as const,
+    networks: [],
+    volumes: [],
+    services: [baseService],
+    ...extra,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('POST /api/stack-templates — single-call create with vault + inputs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApiKeyRef.permissions = ['stacks:write', 'template-vault:write'];
+    mockIsSessionRef.value = false;
+  });
+
+  it('persists inputs[] on the v0 draft StackTemplateVersion row', async () => {
+    const body = createBody({
+      inputs: [
+        { name: 'apiKey' },
+        { name: 'dbPassword', sensitive: true, required: false, rotateOnUpgrade: true },
+      ],
+    });
+
+    const res = await supertest(buildApp()).post('/api/stack-templates').send(body);
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+
+    const tmplId = res.body.data.id;
+    const tmpl = await testPrisma.stackTemplate.findUnique({
+      where: { id: tmplId },
+      include: { draftVersion: true },
+    });
+    expect(tmpl?.draftVersion?.inputs).toBeTruthy();
+    const persistedInputs = tmpl!.draftVersion!.inputs as Array<{
+      name: string;
+      sensitive: boolean;
+      required: boolean;
+      rotateOnUpgrade: boolean;
+    }>;
+    expect(persistedInputs).toHaveLength(2);
+    expect(persistedInputs.find((i) => i.name === 'apiKey')).toBeTruthy();
+    expect(persistedInputs.find((i) => i.name === 'dbPassword')?.required).toBe(false);
+  });
+
+  it('persists every vault column (policies, appRoles, kv) on the v0 draft', async () => {
+    const body = createBody({
+      inputs: [{ name: 'token' }],
+      vault: {
+        policies: [
+          { name: 'my-policy', body: 'path "secret/data/shared/*" { capabilities = ["read"] }' },
+        ],
+        appRoles: [{ name: 'my-role', policy: 'my-policy', tokenTtl: '1h' }],
+        kv: [{ path: 'shared/cfg', fields: { token: { fromInput: 'token' } } }],
+      },
+    });
+
+    const res = await supertest(buildApp()).post('/api/stack-templates').send(body);
+    expect(res.status).toBe(201);
+
+    const tmplId = res.body.data.id;
+    const draft = await testPrisma.stackTemplateVersion.findFirst({
+      where: { templateId: tmplId, status: 'draft' },
+    });
+    expect(draft).not.toBeNull();
+    expect(draft!.vaultPolicies).toBeTruthy();
+    expect(draft!.vaultAppRoles).toBeTruthy();
+    expect(draft!.vaultKv).toBeTruthy();
+    const policies = draft!.vaultPolicies as Array<{ name: string }>;
+    const appRoles = draft!.vaultAppRoles as Array<{ name: string }>;
+    const kv = draft!.vaultKv as Array<{ path: string }>;
+    expect(policies[0].name).toBe('my-policy');
+    expect(appRoles[0].name).toBe('my-role');
+    expect(kv[0].path).toBe('shared/cfg');
+  });
+
+  it('still works for legacy creates without inputs/vault (back-compat)', async () => {
+    const res = await supertest(buildApp()).post('/api/stack-templates').send(createBody());
+
+    expect(res.status).toBe(201);
+    const tmplId = res.body.data.id;
+    const draft = await testPrisma.stackTemplateVersion.findFirst({
+      where: { templateId: tmplId, status: 'draft' },
+    });
+    expect(draft!.inputs).toBeNull();
+    expect(draft!.vaultPolicies).toBeNull();
+    expect(draft!.vaultAppRoles).toBeNull();
+    expect(draft!.vaultKv).toBeNull();
+  });
+
+  it('returns 403 when vault section is present and caller lacks template-vault:write', async () => {
+    mockApiKeyRef.permissions = ['stacks:write']; // missing the vault scope
+
+    const body = createBody({
+      vault: {
+        policies: [{ name: 'p', body: 'path "x" { capabilities = ["read"] }' }],
+        appRoles: [{ name: 'r', policy: 'p' }],
+      },
+    });
+
+    const res = await supertest(buildApp()).post('/api/stack-templates').send(body);
+
+    expect(res.status).toBe(403);
+    expect(res.body.success).toBe(false);
+    expect(res.body.code).toBe('template_vault_scope_required');
+  });
+
+  it('session users bypass the vault scope gate', async () => {
+    mockIsSessionRef.value = true;
+
+    const body = createBody({
+      vault: {
+        policies: [{ name: 'p', body: 'path "x" { capabilities = ["read"] }' }],
+        appRoles: [{ name: 'r', policy: 'p' }],
+      },
+    });
+
+    const res = await supertest(buildApp()).post('/api/stack-templates').send(body);
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('returns 400 when a service field has a substitution typo (e.g. {{stak.id}})', async () => {
+    // Pin behaviour: the substitution validator (same one used by
+    // createOrUpdateDraft) runs at create time so authoring typos surface
+    // immediately rather than at apply.
+    const body = createBody({
+      services: [
+        {
+          ...baseService,
+          containerConfig: { env: { ID: '{{stak.id}}' } }, // typo of stack.id
+        },
+      ],
+    });
+
+    const res = await supertest(buildApp()).post('/api/stack-templates').send(body);
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/substitution|stak\.id/i);
+  });
+});

--- a/server/src/routes/stack-templates.ts
+++ b/server/src/routes/stack-templates.ts
@@ -104,6 +104,17 @@ router.get('/:templateId/versions/:versionId', requirePermission('stacks:read'),
 // POST / — Create user template (with initial draft)
 router.post('/', requirePermission('stacks:write'), async (req, res) => {
   try {
+    // Same gate as POST /:templateId/draft: a vault section in the body
+    // requires the elevated template-vault:write scope on top of stacks:write.
+    // Session users always pass.
+    if (draftHasVaultSection(req.body) && !callerHasScope(req, 'template-vault:write')) {
+      return res.status(403).json({
+        success: false,
+        message: 'The vault section requires the template-vault:write scope',
+        code: 'template_vault_scope_required',
+      });
+    }
+
     const parsed = createTemplateSchema.safeParse(req.body);
     if (!parsed.success) {
       return res.status(400).json({ success: false, message: 'Validation failed', issues: parsed.error.issues });

--- a/server/src/services/stacks/stack-template-schemas.ts
+++ b/server/src/services/stacks/stack-template-schemas.ts
@@ -124,6 +124,12 @@ export const createTemplateSchema = z.object({
   // at publish time, so users can create a template and fill it in gradually.
   services: z.array(stackServiceDefinitionSchema),
   configFiles: z.array(configFileInputSchema).optional(),
+  // inputs + vault accepted directly on create so installers can submit a
+  // complete spec in one request rather than create → draft → publish.
+  // Same shapes as draftVersionSchema; the v0 draft persists them on the
+  // initial StackTemplateVersion row.
+  inputs: z.array(templateInputDeclSchema).optional(),
+  vault: templateVaultSectionSchema.optional(),
 });
 
 export const updateTemplateMetaSchema = z.object({

--- a/server/src/services/stacks/stack-template-service.ts
+++ b/server/src/services/stacks/stack-template-service.ts
@@ -270,6 +270,38 @@ export class StackTemplateService {
       );
     }
 
+    // Catch substitution typos (e.g. {{stak.id}}, {{environment.foo}}) at
+    // create time so the operator sees them immediately — same behaviour
+    // as createOrUpdateDraft. Only meaningful when inputs/vault are present;
+    // for back-compat creates (no vault, no inputs) the validator is a no-op
+    // beyond what other layers already check.
+    const inputNamesForValidation = new Set((input.inputs ?? []).map((i) => i.name));
+    const issues = validateTemplateSubstitutions({
+      scope: input.scope,
+      parameterNames: parameterNamesFromDefinitions(input.parameters),
+      inputNames: inputNamesForValidation,
+      services: input.services,
+      configFiles: input.configFiles,
+      networks: input.networks,
+      volumes: input.volumes,
+      resourceInputs: input.resourceInputs,
+      resourceOutputs: input.resourceOutputs,
+      vaultPolicies: input.vault?.policies,
+      vaultAppRoles: input.vault?.appRoles,
+      vaultKvPaths: (input.vault?.kv ?? []).map((k) => k.path),
+    });
+    if (issues.length > 0) {
+      const summary = issues
+        .slice(0, 5)
+        .map((i) => `${i.path}: ${i.message}`)
+        .join('; ');
+      const suffix = issues.length > 5 ? ` (+${issues.length - 5} more)` : '';
+      throw new TemplateError(
+        `Template substitution validation failed: ${summary}${suffix}`,
+        400,
+      );
+    }
+
     // Extract config files from services (they come embedded in StackServiceDefinition.configFiles)
     // and also accept top-level configFiles input
     const configFileInputs = input.configFiles ?? [];
@@ -321,6 +353,10 @@ export class StackTemplateService {
           resourceInputs: input.resourceInputs ? (input.resourceInputs as unknown as Prisma.InputJsonValue) : undefined,
           networks: input.networks as unknown as Prisma.InputJsonValue,
           volumes: input.volumes as unknown as Prisma.InputJsonValue,
+          inputs: input.inputs ? (input.inputs as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
+          vaultPolicies: input.vault?.policies ? (input.vault.policies as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
+          vaultAppRoles: input.vault?.appRoles ? (input.vault.appRoles as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
+          vaultKv: input.vault?.kv ? (input.vault.kv as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
           createdById: createdById ?? null,
           services: {
             create: input.services.map((s, i) =>


### PR DESCRIPTION
## Summary

Installers building stack templates that need a vault section had to make three round-trips: create-template (no vault/inputs) → POST draft (with vault/inputs) → publish. The intermediate create call left a no-op stub draft that was immediately replaced. This change accepts the same `inputs[]` and `vault` sections that the draft endpoint already accepts, so a complete spec can be submitted in a single request and the v0 draft persists everything.

Customer feedback #6 from the slackbot installer review — explicitly flagged as low-risk because it's purely additive.

## Changes

- `createTemplateSchema` now accepts optional `inputs[]` (`TemplateInputDeclaration[]`) and `vault` (`TemplateVaultSection`) — same shapes already used by `draftVersionSchema`.
- `CreateStackTemplateRequest` (in `lib/types/stack-templates.ts`) gains the same two optional fields.
- `createUserTemplate` persists `inputs` and `vaultPolicies`/`vaultAppRoles`/`vaultKv` on the v0 `StackTemplateVersion` row.
- `POST /api/stack-templates` mirrors the `template-vault:write` permission gate from the draft route: a non-empty vault section requires the elevated scope on top of `stacks:write`. Session users bypass the check, same as draft.
- `validateTemplateSubstitutions` now runs at create time too (mirrors draft) so authoring typos like `{{stak.id}}` fail at create instead of leaking to apply.

## Test plan

- [x] 4 new schema unit cases on `createTemplateSchema` (inputs, full vault, empty vault, invalid kv path; pinned uniqueness contract for input names)
- [x] 6 HTTP integration cases on the route — input persistence, vault persistence, back-compat, 403 on missing scope, session-user bypass, substitution-typo rejection
- [x] Full server suite — 1882 tests pass
- [x] `pnpm --filter mini-infra-server lint` — clean
- [x] `pnpm build:server` and `pnpm --filter mini-infra-client build` — both compile
- [x] Live smoke against the dev worktree:
  - POST with services + inputs + vault → 201; `GET` returns the template with `draftVersion.inputs[]` (defaults applied) and `draftVersion.vault.policies/appRoles/kv` populated.
  - POST with `{{stak.id}}` typo → 400 with substitution-validator message.
  - DELETE the smoke template → 200.

## Notes for reviewer

This works alongside [#300](https://github.com/mrgeoffrich/mini-infra/pull/300) (`vaultAppRoleRef` persistence on the draft path). For the full installer benefit — declaring vault.appRoles AND services that bind to them via `vaultAppRoleRef` in a single create call — both PRs need to land. The schema field for `vaultAppRoleRef` is intentionally not duplicated here to avoid a merge conflict; pick #300 first or rebase this onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)