### PR TITLE
fix(stacks): v3 egress injection + attach networks before container start

### DIFF
--- a/server/src/services/stacks/__tests__/stack-container-manager-egress.test.ts
+++ b/server/src/services/stacks/__tests__/stack-container-manager-egress.test.ts
@@ -42,17 +42,25 @@ function makeOptions(environmentId: string | null | undefined) {
 const mockCreateLongRunningContainer = vi.fn();
 const mockContainerStart = vi.fn().mockResolvedValue(undefined);
 
+// startContainer now goes through getDockerClient().getContainer(id).start(),
+// not container.start() on the dockerode object returned at create time.
+const mockGetDockerClient = vi.fn(() => ({
+  getContainer: vi.fn(() => ({ start: mockContainerStart })),
+}));
+
 const mockDockerExecutor = {
   createLongRunningContainer: mockCreateLongRunningContainer,
-  getDockerClient: vi.fn(),
+  getDockerClient: mockGetDockerClient,
   pullImageWithAutoAuth: vi.fn(),
 } as any;
 
 // ---------------------------------------------------------------------------
-// Tests for Phase 3 HTTP_PROXY injection (egressFirewallEnabled = true)
+// Tests for HTTP_PROXY injection — fires whenever the env has been provisioned
+// with an egress-gateway (egressGatewayIp non-null), regardless of the
+// egressFirewallEnabled flag (which only gates fw-agent policy enforcement).
 // ---------------------------------------------------------------------------
 
-describe('StackContainerManager — Phase 3 HTTP_PROXY injection (flag ON)', () => {
+describe('StackContainerManager — HTTP_PROXY injection (egressGatewayIp set, flag ON)', () => {
   let mockPrisma: any;
   let manager: StackContainerManager;
 
@@ -79,9 +87,9 @@ describe('StackContainerManager — Phase 3 HTTP_PROXY injection (flag ON)', () 
     return new StackContainerManager(mockDockerExecutor, mockPrisma);
   }
 
-  it('injects HTTP_PROXY env vars when egressFirewallEnabled=true', async () => {
+  it('injects HTTP_PROXY env vars when egressGatewayIp is set (flag ON)', async () => {
     manager = buildManager(
-      { egressFirewallEnabled: true, egressGatewayIp: null },
+      { egressFirewallEnabled: true, egressGatewayIp: '172.30.16.3' },
       { metadata: { subnet: '172.30.5.0/24' } },
     );
     const service = makeService();
@@ -105,7 +113,7 @@ describe('StackContainerManager — Phase 3 HTTP_PROXY injection (flag ON)', () 
 
   it('includes NO_PROXY without bridge CIDR when subnet not found', async () => {
     manager = buildManager(
-      { egressFirewallEnabled: true, egressGatewayIp: null },
+      { egressFirewallEnabled: true, egressGatewayIp: '172.30.16.3' },
       null, // no infra resource → no subnet
     );
     const service = makeService();
@@ -123,7 +131,7 @@ describe('StackContainerManager — Phase 3 HTTP_PROXY injection (flag ON)', () 
 
   it('skips HTTP_PROXY injection when egressBypass=true (v3 gateway service)', async () => {
     manager = buildManager(
-      { egressFirewallEnabled: true, egressGatewayIp: null },
+      { egressFirewallEnabled: true, egressGatewayIp: '172.30.16.3' },
     );
     const service = makeService({ egressBypass: true });
     const options = makeOptions('env-1');
@@ -153,7 +161,7 @@ describe('StackContainerManager — Phase 3 HTTP_PROXY injection (flag ON)', () 
 
   it('merges injected proxy env vars with static service env vars (service vars take precedence)', async () => {
     manager = buildManager(
-      { egressFirewallEnabled: true, egressGatewayIp: null },
+      { egressFirewallEnabled: true, egressGatewayIp: '172.30.16.3' },
       { metadata: { subnet: '172.30.1.0/24' } },
     );
     // Service explicitly sets its own HTTP_PROXY (override)
@@ -172,10 +180,12 @@ describe('StackContainerManager — Phase 3 HTTP_PROXY injection (flag ON)', () 
 });
 
 // ---------------------------------------------------------------------------
-// Tests for legacy DNS injection (egressFirewallEnabled = false)
+// Tests for HTTP_PROXY injection with egressFirewallEnabled = false.
+// Same behavior as flag ON: gateway presence (egressGatewayIp) drives the
+// injection, not the flag. Also covers the no-gateway short-circuit.
 // ---------------------------------------------------------------------------
 
-describe('StackContainerManager — Legacy DNS injection (flag OFF)', () => {
+describe('StackContainerManager — HTTP_PROXY injection (egressGatewayIp set, flag OFF)', () => {
   let mockPrisma: any;
   let manager: StackContainerManager;
 
@@ -187,32 +197,42 @@ describe('StackContainerManager — Legacy DNS injection (flag OFF)', () => {
     });
   });
 
-  function buildManager(envResult: { egressFirewallEnabled: boolean; egressGatewayIp: string | null } | null) {
+  function buildManager(
+    envResult: { egressFirewallEnabled: boolean; egressGatewayIp: string | null } | null,
+    infraResourceResult: { metadata: unknown } | null = null,
+  ) {
     mockPrisma = {
       environment: {
         findUnique: vi.fn().mockResolvedValue(envResult),
       },
       infraResource: {
-        findFirst: vi.fn().mockResolvedValue(null),
+        findFirst: vi.fn().mockResolvedValue(infraResourceResult),
       },
     };
     return new StackContainerManager(mockDockerExecutor, mockPrisma);
   }
 
-  it('injects DNS servers when egressFirewallEnabled=false and egressGatewayIp is set', async () => {
-    manager = buildManager({ egressFirewallEnabled: false, egressGatewayIp: '10.100.0.2' });
+  it('injects HTTP_PROXY env vars when egressGatewayIp is set even though flag is OFF', async () => {
+    manager = buildManager(
+      { egressFirewallEnabled: false, egressGatewayIp: '172.30.16.3' },
+      { metadata: { subnet: '172.30.16.0/22' } },
+    );
     const service = makeService();
     const options = makeOptions('env-1');
 
     await manager.createAndStartContainer('web', service, options);
 
     const callArgs = mockCreateLongRunningContainer.mock.calls[0][0];
-    expect(callArgs.dnsServers).toEqual(['10.100.0.2']);
-    // No HTTP_PROXY vars for legacy path
-    expect(callArgs.env['HTTP_PROXY']).toBeUndefined();
+    expect(callArgs.env['HTTP_PROXY']).toBe('http://egress-gateway:3128');
+    expect(callArgs.env['HTTPS_PROXY']).toBe('http://egress-gateway:3128');
+    expect(callArgs.env['http_proxy']).toBe('http://egress-gateway:3128');
+    expect(callArgs.env['https_proxy']).toBe('http://egress-gateway:3128');
+    expect(callArgs.env['NO_PROXY']).toContain('172.30.16.0/22');
+    // No legacy DNS injection — Docker's default resolver remains.
+    expect(callArgs.dnsServers).toBeUndefined();
   });
 
-  it('injects no DNS and does not throw when egressGatewayIp is null and flag is OFF', async () => {
+  it('skips injection entirely when egressGatewayIp is null', async () => {
     manager = buildManager({ egressFirewallEnabled: false, egressGatewayIp: null });
     const service = makeService();
     const options = makeOptions('env-1');
@@ -224,8 +244,8 @@ describe('StackContainerManager — Legacy DNS injection (flag OFF)', () => {
     expect(callArgs.env['HTTP_PROXY']).toBeUndefined();
   });
 
-  it('injects no DNS when egressBypass=true (legacy TS sidecar)', async () => {
-    manager = buildManager({ egressFirewallEnabled: false, egressGatewayIp: '10.100.0.2' });
+  it('skips injection when egressBypass=true', async () => {
+    manager = buildManager({ egressFirewallEnabled: false, egressGatewayIp: '172.30.16.3' });
     const service = makeService({ egressBypass: true });
     const options = makeOptions('env-1');
 
@@ -233,11 +253,12 @@ describe('StackContainerManager — Legacy DNS injection (flag OFF)', () => {
 
     const callArgs = mockCreateLongRunningContainer.mock.calls[0][0];
     expect(callArgs.dnsServers).toBeUndefined();
+    expect(callArgs.env['HTTP_PROXY']).toBeUndefined();
     // Prisma must not be called
     expect(mockPrisma.environment.findUnique).not.toHaveBeenCalled();
   });
 
-  it('injects no DNS for host-level stack (no environmentId)', async () => {
+  it('skips injection for host-level stack (no environmentId)', async () => {
     manager = buildManager(null);
     const service = makeService();
     const options = makeOptions(null);
@@ -246,11 +267,15 @@ describe('StackContainerManager — Legacy DNS injection (flag OFF)', () => {
 
     const callArgs = mockCreateLongRunningContainer.mock.calls[0][0];
     expect(callArgs.dnsServers).toBeUndefined();
+    expect(callArgs.env['HTTP_PROXY']).toBeUndefined();
     expect(mockPrisma.environment.findUnique).not.toHaveBeenCalled();
   });
 
-  it('injects DNS only for non-bypass services in the same stack', async () => {
-    manager = buildManager({ egressFirewallEnabled: false, egressGatewayIp: '10.100.0.5' });
+  it('injects HTTP_PROXY only for non-bypass services in the same stack', async () => {
+    manager = buildManager(
+      { egressFirewallEnabled: false, egressGatewayIp: '172.30.16.3' },
+      { metadata: { subnet: '172.30.16.0/22' } },
+    );
     const options = makeOptions('env-1');
 
     const normalService = makeService({ egressBypass: false });
@@ -262,7 +287,9 @@ describe('StackContainerManager — Legacy DNS injection (flag OFF)', () => {
     const firstCallArgs = mockCreateLongRunningContainer.mock.calls[0][0];
     const secondCallArgs = mockCreateLongRunningContainer.mock.calls[1][0];
 
-    expect(firstCallArgs.dnsServers).toEqual(['10.100.0.5']);
+    expect(firstCallArgs.env['HTTP_PROXY']).toBe('http://egress-gateway:3128');
+    expect(secondCallArgs.env['HTTP_PROXY']).toBeUndefined();
+    expect(firstCallArgs.dnsServers).toBeUndefined();
     expect(secondCallArgs.dnsServers).toBeUndefined();
   });
 });

--- a/server/src/services/stacks/pool-spawner.ts
+++ b/server/src/services/stacks/pool-spawner.ts
@@ -246,9 +246,15 @@ export async function spawnPoolInstance(
       }
     : undefined;
 
+  // Create the container BEFORE starting it so we can attach all required
+  // networks (joinNetworks + joinResourceNetworks) up front. Starting first
+  // races the container's bootstrap (e.g. vault unwrap) against late-attached
+  // networks like `mini-infra-vault` — see createContainer/startContainer in
+  // StackContainerManager for the same pattern on the static service path.
   let containerId: string;
+  let createdContainer: Awaited<ReturnType<typeof dockerExecutor.createLongRunningContainer>>;
   try {
-    const container = await dockerExecutor.createLongRunningContainer({
+    createdContainer = await dockerExecutor.createLongRunningContainer({
       image: `${dockerImage}:${dockerTag}`,
       name: containerName,
       projectName,
@@ -267,12 +273,11 @@ export async function spawnPoolInstance(
       logConfig,
       labels,
     });
-    await container.start();
-    containerId = container.id;
+    containerId = createdContainer.id;
   } catch (err) {
     return {
       success: false,
-      error: `Container create/start failed: ${err instanceof Error ? err.message : String(err)}`,
+      error: `Container create failed: ${err instanceof Error ? err.message : String(err)}`,
     };
   }
 
@@ -356,6 +361,18 @@ export async function spawnPoolInstance(
         }
       }
     }
+  }
+
+  // All required networks are attached — start the container now so its
+  // bootstrap code sees them on first instruction.
+  try {
+    await createdContainer.start();
+  } catch (err) {
+    return {
+      success: false,
+      containerId,
+      error: `Container start failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
   }
 
   // Poll for running state (up to 30s).

--- a/server/src/services/stacks/stack-container-manager.ts
+++ b/server/src/services/stacks/stack-container-manager.ts
@@ -115,6 +115,25 @@ export class StackContainerManager {
     service: StackServiceDefinition,
     options: CreateContainerOptions
   ): Promise<string> {
+    const containerId = await this.createContainer(serviceName, service, options);
+    await this.startContainer(containerId);
+    return containerId;
+  }
+
+  /**
+   * Create a container without starting it. Use this when you need to attach
+   * additional networks (e.g. joinNetworks, joinResourceNetworks) BEFORE the
+   * container's PID 1 starts running — otherwise the container's bootstrap
+   * code can race a synchronous DNS lookup against networks that haven't
+   * been hot-attached yet (e.g. vault, applications).
+   *
+   * Pair with {@link startContainer} once all networks are joined.
+   */
+  async createContainer(
+    serviceName: string,
+    service: StackServiceDefinition,
+    options: CreateContainerOptions
+  ): Promise<string> {
     const containerName = `${options.projectName}-${serviceName}`;
     const image = `${service.dockerImage}:${service.dockerTag}`;
     const config = service.containerConfig;
@@ -189,7 +208,6 @@ export class StackContainerManager {
     this.log.info({ containerName, image }, 'Creating container');
 
     const egressResult = await this.resolveEgressInjection(service, options);
-    const dnsServers = egressResult.type === 'dns' ? egressResult.dnsServers : undefined;
     const egressEnv = egressResult.type === 'proxy' ? egressResult.env : {};
 
     const container = await this.dockerExecutor.createLongRunningContainer({
@@ -210,13 +228,19 @@ export class StackContainerManager {
       healthcheck,
       logConfig,
       labels,
-      dnsServers,
     });
 
-    await container.start();
-    this.log.info({ containerId: container.id, containerName }, 'Container started');
-
     return container.id;
+  }
+
+  /**
+   * Start a previously-created container. Pair with {@link createContainer}
+   * after all required networks are attached.
+   */
+  async startContainer(containerId: string): Promise<void> {
+    const docker = this.dockerExecutor.getDockerClient();
+    await docker.getContainer(containerId).start();
+    this.log.info({ containerId }, 'Container started');
   }
 
   /**
@@ -225,29 +249,24 @@ export class StackContainerManager {
    * Gates (in order):
    * - Host-level stack (no environmentId) → no injection.
    * - Service has egressBypass === true → no injection (egress-gateway itself, fw-agent, etc.)
+   * - Environment has no egressGatewayIp → no injection (gateway not provisioned).
    *
-   * Then, based on the per-env feature flag `egressFirewallEnabled`:
+   * When the env has been provisioned with an egress-gateway, inject
+   * HTTP_PROXY / HTTPS_PROXY / NO_PROXY env vars pointing at the
+   * egress-gateway container via Docker DNS alias `egress-gateway:3128`.
+   * Docker's default 127.0.0.11 resolver remains in place for DNS.
    *
-   * - FLAG ON  (Phase 3 / v3 Go gateway):
-   *   Injects HTTP_PROXY / HTTPS_PROXY / NO_PROXY env vars pointing at the
-   *   egress-gateway container resolved via Docker DNS alias `egress-gateway:3128`.
-   *   DNS injection is skipped (Docker's default 127.0.0.11 applies).
-   *
-   * - FLAG OFF (legacy / v1 TS sidecar):
-   *   Injects the gateway's IP as a custom DNS server so managed containers
-   *   resolve external FQDNs via the TS sidecar's DNS filter.
-   *   This keeps the TS sidecar fully functional during Phase 4 rollout.
+   * Note: `egressFirewallEnabled` is intentionally not consulted here. That
+   * flag gates whether the fw-agent actively enforces policies, not which
+   * gateway is provisioned. `egressGatewayIp` (set once at env creation by
+   * provisionEgressGateway) is the canonical "gateway exists" signal.
    *
    * Never throws — egress injection failure must not break stack apply.
    */
   private async resolveEgressInjection(
     service: StackServiceDefinition,
     options: CreateContainerOptions,
-  ): Promise<
-    | { type: 'none' }
-    | { type: 'dns'; dnsServers: string[] }
-    | { type: 'proxy'; env: Record<string, string> }
-  > {
+  ): Promise<{ type: 'none' } | { type: 'proxy'; env: Record<string, string> }> {
     if (!options.environmentId) {
       return { type: 'none' };
     }
@@ -259,39 +278,32 @@ export class StackContainerManager {
     try {
       const environment = await this.prisma.environment.findUnique({
         where: { id: options.environmentId },
-        select: { egressFirewallEnabled: true, egressGatewayIp: true },
+        select: { egressGatewayIp: true },
       });
 
-      // --- Phase 3 path: v3 Go gateway with HTTP_PROXY injection ---
-      if (environment?.egressFirewallEnabled === true) {
-        const proxyUrl = 'http://egress-gateway:3128';
-        // Resolve the environment's applications bridge CIDR for NO_PROXY.
-        const bridgeCidr = await this.resolveApplicationsBridgeCidr(options.environmentId);
-        const noProxy = ['localhost', '127.0.0.0/8', ...(bridgeCidr ? [bridgeCidr] : [])].join(',');
-
-        return {
-          type: 'proxy',
-          env: {
-            HTTP_PROXY: proxyUrl,
-            HTTPS_PROXY: proxyUrl,
-            http_proxy: proxyUrl,
-            https_proxy: proxyUrl,
-            NO_PROXY: noProxy,
-            no_proxy: noProxy,
-          },
-        };
+      if (!environment?.egressGatewayIp) {
+        this.log.warn(
+          { environmentId: options.environmentId, stackId: options.stackId },
+          'Environment has no egressGatewayIp — skipping egress injection',
+        );
+        return { type: 'none' };
       }
 
-      // --- Legacy path: v1 TS sidecar DNS injection ---
-      if (environment?.egressGatewayIp) {
-        return { type: 'dns', dnsServers: [environment.egressGatewayIp] };
-      }
+      const proxyUrl = 'http://egress-gateway:3128';
+      const bridgeCidr = await this.resolveApplicationsBridgeCidr(options.environmentId);
+      const noProxy = ['localhost', '127.0.0.0/8', ...(bridgeCidr ? [bridgeCidr] : [])].join(',');
 
-      this.log.warn(
-        { environmentId: options.environmentId, stackId: options.stackId },
-        'Environment has no egressGatewayIp and egressFirewallEnabled is OFF — skipping egress injection',
-      );
-      return { type: 'none' };
+      return {
+        type: 'proxy',
+        env: {
+          HTTP_PROXY: proxyUrl,
+          HTTPS_PROXY: proxyUrl,
+          http_proxy: proxyUrl,
+          https_proxy: proxyUrl,
+          NO_PROXY: noProxy,
+          no_proxy: noProxy,
+        },
+      };
     } catch (err) {
       this.log.warn(
         { environmentId: options.environmentId, stackId: options.stackId, error: err },

--- a/server/src/services/stacks/stack-service-handlers.ts
+++ b/server/src/services/stacks/stack-service-handlers.ts
@@ -104,7 +104,11 @@ export class StackServiceHandlers {
 
         await prepareServiceContainer(this.containerManager, effectiveServiceDef, resolvedConfigsMap.get(action.serviceName) ?? [], projectName);
 
-        const containerId = await this.containerManager.createAndStartContainer(
+        // Create the container BEFORE starting it so we can attach all
+        // required networks (joinNetworks + joinResourceNetworks) up front.
+        // Starting first races the container's bootstrap (e.g. vault unwrap)
+        // against late-attached networks like `mini-infra-vault`.
+        const containerId = await this.containerManager.createContainer(
           action.serviceName,
           effectiveServiceDef,
           {
@@ -120,6 +124,8 @@ export class StackServiceHandlers {
 
         await this.joinJoinNetworks(containerId, action.serviceName, effectiveServiceDef, log);
         await this.infraManager.joinResourceNetworks(containerId, effectiveServiceDef, infraNetworkMap, log);
+
+        await this.containerManager.startContainer(containerId);
 
         const healthy = await this.containerManager.waitForHealthy(containerId);
 
@@ -148,7 +154,8 @@ export class StackServiceHandlers {
 
         await prepareServiceContainer(this.containerManager, effectiveServiceDef, resolvedConfigsMap.get(action.serviceName) ?? [], projectName);
 
-        const containerId = await this.containerManager.createAndStartContainer(
+        // Same ordering as the create case: create → attach all networks → start.
+        const containerId = await this.containerManager.createContainer(
           action.serviceName,
           effectiveServiceDef,
           {
@@ -164,6 +171,8 @@ export class StackServiceHandlers {
 
         await this.joinJoinNetworks(containerId, action.serviceName, effectiveServiceDef, log);
         await this.infraManager.joinResourceNetworks(containerId, effectiveServiceDef, infraNetworkMap, log);
+
+        await this.containerManager.startContainer(containerId);
 
         const healthy = await this.containerManager.waitForHealthy(containerId);
 


### PR DESCRIPTION
## Summary

Two related fixes that surfaced while debugging a slackbot stack deploy: managed containers were getting broken DNS injection from a dead v1 sidecar code path, and even after fixing that, services with vault/applications network bindings were racing their bootstrap against late network attaches. Both reproduced cleanly in dev.

### 1. Egress injection — drop legacy v1 DNS branch

`StackContainerManager.resolveEgressInjection` previously had two paths:

- `egressFirewallEnabled === true` → inject `HTTP_PROXY`/`HTTPS_PROXY` for the v3 Go gateway
- otherwise, fall back to setting `HostConfig.Dns = [egressGatewayIp]` for the v1 TS sidecar

The v1 TS sidecar is dead code — every freshly-provisioned env gets the v3 Go gateway, which only listens on 3128 (HTTP proxy) and 8054 (admin), not port 53. So whenever an env had `egressFirewallEnabled: false` (the default) and `egressGatewayIp` populated (always, post-provision), every managed container got a custom DNS server pointing at a port that nothing listens on. External resolution returned "connection refused" and the container's bootstrap failed (e.g., `slack.com` → "server misbehaving").

Fix: remove the legacy DNS branch entirely and inject `HTTP_PROXY` whenever `egressGatewayIp` is non-null. The flag now correctly gates *only* fw-agent policy enforcement, which was its original intent.

### 2. Network attach race — create → join → start

`stack-service-handlers.ts` (create + recreate) and `pool-spawner.ts` both did:

```
createAndStartContainer(...)            // creates + starts
await joinJoinNetworks(...)             // late attach
await joinResourceNetworks(...)         // late attach (vault, applications)
```

A service template that lists `joinResourceNetworks: ['vault']` would boot without the `mini-infra-vault` network attached — and any synchronous-at-startup vault call (no retry) hit "no such host" and the process exited 1.

Fix: split `createAndStartContainer` into `createContainer` and `startContainer`, and call the network-attach helpers between them. All required networks are present before PID 1 runs.

```
createContainer(...)            // create only
joinJoinNetworks(...)
joinResourceNetworks(...)
startContainer(id)              // start with all networks attached
```

`createAndStartContainer` is preserved as a thin wrapper for any caller that doesn't need the split.

### Files

- `server/src/services/stacks/stack-container-manager.ts` — refactor egress resolver, split create/start
- `server/src/services/stacks/stack-service-handlers.ts` — create + recreate paths use new ordering
- `server/src/services/stacks/pool-spawner.ts` — pool worker spawn uses new ordering
- `server/src/services/stacks/__tests__/stack-container-manager-egress.test.ts` — drop legacy DNS expectations, add `getDockerClient` mock for the new `startContainer` surface

## Test plan

- [x] `pnpm --filter mini-infra-server exec vitest run src/services/stacks/__tests__/` — 56/56 pass (incl. 13 egress unit tests across the new behavior matrix)
- [x] `pnpm --filter mini-infra-server build` clean
- [x] `pnpm --filter mini-infra-server lint` clean
- [x] `pnpm build` (full client+server) clean
- [x] Deployed to dev worktree via `worktree_start.sh`; mini-infra container restarts cleanly with the new code
- [ ] Slackbot redeploy by partner team — verifies the create→join→start ordering and HTTP_PROXY injection on a real stack apply

## Notes

The pool-schema unit tests fail intermittently in this worktree — verified to be pre-existing and unrelated (the test file imports only from `'../schemas'`, no overlap with the changed code). Not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
