### PR TITLE
fix(egress): map pool worker containers so they reach the ACL instead of getting 403'd

### DIFF
--- a/server/src/services/egress/__tests__/egress-container-map-pusher.test.ts
+++ b/server/src/services/egress/__tests__/egress-container-map-pusher.test.ts
@@ -98,7 +98,39 @@ describe('EgressContainerMapPusher', () => {
   // -------------------------------------------------------------------------
 
   it('collapses rapid container-change events into a single push per env', async () => {
-    const prisma = makePrisma();
+    const prisma = makePrisma({
+      environments: [{ id: 'env-1', name: 'staging', egressGatewayIp: '172.30.0.2' }],
+      stacks: [
+        {
+          id: 'stk-1',
+          name: 'app',
+          services: [{ serviceName: 'web', containerConfig: {} }],
+        },
+      ],
+    });
+
+    // First listContainers call (initial push) sees one container.
+    // Second call (after the burst of events) sees a different container.
+    // We have to vary the content so the no-op-skip path doesn't suppress
+    // the debounced push — that's tested separately below.
+    mockDockerInstance.listContainers
+      .mockResolvedValueOnce([
+        {
+          Id: 'c1',
+          Names: ['/staging-app-web'],
+          Labels: { 'mini-infra.stack-id': 'stk-1', 'mini-infra.service': 'web' },
+          NetworkSettings: { Networks: { 'staging-egress': { IPAddress: '172.30.0.10' } } },
+        },
+      ])
+      .mockResolvedValue([
+        {
+          Id: 'c1',
+          Names: ['/staging-app-web'],
+          Labels: { 'mini-infra.stack-id': 'stk-1', 'mini-infra.service': 'web' },
+          NetworkSettings: { Networks: { 'staging-egress': { IPAddress: '172.30.0.11' } } },
+        },
+      ]);
+
     const pusher = new EgressContainerMapPusher(prisma);
     pusher.start();
 
@@ -120,6 +152,118 @@ describe('EgressContainerMapPusher', () => {
 
     // Only 1 additional push despite 5 events
     expect(pushCalls.length).toBe(callCountAfterInit + 1);
+
+    pusher.stop();
+  });
+
+  // -------------------------------------------------------------------------
+  // No-op suppression: skip pushes when entries haven't changed
+  // -------------------------------------------------------------------------
+
+  it('skips the push when the entries fingerprint matches the last successful push', async () => {
+    // Idle env: same single container reported for every Docker poll, so
+    // every container-change event produces an identical map snapshot.
+    const prisma = makePrisma({
+      environments: [{ id: 'env-1', name: 'staging', egressGatewayIp: '172.30.0.2' }],
+      stacks: [
+        {
+          id: 'stk-1',
+          name: 'app',
+          services: [{ serviceName: 'web', containerConfig: {} }],
+        },
+      ],
+    });
+    mockDockerInstance.listContainers.mockResolvedValue([
+      {
+        Id: 'c1',
+        Names: ['/staging-app-web'],
+        Labels: { 'mini-infra.stack-id': 'stk-1', 'mini-infra.service': 'web' },
+        NetworkSettings: { Networks: { 'staging-egress': { IPAddress: '172.30.0.10' } } },
+      },
+    ]);
+
+    const pusher = new EgressContainerMapPusher(prisma);
+    pusher.start();
+
+    // Initial push lands.
+    await vi.runAllTimersAsync();
+    const seedCount = pushCalls.length;
+    expect(seedCount).toBeGreaterThan(0);
+
+    // Fire 10 separate debounced bursts of container events. Each one
+    // would result in a push under the old behaviour — under the new
+    // behaviour the gateway should not be hit again because the snapshot
+    // is identical.
+    for (let burst = 0; burst < 10; burst++) {
+      capturedContainerChangeCallback?.();
+      await vi.advanceTimersByTimeAsync(600);
+    }
+
+    expect(pushCalls.length).toBe(seedCount);
+
+    pusher.stop();
+  });
+
+  // -------------------------------------------------------------------------
+  // No-op suppression: a real change still produces a push
+  // -------------------------------------------------------------------------
+
+  it('pushes again when entries change after a stretch of identical snapshots', async () => {
+    const prisma = makePrisma({
+      environments: [{ id: 'env-1', name: 'staging', egressGatewayIp: '172.30.0.2' }],
+      stacks: [
+        {
+          id: 'stk-1',
+          name: 'app',
+          services: [
+            { serviceName: 'web', containerConfig: {} },
+            { serviceName: 'api', containerConfig: {} },
+          ],
+        },
+      ],
+    });
+
+    const baseContainer = {
+      Id: 'c-web',
+      Names: ['/staging-app-web'],
+      Labels: { 'mini-infra.stack-id': 'stk-1', 'mini-infra.service': 'web' },
+      NetworkSettings: { Networks: { 'staging-egress': { IPAddress: '172.30.0.10' } } },
+    };
+    const apiContainer = {
+      Id: 'c-api',
+      Names: ['/staging-app-api'],
+      Labels: { 'mini-infra.stack-id': 'stk-1', 'mini-infra.service': 'api' },
+      NetworkSettings: { Networks: { 'staging-egress': { IPAddress: '172.30.0.11' } } },
+    };
+
+    // Initial push: just web. Three idle bursts: still just web (skipped).
+    // Then a real change: api joins. Push must fire.
+    mockDockerInstance.listContainers
+      .mockResolvedValueOnce([baseContainer])
+      .mockResolvedValueOnce([baseContainer])
+      .mockResolvedValueOnce([baseContainer])
+      .mockResolvedValueOnce([baseContainer])
+      .mockResolvedValue([baseContainer, apiContainer]);
+
+    const pusher = new EgressContainerMapPusher(prisma);
+    pusher.start();
+    await vi.runAllTimersAsync();
+    const seedCount = pushCalls.length;
+
+    // Three idle bursts — all suppressed.
+    for (let i = 0; i < 3; i++) {
+      capturedContainerChangeCallback?.();
+      await vi.advanceTimersByTimeAsync(600);
+    }
+    expect(pushCalls.length).toBe(seedCount);
+
+    // Real change: api appeared. Push should fire on the next event.
+    capturedContainerChangeCallback?.();
+    await vi.advanceTimersByTimeAsync(600);
+    expect(pushCalls.length).toBe(seedCount + 1);
+
+    const last = pushCalls[pushCalls.length - 1];
+    expect(last.entries).toHaveLength(2);
 
     pusher.stop();
   });

--- a/server/src/services/egress/__tests__/egress-container-map-pusher.test.ts
+++ b/server/src/services/egress/__tests__/egress-container-map-pusher.test.ts
@@ -143,12 +143,15 @@ describe('EgressContainerMapPusher', () => {
       ],
     });
 
-    // Docker has both containers running on the egress network.
-    // Names follow `${env}-${stack}-${service}` (StackContainerManager convention).
+    // Both containers are running on the egress network. Discovery is
+    // label-driven: stackId + serviceName come from container labels, not
+    // names. The bypassed service should still be skipped because its
+    // service definition has egressBypass=true in Prisma.
     mockDockerInstance.listContainers.mockResolvedValue([
       {
         Id: 'c1',
         Names: ['/staging-myapp-web'],
+        Labels: { 'mini-infra.stack-id': 'stk-1', 'mini-infra.service': 'web' },
         NetworkSettings: {
           Networks: { 'staging-egress': { IPAddress: '172.30.0.10' } },
         },
@@ -156,6 +159,10 @@ describe('EgressContainerMapPusher', () => {
       {
         Id: 'c2',
         Names: ['/staging-myapp-egress-gateway'],
+        Labels: {
+          'mini-infra.stack-id': 'stk-1',
+          'mini-infra.service': 'egress-gateway',
+        },
         NetworkSettings: {
           Networks: { 'staging-egress': { IPAddress: '172.30.0.2' } },
         },
@@ -177,10 +184,10 @@ describe('EgressContainerMapPusher', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Map computation: looks up containers by env-prefixed name
+  // Map computation: discovery is label-driven (works regardless of name)
   // -------------------------------------------------------------------------
 
-  it('matches containers using ${env.name}-${stack.name}-${serviceName}', async () => {
+  it('discovers containers via mini-infra.stack-id / mini-infra.service labels', async () => {
     const prisma = makePrisma({
       environments: [{ id: 'env-local', name: 'local', egressGatewayIp: '172.30.0.2' }],
       stacks: [
@@ -192,12 +199,16 @@ describe('EgressContainerMapPusher', () => {
       ],
     });
 
-    // StackContainerManager names this `local-egress-test-alpine` (env + stack + service).
-    // The pusher must look up that exact name — not `egress-test-alpine`.
+    // Container name is whatever the spawner chose — discovery doesn't care
+    // about the name, only about the labels.
     mockDockerInstance.listContainers.mockResolvedValue([
       {
         Id: 'c-alpine',
-        Names: ['/local-egress-test-alpine'],
+        Names: ['/some-arbitrary-name'],
+        Labels: {
+          'mini-infra.stack-id': 'stk-egress-test',
+          'mini-infra.service': 'alpine',
+        },
         NetworkSettings: {
           Networks: { 'local-egress': { IPAddress: '172.30.0.10' } },
         },
@@ -217,6 +228,123 @@ describe('EgressContainerMapPusher', () => {
       serviceName: 'alpine',
       containerId: 'c-alpine',
     });
+
+    pusher.stop();
+  });
+
+  // -------------------------------------------------------------------------
+  // Map computation: pool instances are included even though their names
+  // don't match the static `${env}-${stack}-${service}` pattern
+  // -------------------------------------------------------------------------
+
+  it('includes pool instance containers (multiple per service)', async () => {
+    const prisma = makePrisma({
+      environments: [{ id: 'env-local', name: 'local', egressGatewayIp: '172.30.0.2' }],
+      stacks: [
+        {
+          id: 'stk-slackbot',
+          name: 'slackbot',
+          services: [{ serviceName: 'worker', containerConfig: {} }],
+        },
+      ],
+    });
+
+    // Pool instance names follow `${env}-${stack}-pool-${service}-${instanceId}`
+    // (pool-spawner.ts), so a name-based lookup would miss them entirely.
+    mockDockerInstance.listContainers.mockResolvedValue([
+      {
+        Id: 'c-worker-1',
+        Names: ['/local-slackbot-pool-worker-slack-user-u0at5jhr7d3'],
+        Labels: {
+          'mini-infra.stack-id': 'stk-slackbot',
+          'mini-infra.service': 'worker',
+          'mini-infra.pool-instance': 'true',
+          'mini-infra.pool-instance-id': 'slack-user-u0at5jhr7d3',
+        },
+        NetworkSettings: {
+          Networks: { 'local-egress': { IPAddress: '172.30.0.20' } },
+        },
+      },
+      {
+        Id: 'c-worker-2',
+        Names: ['/local-slackbot-pool-worker-slack-user-u0at5jhr7d4'],
+        Labels: {
+          'mini-infra.stack-id': 'stk-slackbot',
+          'mini-infra.service': 'worker',
+          'mini-infra.pool-instance': 'true',
+          'mini-infra.pool-instance-id': 'slack-user-u0at5jhr7d4',
+        },
+        NetworkSettings: {
+          Networks: { 'local-egress': { IPAddress: '172.30.0.21' } },
+        },
+      },
+    ]);
+
+    const pusher = new EgressContainerMapPusher(prisma);
+    pusher.start();
+    await vi.runAllTimersAsync();
+
+    expect(pushCalls.length).toBeGreaterThan(0);
+    const { entries } = pushCalls[pushCalls.length - 1];
+    expect(entries).toHaveLength(2);
+    const ips = (entries as { ip: string }[]).map((e) => e.ip).sort();
+    expect(ips).toEqual(['172.30.0.20', '172.30.0.21']);
+    // Both should map to the same stack/service, distinct container IDs.
+    expect(new Set((entries as { stackId: string }[]).map((e) => e.stackId))).toEqual(
+      new Set(['stk-slackbot']),
+    );
+    expect(new Set((entries as { containerId: string }[]).map((e) => e.containerId))).toEqual(
+      new Set(['c-worker-1', 'c-worker-2']),
+    );
+
+    pusher.stop();
+  });
+
+  // -------------------------------------------------------------------------
+  // Map computation: foreign / unknown labels are dropped
+  // -------------------------------------------------------------------------
+
+  it('skips containers whose stack-id label does not belong to this env', async () => {
+    const prisma = makePrisma({
+      environments: [{ id: 'env-local', name: 'local', egressGatewayIp: '172.30.0.2' }],
+      stacks: [
+        {
+          id: 'stk-known',
+          name: 'known',
+          services: [{ serviceName: 'web', containerConfig: {} }],
+        },
+      ],
+    });
+
+    mockDockerInstance.listContainers.mockResolvedValue([
+      {
+        Id: 'c-known',
+        Names: ['/local-known-web'],
+        Labels: { 'mini-infra.stack-id': 'stk-known', 'mini-infra.service': 'web' },
+        NetworkSettings: { Networks: { 'local-egress': { IPAddress: '172.30.0.10' } } },
+      },
+      {
+        Id: 'c-unknown-stack',
+        Names: ['/foreign-app-svc'],
+        Labels: { 'mini-infra.stack-id': 'stk-other-env', 'mini-infra.service': 'svc' },
+        NetworkSettings: { Networks: { 'local-egress': { IPAddress: '172.30.0.99' } } },
+      },
+      {
+        Id: 'c-unlabeled',
+        Names: ['/random-container'],
+        Labels: {},
+        NetworkSettings: { Networks: { 'local-egress': { IPAddress: '172.30.0.50' } } },
+      },
+    ]);
+
+    const pusher = new EgressContainerMapPusher(prisma);
+    pusher.start();
+    await vi.runAllTimersAsync();
+
+    expect(pushCalls.length).toBeGreaterThan(0);
+    const { entries } = pushCalls[pushCalls.length - 1];
+    expect(entries).toHaveLength(1);
+    expect((entries as { containerId: string }[])[0].containerId).toBe('c-known');
 
     pusher.stop();
   });

--- a/server/src/services/egress/egress-container-map-pusher.ts
+++ b/server/src/services/egress/egress-container-map-pusher.ts
@@ -228,16 +228,23 @@ export class EgressContainerMapPusher {
   /**
    * Build the container-map entries for an environment.
    *
-   * - Query active stacks (not removed, not archived) in the env.
-   * - Skip stacks that belong to the egress-gateway itself (egressBypass).
-   * - For each service in each stack, find a running container by name and
-   *   get its IPv4 address on the env's egress network (where every
-   *   non-bypass managed container lives — see egress-injection.ts).
+   * Discovery is label-driven: we walk every container with an IP on the
+   * env's egress network and key off the `mini-infra.stack-id` /
+   * `mini-infra.service` labels that both StackContainerManager and the
+   * pool-spawner stamp on every managed container. The stack list from
+   * Prisma is used purely to validate membership and read each service's
+   * `egressBypass` flag — not to construct expected names.
+   *
+   * Doing it by name was wrong because pool instances follow the
+   * `${env}-${stack}-pool-${service}-${instanceId}` pattern from
+   * pool-spawner.ts, not the static `${env}-${stack}-${service}` pattern,
+   * so they were silently dropped from the map and got 403'd at the
+   * gateway's UnknownIPDenyHandler before any ACL eval.
    */
   private async _buildContainerMap(env: EnvRow): Promise<ContainerMapEntry[]> {
     const egressNetwork = `${env.name}-egress`;
 
-    // Stacks in this environment that are not removed
+    // Stacks in this environment that are not removed.
     const stacks = await this.prisma.stack.findMany({
       where: {
         environmentId: env.id,
@@ -256,7 +263,19 @@ export class EgressContainerMapPusher {
       },
     }) as StackRow[];
 
-    // Fetch live container list from Docker (raw API gives per-network IPs)
+    // Index: stackId → service map, so a container's labels can be looked
+    // up in O(1) and validated against this env's stack list.
+    const serviceConfigByKey = new Map<string, Record<string, unknown> | null>();
+    for (const stack of stacks) {
+      for (const service of stack.services) {
+        serviceConfigByKey.set(
+          `${stack.id}:${service.serviceName}`,
+          service.containerConfig as Record<string, unknown> | null,
+        );
+      }
+    }
+
+    // Fetch live container list from Docker (raw API gives per-network IPs and labels).
     const dockerService = DockerService.getInstance();
     if (!dockerService.isConnected()) {
       log.warn({ envId: env.id }, 'Docker not connected — returning empty container map');
@@ -266,42 +285,44 @@ export class EgressContainerMapPusher {
     const docker = await dockerService.getDockerInstance();
     const rawContainers = await docker.listContainers({ all: false });
 
-    // Build a lookup: containerName → IP on the egress network
-    const ipByName = new Map<string, string>();
-    const idByName = new Map<string, string>();
-    for (const c of rawContainers) {
-      const networks = c.NetworkSettings?.Networks ?? {};
-      const networkInfo = networks[egressNetwork];
-      if (networkInfo?.IPAddress) {
-        const name = (c.Names?.[0] ?? '').replace(/^\//, '');
-        ipByName.set(name, networkInfo.IPAddress);
-        idByName.set(name, c.Id);
-      }
-    }
-
     const entries: ContainerMapEntry[] = [];
 
-    // Project name matches StackContainerManager: `${env.name}-${stack.name}` for env-scoped stacks.
-    // Container name: `${projectName}-${serviceName}` → `${env.name}-${stack.name}-${serviceName}`.
-    for (const stack of stacks) {
-      const projectName = `${env.name}-${stack.name}`;
-      for (const service of stack.services) {
-        // Skip services with egressBypass (e.g. the egress-gateway itself)
-        const cfg = service.containerConfig as Record<string, unknown> | null;
-        if (cfg?.egressBypass === true) continue;
+    for (const c of rawContainers) {
+      const ip = c.NetworkSettings?.Networks?.[egressNetwork]?.IPAddress;
+      if (!ip) continue;
 
-        const containerName = `${projectName}-${service.serviceName}`;
-        const ip = ipByName.get(containerName);
-        if (!ip) continue; // Container not running or not on this network
+      const labels = c.Labels ?? {};
+      const stackId = labels['mini-infra.stack-id'];
+      const serviceName = labels['mini-infra.service'];
+      if (!stackId || !serviceName) continue;
 
-        entries.push({
-          ip,
-          stackId: stack.id,
-          serviceName: service.serviceName,
-          containerId: idByName.get(containerName),
-        });
+      const key = `${stackId}:${serviceName}`;
+      if (!serviceConfigByKey.has(key)) {
+        // Container is on this egress network but the stack/service is
+        // unknown to this env (foreign stack, deleted service, or a stale
+        // container that survived a stack rebuild). Skip — don't trust
+        // labels alone for membership.
+        continue;
       }
+
+      const cfg = serviceConfigByKey.get(key);
+      if (cfg?.egressBypass === true) continue;
+
+      entries.push({
+        ip,
+        stackId,
+        serviceName,
+        containerId: c.Id,
+      });
     }
+
+    // Stable ordering keeps log output and downstream snapshot diffs
+    // deterministic across pushes that don't change membership.
+    entries.sort((a, b) => {
+      if (a.stackId !== b.stackId) return a.stackId < b.stackId ? -1 : 1;
+      if (a.serviceName !== b.serviceName) return a.serviceName < b.serviceName ? -1 : 1;
+      return a.ip < b.ip ? -1 : a.ip > b.ip ? 1 : 0;
+    });
 
     log.debug(
       { envId: env.id, envName: env.name, egressNetwork, entryCount: entries.length },

--- a/server/src/services/egress/egress-container-map-pusher.ts
+++ b/server/src/services/egress/egress-container-map-pusher.ts
@@ -30,6 +30,22 @@ interface EnvState {
   timer: NodeJS.Timeout | null;
   version: number;
   lastPushedAt: Date | null;
+  // Fingerprint of the last successfully-pushed entries. Used to suppress
+  // no-op pushes when Docker fires container events that don't change the
+  // map (most events are healthcheck exec_create/exec_start/exec_die churn,
+  // which produces identical entries). Null until the first successful push.
+  lastPushedFingerprint: string | null;
+}
+
+/**
+ * Build a deterministic fingerprint for a set of entries. Entries are
+ * already sorted by _buildContainerMap, so this is just a JSON
+ * serialisation of the fields the gateway cares about.
+ */
+function fingerprintEntries(entries: ContainerMapEntry[]): string {
+  return JSON.stringify(
+    entries.map((e) => [e.ip, e.stackId, e.serviceName, e.containerId ?? '']),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -116,7 +132,7 @@ export class EgressContainerMapPusher {
   private _scheduleEnv(envId: string, env: EnvRow): void {
     let state = this.states.get(envId);
     if (!state) {
-      state = { timer: null, version: 0, lastPushedAt: null };
+      state = { timer: null, version: 0, lastPushedAt: null, lastPushedFingerprint: null };
       this.states.set(envId, state);
     }
 
@@ -145,7 +161,7 @@ export class EgressContainerMapPusher {
       envs.map((env) => {
         let state = this.states.get(env.id);
         if (!state) {
-          state = { timer: null, version: 0, lastPushedAt: null };
+          state = { timer: null, version: 0, lastPushedAt: null, lastPushedFingerprint: null };
           this.states.set(env.id, state);
         }
         return this._pushEnv(env, state);
@@ -156,6 +172,20 @@ export class EgressContainerMapPusher {
   private async _pushEnv(env: EnvRow, state: EnvState): Promise<void> {
     const attempt = async (): Promise<void> => {
       const entries = await this._buildContainerMap(env);
+
+      // Most container events Docker emits (healthcheck exec_create /
+      // exec_start / exec_die, etc.) don't change the map — without this
+      // check the pusher hits the gateway ~once per second on an idle
+      // env. Skip when the snapshot is identical to what we last pushed.
+      const fingerprint = fingerprintEntries(entries);
+      if (state.lastPushedFingerprint === fingerprint) {
+        log.debug(
+          { envId: env.id, envName: env.name, entryCount: entries.length },
+          'Container map unchanged since last push — skipping',
+        );
+        return;
+      }
+
       const client = new EgressGatewayClient(env.egressGatewayIp);
       state.version += 1;
       const result = await client.pushContainerMap({
@@ -163,6 +193,7 @@ export class EgressContainerMapPusher {
         entries,
       });
       state.lastPushedAt = new Date();
+      state.lastPushedFingerprint = fingerprint;
       log.info(
         { envId: env.id, envName: env.name, version: result.version, entryCount: result.entryCount },
         'Container map pushed to gateway',


### PR DESCRIPTION
## Summary

Two related fixes to the per-env egress container-map pusher.

### 1. Map pool worker containers (commit 937f910)

`EgressContainerMapPusher` looked up containers by the static name `${env}-${stack}-${service}`, missing pool instances whose names follow `${env}-${stack}-pool-${service}-${instanceId}` (see [pool-spawner.ts:43-55](server/src/services/stacks/pool-spawner.ts#L43)). Pool workers therefore never made it into the gateway's container map.

The gateway's [UnknownIPDenyHandler](egress-gateway/internal/proxy/role.go#L35) returns an instant 403 for any source IP not in the map — *before* the ACL is consulted. So a pool worker on the egress network with `mode: detect` + `defaultAction: allow` + zero rules got 403'd unconditionally, with no proxy decision logged. The reported "rejection in the proxy" was real but the 403 came from a pre-ACL gate, not the ACL itself.

Switch discovery to label-driven enumeration. Any running container with an IP on the env's egress network plus `mini-infra.stack-id` / `mini-infra.service` labels is included, validated against the env's stack list, and dropped if the matching service has `egressBypass=true`. Static and pool containers go through the same path. Both label keys are already stamped by [stack-container-manager.ts:194-196](server/src/services/stacks/stack-container-manager.ts#L194) and [pool-spawner.ts:204-212](server/src/services/stacks/pool-spawner.ts#L204), so this is purely a discovery change.

### 2. Suppress no-op pushes (commit ca04ba7)

Docker fires container events for every healthcheck `exec_create` / `exec_start` / `exec_die` — three events per healthcheck per container — which translated into roughly one POST to the gateway per second on an otherwise idle env. The 500ms debounce collapsed bursts but didn't deduplicate payloads: most pushes were byte-identical to the previous one.

Fingerprint the entries (already sorted deterministically by `_buildContainerMap`) and short-circuit before bumping the version or hitting the gateway when the snapshot matches the last successful push. Real changes (start, stop, IP reassignment) still go through.

## Test plan

- [x] `pnpm --filter mini-infra-server test` — all 1928 unit tests pass; new tests cover the pool-instance path, multi-instance enumeration, foreign/unlabeled-container drop, no-op suppression, and the suppression-then-real-change transition.
- [x] `pnpm --filter mini-infra-server lint` — clean.
- [x] Live verification in the worktree:
  - **Map fix**: container map count went 3 → 4 to include the pool worker; an HTTPS request from `local-slackbot-pool-worker-*` is now allowed by the ACL (`"allow":true,"decision_reason":"rule has allow and report policy"`) instead of returning instant 403 from `UnknownIPDenyHandler`.
  - **Push suppression**: gateway recorded 0 container-map updates over a 60s idle window post-rebuild (was ~60/min before). A `docker restart` of an in-map container with no IP/ID change correctly produced no push; real changes (container created/destroyed) still produce one.

## Notes / out of scope

- After the map fix, an HTTPS request via busybox `wget` (`HTTPS_PROXY=...; wget https://...`) hits a 500 in the proxy. That's a busybox quirk: it sends `GET https://...` as a forward-proxy request rather than `CONNECT`, and smokescreen's [rejectResponse](https://github.com/stripe/smokescreen/blob/main/pkg/smokescreen/smokescreen.go) catch-all maps the resulting `context.Canceled` to 500. Native node fetch (which the slackbot uses) goes through `CONNECT` and is unaffected. PR #309 already fixed the DNS-layer variant of this; the post-DNS variant is a separate, smaller follow-up worth tightening when convenient.
- `StackPolicyEntry.DefaultAction` in [compile.go](egress-gateway/internal/proxy/compile.go) is parsed but never read — only `Mode` is consulted. Schema drift, not load-bearing for this bug; flagging here so it's not lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)