### PR TITLE
feat(egress): hide firewall infrastructure stacks from egress page

### DIFF
--- a/lib/types/egress.ts
+++ b/lib/types/egress.ts
@@ -50,7 +50,10 @@ export type EgressEventAction = 'allowed' | 'blocked' | 'observed';
  * v3 gateway uses it for explicit HTTP forward proxy. Context disambiguates.
  */
 export type EgressEventProtocol = 'dns' | 'sni' | 'http' | 'connect' | 'tcp' | 'udp' | 'icmp';
-export type EgressArchivedReason = 'stack-deleted' | 'environment-deleted';
+export type EgressArchivedReason =
+  | 'stack-deleted'
+  | 'environment-deleted'
+  | 'system-infrastructure-stack';
 
 /**
  * Reason strings for egress denial or firewall drop events.

--- a/server/src/services/egress/__tests__/egress-policy-lifecycle.test.ts
+++ b/server/src/services/egress/__tests__/egress-policy-lifecycle.test.ts
@@ -195,6 +195,42 @@ describe('EgressPolicyLifecycleService.ensureDefaultPolicy', () => {
       service.ensureDefaultPolicy('stack-1', 'user-1'),
     ).resolves.toBeUndefined();
   });
+
+  it.each(['haproxy', 'egress-gateway'])(
+    'skips policy creation for excluded infrastructure template %s',
+    async (templateName) => {
+      prisma.stack.findUnique.mockResolvedValue(
+        makeStack({ template: { name: templateName } }),
+      );
+      prisma.egressPolicy.updateMany.mockResolvedValue({ count: 0 });
+
+      await service.ensureDefaultPolicy('stack-1', 'user-1');
+
+      expect(prisma.egressPolicy.create).not.toHaveBeenCalled();
+      expect(prisma.egressPolicy.findFirst).not.toHaveBeenCalled();
+    },
+  );
+
+  it('archives an existing policy on an excluded infrastructure stack', async () => {
+    prisma.stack.findUnique.mockResolvedValue(
+      makeStack({ template: { name: 'haproxy' } }),
+    );
+    prisma.egressPolicy.updateMany.mockResolvedValue({ count: 1 });
+    prisma.egressPolicy.findMany.mockResolvedValue([
+      makePolicy({ archivedAt: new Date(), archivedReason: 'system-infrastructure-stack' }),
+    ]);
+
+    await service.ensureDefaultPolicy('stack-1', 'user-1');
+
+    expect(prisma.egressPolicy.updateMany).toHaveBeenCalledWith({
+      where: { stackId: 'stack-1', archivedAt: null },
+      data: expect.objectContaining({
+        archivedReason: 'system-infrastructure-stack',
+        updatedBy: 'user-1',
+      }),
+    });
+    expect(prisma.egressPolicy.create).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/server/src/services/egress/egress-policy-lifecycle.ts
+++ b/server/src/services/egress/egress-policy-lifecycle.ts
@@ -7,6 +7,18 @@ import { emitEgressPolicyUpdated, emitEgressRuleMutation } from './egress-socket
 const log = getLogger('stacks', 'egress-policy-lifecycle');
 
 /**
+ * Built-in templates whose stacks are firewall infrastructure themselves
+ * (haproxy is the in-environment router; egress-gateway IS the firewall).
+ * Egress policies for these stacks are nonsensical — circular for
+ * egress-gateway and breaks east-west routing for haproxy — so we never
+ * create them and archive any that already exist.
+ */
+const EGRESS_EXCLUDED_TEMPLATE_NAMES: ReadonlySet<string> = new Set([
+  'haproxy',
+  'egress-gateway',
+]);
+
+/**
  * Manages the lifecycle of EgressPolicy rows in lockstep with Stack and
  * Environment lifecycle events.
  *
@@ -33,7 +45,7 @@ export class EgressPolicyLifecycleService {
     try {
       const stack = await this.prisma.stack.findUnique({
         where: { id: stackId },
-        include: { environment: true },
+        include: { environment: true, template: { select: { name: true } } },
       });
 
       if (!stack) {
@@ -44,6 +56,18 @@ export class EgressPolicyLifecycleService {
       // Host-scoped stacks are not firewalled in v1
       if (!stack.environmentId || !stack.environment) {
         log.debug({ stackId }, 'ensureDefaultPolicy: host-scoped stack, skipping');
+        return;
+      }
+
+      // Skip firewall infrastructure stacks (haproxy, egress-gateway). Archive
+      // any policy that may already exist from a previous deployment so it
+      // disappears from the egress UI.
+      if (stack.template?.name && EGRESS_EXCLUDED_TEMPLATE_NAMES.has(stack.template.name)) {
+        await this.archiveExcludedPolicyForStack(stackId, userId);
+        log.debug(
+          { stackId, templateName: stack.template.name },
+          'ensureDefaultPolicy: skipping excluded infrastructure stack',
+        );
         return;
       }
 
@@ -96,6 +120,76 @@ export class EgressPolicyLifecycleService {
       log.error(
         { err, stackId },
         'ensureDefaultPolicy: failed to ensure default egress policy — continuing without it',
+      );
+    }
+  }
+
+  /**
+   * Archive any non-archived policy for an infrastructure stack that should
+   * never be firewalled (haproxy, egress-gateway). Caller is responsible for
+   * deciding the stack qualifies — this just performs the write.
+   */
+  private async archiveExcludedPolicyForStack(
+    stackId: string,
+    userId: string | null,
+  ): Promise<void> {
+    const archivedAt = new Date();
+    const result = await this.prisma.egressPolicy.updateMany({
+      where: { stackId, archivedAt: null },
+      data: {
+        archivedAt,
+        archivedReason: 'system-infrastructure-stack' satisfies EgressArchivedReason,
+        updatedBy: userId,
+      },
+    });
+
+    if (result.count > 0) {
+      const policies = await this.prisma.egressPolicy.findMany({
+        where: {
+          stackId,
+          archivedReason: 'system-infrastructure-stack' satisfies EgressArchivedReason,
+          archivedAt,
+        },
+      });
+      for (const policy of policies) {
+        emitEgressPolicyUpdated(policy);
+      }
+      log.info(
+        { stackId, archivedCount: result.count },
+        'archiveExcludedPolicyForStack: archived policy on excluded infrastructure stack',
+      );
+    }
+  }
+
+  /**
+   * One-shot startup cleanup. Finds policies whose stack is one of the
+   * firewall-excluded built-in templates (haproxy, egress-gateway) and
+   * archives them so older deployments stop showing them on the egress page.
+   * Idempotent.
+   */
+  async archiveExcludedStackPolicies(): Promise<void> {
+    try {
+      const policies = await this.prisma.egressPolicy.findMany({
+        where: {
+          archivedAt: null,
+          stack: {
+            template: { name: { in: Array.from(EGRESS_EXCLUDED_TEMPLATE_NAMES) } },
+          },
+        },
+        select: { stackId: true },
+      });
+
+      const stackIds = Array.from(
+        new Set(policies.map((p) => p.stackId).filter((id): id is string => id !== null)),
+      );
+
+      for (const stackId of stackIds) {
+        await this.archiveExcludedPolicyForStack(stackId, null);
+      }
+    } catch (err) {
+      log.error(
+        { err },
+        'archiveExcludedStackPolicies: failed to clean up excluded-stack policies — continuing',
       );
     }
   }

