### PR TITLE
fix(stacks): reject vault-wrapped-secret-id with auto-restart policies

### DIFF
--- a/docs/user/vault-app-developer-guide.md
+++ b/docs/user/vault-app-developer-guide.md
@@ -268,7 +268,7 @@ This is the built-in `hello-vault` example template ([server/templates/hello-vau
           "VAULT_WRAPPED_SECRET_ID": { "kind": "vault-wrapped-secret-id", "ttlSeconds": 300 }
         },
         "joinResourceNetworks": ["vault"],
-        "restartPolicy": "unless-stopped"
+        "restartPolicy": "no"
       },
       "order": 1
     }
@@ -321,12 +321,17 @@ Most apps can simply retry: catch the startup failure, sleep, and try again. On 
 
 ### Handling container restarts
 
-The wrapped secret_id is only valid for its TTL window (default 300s). If your container crashes and Docker restarts it **after** the TTL has elapsed, the env var is stale — unwrap will fail. This is expected. Either:
+A wrapped secret_id is **single-use**. The unwrap call on first boot consumes it. Any later restart of the same container (Docker auto-restart, host reboot, manual `docker restart`) hits a Vault that no longer recognises the token, and unwrap fails with `wrapping token is not valid or does not exist`.
 
-- Let the container crash-loop until the next apply (simplest).
-- If you have a persistent volume, cache the unwrapped client_token there and renew it instead of re-logging in. Be aware this makes the volume sensitive.
+If your container is on `restartPolicy: "always"` or `"unless-stopped"`, that error will spam the logs every few seconds — burying the *original* failure (e.g. an invalid Slack token or a misconfigured AppRole policy) under a wall of misleading wrapper-token errors. Mini Infra rejects this combo at template/draft validation time so you can't accidentally ship it.
 
-For most apps, the "just re-apply the stack" approach is fine — restarts after a crash are rare, and if your container is crashing more than every 5 minutes you have bigger problems.
+Pick one of these instead:
+
+- **`restartPolicy: "no"`** *(recommended)* — if first boot fails, the container stays dead and the original error is the last thing in `docker logs`. Redeploy the stack to mint a fresh wrapped token and try again.
+- **`restartPolicy: "on-failure"`** — Docker retries on non-zero exit. Same caveat applies (each retry will see the consumed token and fail), but the operator has explicitly opted into the retry semantics. Useful if your entrypoint persists the unwrapped credential to a tmpfs or volume on first success.
+- **Cache the unwrapped client_token on a persistent volume** and renew via `POST /v1/auth/token/renew-self` rather than re-logging in. Only the first boot ever calls unwrap. Be aware this makes the volume sensitive.
+
+The TTL (default 300s) is a separate concern: even with the right restartPolicy, if the wrapped token expires before your entrypoint reaches the unwrap call, you'll need a redeploy.
 
 ## Secrets engine and paths
 

--- a/server/src/__tests__/builtin-vault-reconcile.test.ts
+++ b/server/src/__tests__/builtin-vault-reconcile.test.ts
@@ -6,7 +6,7 @@
  *
  * Covers:
  *   - hello-vault template parses correctly and has the expected vault section
- *   - builtinVersion on hello-vault is 2
+ *   - builtinVersion on hello-vault is 3
  *   - Service vaultAppRoleRef matches declared appRole
  *   - All 7 system templates parse without errors
  *   - Cross-references in vault sections are valid for every system template
@@ -40,8 +40,8 @@ describe('hello-vault template.json', () => {
     expect(() => loadTemplate('hello-vault')).not.toThrow();
   });
 
