### PR TITLE
feat(dev): mirror worktree-env logs to a 200K-capped file

### DIFF
--- a/deployment/development/lib/log.ts
+++ b/deployment/development/lib/log.ts
@@ -1,9 +1,59 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 const RED = '\x1b[0;31m';
 const GREEN = '\x1b[0;32m';
 const CYAN = '\x1b[0;36m';
 const YELLOW = '\x1b[0;33m';
 const GRAY = '\x1b[0;90m';
 const NC = '\x1b[0m';
+
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const LOG_FILE = path.join(SCRIPT_DIR, '..', 'worktree-env.log');
+const MAX_BYTES = 200_000;
+const KEEP_BYTES = 100_000;
+
+let trimmed = false;
+
+// Trim once per process: if the file is over MAX_BYTES, keep the last
+// KEEP_BYTES (advancing past the next newline so the surviving content
+// starts on a clean line). Soft cap — concurrent writers can briefly
+// exceed MAX_BYTES; the next process trims it back.
+function trimIfNeeded(): void {
+  if (trimmed) return;
+  trimmed = true;
+  try {
+    const st = fs.statSync(LOG_FILE);
+    if (st.size <= MAX_BYTES) return;
+    const fd = fs.openSync(LOG_FILE, 'r');
+    try {
+      const buf = Buffer.alloc(KEEP_BYTES);
+      fs.readSync(fd, buf, 0, KEEP_BYTES, st.size - KEEP_BYTES);
+      const nl = buf.indexOf(0x0a);
+      const tail = nl >= 0 ? buf.subarray(nl + 1) : buf;
+      fs.writeFileSync(LOG_FILE, tail);
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    // No file yet, or we couldn't read it — appendFileSync below will create one.
+  }
+}
+
+function isoTs(): string {
+  return new Date().toISOString();
+}
+
+function appendToFile(level: string, msg: string): void {
+  try {
+    trimIfNeeded();
+    fs.appendFileSync(LOG_FILE, `${isoTs()} ${level} ${msg.replace(ANSI_RE, '')}\n`);
+  } catch {
+    // Disk full / permission denied — never let logging crash the script.
+  }
+}
 
 function ts(): string {
   const d = new Date();
@@ -13,16 +63,21 @@ function ts(): string {
 
 export function logInfo(msg: string): void {
   console.log(`${CYAN}[${ts()}] ${msg}${NC}`);
+  appendToFile('INFO', msg);
 }
 export function logOk(msg: string): void {
   console.log(`${GREEN}[${ts()}] ${msg}${NC}`);
+  appendToFile('OK  ', msg);
 }
 export function logWarn(msg: string): void {
   console.log(`${YELLOW}[${ts()}] ${msg}${NC}`);
+  appendToFile('WARN', msg);
 }
 export function logError(msg: string): void {
   console.error(`${RED}[${ts()}] ${msg}${NC}`);
+  appendToFile('ERR ', msg);
 }
 export function logSkip(msg: string): void {
   console.log(`${GRAY}[${ts()}] · ${msg}${NC}`);
+  appendToFile('SKIP', msg);
 }


### PR DESCRIPTION
## Summary

Every `worktree-env` invocation now also appends its log output to `deployment/development/worktree-env.log` alongside the existing colourised console output. The file is soft-capped at 200K — on the first log call per process, if the file is over the cap it is trimmed to the most recent ~100K (advancing past the next newline so surviving content starts cleanly).

Follow-up to #310, which the user spotted needed a paper trail when running things non-interactively.

## What changed

- `deployment/development/lib/log.ts` now appends a single line per `logInfo / logOk / logWarn / logError / logSkip` call. Lines are ISO-8601 timestamped, level-tagged, and stripped of ANSI escape codes.
- Soft 200K cap with rotation-on-overrun (keep last 100K). Cheap: stat + one read + one write, only on the first log call per process.
- Disk-write failures are swallowed so logging never crashes the script.
- The log file is already covered by the root `.gitignore`'s `*.log` rule — no new ignore entry needed.

## Why no library

`pino` + `pino-roll` or `rotating-file-stream` were considered. Both pull in more than needed for a single capped file. The existing `lib/log.ts` is 28 lines with zero deps; ~50 lines of `node:fs` keeps that style.

## Test plan

- [x] First run creates the file with one ANSI-stripped, ISO-timestamped line per `log*` call.
- [x] Seed a 365K log file, run a command that logs once → file is trimmed to ~100K, oldest lines dropped, recent lines preserved, new line appended.
- [x] `tsc --noEmit` clean on the updated `lib/log.ts`.
- [x] `npm test` in `deployment/development` — 14/14 pass.
- [x] `pnpm --filter mini-infra-server lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)