--- a/server/src/services/stacks/builtin-stack-sync.ts
+++ b/server/src/services/stacks/builtin-stack-sync.ts
@@ -79,6 +79,11 @@ export async function syncBuiltinStacks(
   // 3. Run one-time backfill migrations (e.g. EnvironmentNetwork → InfraResource).
   await runSystemStackMigrations(prisma);
 
+  // 4. Archive any egress policies that were created for firewall infra stacks
+  // (haproxy, egress-gateway) by older versions of the policy lifecycle. Newer
+  // deployments skip these at create-time; this catches existing rows.
+  await new EgressPolicyLifecycleService(prisma).archiveExcludedStackPolicies();
+
   log.info("Built-in stack sync complete");
 
   return templateByName;


### PR DESCRIPTION
## Summary

- The `/egress` page was showing policy entries for `haproxy` and `egress-gateway` — these are firewall infrastructure (one *is* the firewall, the other is the in-environment router), so a user-facing policy for them is nonsensical.
- New stacks built from these templates skip policy creation in `ensureDefaultPolicy`, and a one-shot startup cleanup archives any existing rows so the entries disappear from the UI without a manual DB step.
- Added `'system-infrastructure-stack'` as a new `EgressArchivedReason` so archived rows remain auditable.

## Test plan

- [x] `vitest run --project unit src/services/egress/__tests__/egress-policy-lifecycle.test.ts` — added cases for both excluded templates plus the archive-existing path; all 43 tests pass
- [x] `pnpm build:lib && pnpm --filter mini-infra-server build` — clean
- [ ] After merge, run `pnpm worktree-env start` and confirm the haproxy / egress-gateway entries are no longer listed on `/egress`

🤖 Generated with [Claude Code](https://claude.com/claude-code)