-  it('has builtinVersion 2', () => {
-    expect(loadTemplate('hello-vault').builtinVersion).toBe(2);
+  it('has builtinVersion 3', () => {
+    expect(loadTemplate('hello-vault').builtinVersion).toBe(3);
   });
 
   it('declares exactly one policy and one appRole', () => {

--- a/server/src/__tests__/dynamic-env-source-schema.test.ts
+++ b/server/src/__tests__/dynamic-env-source-schema.test.ts
@@ -78,3 +78,71 @@ describe('dynamicEnvSource — vault-kv (new in Phase 1)', () => {
     expect(parseDyn({ K: { kind: 'vault-something-else', path: 'x', field: 'y' } }).success).toBe(false);
   });
 });
+
+describe('stackContainerConfigSchema — wrapped-secret-id + restartPolicy guard', () => {
+  // Single-use credentials must not be paired with a restart policy that
+  // retries forever. Auto-restart after first unwrap floods logs with
+  // "wrapping token is not valid" and buries the original first-boot error.
+  // Customer feedback #3 from the slackbot installer review.
+
+  function parseFull(restartPolicy: string | undefined, kind = 'vault-wrapped-secret-id') {
+    return stackContainerConfigSchema.safeParse({
+      dynamicEnv: { TOKEN: kind === 'vault-wrapped-secret-id' ? { kind } : { kind, path: 'x', field: 'y' } },
+      ...(restartPolicy === undefined ? {} : { restartPolicy }),
+    });
+  }
+
+  it('rejects wrapped-secret-id with restartPolicy="always"', () => {
+    const r = parseFull('always');
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const messages = r.error.issues.map((i) => i.message);
+      expect(messages.some((m) => m.includes('wrapped') && m.includes('always'))).toBe(true);
+      expect(messages.some((m) => m.includes('TOKEN'))).toBe(true);
+    }
+  });
+
+  it('rejects wrapped-secret-id with restartPolicy="unless-stopped"', () => {
+    const r = parseFull('unless-stopped');
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const messages = r.error.issues.map((i) => i.message);
+      expect(messages.some((m) => m.includes('unless-stopped'))).toBe(true);
+    }
+  });
+
+  it('accepts wrapped-secret-id with restartPolicy="no"', () => {
+    expect(parseFull('no').success).toBe(true);
+  });
+
+  it('accepts wrapped-secret-id with restartPolicy="on-failure"', () => {
+    expect(parseFull('on-failure').success).toBe(true);
+  });
+
+  it('accepts wrapped-secret-id with restartPolicy unset (Docker default = no)', () => {
+    expect(parseFull(undefined).success).toBe(true);
+  });
+
+  it('does not block restartPolicy="always" when no wrapped-secret-id is present', () => {
+    const r = stackContainerConfigSchema.safeParse({
+      dynamicEnv: { ROLE_ID: { kind: 'vault-role-id' } },
+      restartPolicy: 'always',
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('reports every wrapped key when multiple dynamicEnv entries use the same kind', () => {
+    const r = stackContainerConfigSchema.safeParse({
+      dynamicEnv: {
+        TOKEN_A: { kind: 'vault-wrapped-secret-id' },
+        TOKEN_B: { kind: 'vault-wrapped-secret-id', ttlSeconds: 600 },
+      },
+      restartPolicy: 'always',
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const messages = r.error.issues.map((i) => i.message);
+      expect(messages.some((m) => m.includes('TOKEN_A') && m.includes('TOKEN_B'))).toBe(true);
+    }
+  });
+});

--- a/server/src/__tests__/stack-templates-wrapped-secret-restart.integration.test.ts
+++ b/server/src/__tests__/stack-templates-wrapped-secret-restart.integration.test.ts
@@ -1,0 +1,172 @@
+/**
+ * HTTP regression test for the wrapped-secret-id + restartPolicy guard.
+ *
+ * Customer feedback #3: a service that combines `vault-wrapped-secret-id`
+ * with `restartPolicy: "always"` (or `"unless-stopped"`) hits a buried-error
+ * trap — the wrapped token is consumed on first unwrap, every restart
+ * thereafter spams "wrapping token is not valid", and the original
+ * first-boot failure scrolls off the operator's logs.
+ *
+ * The validator now rejects this combo at template-draft validation time.
+ * This test posts both the bad combo and a valid combo through the real
+ * HTTP draft route to confirm the guard is on the wire.
+ */
+
+import supertest from 'supertest';
+import express, { type Request, type Response, type NextFunction } from 'express';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { testPrisma } from './integration-test-helpers';
+
+vi.mock('../middleware/auth', () => ({
+  requirePermission: () => (req: Request, _res: Response, next: NextFunction) => {
+    (req as Request & { user?: { id: string } }).user = { id: 'session-user' };
+    next();
+  },
+}));
+
+vi.mock('../lib/prisma', () => ({ default: testPrisma }));
+
+import stackTemplateRouter from '../routes/stack-templates';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/stack-templates', stackTemplateRouter);
+  return app;
+}
+
+async function createUserTemplateRow(): Promise<string> {
+  const templateId = createId();
+  await testPrisma.stackTemplate.create({
+    data: {
+      id: templateId,
+      name: `tpl-${templateId.slice(0, 6)}`,
+      displayName: 'Wrapped-secret restart-guard test',
+      source: 'user',
+      scope: 'environment',
+      currentVersionId: null,
+      draftVersionId: null,
+    },
+  });
+  return templateId;
+}
+
+const baseService = {
+  serviceName: 'web',
+  serviceType: 'Stateful',
+  dockerImage: 'nginx',
+  dockerTag: 'latest',
+  dependsOn: [],
+  order: 0,
+};
+
+describe('POST /api/stack-templates/:id/draft — wrapped-secret-id + restartPolicy guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects services that combine vault-wrapped-secret-id with restartPolicy="always"', async () => {
+    const templateId = await createUserTemplateRow();
+
+    const draftBody = {
+      networks: [],
+      volumes: [],
+      services: [
+        {
+          ...baseService,
+          containerConfig: {
+            dynamicEnv: { VAULT_WRAPPED_SECRET_ID: { kind: 'vault-wrapped-secret-id' } },
+            restartPolicy: 'always',
+          },
+        },
+      ],
+    };
+
+    const res = await supertest(buildApp())
+      .post(`/api/stack-templates/${templateId}/draft`)
+      .send(draftBody);
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toMatch(/Validation failed/);
+    const issueMessages = (res.body.issues as Array<{ message: string }>).map((i) => i.message);
+    expect(issueMessages.some((m) => m.includes('wrapped') && m.includes('always'))).toBe(true);
+    expect(issueMessages.some((m) => m.includes('redeploy'))).toBe(true);
+  });
+
+  it('rejects the same combo with restartPolicy="unless-stopped"', async () => {
+    const templateId = await createUserTemplateRow();
+
+    const draftBody = {
+      networks: [],
+      volumes: [],
+      services: [
+        {
+          ...baseService,
+          containerConfig: {
+            dynamicEnv: { VAULT_WRAPPED_SECRET_ID: { kind: 'vault-wrapped-secret-id' } },
+            restartPolicy: 'unless-stopped',
+          },
+        },
+      ],
+    };
+
+    const res = await supertest(buildApp())
+      .post(`/api/stack-templates/${templateId}/draft`)
+      .send(draftBody);
+
+    expect(res.status).toBe(400);
+    const issueMessages = (res.body.issues as Array<{ message: string }>).map((i) => i.message);
+    expect(issueMessages.some((m) => m.includes('unless-stopped'))).toBe(true);
+  });
+
+  it('accepts the same dynamicEnv when restartPolicy is "no"', async () => {
+    const templateId = await createUserTemplateRow();
+
+    const draftBody = {
+      networks: [],
+      volumes: [],
+      services: [
+        {
+          ...baseService,
+          containerConfig: {
+            dynamicEnv: { VAULT_WRAPPED_SECRET_ID: { kind: 'vault-wrapped-secret-id' } },
+            restartPolicy: 'no',
+          },
+        },
+      ],
+    };
+
+    const res = await supertest(buildApp())
+      .post(`/api/stack-templates/${templateId}/draft`)
+      .send(draftBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('still allows restartPolicy="always" when no wrapped-secret-id is in dynamicEnv', async () => {
+    const templateId = await createUserTemplateRow();
+
+    const draftBody = {
+      networks: [],
+      volumes: [],
+      services: [
+        {
+          ...baseService,
+          containerConfig: {
+            dynamicEnv: { VAULT_ROLE_ID: { kind: 'vault-role-id' } },
+            restartPolicy: 'always',
+          },
+        },
+      ],
+    };
+
+    const res = await supertest(buildApp())
+      .post(`/api/stack-templates/${templateId}/draft`)
+      .send(draftBody);
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/server/src/services/stacks/schemas.ts
+++ b/server/src/services/stacks/schemas.ts
@@ -180,14 +180,37 @@ export const stackContainerConfigSchema = z.object({
     )
     .optional(),
 }).superRefine((config, ctx) => {
-  if (!config.env || !config.dynamicEnv) return;
-  const overlap = Object.keys(config.env).filter((k) => k in config.dynamicEnv!);
-  if (overlap.length > 0) {
-    ctx.addIssue({
-      code: "custom",
-      path: ["dynamicEnv"],
-      message: `env and dynamicEnv share key(s): ${overlap.join(", ")}. Dynamic keys must be disjoint from static env.`,
-    });
+  if (config.env && config.dynamicEnv) {
+    const overlap = Object.keys(config.env).filter((k) => k in config.dynamicEnv!);
+    if (overlap.length > 0) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["dynamicEnv"],
+        message: `env and dynamicEnv share key(s): ${overlap.join(", ")}. Dynamic keys must be disjoint from static env.`,
+      });
+    }
+  }
+
+  // Single-use credentials must not be paired with a restart policy that
+  // retries forever. A wrapped secret_id is consumed by the unwrap call on
+  // first boot; subsequent restarts spam "wrapping token is not valid",
+  // which buries the original first-boot error (e.g. invalid Slack token).
+  // For these services, restartPolicy must be 'no' or 'on-failure' so the
+  // operator sees the real failure and can redeploy to mint a fresh token.
+  if (config.dynamicEnv && (config.restartPolicy === 'always' || config.restartPolicy === 'unless-stopped')) {
+    const wrappedKeys = Object.entries(config.dynamicEnv)
+      .filter(([, src]) => src.kind === 'vault-wrapped-secret-id')
+      .map(([k]) => k);
+    if (wrappedKeys.length > 0) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["restartPolicy"],
+        message:
+          `restartPolicy="${config.restartPolicy}" cannot be combined with vault-wrapped-secret-id (${wrappedKeys.join(', ')}). ` +
+          `Wrapped secret IDs are single-use; auto-restart will retry the unwrap forever and bury the original first-boot error. ` +
+          `Use restartPolicy="no" (preferred) or "on-failure" so the original failure stays visible — redeploy the stack to mint a fresh wrapped token.`,
+      });
+    }
   }
 });
 

--- a/server/templates/hello-vault/template.json
+++ b/server/templates/hello-vault/template.json
@@ -1,7 +1,7 @@
 {
   "name": "hello-vault",
   "displayName": "Hello Vault (demo)",
-  "builtinVersion": 2,
+  "builtinVersion": 3,
   "scope": "environment",
   "category": "examples",
   "description": "End-to-end demo: unwraps a secret_id at boot, logs into Vault via AppRole, reads a KV secret, and echoes it. Bind a VaultAppRole in the Application settings before deploying.",
@@ -57,7 +57,7 @@
           "VAULT_ROLE_ID": { "kind": "vault-role-id" },
           "VAULT_WRAPPED_SECRET_ID": { "kind": "vault-wrapped-secret-id", "ttlSeconds": 300 }
         },
-        "restartPolicy": "unless-stopped",
+        "restartPolicy": "no",
         "joinResourceNetworks": ["vault"],
         "logConfig": {
           "type": "json-file",


### PR DESCRIPTION
## Summary

A wrapped `secret_id` is single-use: the unwrap call on first boot consumes it, and any subsequent restart of the same container hits a Vault that no longer recognises the token. With `restartPolicy: "always"` or `"unless-stopped"`, Docker's auto-restart loop spams `wrapping token is not valid or does not exist` every few seconds and **buries the original first-boot failure** (e.g. an invalid Slack token caught by `auth.test`).

Customer reproduction: 30-second diagnosis → 30 minutes because the real error scrolled off the logs.

## What this PR changes

### Schema-level reject (the actual fix)
`stackContainerConfigSchema.superRefine` now flags any `dynamicEnv.{}.kind === "vault-wrapped-secret-id"` combined with `restartPolicy === "always" | "unless-stopped"` and returns a 400 at draft / create / update time. The error message names the offending env keys, explains the failure mode, and tells the operator what to do:

> `restartPolicy="always"` cannot be combined with `vault-wrapped-secret-id (VAULT_WRAPPED_SECRET_ID)`. Wrapped secret IDs are single-use; auto-restart will retry the unwrap forever and bury the original first-boot error. Use `restartPolicy="no"` (preferred) or `"on-failure"` so the original failure stays visible — redeploy the stack to mint a fresh wrapped token.

`"no"`, `"on-failure"`, and unset (Docker default = no) all remain valid. `"on-failure"` is intentionally allowed for operators who want explicit retry semantics (e.g. they cache the unwrapped client_token to a tmpfs/volume on first success).

### Stops shipping the bug pattern in our own demos
- `server/templates/hello-vault/template.json`: change `restartPolicy "unless-stopped"` → `"no"`, bump `builtinVersion` 2 → 3 so existing instances upgrade automatically.
- `docs/user/vault-app-developer-guide.md`:
  - The walkthrough example template had the same `"unless-stopped"` pattern — now `"no"`.
  - The "Handling container restarts" section previously recommended **letting the container crash-loop until next apply** — which is exactly the customer's pain. Rewritten to explain why the unbounded policies are now rejected and what the alternatives are.

## Test plan

- [x] 6 new unit cases on `stackContainerConfigSchema` covering each bad/safe combo + unset + the multi-key case
- [x] 4 HTTP integration cases on `POST /api/stack-templates/:id/draft` proving the guard fires through the real route
- [x] `builtin-vault-reconcile.test.ts` pins `builtinVersion=3` for `hello-vault`
- [x] Full server suite — 1882 tests pass
- [x] `pnpm --filter mini-infra-server lint` — clean
- [x] `pnpm build:server` and `pnpm --filter mini-infra-client build` — both compile
- [x] Live smoke against the dev worktree:
  - `POST /draft` with `wrapped-secret-id + restartPolicy: "always"` → **400** with the full guidance message including the recommended fix and "redeploy to mint a fresh wrapped token"
  - `POST /draft` with `wrapped-secret-id + restartPolicy: "no"` → **200**
  - `GET /api/stack-templates/<hello-vault-id>` after rebuild shows `currentVersion.version=3` with `containerConfig.restartPolicy="no"`

## Notes

This is the most actionable slice of customer feedback #3. The customer also suggested:
- (a) the slackbot's own entrypoints should detect "wrapped token consumed" and exit cleanly — that's their codebase, can't fix here
- (b) Mini Infra could re-mint on container restart — genuinely impractical because env vars are immutable post-start; would need an init-container/tmpfs redesign

Rejecting the unbounded restart policies up-front prevents the buried-error pattern at the root, which is the closest Mini Infra can get to the customer's stated intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)