### PR TITLE
chore(containers): bump alpine runtime base to 3.23

### DIFF
--- a/egress-fw-agent/Dockerfile
+++ b/egress-fw-agent/Dockerfile
@@ -34,7 +34,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
 # ============================================================
 # Stage 2: Runtime
 # ============================================================
-FROM alpine:3.19
+FROM alpine:3.23
 
 # iptables / ip6tables / ipset for kernel rule programming;
 # libnetfilter_log for NFLOG group reads.

--- a/egress-gateway/Dockerfile
+++ b/egress-gateway/Dockerfile
@@ -31,7 +31,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
 # ============================================================
 # Stage 2: Runtime
 # ============================================================
-FROM alpine:3.19
+FROM alpine:3.23
 
 RUN apk add --no-cache ca-certificates
 

--- a/pg-az-backup/Dockerfile
+++ b/pg-az-backup/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.23
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash curl postgresql-client gzip


### PR DESCRIPTION
## Summary
- Bumps `egress-gateway/Dockerfile` and `egress-fw-agent/Dockerfile` from `alpine:3.19` (EOL May 2025, no more security updates) to `alpine:3.23` (supported through Nov 2027), aligning with the recent auth-proxy bump.
- Also bumps `pg-az-backup/Dockerfile` from `alpine:3.21` to `alpine:3.23` to unify the runtime base across the repo's containers (3.21 isn't EOL until Nov 2026, but rolling all three at once removes the drift).

## Test plan
- [x] `pnpm build:egress-gateway` — image builds cleanly; container boots and proxy listener comes up on `:3128` (`gateway: proxy listener up` log line).
- [x] `pnpm build:egress-fw-agent` — image builds cleanly; runtime apk install resolves on 3.23 with `iptables 1.8.11-r1`, `ip6tables 1.8.11-r1`, `ipset 7.24-r0`, `libnetfilter_log 1.0.2-r2`, and `ca-certificates 20260413-r0`. `iptables --version` / `ip6tables --version` confirm the `nf_tables` backend, matching the runtime expectation in the egress-fw-agent CLAUDE.md.
- [x] `pnpm build:pg-backup` — image builds cleanly; `pg_dump 18.3`, `bash 5.3.3`, `curl 8.17.0` all install and run.
- [x] All three resulting images report `3.23.4` from `/etc/alpine-release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)