### PR TITLE
refactor(stacks): unify service schemas on a shared base + pin the contract

### DIFF
--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -256,6 +256,42 @@ Per-component levels live in `config/logging.json` under `development` / `produc
 
 Console output is reserved for pre-logger boot (`server.ts`, `app-factory.ts`, `prisma.ts`, `config-new.ts`, `logging-config.ts` fallback) plus scripts and tests. Don't add new `console.*` calls outside those sites.
 
+## Test Conventions
+
+### Field-persistence regression tests must go through the HTTP route
+
+If you're testing that a field set on a request body lands on the correct DB column, write the test against the HTTP route via **supertest** — do NOT seed the DB with `prisma.<model>.create({ data: {...} })` and assert what comes back.
+
+**Why:** Mini Infra hit a real bug where `services[].vaultAppRoleRef` was silently stripped by Zod's default unknown-key behaviour at the HTTP boundary. Existing integration tests for the apply pipeline wrote rows directly via `testPrisma.stackTemplateService.create({...})` — those tests passed because they bypassed the validation layer entirely. The field never made it from a real POST body to the DB column, but no test caught that the public API surface was broken.
+
+```ts
+// ❌ Tests the apply orchestrator, NOT the HTTP contract.
+//    Will pass even if the route's Zod schema strips the field.
+await testPrisma.stackTemplateService.create({
+  data: { /* ... */, vaultAppRoleRef: 'my-approle' },
+});
+const apply = await runApply(stackId);
+expect(apply.serviceResults[0].vaultAppRoleRef).toBe('my-approle');
+
+// ✅ Posts a real body and asserts the column is set after the route handler runs.
+//    Catches Zod-strip bugs and any future schema drift.
+await supertest(app)
+  .post(`/api/stack-templates/${tmplId}/draft`)
+  .send({ services: [{ /* ... */, vaultAppRoleRef: 'my-approle' }], /* ... */ });
+const row = await testPrisma.stackTemplateService.findFirst({ where: { versionId } });
+expect(row?.vaultAppRoleRef).toBe('my-approle');
+```
+
+Direct Prisma fixture inserts are still the right tool for testing the orchestrator/reconciler in isolation (e.g., "given a row with X, the apply pipeline does Y") — just don't rely on them as a contract test for the public API.
+
+References:
+- [`server/src/__tests__/stack-templates-draft-route.integration.test.ts`](src/__tests__/stack-templates-draft-route.integration.test.ts) — example of the supertest-over-fixtures pattern.
+- [`server/src/__tests__/service-schema-drift.test.ts`](src/__tests__/service-schema-drift.test.ts) — structural pin so the two service schemas can't drift on the common base again.
+
+### Schemas that share a field set should share a base
+
+When two schemas describe the same logical entity at different layers (e.g. a service in a file-loaded template vs in an HTTP draft body), put the shared fields on a single `z.object({...})` and have each leaf `.extend({...})` it. Refines stay on the leaves; the base is field-only. See `stackServiceCommonFieldsSchema` in [`server/src/services/stacks/schemas.ts`](src/services/stacks/schemas.ts) and how `stackServiceDefinitionSchema` and `templateServiceSchema` build on it. A literal `z.object({...})` per layer is what produced the original `vaultAppRoleRef` drift.
+
 ## General Rules
 
 1. **Always use service wrappers over raw SDK calls** — they add caching, auth, retries, circuit breakers, error mapping, and audit logging

--- a/server/src/__tests__/service-schema-drift.test.ts
+++ b/server/src/__tests__/service-schema-drift.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Structural drift-prevention test for the two "service" schemas.
+ *
+ * Background: Mini Infra has two Zod schemas that describe a service entry
+ * in a stack/template. They previously drifted (`vaultAppRoleRef` was added
+ * to the file-loader schema but not the HTTP draft schema), and Zod's
+ * default of stripping unknown keys silently dropped the field on the way
+ * to Prisma — apply-time bound nothing because the column was NULL.
+ * Customer feedback #1 from the slackbot installer review.
+ *
+ * The two schemas now extend a shared `stackServiceCommonFieldsSchema`
+ * base. This test exercises a fixture covering every common field and
+ * proves the field round-trips through BOTH schemas. If a future change
+ * adds a common field to only one of them (e.g. by re-introducing a
+ * literal `z.object({...})` instead of extending the base), the matching
+ * assertion here fails — well before a deploy hits the silent-drop bug.
+ *
+ * NOT a contract test for serviceType-specific refines or for HTTP-only
+ * fields like `configFiles` / `adoptedContainer` / `vaultAppRoleId` — those
+ * intentionally live only on `stackServiceDefinitionSchema`.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  stackServiceCommonFieldsSchema,
+  stackServiceDefinitionSchema,
+} from '../services/stacks/schemas';
+import { templateFileSchema } from '../services/stacks/template-file-loader';
+
+// ─── Fixture covering every common field with a representative value ─────────
+
+const commonFieldFixture = {
+  serviceName: 'web',
+  serviceType: 'Stateful' as const,
+  dockerImage: 'nginx',
+  dockerTag: '1.25',
+  containerConfig: {
+    env: { LOG_LEVEL: 'info' },
+    restartPolicy: 'no' as const,
+  },
+  initCommands: [
+    { volumeName: 'data', mountPath: '/data', commands: ['chown 1000:1000 /data'] },
+  ],
+  dependsOn: ['db'],
+  order: 1,
+  // routing intentionally omitted (Stateful + routing is rejected by the
+  // file-loader's stricter refine; the field itself still belongs to the
+  // common base).
+  vaultAppRoleRef: 'web-approle',
+};
+
+const COMMON_FIELDS = [
+  'serviceName',
+  'serviceType',
+  'dockerImage',
+  'dockerTag',
+  'containerConfig',
+  'initCommands',
+  'dependsOn',
+  'order',
+  'routing',
+  'vaultAppRoleRef',
+] as const;
+
+// Every key in COMMON_FIELDS must also be a key of the shared base. If
+// someone adds a key to the array without adding it to the schema (or vice
+// versa), this fails immediately.
+describe('stackServiceCommonFieldsSchema — pinned key set', () => {
+  it('exposes every documented common field on .shape', () => {
+    const shapeKeys = new Set(Object.keys(stackServiceCommonFieldsSchema.shape));
+    for (const field of COMMON_FIELDS) {
+      expect(shapeKeys.has(field), `common base missing field "${field}"`).toBe(true);
+    }
+  });
+
+  it('does not silently drop common fields when parsed (Zod strict-keys check)', () => {
+    const r = stackServiceCommonFieldsSchema.safeParse(commonFieldFixture);
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.serviceName).toBe('web');
+      expect(r.data.dockerImage).toBe('nginx');
+      expect(r.data.vaultAppRoleRef).toBe('web-approle');
+      expect(r.data.dependsOn).toEqual(['db']);
+      expect(r.data.order).toBe(1);
+    }
+  });
+});
+
+// ─── stackServiceDefinitionSchema (HTTP/DB) ─────────────────────────────────
+
+describe('stackServiceDefinitionSchema — preserves every common field', () => {
+  it('round-trips the full common fixture without dropping fields', () => {
+    const r = stackServiceDefinitionSchema.safeParse(commonFieldFixture);
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+
+    // Each assertion below catches a different drift scenario: a future PR
+    // that overrides one of these fields with a stricter shape on the
+    // extension side without keeping it accept-shaped on the base.
+    expect(r.data.serviceName).toBe(commonFieldFixture.serviceName);
+    expect(r.data.serviceType).toBe(commonFieldFixture.serviceType);
+    expect(r.data.dockerImage).toBe(commonFieldFixture.dockerImage);
+    expect(r.data.dockerTag).toBe(commonFieldFixture.dockerTag);
+    expect(r.data.containerConfig).toEqual(commonFieldFixture.containerConfig);
+    expect(r.data.initCommands).toEqual(commonFieldFixture.initCommands);
+    expect(r.data.dependsOn).toEqual(commonFieldFixture.dependsOn);
+    expect(r.data.order).toBe(commonFieldFixture.order);
+    // The vaultAppRoleRef bug: if a future refactor accidentally drops the
+    // field off the HTTP schema's accepted set (the Zod-strip-unknown trap),
+    // this assertion fails.
+    expect(r.data.vaultAppRoleRef).toBe(commonFieldFixture.vaultAppRoleRef);
+  });
+});
+
+// ─── templateFileSchema → services[] (file loader) ──────────────────────────
+
+describe('templateFileSchema services[] — preserves every common field', () => {
+  // Wrap the fixture in a complete template body so we can hand it to
+  // the top-level schema (no need to export the inner templateServiceSchema
+  // just for tests). Include the vault section that vaultAppRoleRef refers
+  // to — the file-loader has a cross-validator that rejects dangling refs.
+  function templateBody(svc: Record<string, unknown>) {
+    return {
+      name: 'tpl',
+      displayName: 'Test',
+      builtinVersion: 1,
+      scope: 'environment' as const,
+      networks: [],
+      volumes: [],
+      services: [svc],
+      vault: {
+        policies: [{ name: 'web-policy', body: 'path "x" { capabilities = ["read"] }' }],
+        appRoles: [{ name: 'web-approle', policy: 'web-policy' }],
+      },
+    };
+  }
+
+  it('round-trips the full common fixture without dropping fields', () => {
+    const r = templateFileSchema.safeParse(templateBody(commonFieldFixture));
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+
+    const svc = r.data.services[0];
+    expect(svc.serviceName).toBe(commonFieldFixture.serviceName);
+    expect(svc.serviceType).toBe(commonFieldFixture.serviceType);
+    expect(svc.dockerImage).toBe(commonFieldFixture.dockerImage);
+    expect(svc.dockerTag).toBe(commonFieldFixture.dockerTag);
+    expect(svc.containerConfig).toEqual(commonFieldFixture.containerConfig);
+    expect(svc.initCommands).toEqual(commonFieldFixture.initCommands);
+    expect(svc.dependsOn).toEqual(commonFieldFixture.dependsOn);
+    expect(svc.order).toBe(commonFieldFixture.order);
+    expect(svc.vaultAppRoleRef).toBe(commonFieldFixture.vaultAppRoleRef);
+  });
+});
+
+// ─── HTTP-only fields stay HTTP-only ─────────────────────────────────────────
+
+describe('schema separation — HTTP-only fields are not on the common base', () => {
+  // These fields are intentionally absent from the file-loader shape:
+  //   - configFiles  : the loader uses a top-level `configFiles[]` array
+  //                    (referenced by serviceName); the embedded form here
+  //                    only exists post-load.
+  //   - adoptedContainer / poolConfig: file-format doesn't support these
+  //                    service types yet.
+  //   - vaultAppRoleId: resolved concrete ID set at apply time, not authored.
+  it('common base does not expose HTTP-only fields', () => {
+    const baseKeys = new Set(Object.keys(stackServiceCommonFieldsSchema.shape));
+    expect(baseKeys.has('configFiles')).toBe(false);
+    expect(baseKeys.has('adoptedContainer')).toBe(false);
+    expect(baseKeys.has('poolConfig')).toBe(false);
+    expect(baseKeys.has('vaultAppRoleId')).toBe(false);
+  });
+});

--- a/server/src/services/stacks/schemas.ts
+++ b/server/src/services/stacks/schemas.ts
@@ -280,25 +280,56 @@ const stackNameSchema = z
   .max(100)
   .regex(nameRegex, "Stack name can only contain letters, numbers, hyphens, and underscores");
 
-export const stackServiceDefinitionSchema = z
-  .object({
-    serviceName: z
-      .string()
-      .min(1)
-      .max(100)
-      .regex(
-        nameRegex,
-        "Service name can only contain letters, numbers, hyphens, and underscores"
-      ),
-    serviceType: z.enum(STACK_SERVICE_TYPES),
-    dockerImage: z.string().min(1),
-    dockerTag: z.string().min(1),
-    containerConfig: stackContainerConfigSchema,
+/**
+ * Shared field set for "a service" — common to both the HTTP/DB shape
+ * (`stackServiceDefinitionSchema` below) and the file-loaded template shape
+ * (`templateServiceSchema` in `template-file-loader.ts`). Each leaf schema
+ * extends this with its own additions and applies its own `.refine()`s.
+ *
+ * Why a shared base: previously these two schemas were independent
+ * `z.object({...})` literals. They drifted (vaultAppRoleRef was added to the
+ * file loader but not the HTTP schema), and Zod's strip-unknown-keys default
+ * made the gap silent — POST /draft would parse successfully but lose the
+ * field before it reached Prisma, and apply-time bound nothing. Customer
+ * feedback #1 from the slackbot installer review.
+ *
+ * Adding a new common field here makes it appear in BOTH schemas with no
+ * further work, which is the structural property the bug needed. If a field
+ * is intentionally specific to one shape (e.g. `configFiles` is only the
+ * resolved/embedded form, `vaultAppRoleId` is only set after apply), keep
+ * it on the leaf schema's `.extend({...})`.
+ *
+ * Pure ZodObject (no refines) so leaves can `.extend()` and then `.refine()`
+ * without losing extensibility.
+ */
+export const stackServiceCommonFieldsSchema = z.object({
+  serviceName: z
+    .string()
+    .min(1)
+    .max(100)
+    .regex(
+      nameRegex,
+      "Service name can only contain letters, numbers, hyphens, and underscores"
+    ),
+  serviceType: z.enum(STACK_SERVICE_TYPES),
+  dockerImage: z.string().min(1),
+  dockerTag: z.string().min(1),
+  containerConfig: stackContainerConfigSchema,
+  initCommands: z.array(stackInitCommandSchema).optional(),
+  dependsOn: z.array(z.string()),
+  order: z.number().int().min(0),
+  routing: stackServiceRoutingSchema.optional(),
+  // Symbolic reference to a vault.appRoles[].name declared in the same draft
+  // / template. Resolved to a concrete vaultAppRoleId at apply time.
+  vaultAppRoleRef: z.string().min(1).optional(),
+});
+
+export const stackServiceDefinitionSchema = stackServiceCommonFieldsSchema
+  .extend({
+    // Resolved-only fields (post-loader / post-apply): these don't appear in
+    // the file-loaded template shape because they are either materialised by
+    // the loader (configFiles) or set at apply time (vaultAppRoleId).
     configFiles: z.array(stackConfigFileSchema).optional(),
-    initCommands: z.array(stackInitCommandSchema).optional(),
-    dependsOn: z.array(z.string()),
-    order: z.number().int().min(0),
-    routing: stackServiceRoutingSchema.optional(),
     adoptedContainer: adoptedContainerSchema.optional(),
     poolConfig: poolConfigSchema.optional(),
     vaultAppRoleId: z.string().min(1).nullable().optional(),

--- a/server/src/services/stacks/template-file-loader.ts
+++ b/server/src/services/stacks/template-file-loader.ts
@@ -10,6 +10,7 @@ import {
   stackVolumeSchema,
   stackResourceOutputSchema,
   stackResourceInputSchema,
+  stackServiceCommonFieldsSchema,
 } from "./schemas";
 import {
   templateInputDeclSchema,
@@ -41,20 +42,11 @@ const templateConfigFileSchema = z.object({
   { message: "Either 'content' or 'contentFile' must be provided" }
 );
 
-const templateServiceSchema = z.object({
-  serviceName: z.string().min(1).max(100).regex(nameRegex, "Service name can only contain letters, numbers, hyphens, and underscores"),
-  serviceType: z.enum(STACK_SERVICE_TYPES),
-  dockerImage: z.string().min(1),
-  dockerTag: z.string().min(1),
-  containerConfig: stackContainerConfigSchema,
-  initCommands: z.array(stackInitCommandSchema).optional(),
-  dependsOn: z.array(z.string()),
-  order: z.number().int().min(0),
-  routing: stackServiceRoutingSchema.optional(),
-  // Symbolic reference to a vault.appRoles[].name declared in this template;
-  // resolved to a concrete vaultAppRoleId at apply time in PR 2.
-  vaultAppRoleRef: z.string().min(1).optional(),
-}).refine(
+// Shares its field set with `stackServiceDefinitionSchema` via
+// `stackServiceCommonFieldsSchema` so adding a new common field can't drift
+// silently (customer feedback #1). Leaf-specific fields and the
+// stricter-than-HTTP refine (Stateful must not have routing) stay here.
+const templateServiceSchema = stackServiceCommonFieldsSchema.refine(
   (data) => {
     if (data.serviceType === "StatelessWeb" && !data.routing) return false;
     if (data.serviceType === "AdoptedWeb" && !data.routing) return false;


### PR DESCRIPTION
## Summary

Mini Infra has two Zod schemas that describe a service entry — `templateServiceSchema` (file-loaded templates) and `stackServiceDefinitionSchema` (HTTP/DB) — and they were independent `z.object({...})` literals. They drifted: `vaultAppRoleRef` got added to the file-loader but not the HTTP schema, and Zod's default of stripping unknown keys made the gap silent. Customer feedback #1 from the slackbot installer review:

> "the two schemas should share a base (or one generate the other) so they can't drift again"
> "any test that asserts 'field X persists' should send it through the HTTP route via supertest, not through fixtures"

This PR addresses both halves.

## Structural fix (Zod side)

1. **New `stackServiceCommonFieldsSchema`** — a pure `z.object({...})` carrying every field that's common to both layers: `serviceName`, `serviceType`, `dockerImage`, `dockerTag`, `containerConfig`, `initCommands`, `dependsOn`, `order`, `routing`, `vaultAppRoleRef`.
2. **`stackServiceDefinitionSchema`** is now `commonBase.extend({ ...HTTP-only })` with the existing 5 `.refine()`s preserved verbatim. HTTP-only set: `configFiles` (the resolved/embedded form), `adoptedContainer`, `poolConfig`, `vaultAppRoleId`.
3. **`templateServiceSchema`** is now `commonBase.refine(...)`. The file-loader's stricter rule (Stateful must NOT have routing) stays on the leaf — refines are intentional behaviour; fields are structural.

Adding a new common field now means editing one place. A future literal `z.object({...})` on either layer can't silently drop fields anymore.

## Pinning test (`service-schema-drift.test.ts`)

5 cases that catch the bug pattern before it can ship:

- `.shape` of the common base contains every documented common field
- The same fixture round-trips through `stackServiceDefinitionSchema` **and** `templateFileSchema → services[]`
- The HTTP-only set is asserted absent from the common base

If anyone re-introduces independent `z.object({...})` literals on either layer, the round-trip assertion fails on the field they forgot.

## Test convention (`server/CLAUDE.md`)

New "Test Conventions" section captures the second half of the customer's feedback: **field-persistence regression tests must POST through the route via supertest, not seed via `prisma.<model>.create`**. Direct Prisma fixture inserts are still appropriate for orchestrator/reconciler unit tests, but they're a bad contract test for the public API surface — the original `vaultAppRoleRef` bug existed because every test bypassed the validation layer.

References the new drift test and [`stack-templates-draft-route.integration.test.ts`](https://github.com/mrgeoffrich/mini-infra/pull/300/files) (from #300) as the canonical example of the pattern.

## Behaviour change as a side effect

The HTTP schema now accepts `vaultAppRoleRef` (it's on the common base). That's the same fix as #300 done structurally. The two PRs touch the same line and will conflict trivially. **#300 has independent scope** — `superRefine` on `draftVersionSchema`, the `StackServiceDefinition` lib type, dropping the intersection cast in `toTemplateServiceCreate` — that this PR does NOT duplicate. Either order works; the conflict is one-line.

## Test plan

- [x] `pnpm --filter mini-infra-server test` — 1876 tests pass, including the 5 new drift cases
- [x] `pnpm --filter mini-infra-server lint` — clean
- [x] `pnpm build:server` and `pnpm --filter mini-infra-client build` — both compile
- [x] Live smoke against the dev worktree:
  - 8 built-in system templates parse via the file-loader path (unification didn't break the file format)
  - `POST /api/stack-templates/<id>/draft` with `vaultAppRoleRef` on a service → 200; `GET` returns the field round-tripped
  - `DELETE` cleans up

🤖 Generated with [Claude Code](https://claude.com/claude-code)