### PR TITLE
feat(dev): quiet worktree-env console to status-only by default

### DIFF
--- a/deployment/development/README.md
+++ b/deployment/development/README.md
@@ -70,6 +70,16 @@ MINI_INFRA_URL=$(xmllint --xpath 'string(//environment/endpoints/ui)' environmen
 
 Run `pnpm worktree-env <command> --help` for command-specific options.
 
+### Logging
+
+The console shows status-only output: completed milestones, warnings, and errors. The full progress chatter (every step the seeder is about to take, every "already done" skip) is appended to `deployment/development/worktree-env.log` (capped at ~200 KB, trimmed in place). Tail it when you want detail:
+
+```bash
+tail -f deployment/development/worktree-env.log
+```
+
+Set `WORKTREE_ENV_VERBOSE=1` in front of any `pnpm worktree-env` invocation to mirror the verbose chatter to the console.
+
 ## When to use this vs `pnpm dev`
 
 | Scenario | Worktree flow | `pnpm dev` |

--- a/deployment/development/lib/log.ts
+++ b/deployment/development/lib/log.ts
@@ -61,8 +61,14 @@ function ts(): string {
   return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
 }
 
+// Console output is kept to status-only by default — milestones (logOk),
+// warnings, and errors. The progress chatter (logInfo / logSkip) goes to
+// the rolling worktree-env.log only so the file stays verbose. Set
+// WORKTREE_ENV_VERBOSE=1 to mirror the chatter to the console too.
+const VERBOSE = process.env.WORKTREE_ENV_VERBOSE === '1';
+
 export function logInfo(msg: string): void {
-  console.log(`${CYAN}[${ts()}] ${msg}${NC}`);
+  if (VERBOSE) console.log(`${CYAN}[${ts()}] ${msg}${NC}`);
   appendToFile('INFO', msg);
 }
 export function logOk(msg: string): void {
@@ -78,6 +84,6 @@ export function logError(msg: string): void {
   appendToFile('ERR ', msg);
 }
 export function logSkip(msg: string): void {
-  console.log(`${GRAY}[${ts()}] · ${msg}${NC}`);
+  if (VERBOSE) console.log(`${GRAY}[${ts()}] · ${msg}${NC}`);
   appendToFile('SKIP', msg);
 }


### PR DESCRIPTION
## Summary

`pnpm worktree-env start` was printing every per-step "Looking for X", "Locating Y", "Polling for Z" line, drowning out the actual milestones. The 200K rolling log file at [`deployment/development/worktree-env.log`](deployment/development/worktree-env.log) (added in #311) already captures everything verbatim, so the console doesn't need to.

- `logInfo` / `logSkip` now go to the log file only (the chatter).
- `logOk` / `logWarn` / `logError` still print to the console — these are the actual status updates ("HAProxy stack created", "Mini Infra is healthy", etc.).
- `WORKTREE_ENV_VERBOSE=1` mirrors the chatter back to the console for anyone who wants the old behavior — useful when debugging the scripts themselves.
- README updated with where to find the verbose output and how to opt back in.

Splits cleanly along the existing log levels — no call sites need to change. Smoke-tested both default and verbose modes; both still write everything to the log file.

## Test plan

- [x] Default mode shows only `OK` / `WARN` / `ERR` on console.
- [x] `WORKTREE_ENV_VERBOSE=1` brings back the cyan/gray chatter.
- [x] `worktree-env.log` continues to capture all five levels regardless of console mode.
- [ ] Reviewer can verify by running `pnpm worktree-env start` in a fresh worktree — should be noticeably less noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)