### PR TITLE
feat(egress): split egress onto a dedicated per-env network

### DIFF
--- a/server/src/__tests__/egress-network-allocator.test.ts
+++ b/server/src/__tests__/egress-network-allocator.test.ts
@@ -139,7 +139,7 @@ describe('EgressNetworkAllocator', () => {
         isConnected: vi.fn().mockReturnValue(true),
         listNetworks: vi.fn().mockResolvedValue([
           {
-            name: 'staging-applications',
+            name: 'staging-egress',
             ipam: { config: [{ subnet: '172.30.5.0/24' }] },
             containers: [],
           },
@@ -149,7 +149,7 @@ describe('EgressNetworkAllocator', () => {
       const prisma = makeMockPrisma();
       const allocator = new EgressNetworkAllocator(prisma);
 
-      const ip = await allocator.allocateGatewayIp('staging-applications');
+      const ip = await allocator.allocateGatewayIp('staging-egress');
 
       expect(ip).toBe('172.30.5.2');
     });
@@ -160,7 +160,7 @@ describe('EgressNetworkAllocator', () => {
         isConnected: vi.fn().mockReturnValue(true),
         listNetworks: vi.fn().mockResolvedValue([
           {
-            name: 'staging-applications',
+            name: 'staging-egress',
             ipam: { config: [{ subnet: '172.30.5.0/24' }] },
             containers: [
               { ipv4Address: '172.30.5.2' },
@@ -172,7 +172,7 @@ describe('EgressNetworkAllocator', () => {
       const prisma = makeMockPrisma();
       const allocator = new EgressNetworkAllocator(prisma);
 
-      const ip = await allocator.allocateGatewayIp('staging-applications');
+      const ip = await allocator.allocateGatewayIp('staging-egress');
 
       expect(ip).toBe('172.30.5.3');
     });
@@ -190,7 +190,7 @@ describe('EgressNetworkAllocator', () => {
       });
       const allocator = new EgressNetworkAllocator(prisma);
 
-      const ip = await allocator.allocateGatewayIp('staging-applications');
+      const ip = await allocator.allocateGatewayIp('staging-egress');
 
       expect(ip).toBe('172.30.7.2');
     });

--- a/server/src/__tests__/stack-reconciler-apply-stateless.test.ts
+++ b/server/src/__tests__/stack-reconciler-apply-stateless.test.ts
@@ -201,6 +201,7 @@ const mockCreateContainer = vi.fn().mockResolvedValue({
 });
 
 const mockGetContainer = vi.fn().mockReturnValue({
+  start: mockContainerStart,
   stop: mockContainerStop,
   remove: mockContainerRemove,
   inspect: mockContainerInspect,
@@ -232,8 +233,12 @@ const mockPrisma = {
     update: mockStackUpdate,
   },
   environment: {
-    // Default: no gateway IP set — resolveEgressDnsServers will warn and return undefined
+    // Default: no gateway IP set — egress injection short-circuits.
     findUnique: vi.fn().mockResolvedValue({ egressGatewayIp: null }),
+  },
+  infraResource: {
+    // Default: no egress InfraResource. Auto-attach to egress network is a no-op.
+    findFirst: vi.fn().mockResolvedValue(null),
   },
   stackDeployment: {
     create: mockStackDeploymentCreate,

--- a/server/src/__tests__/stack-reconciler-apply.test.ts
+++ b/server/src/__tests__/stack-reconciler-apply.test.ts
@@ -157,6 +157,7 @@ const mockCreateContainer = vi.fn().mockResolvedValue({
 });
 
 const mockGetContainer = vi.fn().mockReturnValue({
+  start: mockContainerStart,
   stop: mockContainerStop,
   remove: mockContainerRemove,
   inspect: mockContainerInspect,
@@ -182,8 +183,12 @@ const mockPrisma = {
     update: mockStackUpdate,
   },
   environment: {
-    // Default: no gateway IP set — resolveEgressDnsServers will warn and return undefined
+    // Default: no gateway IP set — egress injection short-circuits.
     findUnique: vi.fn().mockResolvedValue({ egressGatewayIp: null }),
+  },
+  infraResource: {
+    // Default: no egress InfraResource. Auto-attach is a no-op.
+    findFirst: vi.fn().mockResolvedValue(null),
   },
   stackDeployment: {
     create: mockStackDeploymentCreate,
@@ -251,9 +256,12 @@ describe('StackReconciler.apply', () => {
     // Verify pull was called
     expect(mockPullImageWithAutoAuth).toHaveBeenCalledWith('grafana/loki:2.9.0');
 
-    // Verify container was created and started
+    // Verify container was created and started. Since 4bc803e, the static
+    // service path uses createContainer + startContainer (with start coming
+    // from docker.getContainer(id).start() — i.e. mockContainerStart) rather
+    // than the start method on the createLongRunningContainer return value.
     expect(mockCreateLongRunningContainer).toHaveBeenCalledTimes(1);
-    expect(mockLongRunningContainer.start).toHaveBeenCalled();
+    expect(mockContainerStart).toHaveBeenCalled();
 
     // Verify init commands were run (alpine container created)
     expect(mockCreateContainer).toHaveBeenCalled();

--- a/server/src/services/egress/__tests__/egress-container-map-pusher.test.ts
+++ b/server/src/services/egress/__tests__/egress-container-map-pusher.test.ts
@@ -143,21 +143,21 @@ describe('EgressContainerMapPusher', () => {
       ],
     });
 
-    // Docker has both containers running on the applications network.
+    // Docker has both containers running on the egress network.
     // Names follow `${env}-${stack}-${service}` (StackContainerManager convention).
     mockDockerInstance.listContainers.mockResolvedValue([
       {
         Id: 'c1',
         Names: ['/staging-myapp-web'],
         NetworkSettings: {
-          Networks: { 'staging-applications': { IPAddress: '172.30.0.10' } },
+          Networks: { 'staging-egress': { IPAddress: '172.30.0.10' } },
         },
       },
       {
         Id: 'c2',
         Names: ['/staging-myapp-egress-gateway'],
         NetworkSettings: {
-          Networks: { 'staging-applications': { IPAddress: '172.30.0.2' } },
+          Networks: { 'staging-egress': { IPAddress: '172.30.0.2' } },
         },
       },
     ]);
@@ -199,7 +199,7 @@ describe('EgressContainerMapPusher', () => {
         Id: 'c-alpine',
         Names: ['/local-egress-test-alpine'],
         NetworkSettings: {
-          Networks: { 'local-applications': { IPAddress: '172.30.0.10' } },
+          Networks: { 'local-egress': { IPAddress: '172.30.0.10' } },
         },
       },
     ]);

--- a/server/src/services/egress/egress-container-map-pusher.ts
+++ b/server/src/services/egress/egress-container-map-pusher.ts
@@ -231,10 +231,11 @@ export class EgressContainerMapPusher {
    * - Query active stacks (not removed, not archived) in the env.
    * - Skip stacks that belong to the egress-gateway itself (egressBypass).
    * - For each service in each stack, find a running container by name and
-   *   get its IPv4 address on the env's applications network.
+   *   get its IPv4 address on the env's egress network (where every
+   *   non-bypass managed container lives — see egress-injection.ts).
    */
   private async _buildContainerMap(env: EnvRow): Promise<ContainerMapEntry[]> {
-    const applicationsNetwork = `${env.name}-applications`;
+    const egressNetwork = `${env.name}-egress`;
 
     // Stacks in this environment that are not removed
     const stacks = await this.prisma.stack.findMany({
@@ -265,12 +266,12 @@ export class EgressContainerMapPusher {
     const docker = await dockerService.getDockerInstance();
     const rawContainers = await docker.listContainers({ all: false });
 
-    // Build a lookup: containerName → IP on the applications network
+    // Build a lookup: containerName → IP on the egress network
     const ipByName = new Map<string, string>();
     const idByName = new Map<string, string>();
     for (const c of rawContainers) {
       const networks = c.NetworkSettings?.Networks ?? {};
-      const networkInfo = networks[applicationsNetwork];
+      const networkInfo = networks[egressNetwork];
       if (networkInfo?.IPAddress) {
         const name = (c.Names?.[0] ?? '').replace(/^\//, '');
         ipByName.set(name, networkInfo.IPAddress);
@@ -303,7 +304,7 @@ export class EgressContainerMapPusher {
     }
 
     log.debug(
-      { envId: env.id, envName: env.name, applicationsNetwork, entryCount: entries.length },
+      { envId: env.id, envName: env.name, egressNetwork, entryCount: entries.length },
       'Built container map',
     );
 

--- a/server/src/services/egress/egress-network-allocator.ts
+++ b/server/src/services/egress/egress-network-allocator.ts
@@ -105,7 +105,8 @@ function parseCidrNetworkAddress(cidr: string): number[] | null {
 
 /**
  * EgressNetworkAllocator picks deterministic, non-conflicting /24 subnets
- * and gateway IPs from the egress pool for environment applications networks.
+ * and gateway IPs from the egress pool for the per-env egress network
+ * (where the egress-gateway container and managed app containers live).
  */
 export class EgressNetworkAllocator {
   constructor(private readonly prisma: PrismaClient) {}
@@ -124,9 +125,11 @@ export class EgressNetworkAllocator {
     const totalSlots = poolSlotCount(poolMask, subnetMask);
 
     // Collect subnets already in use from the DB.
-    // Subnets are persisted on InfraResource.metadata.subnet for docker-network/applications resources.
+    // Subnets are persisted on InfraResource.metadata.subnet for the per-env
+    // egress network. The Docker scan below catches anything else that lives
+    // in the pool (e.g. an applications network deployed elsewhere).
     const dbResources = await this.prisma.infraResource.findMany({
-      where: { type: 'docker-network', purpose: 'applications', scope: 'environment' },
+      where: { type: 'docker-network', purpose: 'egress', scope: 'environment' },
       select: { metadata: true },
     });
 
@@ -179,9 +182,10 @@ export class EgressNetworkAllocator {
   }
 
   /**
-   * For an applications network already created with a known subnet, pick the gateway
-   * container IP (lowest unused host address >= .2 in that subnet).
-   * Validates against currently connected containers on that network via Docker inspect.
+   * For the per-env egress network already created with a known subnet, pick
+   * the gateway container IP (lowest unused host address >= .2 in that
+   * subnet). Validates against currently connected containers on that
+   * network via Docker inspect.
    *
    * @param networkName - Docker network name to inspect
    * @returns The IPv4 address the egress container should use
@@ -216,7 +220,7 @@ export class EgressNetworkAllocator {
     if (!subnet) {
       // Fallback: look in InfraResource.metadata.subnet
       const resource = await this.prisma.infraResource.findFirst({
-        where: { type: 'docker-network', purpose: 'applications', scope: 'environment', name: networkName },
+        where: { type: 'docker-network', purpose: 'egress', scope: 'environment', name: networkName },
         select: { metadata: true },
       });
       const meta = resource?.metadata as Record<string, unknown> | null;

--- a/server/src/services/egress/env-firewall-manager.ts
+++ b/server/src/services/egress/env-firewall-manager.ts
@@ -126,14 +126,14 @@ export class EnvFirewallManager {
     const env = await this._getEnabledEnv(envId);
     if (!env) return;
 
-    // Resolve the real bridge CIDR from the applications network InfraResource.
-    // The subnet is stored in InfraResource.metadata.subnet for the docker-network
-    // resource with purpose "applications" in this environment.
+    // Resolve the real bridge CIDR from the egress network InfraResource. The
+    // subnet is stored in InfraResource.metadata.subnet for the docker-network
+    // resource with purpose "egress" in this environment.
     const bridgeCidr = await this._getBridgeCidr(envId, env.name);
     if (!bridgeCidr) {
       log.error(
         { envId, envName: env.name },
-        'fw-agent: applyEnv: cannot resolve bridge CIDR — env has no applications network yet; skipping',
+        'fw-agent: applyEnv: cannot resolve bridge CIDR — env has no egress network yet; skipping',
       );
       return;
     }
@@ -302,7 +302,7 @@ export class EnvFirewallManager {
         if (!modeResults.has(env.id)) continue;
 
         try {
-          const applicationsNetwork = `${env.name}-applications`;
+          const egressNetwork = `${env.name}-egress`;
           // Collect IPs of managed running containers in this env.
           const ips: string[] = [];
           for (const c of rawContainers) {
@@ -313,17 +313,17 @@ export class EnvFirewallManager {
             if (labels['mini-infra.egress.gateway'] === 'true') continue;
             if (labels['mini-infra.egress.fw-agent'] === 'true') continue;
 
-            // Extract IP from the env's applications network (same pattern as
+            // Extract IP from the env's egress network (same pattern as
             // egress-container-map-pusher).
             const networks = c.NetworkSettings?.Networks ?? {};
-            const networkInfo = networks[applicationsNetwork];
+            const networkInfo = networks[egressNetwork];
             const ip = networkInfo?.IPAddress;
             if (ip) {
               ips.push(ip);
             } else {
               log.debug(
-                { containerId: c.Id, envName: env.name, applicationsNetwork },
-                'EnvFirewallManager reconcile: container not on env applications network — skipping',
+                { containerId: c.Id, envName: env.name, egressNetwork },
+                'EnvFirewallManager reconcile: container not on env egress network — skipping',
               );
             }
           }
@@ -548,7 +548,7 @@ export class EnvFirewallManager {
   }
 
   /**
-   * Resolve the bridge CIDR (e.g. "172.30.5.0/24") for an env's applications
+   * Resolve the bridge CIDR (e.g. "172.30.5.0/24") for an env's egress
    * network by reading the subnet stored in the InfraResource row.
    *
    * Returns null if no subnet is recorded yet (env not fully provisioned).
@@ -558,7 +558,7 @@ export class EnvFirewallManager {
       const resource = await this.prisma.infraResource.findFirst({
         where: {
           type: 'docker-network',
-          purpose: 'applications',
+          purpose: 'egress',
           scope: 'environment',
           environmentId: envId,
         },

--- a/server/src/services/environment/environment-manager.ts
+++ b/server/src/services/environment/environment-manager.ts
@@ -562,19 +562,24 @@ export class EnvironmentManager {
    * Provision the egress gateway for a newly-created environment.
    *
    * Steps:
-   * 1. Allocate a /24 subnet from the egress pool and persist it on the applications
-   *    InfraResource.metadata so the HAProxy stack's reconcileOutputs creates the
-   *    Docker network with the correct subnet.
-   * 2. Create the applications Docker network and attach the mini-infra-server
-   *    so the container-map-pusher can reach the gateway later.
+   * 1. Allocate a /24 subnet from the egress pool and persist it on the
+   *    `egress` InfraResource.metadata so the egress-gateway stack's
+   *    reconcileOutputs reuses the same subnet when it creates the Docker
+   *    network.
+   * 2. Create the per-env egress Docker network and attach mini-infra-server
+   *    so the container-map-pusher can reach the gateway admin API.
    * 3. Allocate the gateway IP via EgressNetworkAllocator.allocateGatewayIp() —
    *    inspects connected containers and picks the first free address. Done
-   *    after the server has joined so we don't collide with whatever IP Docker
-   *    auto-assigned to it. Persist on Environment.egressGatewayIp.
+   *    after the server has joined so we don't collide with whatever IP
+   *    Docker auto-assigned to it. Persist on Environment.egressGatewayIp.
    * 4. Instantiate the egress-gateway system stack for this environment and
    *    apply it so the container comes up.
-   * 5. After apply, reconnect the container to the applications network with the
+   * 5. After apply, reconnect the container to the egress network with the
    *    static IP so the gateway is reachable at the pre-allocated address.
+   *
+   * Every non-bypass managed container in this env will then be auto-attached
+   * to the same egress network at create time (see egress-injection.ts), so
+   * `egress-gateway:3128` resolves from any app/pool/StatelessWeb container.
    *
    * All steps are wrapped in try/catch. A failure at any step leaves the env
    * usable but logs a loud warning. The failure is appended to the UserEvent
@@ -589,28 +594,29 @@ export class EnvironmentManager {
     try {
       await this.userEventService.appendLogs(userEventId, `[${new Date().toISOString()}] Provisioning egress gateway...`);
 
-      const applicationsNetworkName = `${environmentName}-applications`;
+      const egressNetworkName = `${environmentName}-egress`;
       const executor = new DockerExecutorService();
       await executor.initialize();
       const allocator = new EgressNetworkAllocator(this.prisma);
 
-      // Step 1: Determine subnet. If the applications network already exists (e.g. from a prior
-      // failed attempt, or external creation), use its subnet so we stay consistent with reality.
-      // Otherwise allocate a fresh /24 from the pool.
+      // Step 1: Determine subnet. If the egress network already exists (e.g.
+      // from a prior failed attempt, or external creation), use its subnet so
+      // we stay consistent with reality. Otherwise allocate a fresh /24 from
+      // the pool.
       let subnet: string;
       let gateway: string;
-      const networkAlreadyExists = await executor.networkExists(applicationsNetworkName);
+      const networkAlreadyExists = await executor.networkExists(egressNetworkName);
       if (networkAlreadyExists) {
         const dockerClient = executor.getDockerClient();
-        const inspect = await dockerClient.getNetwork(applicationsNetworkName).inspect();
+        const inspect = await dockerClient.getNetwork(egressNetworkName).inspect();
         const ipamCfg = inspect.IPAM?.Config?.[0];
         if (!ipamCfg?.Subnet) {
-          throw new Error(`Existing network ${applicationsNetworkName} has no IPAM subnet`);
+          throw new Error(`Existing network ${egressNetworkName} has no IPAM subnet`);
         }
         subnet = ipamCfg.Subnet;
         const subnetOctets = subnet.split('/')[0].split('.');
         gateway = ipamCfg.Gateway ?? `${subnetOctets.slice(0, 3).join('.')}.1`;
-        this.logger.info({ environmentId, subnet, gateway, applicationsNetworkName }, 'Reusing existing applications network subnet');
+        this.logger.info({ environmentId, subnet, gateway, egressNetworkName }, 'Reusing existing egress network subnet');
       } else {
         const allocated = await allocator.allocateSubnet();
         subnet = allocated.subnet;
@@ -621,12 +627,12 @@ export class EnvironmentManager {
       // mini-infra-server has joined, so we can pick the first IP that isn't
       // already taken. See "Step 3c" below.
 
-      // Step 2: Pre-create the InfraResource record with the subnet in metadata so
-      // that when the HAProxy stack (or egress-gateway stack) runs reconcileOutputs
-      // it knows to use this subnet for the applications network.
-      // Use upsert-by-findFirst since SQLite NULL uniqueness prevents true upsert.
+      // Step 2: Pre-create the InfraResource record with the subnet in metadata
+      // so that when the egress-gateway stack runs reconcileOutputs it reuses
+      // this subnet for the egress network. Use upsert-by-findFirst since
+      // SQLite NULL uniqueness prevents true upsert.
       const existingResource = await this.prisma.infraResource.findFirst({
-        where: { type: 'docker-network', purpose: 'applications', scope: 'environment', environmentId },
+        where: { type: 'docker-network', purpose: 'egress', scope: 'environment', environmentId },
       });
       if (existingResource) {
         const existingMeta = (existingResource.metadata as Record<string, unknown> | null) ?? {};
@@ -637,63 +643,61 @@ export class EnvironmentManager {
           },
         });
       } else {
-        const applicationsNetworkName = `${environmentName}-applications`;
         await this.prisma.infraResource.create({
           data: {
             type: 'docker-network',
-            purpose: 'applications',
+            purpose: 'egress',
             scope: 'environment',
             environmentId,
-            name: applicationsNetworkName,
+            name: egressNetworkName,
             metadata: { subnet, gateway } as Prisma.InputJsonValue,
           },
         });
       }
 
-      // Step 3a: Create the applications Docker network up-front with the allocated subnet.
-      // The egress-gateway template declares it as a resourceInput, so something must own
-      // network creation. Doing it here guarantees it exists before any stack apply, works
-      // for all env types (local + internet). If networkAlreadyExists, we already discovered
-      // its subnet above and reused it — no create needed.
+      // Step 3a: Create the egress Docker network up-front with the allocated
+      // subnet. We do this before the egress-gateway stack apply so that
+      // mini-infra-server can join (Step 3b) and we can pick a non-colliding
+      // gateway IP (Step 3c) before any container races onto the network.
       if (!networkAlreadyExists) {
         try {
-          await executor.createNetwork(applicationsNetworkName, '', {
+          await executor.createNetwork(egressNetworkName, '', {
             driver: 'bridge',
             labels: {
               'mini-infra.infra-resource': 'true',
-              'mini-infra.resource-purpose': 'applications',
+              'mini-infra.resource-purpose': 'egress',
               'mini-infra.environment': environmentId,
             },
             ipam: { subnet, gateway },
           });
-          await this.userEventService.appendLogs(userEventId, `[${new Date().toISOString()}] Applications network ${applicationsNetworkName} created (subnet ${subnet})`);
+          await this.userEventService.appendLogs(userEventId, `[${new Date().toISOString()}] Egress network ${egressNetworkName} created (subnet ${subnet})`);
         } catch (netErr) {
           const msg = netErr instanceof Error ? netErr.message : String(netErr);
-          this.logger.error({ environmentId, err: msg }, 'Failed to create applications network for env');
-          await this.userEventService.appendLogs(userEventId, `[${new Date().toISOString()}] WARNING: applications network create failed: ${msg}`);
+          this.logger.error({ environmentId, err: msg }, 'Failed to create egress network for env');
+          await this.userEventService.appendLogs(userEventId, `[${new Date().toISOString()}] WARNING: egress network create failed: ${msg}`);
           // Continue — stack apply may still succeed if something else creates the network
         }
       }
 
-      // Step 3b: Connect the mini-infra-server container itself to this env's applications network
-      // so the container-map-pusher and log-ingester can reach the egress-gateway's admin API.
-      // Without this, mini-infra has no route to the per-env gateway IP and the audit pipeline
-      // never starts. Inside Docker, os.hostname() returns the container ID — use that to self-attach.
+      // Step 3b: Connect the mini-infra-server container itself to this env's
+      // egress network so the container-map-pusher and log-ingester can reach
+      // the egress-gateway's admin API at egressGatewayIp:8054. Inside Docker,
+      // os.hostname() returns the container ID — use that to self-attach.
       try {
         const { hostname } = await import('node:os');
         const selfContainerId = hostname();
         const dockerClient = executor.getDockerClient();
-        const network = dockerClient.getNetwork(applicationsNetworkName);
+        const network = dockerClient.getNetwork(egressNetworkName);
         await network.connect({ Container: selfContainerId });
-        this.logger.info({ environmentId, applicationsNetworkName, selfContainerId }, 'Connected mini-infra-server to env applications network');
+        this.logger.info({ environmentId, egressNetworkName, selfContainerId }, 'Connected mini-infra-server to env egress network');
       } catch (connErr) {
         const msg = connErr instanceof Error ? connErr.message : String(connErr);
         if (msg.includes('already exists') || msg.includes('already in network') || msg.includes('endpoint with name')) {
           // Idempotent — already connected from a prior provisioning
-          this.logger.debug({ environmentId, applicationsNetworkName }, 'mini-infra-server already attached to env network');
+          this.logger.debug({ environmentId, egressNetworkName }, 'mini-infra-server already attached to env egress network');
         } else {
-          this.logger.warn({ environmentId, applicationsNetworkName, err: msg }, 'Failed to attach mini-infra-server to env network — container-map push will be unreachable');
-          await this.userEventService.appendLogs(userEventId, `[${new Date().toISOString()}] WARNING: mini-infra-server could not join ${applicationsNetworkName}: ${msg}`);
+          this.logger.warn({ environmentId, egressNetworkName, err: msg }, 'Failed to attach mini-infra-server to env egress network — container-map push will be unreachable');
+          await this.userEventService.appendLogs(userEventId, `[${new Date().toISOString()}] WARNING: mini-infra-server could not join ${egressNetworkName}: ${msg}`);
         }
       }
 
@@ -704,10 +708,10 @@ export class EnvironmentManager {
       // the network first.
       let egressGatewayIp: string;
       try {
-        egressGatewayIp = await allocator.allocateGatewayIp(applicationsNetworkName);
+        egressGatewayIp = await allocator.allocateGatewayIp(egressNetworkName);
       } catch (allocErr) {
         const msg = allocErr instanceof Error ? allocErr.message : String(allocErr);
-        this.logger.error({ environmentId, applicationsNetworkName, err: msg }, 'Failed to allocate egress gateway IP — skipping gateway deployment');
+        this.logger.error({ environmentId, egressNetworkName, err: msg }, 'Failed to allocate egress gateway IP — skipping gateway deployment');
         await this.userEventService.appendLogs(userEventId, `[${new Date().toISOString()}] WARNING: Failed to allocate egress gateway IP: ${msg}`);
         return;
       }
@@ -791,8 +795,8 @@ export class EnvironmentManager {
           this.logger.info({ environmentId, stackId: egressStack.id, egressGatewayIp }, 'Egress gateway deployed successfully');
           await this.userEventService.appendLogs(userEventId, `[${new Date().toISOString()}] Egress gateway deployed successfully at ${egressGatewayIp}`);
 
-          // Step 6: Reconnect egress container to the applications network with static IP
-          // so the DNS server is reachable at the pre-allocated address.
+          // Step 6: Reconnect egress container to the egress network with the
+          // pre-allocated static IP so it's reachable at the expected address.
           await this.assignStaticGatewayIp(environmentName, egressStack.id, egressGatewayIp, userEventId);
         } else {
           const failureMessages = applyResult.serviceResults
@@ -817,9 +821,9 @@ export class EnvironmentManager {
   }
 
   /**
-   * After the egress-gateway container is created by the reconciler, disconnect it
-   * from the applications network and reconnect with the pre-allocated static IP.
-   * This ensures the egress DNS server is reachable at the expected address.
+   * After the egress-gateway container is created by the reconciler,
+   * disconnect it from the egress network and reconnect with the pre-allocated
+   * static IP so it's reachable at the expected address.
    */
   private async assignStaticGatewayIp(
     environmentName: string,
@@ -827,7 +831,7 @@ export class EnvironmentManager {
     egressGatewayIp: string,
     userEventId: string,
   ): Promise<void> {
-    const networkName = `${environmentName}-applications`;
+    const networkName = `${environmentName}-egress`;
     const containerName = `${environmentName}-egress-gateway-egress-gateway`;
 
     try {

--- a/server/src/services/stacks/__tests__/egress-injection.test.ts
+++ b/server/src/services/stacks/__tests__/egress-injection.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveEgressEnv, attachEgressNetworkIfNeeded } from '../egress-injection';
+
+// The logger factory is mocked globally by setup-unit.ts.
+const log = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  error: vi.fn(),
+} as any;
+
+function buildPrisma(
+  envRow: { egressGatewayIp: string | null } | null,
+  egressResource: { name: string; metadata: unknown } | null = null,
+) {
+  return {
+    environment: {
+      findUnique: vi.fn().mockResolvedValue(envRow),
+    },
+    infraResource: {
+      findFirst: vi.fn().mockResolvedValue(egressResource),
+    },
+  } as any;
+}
+
+// ---------------------------------------------------------------------------
+// resolveEgressEnv
+// ---------------------------------------------------------------------------
+
+describe('resolveEgressEnv', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns proxy env when env has gateway and egress InfraResource exists', async () => {
+    const prisma = buildPrisma(
+      { egressGatewayIp: '172.30.16.3' },
+      { name: 'env1-egress', metadata: { subnet: '172.30.16.0/24' } },
+    );
+    const env = await resolveEgressEnv(prisma, 'env-1', /* egressBypass */ false);
+    expect(env).toEqual({
+      HTTP_PROXY: 'http://egress-gateway:3128',
+      HTTPS_PROXY: 'http://egress-gateway:3128',
+      http_proxy: 'http://egress-gateway:3128',
+      https_proxy: 'http://egress-gateway:3128',
+      NO_PROXY: 'localhost,127.0.0.0/8,172.30.16.0/24',
+      no_proxy: 'localhost,127.0.0.0/8,172.30.16.0/24',
+    });
+  });
+
+  it('omits the bridge CIDR when egress InfraResource has no subnet metadata', async () => {
+    const prisma = buildPrisma(
+      { egressGatewayIp: '172.30.16.3' },
+      { name: 'env1-egress', metadata: null },
+    );
+    const env = await resolveEgressEnv(prisma, 'env-1', false);
+    expect(env.NO_PROXY).toBe('localhost,127.0.0.0/8');
+  });
+
+  it('returns empty when egressBypass is true (gateway service itself)', async () => {
+    const prisma = buildPrisma({ egressGatewayIp: '172.30.16.3' });
+    const env = await resolveEgressEnv(prisma, 'env-1', true);
+    expect(env).toEqual({});
+    // Bypass short-circuits before any DB lookup.
+    expect(prisma.environment.findUnique).not.toHaveBeenCalled();
+    expect(prisma.infraResource.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('returns empty for host-level stacks (no environmentId)', async () => {
+    const prisma = buildPrisma(null);
+    const env = await resolveEgressEnv(prisma, null, false);
+    expect(env).toEqual({});
+    expect(prisma.environment.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('returns empty when env has no egressGatewayIp (gateway not provisioned)', async () => {
+    const prisma = buildPrisma({ egressGatewayIp: null });
+    const env = await resolveEgressEnv(prisma, 'env-1', false);
+    expect(env).toEqual({});
+    expect(prisma.infraResource.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('returns empty when egress InfraResource is missing', async () => {
+    const prisma = buildPrisma({ egressGatewayIp: '172.30.16.3' }, null);
+    const env = await resolveEgressEnv(prisma, 'env-1', false);
+    expect(env).toEqual({});
+  });
+
+  it('returns empty (never throws) when prisma lookup fails', async () => {
+    const prisma = {
+      environment: {
+        findUnique: vi.fn().mockRejectedValue(new Error('db down')),
+      },
+      infraResource: {
+        findFirst: vi.fn(),
+      },
+    } as any;
+    const env = await resolveEgressEnv(prisma, 'env-1', false);
+    expect(env).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attachEgressNetworkIfNeeded
+// ---------------------------------------------------------------------------
+
+describe('attachEgressNetworkIfNeeded', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function buildContainerManager() {
+    return {
+      connectToNetwork: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  it('connects the container to the egress network when all gates pass', async () => {
+    const prisma = buildPrisma(
+      { egressGatewayIp: '172.30.16.3' },
+      { name: 'env1-egress', metadata: { subnet: '172.30.16.0/24' } },
+    );
+    const cm = buildContainerManager();
+
+    await attachEgressNetworkIfNeeded(prisma, cm, 'container-1', 'env-1', false, log);
+
+    expect(cm.connectToNetwork).toHaveBeenCalledWith('container-1', 'env1-egress');
+  });
+
+  it('skips connect when egressBypass=true', async () => {
+    const prisma = buildPrisma({ egressGatewayIp: '172.30.16.3' });
+    const cm = buildContainerManager();
+
+    await attachEgressNetworkIfNeeded(prisma, cm, 'container-1', 'env-1', true, log);
+
+    expect(cm.connectToNetwork).not.toHaveBeenCalled();
+    expect(prisma.environment.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('skips connect for host-level stacks', async () => {
+    const prisma = buildPrisma(null);
+    const cm = buildContainerManager();
+
+    await attachEgressNetworkIfNeeded(prisma, cm, 'container-1', null, false, log);
+
+    expect(cm.connectToNetwork).not.toHaveBeenCalled();
+  });
+
+  it('skips connect when env has no egressGatewayIp', async () => {
+    const prisma = buildPrisma({ egressGatewayIp: null });
+    const cm = buildContainerManager();
+
+    await attachEgressNetworkIfNeeded(prisma, cm, 'container-1', 'env-1', false, log);
+
+    expect(cm.connectToNetwork).not.toHaveBeenCalled();
+  });
+
+  it('skips connect when egress InfraResource is missing', async () => {
+    const prisma = buildPrisma({ egressGatewayIp: '172.30.16.3' }, null);
+    const cm = buildContainerManager();
+
+    await attachEgressNetworkIfNeeded(prisma, cm, 'container-1', 'env-1', false, log);
+
+    expect(cm.connectToNetwork).not.toHaveBeenCalled();
+  });
+
+  it('treats "already exists" as success (idempotent)', async () => {
+    const prisma = buildPrisma(
+      { egressGatewayIp: '172.30.16.3' },
+      { name: 'env1-egress', metadata: { subnet: '172.30.16.0/24' } },
+    );
+    const cm = {
+      connectToNetwork: vi.fn().mockRejectedValue(
+        Object.assign(new Error('endpoint with name container-1 already exists in network env1-egress'), { statusCode: 403 }),
+      ),
+    };
+
+    // Should not throw.
+    await expect(
+      attachEgressNetworkIfNeeded(prisma, cm, 'container-1', 'env-1', false, log),
+    ).resolves.toBeUndefined();
+  });
+
+  it('logs a warning but does not throw on unexpected connect failure', async () => {
+    const prisma = buildPrisma(
+      { egressGatewayIp: '172.30.16.3' },
+      { name: 'env1-egress', metadata: { subnet: '172.30.16.0/24' } },
+    );
+    const cm = {
+      connectToNetwork: vi.fn().mockRejectedValue(new Error('docker daemon unreachable')),
+    };
+
+    await expect(
+      attachEgressNetworkIfNeeded(prisma, cm, 'container-1', 'env-1', false, log),
+    ).resolves.toBeUndefined();
+    expect(log.warn).toHaveBeenCalled();
+  });
+});

--- a/server/src/services/stacks/__tests__/stack-container-manager-egress.test.ts
+++ b/server/src/services/stacks/__tests__/stack-container-manager-egress.test.ts
@@ -42,8 +42,6 @@ function makeOptions(environmentId: string | null | undefined) {
 const mockCreateLongRunningContainer = vi.fn();
 const mockContainerStart = vi.fn().mockResolvedValue(undefined);
 
-// startContainer now goes through getDockerClient().getContainer(id).start(),
-// not container.start() on the dockerode object returned at create time.
 const mockGetDockerClient = vi.fn(() => ({
   getContainer: vi.fn(() => ({ start: mockContainerStart })),
 }));
@@ -55,12 +53,13 @@ const mockDockerExecutor = {
 } as any;
 
 // ---------------------------------------------------------------------------
-// Tests for HTTP_PROXY injection — fires whenever the env has been provisioned
-// with an egress-gateway (egressGatewayIp non-null), regardless of the
-// egressFirewallEnabled flag (which only gates fw-agent policy enforcement).
+// HTTP_PROXY env injection — fires when env has a provisioned egress gateway
+// AND an `egress` InfraResource exists for that env. The helper that decides
+// is exercised in egress-injection.test.ts; here we verify the StackContainer-
+// Manager wires it through to createLongRunningContainer correctly.
 // ---------------------------------------------------------------------------
 
-describe('StackContainerManager — HTTP_PROXY injection (egressGatewayIp set, flag ON)', () => {
+describe('StackContainerManager — egress env injection', () => {
   let mockPrisma: any;
   let manager: StackContainerManager;
 
@@ -73,24 +72,24 @@ describe('StackContainerManager — HTTP_PROXY injection (egressGatewayIp set, f
   });
 
   function buildManager(
-    envResult: { egressFirewallEnabled: boolean; egressGatewayIp: string | null } | null,
-    infraResourceResult: { metadata: unknown } | null = null,
+    envResult: { egressGatewayIp: string | null } | null,
+    egressResource: { name: string; metadata: unknown } | null = null,
   ) {
     mockPrisma = {
       environment: {
         findUnique: vi.fn().mockResolvedValue(envResult),
       },
       infraResource: {
-        findFirst: vi.fn().mockResolvedValue(infraResourceResult),
+        findFirst: vi.fn().mockResolvedValue(egressResource),
       },
     };
     return new StackContainerManager(mockDockerExecutor, mockPrisma);
   }
 
-  it('injects HTTP_PROXY env vars when egressGatewayIp is set (flag ON)', async () => {
+  it('injects HTTP_PROXY env vars when egress gateway and egress InfraResource exist', async () => {
     manager = buildManager(
-      { egressFirewallEnabled: true, egressGatewayIp: '172.30.16.3' },
-      { metadata: { subnet: '172.30.5.0/24' } },
+      { egressGatewayIp: '172.30.16.3' },
+      { name: 'env1-egress', metadata: { subnet: '172.30.16.0/24' } },
     );
     const service = makeService();
     const options = makeOptions('env-1');
@@ -102,19 +101,18 @@ describe('StackContainerManager — HTTP_PROXY injection (egressGatewayIp set, f
     expect(callArgs.env['HTTPS_PROXY']).toBe('http://egress-gateway:3128');
     expect(callArgs.env['http_proxy']).toBe('http://egress-gateway:3128');
     expect(callArgs.env['https_proxy']).toBe('http://egress-gateway:3128');
-    // NO_PROXY includes localhost, loopback block, and bridge CIDR
     expect(callArgs.env['NO_PROXY']).toContain('localhost');
     expect(callArgs.env['NO_PROXY']).toContain('127.0.0.0/8');
-    expect(callArgs.env['NO_PROXY']).toContain('172.30.5.0/24');
+    expect(callArgs.env['NO_PROXY']).toContain('172.30.16.0/24');
     expect(callArgs.env['no_proxy']).toBe(callArgs.env['NO_PROXY']);
-    // DNS injection must NOT be present (we use Docker's default resolver)
+    // No legacy DNS injection — Docker's default resolver remains.
     expect(callArgs.dnsServers).toBeUndefined();
   });
 
-  it('includes NO_PROXY without bridge CIDR when subnet not found', async () => {
+  it('omits the bridge CIDR from NO_PROXY when egress InfraResource has no subnet metadata', async () => {
     manager = buildManager(
-      { egressFirewallEnabled: true, egressGatewayIp: '172.30.16.3' },
-      null, // no infra resource → no subnet
+      { egressGatewayIp: '172.30.16.3' },
+      { name: 'env1-egress', metadata: null },
     );
     const service = makeService();
     const options = makeOptions('env-1');
@@ -123,16 +121,11 @@ describe('StackContainerManager — HTTP_PROXY injection (egressGatewayIp set, f
 
     const callArgs = mockCreateLongRunningContainer.mock.calls[0][0];
     expect(callArgs.env['HTTP_PROXY']).toBe('http://egress-gateway:3128');
-    expect(callArgs.env['NO_PROXY']).toContain('localhost');
-    expect(callArgs.env['NO_PROXY']).toContain('127.0.0.0/8');
-    // Should not crash, just omit the bridge CIDR
-    expect(callArgs.dnsServers).toBeUndefined();
+    expect(callArgs.env['NO_PROXY']).toBe('localhost,127.0.0.0/8');
   });
 
-  it('skips HTTP_PROXY injection when egressBypass=true (v3 gateway service)', async () => {
-    manager = buildManager(
-      { egressFirewallEnabled: true, egressGatewayIp: '172.30.16.3' },
-    );
+  it('skips injection when service has egressBypass=true (gateway service itself)', async () => {
+    manager = buildManager({ egressGatewayIp: '172.30.16.3' });
     const service = makeService({ egressBypass: true });
     const options = makeOptions('env-1');
 
@@ -141,12 +134,11 @@ describe('StackContainerManager — HTTP_PROXY injection (egressGatewayIp set, f
     const callArgs = mockCreateLongRunningContainer.mock.calls[0][0];
     expect(callArgs.env['HTTP_PROXY']).toBeUndefined();
     expect(callArgs.env['HTTPS_PROXY']).toBeUndefined();
-    expect(callArgs.dnsServers).toBeUndefined();
-    // Prisma must not be called (bypass short-circuits before DB lookup)
+    // Bypass short-circuits before any DB lookup.
     expect(mockPrisma.environment.findUnique).not.toHaveBeenCalled();
   });
 
-  it('skips HTTP_PROXY injection for host-level stacks (no environmentId)', async () => {
+  it('skips injection for host-level stacks (no environmentId)', async () => {
     manager = buildManager(null);
     const service = makeService();
     const options = makeOptions(null);
@@ -155,147 +147,54 @@ describe('StackContainerManager — HTTP_PROXY injection (egressGatewayIp set, f
 
     const callArgs = mockCreateLongRunningContainer.mock.calls[0][0];
     expect(callArgs.env['HTTP_PROXY']).toBeUndefined();
-    expect(callArgs.dnsServers).toBeUndefined();
     expect(mockPrisma.environment.findUnique).not.toHaveBeenCalled();
   });
 
-  it('merges injected proxy env vars with static service env vars (service vars take precedence)', async () => {
+  it('skips injection when env has no egressGatewayIp (gateway not provisioned)', async () => {
+    manager = buildManager({ egressGatewayIp: null });
+    const service = makeService();
+    const options = makeOptions('env-1');
+
+    await manager.createAndStartContainer('web', service, options);
+
+    const callArgs = mockCreateLongRunningContainer.mock.calls[0][0];
+    expect(callArgs.env['HTTP_PROXY']).toBeUndefined();
+  });
+
+  it('skips injection when egress InfraResource is missing (gateway provisioning incomplete)', async () => {
     manager = buildManager(
-      { egressFirewallEnabled: true, egressGatewayIp: '172.30.16.3' },
-      { metadata: { subnet: '172.30.1.0/24' } },
+      { egressGatewayIp: '172.30.16.3' },
+      null,
     );
-    // Service explicitly sets its own HTTP_PROXY (override)
+    const service = makeService();
+    const options = makeOptions('env-1');
+
+    await manager.createAndStartContainer('web', service, options);
+
+    const callArgs = mockCreateLongRunningContainer.mock.calls[0][0];
+    expect(callArgs.env['HTTP_PROXY']).toBeUndefined();
+  });
+
+  it('lets static service env override injected proxy env', async () => {
+    manager = buildManager(
+      { egressGatewayIp: '172.30.16.3' },
+      { name: 'env1-egress', metadata: { subnet: '172.30.1.0/24' } },
+    );
     const service = makeService({ env: { HTTP_PROXY: 'http://custom-proxy:9090', APP_VAR: 'hello' } });
     const options = makeOptions('env-1');
 
     await manager.createAndStartContainer('web', service, options);
 
     const callArgs = mockCreateLongRunningContainer.mock.calls[0][0];
-    // Service env takes precedence over injected env
     expect(callArgs.env['HTTP_PROXY']).toBe('http://custom-proxy:9090');
     expect(callArgs.env['APP_VAR']).toBe('hello');
-    // Other proxy vars are still injected
+    // Other proxy vars are still injected.
     expect(callArgs.env['HTTPS_PROXY']).toBe('http://egress-gateway:3128');
   });
 });
 
 // ---------------------------------------------------------------------------
-// Tests for HTTP_PROXY injection with egressFirewallEnabled = false.
-// Same behavior as flag ON: gateway presence (egressGatewayIp) drives the
-// injection, not the flag. Also covers the no-gateway short-circuit.
-// ---------------------------------------------------------------------------
-
-describe('StackContainerManager — HTTP_PROXY injection (egressGatewayIp set, flag OFF)', () => {
-  let mockPrisma: any;
-  let manager: StackContainerManager;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockCreateLongRunningContainer.mockResolvedValue({
-      id: 'container-new',
-      start: mockContainerStart,
-    });
-  });
-
-  function buildManager(
-    envResult: { egressFirewallEnabled: boolean; egressGatewayIp: string | null } | null,
-    infraResourceResult: { metadata: unknown } | null = null,
-  ) {
-    mockPrisma = {
-      environment: {
-        findUnique: vi.fn().mockResolvedValue(envResult),
-      },
-      infraResource: {
-        findFirst: vi.fn().mockResolvedValue(infraResourceResult),
-      },
-    };
-    return new StackContainerManager(mockDockerExecutor, mockPrisma);
-  }
-
-  it('injects HTTP_PROXY env vars when egressGatewayIp is set even though flag is OFF', async () => {
-    manager = buildManager(
-      { egressFirewallEnabled: false, egressGatewayIp: '172.30.16.3' },
-      { metadata: { subnet: '172.30.16.0/22' } },
-    );
-    const service = makeService();
-    const options = makeOptions('env-1');
-
-    await manager.createAndStartContainer('web', service, options);
-
-    const callArgs = mockCreateLongRunningContainer.mock.calls[0][0];
-    expect(callArgs.env['HTTP_PROXY']).toBe('http://egress-gateway:3128');
-    expect(callArgs.env['HTTPS_PROXY']).toBe('http://egress-gateway:3128');
-    expect(callArgs.env['http_proxy']).toBe('http://egress-gateway:3128');
-    expect(callArgs.env['https_proxy']).toBe('http://egress-gateway:3128');
-    expect(callArgs.env['NO_PROXY']).toContain('172.30.16.0/22');
-    // No legacy DNS injection — Docker's default resolver remains.
-    expect(callArgs.dnsServers).toBeUndefined();
-  });
-
-  it('skips injection entirely when egressGatewayIp is null', async () => {
-    manager = buildManager({ egressFirewallEnabled: false, egressGatewayIp: null });
-    const service = makeService();
-    const options = makeOptions('env-1');
-
-    await expect(manager.createAndStartContainer('web', service, options)).resolves.toBeDefined();
-
-    const callArgs = mockCreateLongRunningContainer.mock.calls[0][0];
-    expect(callArgs.dnsServers).toBeUndefined();
-    expect(callArgs.env['HTTP_PROXY']).toBeUndefined();
-  });
-
-  it('skips injection when egressBypass=true', async () => {
-    manager = buildManager({ egressFirewallEnabled: false, egressGatewayIp: '172.30.16.3' });
-    const service = makeService({ egressBypass: true });
-    const options = makeOptions('env-1');
-
-    await manager.createAndStartContainer('egress-gw', service, options);
-
-    const callArgs = mockCreateLongRunningContainer.mock.calls[0][0];
-    expect(callArgs.dnsServers).toBeUndefined();
-    expect(callArgs.env['HTTP_PROXY']).toBeUndefined();
-    // Prisma must not be called
-    expect(mockPrisma.environment.findUnique).not.toHaveBeenCalled();
-  });
-
-  it('skips injection for host-level stack (no environmentId)', async () => {
-    manager = buildManager(null);
-    const service = makeService();
-    const options = makeOptions(null);
-
-    await manager.createAndStartContainer('web', service, options);
-
-    const callArgs = mockCreateLongRunningContainer.mock.calls[0][0];
-    expect(callArgs.dnsServers).toBeUndefined();
-    expect(callArgs.env['HTTP_PROXY']).toBeUndefined();
-    expect(mockPrisma.environment.findUnique).not.toHaveBeenCalled();
-  });
-
-  it('injects HTTP_PROXY only for non-bypass services in the same stack', async () => {
-    manager = buildManager(
-      { egressFirewallEnabled: false, egressGatewayIp: '172.30.16.3' },
-      { metadata: { subnet: '172.30.16.0/22' } },
-    );
-    const options = makeOptions('env-1');
-
-    const normalService = makeService({ egressBypass: false });
-    const bypassService = makeService({ egressBypass: true });
-
-    await manager.createAndStartContainer('app', normalService, options);
-    await manager.createAndStartContainer('gw', bypassService, options);
-
-    const firstCallArgs = mockCreateLongRunningContainer.mock.calls[0][0];
-    const secondCallArgs = mockCreateLongRunningContainer.mock.calls[1][0];
-
-    expect(firstCallArgs.env['HTTP_PROXY']).toBe('http://egress-gateway:3128');
-    expect(secondCallArgs.env['HTTP_PROXY']).toBeUndefined();
-    expect(firstCallArgs.dnsServers).toBeUndefined();
-    expect(secondCallArgs.dnsServers).toBeUndefined();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Tests for Phase 2 egress bypass label (unchanged)
+// Phase 2 egress bypass label (unchanged contract, retained here for sanity).
 // ---------------------------------------------------------------------------
 
 describe('StackContainerManager — egress bypass label', () => {
@@ -310,7 +209,7 @@ describe('StackContainerManager — egress bypass label', () => {
     });
   });
 
-  function buildManager(envResult: { egressFirewallEnabled: boolean; egressGatewayIp: string | null } | null) {
+  function buildManager(envResult: { egressGatewayIp: string | null } | null) {
     mockPrisma = {
       environment: {
         findUnique: vi.fn().mockResolvedValue(envResult),
@@ -323,7 +222,7 @@ describe('StackContainerManager — egress bypass label', () => {
   }
 
   it('sets mini-infra.egress.bypass=true label for bypass services', async () => {
-    manager = buildManager({ egressFirewallEnabled: false, egressGatewayIp: null });
+    manager = buildManager({ egressGatewayIp: null });
     const bypassService = makeService({ egressBypass: true });
     const options = makeOptions('env-1');
 
@@ -333,19 +232,19 @@ describe('StackContainerManager — egress bypass label', () => {
     expect(callArgs.labels?.['mini-infra.egress.bypass']).toBe('true');
   });
 
-  it('does NOT set mini-infra.egress.bypass label for normal services', async () => {
-    manager = buildManager({ egressFirewallEnabled: false, egressGatewayIp: null });
-    const normalService = makeService({ egressBypass: false });
+  it('does not set the egress.bypass label for non-bypass services', async () => {
+    manager = buildManager({ egressGatewayIp: null });
+    const service = makeService({ egressBypass: false });
     const options = makeOptions('env-1');
 
-    await manager.createAndStartContainer('app', normalService, options);
+    await manager.createAndStartContainer('app', service, options);
 
     const callArgs = mockCreateLongRunningContainer.mock.calls[0][0];
     expect(callArgs.labels?.['mini-infra.egress.bypass']).toBeUndefined();
   });
 
-  it('does NOT set mini-infra.egress.bypass label when egressBypass is unset', async () => {
-    manager = buildManager({ egressFirewallEnabled: false, egressGatewayIp: null });
+  it('does not set the egress.bypass label when egressBypass is unset', async () => {
+    manager = buildManager({ egressGatewayIp: null });
     const service = makeService({});
     const options = makeOptions('env-1');
 

--- a/server/src/services/stacks/egress-injection.ts
+++ b/server/src/services/stacks/egress-injection.ts
@@ -1,0 +1,137 @@
+/**
+ * Egress proxy injection — env vars + network attach.
+ *
+ * Every managed container in an env-scoped stack that doesn't opt out via
+ * `egressBypass: true` should both (a) receive HTTP_PROXY env pointing at
+ * the per-env egress-gateway and (b) be attached to the per-env egress
+ * Docker network so the `egress-gateway:3128` hostname actually resolves.
+ *
+ * The two halves were previously decided independently: env injection fired
+ * whenever the env had `egressGatewayIp` set, but network attach was left to
+ * stack templates to declare. Stacks that didn't happen to join the right
+ * resource network ended up with proxy env pointing at an unresolvable
+ * hostname — every outbound HTTPS call died at DNS resolution.
+ *
+ * This module collapses both decisions into a single set of gates so they
+ * can't drift again.
+ */
+import type { Logger } from 'pino';
+import type { PrismaClient } from '../../generated/prisma/client';
+
+interface EgressContext {
+  shouldInject: boolean;
+  networkName?: string;
+  subnet?: string;
+}
+
+/**
+ * Resolve whether egress injection should fire for a managed container, and
+ * the per-env egress network name + subnet if so.
+ *
+ * Gates (in order):
+ * - egressBypass === true → no injection (egress-gateway itself, fw-agent, etc.)
+ * - No environmentId → host-level stack, no injection.
+ * - Environment has no egressGatewayIp → gateway not provisioned, skip.
+ * - No `egress` InfraResource for the env → gateway provisioning incomplete, skip.
+ *
+ * Never throws — egress injection failure must not break stack apply.
+ */
+async function resolveEgressContext(
+  prisma: PrismaClient,
+  environmentId: string | null | undefined,
+  egressBypass: boolean,
+): Promise<EgressContext> {
+  if (egressBypass) return { shouldInject: false };
+  if (!environmentId) return { shouldInject: false };
+
+  try {
+    const env = await prisma.environment.findUnique({
+      where: { id: environmentId },
+      select: { egressGatewayIp: true },
+    });
+    if (!env?.egressGatewayIp) return { shouldInject: false };
+
+    const resource = await prisma.infraResource.findFirst({
+      where: {
+        type: 'docker-network',
+        purpose: 'egress',
+        scope: 'environment',
+        environmentId,
+      },
+      select: { name: true, metadata: true },
+    });
+    if (!resource) return { shouldInject: false };
+
+    const meta = resource.metadata as Record<string, unknown> | null;
+    const subnet = typeof meta?.['subnet'] === 'string' ? (meta['subnet'] as string) : undefined;
+
+    return { shouldInject: true, networkName: resource.name, subnet };
+  } catch {
+    return { shouldInject: false };
+  }
+}
+
+const PROXY_URL = 'http://egress-gateway:3128';
+
+function buildProxyEnv(subnet: string | undefined): Record<string, string> {
+  const noProxy = ['localhost', '127.0.0.0/8', ...(subnet ? [subnet] : [])].join(',');
+  return {
+    HTTP_PROXY: PROXY_URL,
+    HTTPS_PROXY: PROXY_URL,
+    http_proxy: PROXY_URL,
+    https_proxy: PROXY_URL,
+    NO_PROXY: noProxy,
+    no_proxy: noProxy,
+  };
+}
+
+/**
+ * Resolve the proxy env vars for a managed container. Returns an empty
+ * record when any gate fails — callers can spread it unconditionally.
+ *
+ * Caller env vars from the service definition should be merged AFTER this
+ * record so service overrides win.
+ */
+export async function resolveEgressEnv(
+  prisma: PrismaClient,
+  environmentId: string | null | undefined,
+  egressBypass: boolean,
+): Promise<Record<string, string>> {
+  const ctx = await resolveEgressContext(prisma, environmentId, egressBypass);
+  if (!ctx.shouldInject) return {};
+  return buildProxyEnv(ctx.subnet);
+}
+
+/**
+ * Attach a container to the per-env egress Docker network so it can resolve
+ * `egress-gateway:3128`. Idempotent — already-connected is treated as success.
+ *
+ * No-op when any gate fails. Logs a warning on connect failure but never
+ * throws (mirrors the resolveEgressEnv contract — egress wiring failures
+ * must not break stack apply).
+ */
+export async function attachEgressNetworkIfNeeded(
+  prisma: PrismaClient,
+  containerManager: { connectToNetwork(containerId: string, networkName: string): Promise<void> },
+  containerId: string,
+  environmentId: string | null | undefined,
+  egressBypass: boolean,
+  log: Logger,
+): Promise<void> {
+  const ctx = await resolveEgressContext(prisma, environmentId, egressBypass);
+  if (!ctx.shouldInject || !ctx.networkName) return;
+
+  try {
+    await containerManager.connectToNetwork(containerId, ctx.networkName);
+    log.info({ containerId, network: ctx.networkName }, 'Attached container to egress network');
+  } catch (err) {
+    const e = err as { message?: string; statusCode?: number };
+    const msg = e?.message || '';
+    if (!msg.includes('already exists') && e?.statusCode !== 403) {
+      log.warn(
+        { containerId, network: ctx.networkName, error: msg },
+        'Failed to attach container to egress network',
+      );
+    }
+  }
+}

--- a/server/src/services/stacks/pool-spawner.ts
+++ b/server/src/services/stacks/pool-spawner.ts
@@ -17,6 +17,7 @@ import {
   resolveServiceConfigs,
   synthesiseDefaultNetworkIfNeeded,
 } from './utils';
+import { resolveEgressEnv, attachEgressNetworkIfNeeded } from './egress-injection';
 
 const log = getLogger('stacks', 'pool-spawner');
 
@@ -164,8 +165,20 @@ export async function spawnPoolInstance(
     }
   }
 
-  // Caller env wins over base/Vault env; VAULT_* is stripped.
+  // Egress proxy env — injected for non-bypass services in env-scoped stacks
+  // when the env has a provisioned gateway. Pool workers need this on the
+  // same gates as the static service path so outbound calls flow through the
+  // gateway. See egress-injection.ts.
+  const egressEnv = await resolveEgressEnv(
+    prisma,
+    stack.environmentId,
+    containerConfig.egressBypass === true,
+  );
+
+  // Caller env wins over base/Vault env; VAULT_* is stripped. Egress proxy
+  // env goes first so service-defined env or caller env can still override.
   const finalEnv: Record<string, string> = {
+    ...egressEnv,
     ...(containerConfig.env ?? {}),
     ...vaultEnv,
     ...sanitiseCallerEnv(ctx.callerEnv),
@@ -361,6 +374,25 @@ export async function spawnPoolInstance(
         }
       }
     }
+  }
+
+  // Auto-attach to the per-env egress network so the proxy env injected
+  // above (HTTP_PROXY=http://egress-gateway:3128) can resolve the DNS alias.
+  // Same gates as resolveEgressEnv: non-bypass + env has gateway provisioned.
+  {
+    const egressDocker = dockerExecutor.getDockerClient();
+    await attachEgressNetworkIfNeeded(
+      prisma,
+      {
+        connectToNetwork: async (id, name) => {
+          await egressDocker.getNetwork(name).connect({ Container: id });
+        },
+      },
+      containerId,
+      stack.environmentId,
+      containerConfig.egressBypass === true,
+      log,
+    );
   }
 
   // All required networks are attached — start the container now so its

--- a/server/src/services/stacks/stack-container-manager.ts
+++ b/server/src/services/stacks/stack-container-manager.ts
@@ -6,6 +6,7 @@ import {
 } from '@mini-infra/types';
 import { getLogger } from '../../lib/logger-factory';
 import { groupByProperty } from './utils';
+import { resolveEgressEnv } from './egress-injection';
 import type { PrismaClient } from '../../generated/prisma/client';
 
 export interface CreateContainerOptions {
@@ -207,8 +208,11 @@ export class StackContainerManager {
 
     this.log.info({ containerName, image }, 'Creating container');
 
-    const egressResult = await this.resolveEgressInjection(service, options);
-    const egressEnv = egressResult.type === 'proxy' ? egressResult.env : {};
+    const egressEnv = await resolveEgressEnv(
+      this.prisma,
+      options.environmentId,
+      config.egressBypass === true,
+    );
 
     const container = await this.dockerExecutor.createLongRunningContainer({
       image,
@@ -241,109 +245,6 @@ export class StackContainerManager {
     const docker = this.dockerExecutor.getDockerClient();
     await docker.getContainer(containerId).start();
     this.log.info({ containerId }, 'Container started');
-  }
-
-  /**
-   * Resolve what egress injection to apply for a managed container.
-   *
-   * Gates (in order):
-   * - Host-level stack (no environmentId) → no injection.
-   * - Service has egressBypass === true → no injection (egress-gateway itself, fw-agent, etc.)
-   * - Environment has no egressGatewayIp → no injection (gateway not provisioned).
-   *
-   * When the env has been provisioned with an egress-gateway, inject
-   * HTTP_PROXY / HTTPS_PROXY / NO_PROXY env vars pointing at the
-   * egress-gateway container via Docker DNS alias `egress-gateway:3128`.
-   * Docker's default 127.0.0.11 resolver remains in place for DNS.
-   *
-   * Note: `egressFirewallEnabled` is intentionally not consulted here. That
-   * flag gates whether the fw-agent actively enforces policies, not which
-   * gateway is provisioned. `egressGatewayIp` (set once at env creation by
-   * provisionEgressGateway) is the canonical "gateway exists" signal.
-   *
-   * Never throws — egress injection failure must not break stack apply.
-   */
-  private async resolveEgressInjection(
-    service: StackServiceDefinition,
-    options: CreateContainerOptions,
-  ): Promise<{ type: 'none' } | { type: 'proxy'; env: Record<string, string> }> {
-    if (!options.environmentId) {
-      return { type: 'none' };
-    }
-
-    if (service.containerConfig.egressBypass === true) {
-      return { type: 'none' };
-    }
-
-    try {
-      const environment = await this.prisma.environment.findUnique({
-        where: { id: options.environmentId },
-        select: { egressGatewayIp: true },
-      });
-
-      if (!environment?.egressGatewayIp) {
-        this.log.warn(
-          { environmentId: options.environmentId, stackId: options.stackId },
-          'Environment has no egressGatewayIp — skipping egress injection',
-        );
-        return { type: 'none' };
-      }
-
-      const proxyUrl = 'http://egress-gateway:3128';
-      const bridgeCidr = await this.resolveApplicationsBridgeCidr(options.environmentId);
-      const noProxy = ['localhost', '127.0.0.0/8', ...(bridgeCidr ? [bridgeCidr] : [])].join(',');
-
-      return {
-        type: 'proxy',
-        env: {
-          HTTP_PROXY: proxyUrl,
-          HTTPS_PROXY: proxyUrl,
-          http_proxy: proxyUrl,
-          https_proxy: proxyUrl,
-          NO_PROXY: noProxy,
-          no_proxy: noProxy,
-        },
-      };
-    } catch (err) {
-      this.log.warn(
-        { environmentId: options.environmentId, stackId: options.stackId, error: err },
-        'Error resolving egress injection — skipping to not block stack apply',
-      );
-      return { type: 'none' };
-    }
-  }
-
-  /**
-   * Resolve the CIDR of the applications bridge for the given environment.
-   * Used to populate NO_PROXY so managed containers bypass the proxy for
-   * intra-env traffic (e.g., container-to-container, container-to-gateway).
-   *
-   * Returns null when the bridge CIDR is not yet known (e.g., network not yet
-   * created). The caller omits it from NO_PROXY in that case.
-   */
-  private async resolveApplicationsBridgeCidr(environmentId: string): Promise<string | null> {
-    try {
-      const resource = await this.prisma.infraResource.findFirst({
-        where: {
-          type: 'docker-network',
-          purpose: 'applications',
-          scope: 'environment',
-          environmentId,
-        },
-        select: { metadata: true },
-      });
-      const meta = resource?.metadata as Record<string, unknown> | null;
-      const subnet = meta?.['subnet'];
-      if (typeof subnet === 'string') {
-        return subnet;
-      }
-    } catch (err) {
-      this.log.warn(
-        { environmentId, error: err },
-        'Could not resolve applications bridge CIDR for NO_PROXY',
-      );
-    }
-    return null;
   }
 
   async connectToNetwork(containerId: string, networkName: string, aliases?: string[]): Promise<void> {

--- a/server/src/services/stacks/stack-infra-resource-manager.ts
+++ b/server/src/services/stacks/stack-infra-resource-manager.ts
@@ -53,16 +53,16 @@ export class StackInfraResourceManager {
           labels['mini-infra.environment'] = stack.environmentId;
         }
 
-        // For environment-scoped applications networks, use the subnet pre-allocated
+        // For environment-scoped egress networks, use the subnet pre-allocated
         // by EgressNetworkAllocator and persisted on InfraResource.metadata.subnet.
         // This gives the egress gateway a stable, known network segment.
         let ipamConfig: { subnet: string; gateway?: string } | undefined;
-        if (output.purpose === 'applications' && stack.environmentId) {
+        if (output.purpose === 'egress' && stack.environmentId) {
           // Check for an existing InfraResource record that may carry a pre-allocated subnet
           const existingResource = await this.prisma.infraResource.findFirst({
             where: {
               type: 'docker-network',
-              purpose: 'applications',
+              purpose: 'egress',
               scope: 'environment',
               environmentId: stack.environmentId,
             },
@@ -76,7 +76,7 @@ export class StackInfraResourceManager {
               subnet,
               ...(typeof gateway === 'string' ? { gateway } : {}),
             };
-            log.info({ network: name, subnet, gateway }, 'Using pre-allocated subnet for applications network');
+            log.info({ network: name, subnet, gateway }, 'Using pre-allocated subnet for egress network');
           }
         }
 
@@ -180,9 +180,12 @@ export class StackInfraResourceManager {
       const netName = infraNetworkMap.get(purpose);
       if (!netName) continue;
       try {
-        // For egressBypass services joining the applications resource network,
+        // For egressBypass services (the egress-gateway itself, fw-agent, etc.),
         // add the service name as a DNS alias so managed containers can resolve
-        // `egress-gateway:3128` regardless of which IP the container gets on recreate.
+        // `egress-gateway:3128` regardless of which IP the container gets on
+        // recreate. The egress-gateway service joins the per-env `egress`
+        // network with this alias; non-bypass containers are auto-attached to
+        // the same network via attachEgressNetworkIfNeeded.
         const aliases =
           serviceDef.containerConfig.egressBypass === true ? [serviceDef.serviceName] : undefined;
         await this.containerManager.connectToNetwork(containerId, netName, aliases);

--- a/server/src/services/stacks/stack-service-handlers.ts
+++ b/server/src/services/stacks/stack-service-handlers.ts
@@ -15,6 +15,7 @@ import { removalDeploymentMachine, type RemovalDeploymentContext } from '../hapr
 import { runStateMachineToCompletion } from './state-machine-runner';
 import { prepareServiceContainer } from './utils';
 import { removeConflictingContainer } from './stack-conflict-detector';
+import { attachEgressNetworkIfNeeded } from './egress-injection';
 import type { StackContainerManager } from './stack-container-manager';
 import type { StackInfraResourceManager } from './stack-infra-resource-manager';
 import { StackRoutingManager, type StackRoutingContext } from './stack-routing-manager';
@@ -124,6 +125,14 @@ export class StackServiceHandlers {
 
         await this.joinJoinNetworks(containerId, action.serviceName, effectiveServiceDef, log);
         await this.infraManager.joinResourceNetworks(containerId, effectiveServiceDef, infraNetworkMap, log);
+        await attachEgressNetworkIfNeeded(
+          this.prisma,
+          this.containerManager,
+          containerId,
+          stack.environmentId,
+          effectiveServiceDef.containerConfig.egressBypass === true,
+          log,
+        );
 
         await this.containerManager.startContainer(containerId);
 
@@ -171,6 +180,14 @@ export class StackServiceHandlers {
 
         await this.joinJoinNetworks(containerId, action.serviceName, effectiveServiceDef, log);
         await this.infraManager.joinResourceNetworks(containerId, effectiveServiceDef, infraNetworkMap, log);
+        await attachEgressNetworkIfNeeded(
+          this.prisma,
+          this.containerManager,
+          containerId,
+          stack.environmentId,
+          effectiveServiceDef.containerConfig.egressBypass === true,
+          log,
+        );
 
         await this.containerManager.startContainer(containerId);
 

--- a/server/src/services/stacks/stack-state-machine-context.ts
+++ b/server/src/services/stacks/stack-state-machine-context.ts
@@ -9,6 +9,7 @@ import type {
 import type { HAProxyDataPlaneClient } from '../haproxy';
 import { EnvironmentValidationService, type HAProxyEnvironmentContext } from '../environment';
 import type { StackRoutingManager, StackRoutingContext } from './stack-routing-manager';
+import { resolveEgressEnv } from './egress-injection';
 
 export interface StackWithReconcilerContext {
   id: string;
@@ -43,7 +44,39 @@ export async function buildStateMachineContext(
   }
 
   const dockerImage = `${serviceDef.dockerImage}:${serviceDef.dockerTag}`;
-  const envRecord = serviceDef.containerConfig.env ?? {};
+
+  // Egress proxy env — injected for non-bypass services in env-scoped stacks
+  // when the env has a provisioned gateway. Same gates as the static service
+  // path (StackContainerManager) and pool-spawner. See egress-injection.ts.
+  const egressEnv = await resolveEgressEnv(
+    prisma,
+    stack.environmentId,
+    serviceDef.containerConfig.egressBypass === true,
+  );
+  // Service-defined env wins over injected egress env so explicit overrides hold.
+  const envRecord = { ...egressEnv, ...(serviceDef.containerConfig.env ?? {}) };
+
+  // Resolve the per-env egress network so the container can reach the proxy
+  // hostname. Looked up directly off InfraResource because StatelessWeb stacks
+  // don't declare `egress` as a resource input (auto-attach is implicit).
+  // Never throws — failures here must not block stack apply.
+  let egressNetworkName: string | null = null;
+  if (stack.environmentId && serviceDef.containerConfig.egressBypass !== true) {
+    try {
+      const egressResource = await prisma.infraResource.findFirst({
+        where: {
+          type: 'docker-network',
+          purpose: 'egress',
+          scope: 'environment',
+          environmentId: stack.environmentId,
+        },
+        select: { name: true },
+      });
+      egressNetworkName = egressResource?.name ?? null;
+    } catch {
+      egressNetworkName = null;
+    }
+  }
 
   // Resolve TLS from stack-level resource if referenced
   let enableSsl = false;
@@ -76,6 +109,10 @@ export async function buildStateMachineContext(
         containerNetworks.push(netName);
       }
     }
+  }
+  // Auto-attach to per-env egress network so the proxy hostname resolves.
+  if (egressNetworkName && !containerNetworks.includes(egressNetworkName)) {
+    containerNetworks.push(egressNetworkName);
   }
 
   return {

--- a/server/templates/egress-gateway/template.json
+++ b/server/templates/egress-gateway/template.json
@@ -1,7 +1,7 @@
 {
   "name": "egress-gateway",
   "displayName": "Egress Gateway",
-  "builtinVersion": 7,
+  "builtinVersion": 8,
   "scope": "environment",
   "category": "infrastructure",
   "description": "Smokescreen-based HTTP/HTTPS forward proxy for environment egress traffic control",
@@ -13,8 +13,8 @@
       "description": "Log level for the egress gateway (debug, info, warn, error)"
     }
   ],
-  "resourceInputs": [
-    { "type": "docker-network", "purpose": "applications" }
+  "resourceOutputs": [
+    { "type": "docker-network", "purpose": "egress", "joinSelf": true }
   ],
   "networks": [],
   "volumes": [],
@@ -36,7 +36,7 @@
           { "containerPort": 8054, "hostPort": 0, "protocol": "tcp", "exposeOnHost": false }
         ],
         "restartPolicy": "unless-stopped",
-        "joinResourceNetworks": ["applications"],
+        "joinResourceNetworks": ["egress"],
         "logConfig": { "type": "json-file", "maxSize": "10m", "maxFile": "3" }
       },
       "dependsOn": [],


### PR DESCRIPTION
## Summary

- Splits the egress topology so the egress-gateway lives on its own per-env `<env>-egress` network instead of HAProxy's `applications` network. Every non-bypass managed container — Stateful, StatelessWeb, pool workers — is auto-attached to that network at create time, so the injected `HTTP_PROXY=http://egress-gateway:3128` can actually resolve.
- Collapses env injection and network attach into a single set of gates in a shared helper (`server/src/services/stacks/egress-injection.ts`) so they can't drift again. The two were previously independent decisions, which is how stacks with `joinResourceNetworks: ['vault']` ended up with proxy env pointing at an unresolvable hostname.
- Pool workers also gain the proxy env injection they were missing — they'd previously been making outbound calls direct via the Docker bridge.

### What moved
- `<env>-egress` Docker network — new, owned by the egress-gateway stack via `resourceOutputs: [{ purpose: 'egress', joinSelf: true }]`. Subnet allocated from the egress pool the same way `applications` used to be.
- `applications` returns to being purely HAProxy's frontend network.
- `egress-container-map-pusher` and `env-firewall-manager` now read container IPs and the bridge CIDR from the egress network / `purpose: 'egress'` InfraResource.
- `EgressNetworkAllocator.allocateSubnet` scans `purpose: 'egress'` for used slots.
- `environment-manager.provisionEgressGateway` allocates the egress /24, creates the network, joins mini-infra-server, allocates the gateway IP on it, then applies the egress-gateway stack.

### Migration
None. Existing envs must be deleted and recreated. Confirmed with @geoffrich during planning — no migration code needed.

### Verification (end-to-end on worktree)
- Fresh env: `local-egress` Docker network at `172.30.20.0/24`
- `egress-gateway` container at `172.30.20.3` with `egress-gateway` DNS alias
- `mini-infra-server` at `172.30.20.2`
- Test Stateful container with no `joinResourceNetworks` declared lands on `172.30.20.4` automatically
- `HTTP_PROXY=http://egress-gateway:3128`, `NO_PROXY` includes the egress subnet
- `curl https://api.github.com/zen` from inside the test container → `Encourage flow.` 

## Test plan

- [x] `pnpm --filter mini-infra-server test` — 1924 passed (including 12 new tests in `egress-injection.test.ts`, refreshed `stack-container-manager-egress.test.ts`)
- [x] `pnpm --filter mini-infra-server lint` — clean
- [x] `pnpm --filter mini-infra-server build` — clean
- [x] `pnpm --filter mini-infra-client build` — clean
- [x] Provision a fresh env on the worktree → confirm the `<env>-egress` network is created with the right subnet, the gateway is on it with the `egress-gateway` alias, mini-infra-server is on it
- [x] Deploy a non-bypass Stateful stack with no `joinResourceNetworks` declared → confirm it auto-joins `<env>-egress` and outbound HTTPS through the proxy works
- [ ] Sanity check: pool workers in a non-bypass pool service get the same auto-attach + proxy env (covered by the shared helper but not exercised on the worktree this round — slackbot stack would be the natural test)
- [ ] Sanity check: StatelessWeb services in a non-bypass stack get the same wiring (HAProxy frontend network + egress network + proxy env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)