### PR TITLE
feat(nats): add vault-nats built-in stack with NKey/JWT auth

### DIFF
--- a/deployment/development/README.md
+++ b/deployment/development/README.md
@@ -19,7 +19,7 @@ On macOS this auto-selects Colima; on Windows it auto-selects WSL2 (first run al
 The script:
 
 1. Picks a per-worktree VM driver (Colima on macOS, WSL2 on Windows) and creates the VM if needed.
-2. Allocates per-worktree UI / registry / Vault / Docker ports from `~/.mini-infra/worktrees.yaml`.
+2. Allocates per-worktree UI / registry / Vault / Docker / HAProxy / NATS ports from `~/.mini-infra/worktrees.yaml`.
 3. Builds and pushes the **agent sidecar**, **egress gateway**, and **egress firewall agent** images to the per-worktree local Docker registry.
 4. Builds the **main app** image with those image tags baked in as build args.
 5. Runs `docker compose up` against `docker-compose.worktree.yaml` to bring up `registry` and `mini-infra`. The agent sidecar and the egress firewall agent are launched at runtime by the `mini-infra` server itself (not by compose), so they do not appear as compose services.
@@ -66,6 +66,8 @@ pnpm worktree-env install-cleanup-agent --remove
 
 # Resolve the dev URL from the generated environment manifest
 MINI_INFRA_URL=$(xmllint --xpath 'string(//environment/endpoints/ui)' environment-details.xml)
+NATS_CLIENT_URL=$(xmllint --xpath 'string(//environment/endpoints/natsClient)' environment-details.xml)
+NATS_MONITOR_URL=$(xmllint --xpath 'string(//environment/endpoints/natsMonitor)' environment-details.xml)
 ```
 
 Run `pnpm worktree-env <command> --help` for command-specific options.

--- a/deployment/development/__tests__/registry.test.ts
+++ b/deployment/development/__tests__/registry.test.ts
@@ -16,6 +16,8 @@ import {
   HAPROXY_HTTPS_PORT_MIN,
   HAPROXY_STATS_PORT_MIN,
   HAPROXY_DATAPLANE_PORT_MIN,
+  NATS_CLIENT_PORT_MIN,
+  NATS_MONITOR_PORT_MIN,
 } from '../lib/registry.js';
 
 describe('egressPoolForSlot', () => {
@@ -79,6 +81,8 @@ describe('allocatePorts (egress_pool_cidr wiring)', () => {
   it('first profile lands in slot 0 with 172.30.0.0/22', () => {
     const alloc = allocatePorts('first');
     expect(alloc.ui_port).toBe(UI_PORT_MIN);
+    expect(alloc.nats_client_port).toBe(NATS_CLIENT_PORT_MIN);
+    expect(alloc.nats_monitor_port).toBe(NATS_MONITOR_PORT_MIN);
     expect(alloc.egress_pool_cidr).toBe('172.30.0.0/22');
   });
 
@@ -98,6 +102,8 @@ describe('allocatePorts (egress_pool_cidr wiring)', () => {
       haproxy_https_port: HAPROXY_HTTPS_PORT_MIN,
       haproxy_stats_port: HAPROXY_STATS_PORT_MIN,
       haproxy_dataplane_port: HAPROXY_DATAPLANE_PORT_MIN,
+      nats_client_port: NATS_CLIENT_PORT_MIN,
+      nats_monitor_port: NATS_MONITOR_PORT_MIN,
       seeded: false,
       updated_at: new Date().toISOString(),
     };
@@ -105,6 +111,8 @@ describe('allocatePorts (egress_pool_cidr wiring)', () => {
 
     const alloc = allocatePorts('second');
     expect(alloc.ui_port).toBe(UI_PORT_MIN + 1);
+    expect(alloc.nats_client_port).toBe(NATS_CLIENT_PORT_MIN + 1);
+    expect(alloc.nats_monitor_port).toBe(NATS_MONITOR_PORT_MIN + 1);
     expect(alloc.egress_pool_cidr).toBe('172.30.4.0/22');
   });
 

--- a/deployment/development/lib/env-details.ts
+++ b/deployment/development/lib/env-details.ts
@@ -71,6 +71,8 @@ export interface MinimalEnvironmentDetailsInput {
   uiPort: number;
   registryPort: number;
   vaultPort: number;
+  natsClientPort: number;
+  natsMonitorPort: number;
   egressPool: string;
   agentSidecarImageTag: string;
   shortDescription?: string;
@@ -112,6 +114,8 @@ ${descBlock}  <seeded>false</seeded>
     <ui>http://localhost:${input.uiPort}</ui>
     <registry>localhost:${input.registryPort}</registry>
     <vault>http://localhost:${input.vaultPort}</vault>
+    <natsClient>nats://localhost:${input.natsClientPort}</natsClient>
+    <natsMonitor>http://localhost:${input.natsMonitorPort}</natsMonitor>
   </endpoints>
   <egressPool>${xmlEscape(input.egressPool)}</egressPool>
   <images>
@@ -144,6 +148,8 @@ export interface FullEnvironmentDetailsInput {
   uiPort: number;
   registryPort: number;
   vaultPort: number;
+  natsClientPort: number;
+  natsMonitorPort: number;
   egressPool: string;
   agentSidecarImageTag: string;
   adminEmail: string;
@@ -204,6 +210,8 @@ ${descBlock}  <seeded>true</seeded>
     <ui>http://localhost:${input.uiPort}</ui>
     <registry>localhost:${input.registryPort}</registry>
     <vault>http://localhost:${input.vaultPort}</vault>
+    <natsClient>nats://localhost:${input.natsClientPort}</natsClient>
+    <natsMonitor>http://localhost:${input.natsMonitorPort}</natsMonitor>
   </endpoints>
   <egressPool>${t(input.egressPool)}</egressPool>
   <images>

--- a/deployment/development/lib/registry.ts
+++ b/deployment/development/lib/registry.ts
@@ -29,6 +29,13 @@ export const HAPROXY_STATS_PORT_MIN = 8400;
 export const HAPROXY_STATS_PORT_MAX = 8499;
 export const HAPROXY_DATAPLANE_PORT_MIN = 5500;
 export const HAPROXY_DATAPLANE_PORT_MAX = 5599;
+// NATS host ports are exposed by the vault-nats template. Keep these outside
+// the Vault 8200–8299 range and HAProxy ranges so optional host infrastructure
+// stacks can run in parallel worktrees without colliding.
+export const NATS_CLIENT_PORT_MIN = 4300;
+export const NATS_CLIENT_PORT_MAX = 4399;
+export const NATS_MONITOR_PORT_MIN = 8600;
+export const NATS_MONITOR_PORT_MAX = 8699;
 
 // Per-worktree egress pool slicing: each worktree gets a /22 carved out of
 // 172.30.0.0/16, keyed off the same slot the port allocator already uses.
@@ -61,6 +68,10 @@ export interface WorktreeEntry {
   haproxy_https_port: number;
   haproxy_stats_port: number;
   haproxy_dataplane_port: number;
+  // Per-worktree NATS host ports — surfaced in environment-details.xml for
+  // the vault-nats stack template's nats-host-port/nats-monitor-port params.
+  nats_client_port: number;
+  nats_monitor_port: number;
   admin_email?: string;
   admin_password?: string;
   api_key?: string;
@@ -116,6 +127,8 @@ export function upsertEntry(
     haproxy_https_port: partial.haproxy_https_port ?? existing?.haproxy_https_port ?? 0,
     haproxy_stats_port: partial.haproxy_stats_port ?? existing?.haproxy_stats_port ?? 0,
     haproxy_dataplane_port: partial.haproxy_dataplane_port ?? existing?.haproxy_dataplane_port ?? 0,
+    nats_client_port: partial.nats_client_port ?? existing?.nats_client_port ?? 0,
+    nats_monitor_port: partial.nats_monitor_port ?? existing?.nats_monitor_port ?? 0,
     admin_email: partial.admin_email ?? existing?.admin_email,
     admin_password: partial.admin_password ?? existing?.admin_password,
     api_key: partial.api_key ?? existing?.api_key,
@@ -154,6 +167,8 @@ export interface PortAllocation {
   haproxy_https_port: number;
   haproxy_stats_port: number;
   haproxy_dataplane_port: number;
+  nats_client_port: number;
+  nats_monitor_port: number;
   egress_pool_cidr: string;
 }
 
@@ -208,6 +223,20 @@ export function slotOf(e: WorktreeEntry): number | undefined {
   ) {
     return e.haproxy_http_port - HAPROXY_HTTP_PORT_MIN;
   }
+  if (
+    e.nats_client_port &&
+    e.nats_client_port >= NATS_CLIENT_PORT_MIN &&
+    e.nats_client_port <= NATS_CLIENT_PORT_MAX
+  ) {
+    return e.nats_client_port - NATS_CLIENT_PORT_MIN;
+  }
+  if (
+    e.nats_monitor_port &&
+    e.nats_monitor_port >= NATS_MONITOR_PORT_MIN &&
+    e.nats_monitor_port <= NATS_MONITOR_PORT_MAX
+  ) {
+    return e.nats_monitor_port - NATS_MONITOR_PORT_MIN;
+  }
   return undefined;
 }
 
@@ -246,6 +275,8 @@ export function allocatePorts(profile: string): PortAllocation {
     haproxy_https_port: HAPROXY_HTTPS_PORT_MIN + slot,
     haproxy_stats_port: HAPROXY_STATS_PORT_MIN + slot,
     haproxy_dataplane_port: HAPROXY_DATAPLANE_PORT_MIN + slot,
+    nats_client_port: NATS_CLIENT_PORT_MIN + slot,
+    nats_monitor_port: NATS_MONITOR_PORT_MIN + slot,
     egress_pool_cidr: egressPoolForSlot(slot),
   };
 }
@@ -285,6 +316,8 @@ export function migrateFromJsonIfNeeded(): void {
       haproxy_https_port: uiPort ? HAPROXY_HTTPS_PORT_MIN + slot : 0,
       haproxy_stats_port: uiPort ? HAPROXY_STATS_PORT_MIN + slot : 0,
       haproxy_dataplane_port: uiPort ? HAPROXY_DATAPLANE_PORT_MIN + slot : 0,
+      nats_client_port: uiPort ? NATS_CLIENT_PORT_MIN + slot : 0,
+      nats_monitor_port: uiPort ? NATS_MONITOR_PORT_MIN + slot : 0,
       seeded: false,
       updated_at: now,
     };

--- a/deployment/development/lib/seeder.ts
+++ b/deployment/development/lib/seeder.ts
@@ -9,8 +9,10 @@
 //   4. Upsert Azure / Cloudflare / GitHub credentials
 //   5. Create a local environment
 //   6. Instantiate + apply the built-in HAProxy stack template
-//   7. Mark onboarding complete
-//   8. Write environment-details.xml at the project root.
+//   7. Instantiate + apply the built-in Vault + NATS stack template
+//   8. Bootstrap/unlock Vault and publish system policies
+//   9. Mark onboarding complete
+//   10. Write environment-details.xml at the project root.
 //
 // Each step is idempotent-ish: already-configured state is skipped, but the
 // seeder does not back out partial state on failure — fix the env file and re-run.
@@ -29,6 +31,8 @@ export interface SeederInput {
   uiPort: number;
   registryPort: number;
   vaultPort: number;
+  natsClientPort: number;
+  natsMonitorPort: number;
   // Per-worktree HAProxy host ports — passed as parameterValues to the
   // haproxy stack template so two worktrees (or any other process binding
   // 80/443) don't collide.
@@ -558,6 +562,7 @@ async function applyAndWaitForSynced(
   api: ApiClient,
   stackId: string,
   label: string,
+  options: { serviceNames?: string[]; allowDrifted?: boolean; force?: boolean } = {},
 ): Promise<void> {
   // Snapshot pre-apply status + lastAppliedAt. The status field may still read
   // "error" (or whatever) from a prior run until the reconciler finishes this
@@ -572,13 +577,15 @@ async function applyAndWaitForSynced(
     prevLastAppliedAt = s?.lastAppliedAt || '';
   }
 
-  if (prevStatus.toLowerCase() === 'synced') {
+  if (!options.force && prevStatus.toLowerCase() === 'synced') {
     logSkip(`${label} stack is already Synced — skipping apply`);
     return;
   }
 
   logInfo(`Applying ${label} stack (current status: ${prevStatus || 'unknown'})`);
-  const applyRes = await api.post(`/api/stacks/${stackId}/apply`, {});
+  const applyRes = await api.post(`/api/stacks/${stackId}/apply`, {
+    ...(options.serviceNames ? { serviceNames: options.serviceNames } : {}),
+  });
   if (applyRes.status !== 200 && applyRes.status !== 202) {
     logError(`Apply returned ${applyRes.status}: ${applyRes.bodyText}`);
     return;
@@ -605,12 +612,22 @@ async function applyAndWaitForSynced(
       logError(`${label} stack apply failed (status=error)`);
       return;
     }
+    if (options.allowDrifted) {
+      logOk(`${label} stack apply completed (status=${lower || 'unknown'})`);
+      return;
+    }
   }
   logSkip(`Timed out waiting for ${label} to sync (last status: ${lastStatus || 'unknown'})`);
 }
 
-async function ensureVaultStack(api: ApiClient, vaultPort: number): Promise<string | null> {
-  const stackName = 'vault';
+interface VaultNatsPorts {
+  vault: number;
+  natsClient: number;
+  natsMonitor: number;
+}
+
+async function ensureVaultNatsStack(api: ApiClient, ports: VaultNatsPorts): Promise<string | null> {
+  const stackName = 'vault-nats';
   logInfo(`Looking for existing ${stackName} host stack`);
   // Vault is host-scoped — no environmentId filter, but the listing returns
   // all stacks the caller can see, so we still match by name.
@@ -623,34 +640,38 @@ async function ensureVaultStack(api: ApiClient, vaultPort: number): Promise<stri
       return existing.id;
     }
   }
-  logInfo('Locating Vault stack template');
-  // Exact-name match: there's also a `hello-vault` template in the catalog
-  // which is environment-scoped, so a substring match would land on the wrong
-  // one and reject our host-scoped instantiate.
-  const templateId = await findTemplate(api, 'vault', { exact: true });
+  logInfo('Locating Vault + NATS stack template');
+  const templateId = await findTemplate(api, 'vault-nats', { exact: true });
   if (!templateId) {
-    logSkip('Vault template not found — skipping Vault setup');
+    logSkip('Vault + NATS template not found — skipping Vault/NATS setup');
     return null;
   }
-  // Host-scoped instantiate: no environmentId. Override host-port so each
-  // worktree's Vault binds a unique macOS host port — the colima VMs all
-  // publish on their VM's :8200 internally, but only one wins host:8200 via
-  // colima's port forwarder, so distinct host ports are essential.
+  // Host-scoped instantiate: no environmentId. Override every exposed port so
+  // each worktree can run Vault + NATS without colliding with sibling VMs.
   const res = await api.post<unknown>(
     `/api/stack-templates/${templateId}/instantiate`,
-    { name: stackName, parameterValues: { 'host-port': vaultPort } },
+    {
+      name: stackName,
+      parameterValues: {
+        'vault-host-port': ports.vault,
+        'nats-host-port': ports.natsClient,
+        'nats-monitor-port': ports.natsMonitor,
+      },
+    },
   );
   if (res.status !== 201) {
-    logError(`Vault instantiate returned ${res.status}: ${res.bodyText}`);
+    logError(`Vault + NATS instantiate returned ${res.status}: ${res.bodyText}`);
     return null;
   }
   const created = pickObject<Stack>(res.body);
   const id = created?.id || '';
   if (!id) {
-    logError(`Vault instantiate response missing id: ${res.bodyText}`);
+    logError(`Vault + NATS instantiate response missing id: ${res.bodyText}`);
     return null;
   }
-  logOk(`Vault stack created (id=${id})`);
+  logOk(
+    `Vault + NATS stack created (id=${id}, ports: vault=${ports.vault} nats=${ports.natsClient} monitor=${ports.natsMonitor})`,
+  );
   return id;
 }
 
@@ -844,12 +865,28 @@ export async function seed(input: SeederInput): Promise<SeederOutput> {
   if (haproxyStackId) {
     await applyAndWaitForSynced(api, haproxyStackId, 'HAProxy');
   }
-  const vaultStackId = await ensureVaultStack(api, input.vaultPort);
-  if (vaultStackId) {
-    await applyAndWaitForSynced(api, vaultStackId, 'Vault');
+  const vaultNatsStackId = await ensureVaultNatsStack(api, {
+    vault: input.vaultPort,
+    natsClient: input.natsClientPort,
+    natsMonitor: input.natsMonitorPort,
+  });
+  if (vaultNatsStackId) {
+    // NATS reads its nats.conf from Vault KV. Bring up Vault first, bootstrap it
+    // so NatsBootstrapService writes shared/nats-config, then apply the whole
+    // stack so NATS can resolve NATS_CONF on first container start.
+    await applyAndWaitForSynced(api, vaultNatsStackId, 'Vault service', {
+      serviceNames: ['vault'],
+      allowDrifted: true,
+    });
   }
   await ensureVaultUnlocked(api);
   await publishSystemVaultPolicies(api);
+  if (vaultNatsStackId) {
+    await applyAndWaitForSynced(api, vaultNatsStackId, 'NATS service', {
+      serviceNames: ['nats'],
+      force: true,
+    });
+  }
   await markOnboardingComplete(api);
 
   logInfo(`Writing ${input.detailsFile}`);
@@ -863,6 +900,8 @@ export async function seed(input: SeederInput): Promise<SeederOutput> {
     uiPort: input.uiPort,
     registryPort: input.registryPort,
     vaultPort: input.vaultPort,
+    natsClientPort: input.natsClientPort,
+    natsMonitorPort: input.natsMonitorPort,
     egressPool: input.egressPoolCidr,
     agentSidecarImageTag: input.agentSidecarImageTag,
     adminEmail: env.ADMIN_EMAIL,

--- a/deployment/development/worktree-list.ts
+++ b/deployment/development/worktree-list.ts
@@ -13,6 +13,8 @@ import {
   EGRESS_PER_WORKTREE_PREFIX,
   EGRESS_PER_WORKTREE_SLOT_COUNT,
   loadRegistry,
+  NATS_CLIENT_PORT_MIN,
+  NATS_MONITOR_PORT_MIN,
   REGISTRY_YAML,
   slotOf,
   type WorktreeEntry,
@@ -28,6 +30,13 @@ function egressPoolFor(e: WorktreeEntry): string {
   if (slot === undefined) return '-';
   if (slot < 0 || slot >= EGRESS_PER_WORKTREE_SLOT_COUNT) return DEFAULT_EGRESS_POOL_CIDR;
   return `172.30.${slot * 4}.0/${EGRESS_PER_WORKTREE_PREFIX}`;
+}
+
+function natsPortsFor(e: WorktreeEntry): string {
+  if (e.nats_client_port) return `${e.nats_client_port}/${e.nats_monitor_port}`;
+  const slot = slotOf(e);
+  if (slot === undefined) return '-';
+  return `${NATS_CLIENT_PORT_MIN + slot}/${NATS_MONITOR_PORT_MIN + slot}`;
 }
 
 interface Args {
@@ -96,6 +105,7 @@ export function run(argv: string[]): void {
       'REG',
       'VAULT',
       'HAPROXY',
+      'NATS',
       'EGRESS POOL',
       'VM',
       'ADMIN EMAIL',
@@ -108,6 +118,7 @@ export function run(argv: string[]): void {
       const haproxy = e.haproxy_http_port
         ? `${e.haproxy_http_port}/${e.haproxy_https_port}`
         : '-';
+      const nats = natsPortsFor(e);
       rows.push([
         e.profile,
         dash(e.description),
@@ -116,6 +127,7 @@ export function run(argv: string[]): void {
         e.registry_port ? String(e.registry_port) : '-',
         e.vault_port ? String(e.vault_port) : '-',
         haproxy,
+        nats,
         egressPoolFor(e),
         dash(e.colima_vm),
         dash(e.admin_email),

--- a/deployment/development/worktree-start.ts
+++ b/deployment/development/worktree-start.ts
@@ -307,6 +307,8 @@ export async function run(argv: string[]): Promise<void> {
     haproxy_https_port: haproxyHttpsPort,
     haproxy_stats_port: haproxyStatsPort,
     haproxy_dataplane_port: haproxyDataplanePort,
+    nats_client_port: natsClientPort,
+    nats_monitor_port: natsMonitorPort,
     egress_pool_cidr: egressPoolCidr,
   } = allocatePorts(profile);
   // Persist early so the entry exists even if later steps fail
@@ -322,6 +324,8 @@ export async function run(argv: string[]): Promise<void> {
     haproxy_https_port: haproxyHttpsPort,
     haproxy_stats_port: haproxyStatsPort,
     haproxy_dataplane_port: haproxyDataplanePort,
+    nats_client_port: natsClientPort,
+    nats_monitor_port: natsMonitorPort,
     egress_pool_cidr: egressPoolCidr,
     url: `http://localhost:${uiPort}`,
     description: shortDesc,
@@ -329,7 +333,8 @@ export async function run(argv: string[]): Promise<void> {
   logInfo(
     `Ports: UI=${uiPort}, registry=${registryPort}, vault=${vaultPort}` +
       (driver === 'wsl' ? `, docker=${dockerPort}` : '') +
-      `, haproxy(http/https/stats/dataplane)=${haproxyHttpPort}/${haproxyHttpsPort}/${haproxyStatsPort}/${haproxyDataplanePort}`,
+      `, haproxy(http/https/stats/dataplane)=${haproxyHttpPort}/${haproxyHttpsPort}/${haproxyStatsPort}/${haproxyDataplanePort}` +
+      `, nats(client/monitor)=${natsClientPort}/${natsMonitorPort}`,
   );
   logInfo(`Egress pool: ${egressPoolCidr}`);
 
@@ -636,6 +641,8 @@ export async function run(argv: string[]): Promise<void> {
     uiPort,
     registryPort,
     vaultPort,
+    natsClientPort,
+    natsMonitorPort,
     egressPool: egressPoolCidr,
     agentSidecarImageTag,
     shortDescription: shortDesc,
@@ -659,6 +666,8 @@ export async function run(argv: string[]): Promise<void> {
         uiPort,
         registryPort,
         vaultPort,
+        natsClientPort,
+        natsMonitorPort,
         haproxyHttpPort,
         haproxyHttpsPort,
         haproxyStatsPort,
@@ -686,6 +695,8 @@ export async function run(argv: string[]): Promise<void> {
         haproxy_https_port: haproxyHttpsPort,
         haproxy_stats_port: haproxyStatsPort,
         haproxy_dataplane_port: haproxyDataplanePort,
+        nats_client_port: natsClientPort,
+        nats_monitor_port: natsMonitorPort,
         url: `http://localhost:${uiPort}`,
         admin_email: result.adminEmail,
         admin_password: result.adminPassword,
@@ -718,6 +729,8 @@ export async function run(argv: string[]): Promise<void> {
       haproxy_https_port: haproxyHttpsPort,
       haproxy_stats_port: haproxyStatsPort,
       haproxy_dataplane_port: haproxyDataplanePort,
+      nats_client_port: natsClientPort,
+      nats_monitor_port: natsMonitorPort,
       url: `http://localhost:${uiPort}`,
       seeded: details?.seeded ?? false,
       admin_email: details?.admin.email,
@@ -748,6 +761,8 @@ export async function run(argv: string[]): Promise<void> {
   console.log(`  URL:         http://localhost:${uiPort}`);
   console.log(`  Registry:    localhost:${registryPort}`);
   console.log(`  Vault:       http://localhost:${vaultPort}`);
+  console.log(`  NATS:        nats://localhost:${natsClientPort}`);
+  console.log(`  NATS monitor: http://localhost:${natsMonitorPort}`);
   console.log(`  HAProxy:     http://localhost:${haproxyHttpPort}  (https=${haproxyHttpsPort}, stats=${haproxyStatsPort}, dataplane=${haproxyDataplanePort})`);
   console.log(`  DOCKER_HOST: ${dockerHost}`);
   console.log('');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,6 +351,12 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
+      nats-jwt:
+        specifier: ^0.0.9
+        version: 0.0.9
+      nkeys.js:
+        specifier: ^1.1.0
+        version: 1.1.0
       node-cache:
         specifier: ^5.1.2
         version: 5.1.2
@@ -4013,6 +4019,9 @@ packages:
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
+  nats-jwt@0.0.9:
+    resolution: {integrity: sha512-1kcxqP4oHoG99HA/+h5qU1yBwScd5CaewD23gWDCdmpIFKJhUfd2NkkFFpCKbcfjwZKHOmCBy9DE2Z1ZVyaZ3g==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -4023,6 +4032,10 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  nkeys.js@1.1.0:
+    resolution: {integrity: sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg==}
+    engines: {node: '>=10.0.0'}
 
   node-abi@3.89.0:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
@@ -4819,6 +4832,9 @@ packages:
 
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -9023,11 +9039,19 @@ snapshots:
 
   napi-build-utils@2.0.0: {}
 
+  nats-jwt@0.0.9:
+    dependencies:
+      nkeys.js: 1.1.0
+
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
+
+  nkeys.js@1.1.0:
+    dependencies:
+      tweetnacl: 1.0.3
 
   node-abi@3.89.0:
     dependencies:
@@ -9930,6 +9954,8 @@ snapshots:
   tw-animate-css@1.4.0: {}
 
   tweetnacl@0.14.5: {}
+
+  tweetnacl@1.0.3: {}
 
   type-check@0.4.0:
     dependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -79,6 +79,8 @@
         "form-data": "^4.0.5",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.3",
+        "nats-jwt": "^0.0.9",
+        "nkeys.js": "^1.1.0",
         "node-cache": "^5.1.2",
         "node-cron": "^4.2.1",
         "node-forge": "^1.4.0",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -62,6 +62,7 @@ import { cleanupOrphanedSidecars, finalizeLastUpdate } from "./services/self-upd
 import { setupHAProxyCrashLoopWatcher } from "./services/haproxy/haproxy-crash-loop-watcher";
 import { initVaultServices } from "./services/vault/vault-services";
 import { seedVaultPolicies } from "./services/vault/vault-seed";
+import { getNatsBootstrapService } from "./services/nats/nats-bootstrap-service";
 import {
   startEgressBackgroundServices,
   ensureFwAgent,
@@ -319,6 +320,17 @@ const initializeServices = async () => {
         if (vaultServices.passphrase.isUnlocked() && meta.bootstrappedAt) {
           try {
             await vaultServices.admin.authenticateAsAdmin();
+            // Idempotent — refreshes operator/account JWTs and the rendered
+            // nats.conf in Vault KV. Safe to skip if no vault-nats stack is
+            // installed; the conf will simply sit unread in the KV.
+            try {
+              await getNatsBootstrapService().bootstrap();
+            } catch (natsErr) {
+              logger.warn(
+                { err: natsErr instanceof Error ? natsErr.message : String(natsErr) },
+                "NATS bootstrap at server boot failed (non-fatal)",
+              );
+            }
           } catch (err) {
             logger.warn(
               { err: err instanceof Error ? err.message : String(err) },

--- a/server/src/services/nats/__tests__/nats-bootstrap-service.test.ts
+++ b/server/src/services/nats/__tests__/nats-bootstrap-service.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { VaultKVError } from "../../vault/vault-kv-paths";
+
+// Mock the vault KV service module before the bootstrap service imports it.
+// The real `vault-kv-service` transitively pulls in Prisma; the bootstrap
+// service only needs `getVaultKVService()`, so a flat mock is enough.
+const kvStore = new Map<string, Record<string, string>>();
+const writeMock = vi.fn(async (path: string, data: Record<string, unknown>) => {
+  kvStore.set(path, { ...(kvStore.get(path) ?? {}), ...(data as Record<string, string>) });
+});
+const readFieldMock = vi.fn(async (path: string, field: string) => {
+  const data = kvStore.get(path);
+  if (!data || !(field in data)) {
+    throw new VaultKVError(`KV ${path}/${field} missing`, "field_not_found", 404);
+  }
+  return data[field];
+});
+
+vi.mock("../../vault/vault-kv-service", () => ({
+  getVaultKVService: () => ({
+    write: writeMock,
+    readField: readFieldMock,
+    read: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  }),
+}));
+
+import {
+  NatsBootstrapService,
+  NATS_OPERATOR_KV_PATH,
+  NATS_ACCOUNT_KV_PATH,
+  NATS_CONFIG_KV_PATH,
+} from "../nats-bootstrap-service";
+
+describe("NatsBootstrapService", () => {
+  beforeEach(() => {
+    kvStore.clear();
+    writeMock.mockClear();
+    readFieldMock.mockClear();
+  });
+
+  it("generates fresh operator and account seeds on first run", async () => {
+    const svc = new NatsBootstrapService();
+    const result = await svc.bootstrap();
+
+    expect(result.generatedSeeds).toBe(true);
+    expect(result.operatorPublic).toMatch(/^O/);
+    expect(result.accountPublic).toMatch(/^A/);
+    expect(kvStore.get(NATS_OPERATOR_KV_PATH)?.operator_seed).toMatch(/^SO/);
+    expect(kvStore.get(NATS_ACCOUNT_KV_PATH)?.account_seed).toMatch(/^SA/);
+    expect(kvStore.get(NATS_CONFIG_KV_PATH)?.conf).toContain("operator:");
+    expect(kvStore.get(NATS_CONFIG_KV_PATH)?.conf).toContain("resolver: MEMORY");
+  });
+
+  it("reuses existing seeds on a subsequent bootstrap call", async () => {
+    const svc = new NatsBootstrapService();
+    const first = await svc.bootstrap();
+    const seedAfterFirst = kvStore.get(NATS_OPERATOR_KV_PATH)?.operator_seed;
+    const acctSeedAfterFirst = kvStore.get(NATS_ACCOUNT_KV_PATH)?.account_seed;
+
+    const second = await svc.bootstrap();
+
+    expect(second.generatedSeeds).toBe(false);
+    expect(second.operatorPublic).toBe(first.operatorPublic);
+    expect(second.accountPublic).toBe(first.accountPublic);
+    expect(kvStore.get(NATS_OPERATOR_KV_PATH)?.operator_seed).toBe(seedAfterFirst);
+    expect(kvStore.get(NATS_ACCOUNT_KV_PATH)?.account_seed).toBe(acctSeedAfterFirst);
+  });
+
+  it("re-renders the config so a renderer change is picked up without rotating seeds", async () => {
+    const svc = new NatsBootstrapService();
+    await svc.bootstrap();
+    const firstConf = kvStore.get(NATS_CONFIG_KV_PATH)?.conf;
+
+    // Simulate an out-of-date conf in Vault.
+    kvStore.set(NATS_CONFIG_KV_PATH, { conf: "stale" });
+    await svc.bootstrap();
+
+    const refreshedConf = kvStore.get(NATS_CONFIG_KV_PATH)?.conf;
+    expect(refreshedConf).not.toBe("stale");
+    expect(refreshedConf).toBe(firstConf);
+  });
+
+  it("mintCreds returns a creds string scoped by permissions", async () => {
+    const svc = new NatsBootstrapService();
+    await svc.bootstrap();
+
+    const creds = await svc.mintCreds(
+      "test-user",
+      { pub: ["test.>"], sub: ["replies.>"] },
+      60,
+    );
+
+    expect(creds).toContain("BEGIN NATS USER JWT");
+    expect(creds).toContain("BEGIN USER NKEY SEED");
+  });
+});

--- a/server/src/services/nats/__tests__/nats-config-renderer.test.ts
+++ b/server/src/services/nats/__tests__/nats-config-renderer.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { renderNatsConfig } from "../nats-config-renderer";
+
+describe("renderNatsConfig", () => {
+  it("emits operator, MEMORY resolver, and the account preload block", () => {
+    const conf = renderNatsConfig({
+      operatorJwt: "OP_JWT_PLACEHOLDER",
+      accountPublicKey: "ACCT_PUBLIC",
+      accountJwt: "ACCT_JWT_PLACEHOLDER",
+      jetStream: false,
+    });
+
+    expect(conf).toContain("operator: OP_JWT_PLACEHOLDER");
+    expect(conf).toContain("resolver: MEMORY");
+    expect(conf).toContain("ACCT_PUBLIC: ACCT_JWT_PLACEHOLDER");
+    expect(conf).not.toContain("jetstream");
+  });
+
+  it("includes a jetstream block with the default store_dir when enabled", () => {
+    const conf = renderNatsConfig({
+      operatorJwt: "OP",
+      accountPublicKey: "AP",
+      accountJwt: "AJ",
+      jetStream: true,
+    });
+
+    expect(conf).toContain("jetstream {");
+    expect(conf).toContain('store_dir: "/data/jetstream"');
+  });
+
+  it("respects custom store_dir and max_file_store", () => {
+    const conf = renderNatsConfig({
+      operatorJwt: "OP",
+      accountPublicKey: "AP",
+      accountJwt: "AJ",
+      jetStream: true,
+      jetStreamStoreDir: "/var/jetstream",
+      jetStreamMaxStore: "10G",
+    });
+
+    expect(conf).toContain('store_dir: "/var/jetstream"');
+    expect(conf).toContain("max_file_store: 10G");
+  });
+
+  it("ends with a trailing newline", () => {
+    const conf = renderNatsConfig({
+      operatorJwt: "OP",
+      accountPublicKey: "AP",
+      accountJwt: "AJ",
+      jetStream: false,
+    });
+    expect(conf.endsWith("\n")).toBe(true);
+  });
+});

--- a/server/src/services/nats/__tests__/nats-config-renderer.test.ts
+++ b/server/src/services/nats/__tests__/nats-config-renderer.test.ts
@@ -13,10 +13,11 @@ describe("renderNatsConfig", () => {
     expect(conf).toContain("operator: OP_JWT_PLACEHOLDER");
     expect(conf).toContain("resolver: MEMORY");
     expect(conf).toContain("ACCT_PUBLIC: ACCT_JWT_PLACEHOLDER");
+    expect(conf).not.toContain("system_account:");
     expect(conf).not.toContain("jetstream");
   });
 
-  it("includes a jetstream block with the default store_dir when enabled", () => {
+  it("includes system_account and a jetstream block with the default store_dir when enabled", () => {
     const conf = renderNatsConfig({
       operatorJwt: "OP",
       accountPublicKey: "AP",
@@ -24,6 +25,7 @@ describe("renderNatsConfig", () => {
       jetStream: true,
     });
 
+    expect(conf).toContain("system_account: AP");
     expect(conf).toContain("jetstream {");
     expect(conf).toContain('store_dir: "/data/jetstream"');
   });

--- a/server/src/services/nats/__tests__/nats-key-manager.test.ts
+++ b/server/src/services/nats/__tests__/nats-key-manager.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateOperator,
+  generateAccount,
+  reissueOperatorJwt,
+  reissueAccountJwt,
+  loadKeyPair,
+  mintUserCreds,
+} from "../nats-key-manager";
+
+describe("nats-key-manager", () => {
+  it("generates operator material with seed/public/jwt", async () => {
+    const op = await generateOperator("test-op");
+    expect(op.seed).toMatch(/^SO/);
+    expect(op.publicKey).toMatch(/^O/);
+    expect(op.jwt.length).toBeGreaterThan(50);
+  });
+
+  it("re-derives the same public key when the same seed is loaded", async () => {
+    const op = await generateOperator("op");
+    const reloaded = await reissueOperatorJwt("op", op.seed);
+    expect(reloaded.publicKey).toBe(op.publicKey);
+    expect(reloaded.seed).toBe(op.seed);
+    // JWT may differ on iat — but the public key must be stable.
+    expect(reloaded.jwt.length).toBeGreaterThan(50);
+  });
+
+  it("signs an account JWT with the operator and matches public key on reload", async () => {
+    const op = await generateOperator("op");
+    const operatorKp = loadKeyPair(op.seed);
+    const acct = await generateAccount("acct", operatorKp);
+    expect(acct.publicKey).toMatch(/^A/);
+
+    const reloaded = await reissueAccountJwt("acct", acct.seed, operatorKp);
+    expect(reloaded.publicKey).toBe(acct.publicKey);
+  });
+
+  it("mints a creds string containing the user JWT block and seed block", async () => {
+    const op = await generateOperator("op");
+    const operatorKp = loadKeyPair(op.seed);
+    const acct = await generateAccount("acct", operatorKp);
+    const accountKp = loadKeyPair(acct.seed);
+
+    const creds = await mintUserCreds(
+      "test-user",
+      accountKp,
+      { pub: ["test.>"], sub: ["test.replies.>"] },
+      60,
+    );
+
+    expect(creds).toContain("-----BEGIN NATS USER JWT-----");
+    expect(creds).toContain("------END NATS USER JWT------");
+    expect(creds).toContain("-----BEGIN USER NKEY SEED-----");
+    expect(creds).toContain("------END USER NKEY SEED------");
+  });
+
+  it("supports non-expiring user creds when ttlSeconds=0", async () => {
+    const op = await generateOperator("op");
+    const operatorKp = loadKeyPair(op.seed);
+    const acct = await generateAccount("acct", operatorKp);
+    const accountKp = loadKeyPair(acct.seed);
+
+    const creds = await mintUserCreds(
+      "long-lived",
+      accountKp,
+      { pub: [">"], sub: [">"] },
+      0,
+    );
+
+    expect(creds).toContain("BEGIN NATS USER JWT");
+  });
+});

--- a/server/src/services/nats/nats-bootstrap-service.ts
+++ b/server/src/services/nats/nats-bootstrap-service.ts
@@ -1,0 +1,186 @@
+// Bootstraps the NATS operator/account NKey material in Vault and writes
+// the rendered nats.conf body to a known KV path. The vault-nats stack
+// template's NATS service consumes that conf via a `vault-kv` dynamicEnv
+// entry, so the container always picks up the latest signed JWTs without
+// needing a separate sidecar to materialise the file.
+//
+// Idempotent: once seeds exist in Vault, re-running re-renders the JWTs
+// from the same seeds (which is cheap and lets us refresh the conf if
+// rendering ever changes) but never rotates the operator. Rotating the
+// operator would invalidate every user `.creds` file we've handed out.
+
+import { getLogger } from "../../lib/logger-factory";
+import { getVaultKVService } from "../vault/vault-kv-service";
+import { VaultKVError } from "../vault/vault-kv-paths";
+import {
+  generateAccount,
+  generateOperator,
+  loadKeyPair,
+  reissueAccountJwt,
+  reissueOperatorJwt,
+  mintUserCreds,
+  type NatsPermissions,
+} from "./nats-key-manager";
+import { renderNatsConfig } from "./nats-config-renderer";
+
+const log = getLogger("platform", "nats-bootstrap-service");
+
+const OPERATOR_NAME = "mini-infra-operator";
+const ACCOUNT_NAME = "mini-infra-account";
+
+/** KV paths we own. */
+export const NATS_OPERATOR_KV_PATH = "shared/nats-operator";
+export const NATS_ACCOUNT_KV_PATH = "shared/nats-account";
+export const NATS_CONFIG_KV_PATH = "shared/nats-config";
+
+/** KV field names used at each path. Kept narrow to satisfy the validator
+ *  in `services/stacks/schemas.ts` (`^[a-zA-Z0-9_-]+$`). */
+const FIELD_OPERATOR_SEED = "operator_seed";
+const FIELD_OPERATOR_JWT = "operator_jwt";
+const FIELD_OPERATOR_PUBLIC = "operator_public";
+const FIELD_ACCOUNT_SEED = "account_seed";
+const FIELD_ACCOUNT_JWT = "account_jwt";
+const FIELD_ACCOUNT_PUBLIC = "account_public";
+const FIELD_CONFIG = "conf";
+
+export interface NatsBootstrapResult {
+  /** True when fresh seeds were generated this call. */
+  generatedSeeds: boolean;
+  operatorPublic: string;
+  accountPublic: string;
+}
+
+/**
+ * Idempotently ensure operator + account NKey material exist in Vault and
+ * the rendered nats.conf is up-to-date. Safe to call from boot, after a
+ * Vault unseal, or on demand — never rotates the operator/account seeds
+ * once they exist.
+ */
+export class NatsBootstrapService {
+  /**
+   * Returns true on first successful call (after generating fresh seeds);
+   * false on subsequent no-op calls. Always re-renders the conf so callers
+   * picking up an updated `renderNatsConfig` get the new shape without
+   * needing a manual KV write.
+   */
+  async bootstrap(): Promise<NatsBootstrapResult> {
+    const kv = getVaultKVService();
+
+    let operatorSeed = await this.tryReadField(NATS_OPERATOR_KV_PATH, FIELD_OPERATOR_SEED);
+    let accountSeed = await this.tryReadField(NATS_ACCOUNT_KV_PATH, FIELD_ACCOUNT_SEED);
+
+    let generatedSeeds = false;
+
+    if (!operatorSeed) {
+      log.info("Generating new NATS operator NKey");
+      const op = await generateOperator(OPERATOR_NAME);
+      await kv.write(NATS_OPERATOR_KV_PATH, {
+        [FIELD_OPERATOR_SEED]: op.seed,
+        [FIELD_OPERATOR_JWT]: op.jwt,
+        [FIELD_OPERATOR_PUBLIC]: op.publicKey,
+      });
+      operatorSeed = op.seed;
+      generatedSeeds = true;
+    }
+
+    const operatorKp = loadKeyPair(operatorSeed);
+    const operatorMaterial = await reissueOperatorJwt(OPERATOR_NAME, operatorSeed);
+
+    if (!accountSeed) {
+      log.info("Generating new NATS account NKey");
+      const acct = await generateAccount(ACCOUNT_NAME, operatorKp);
+      await kv.write(NATS_ACCOUNT_KV_PATH, {
+        [FIELD_ACCOUNT_SEED]: acct.seed,
+        [FIELD_ACCOUNT_JWT]: acct.jwt,
+        [FIELD_ACCOUNT_PUBLIC]: acct.publicKey,
+      });
+      accountSeed = acct.seed;
+      generatedSeeds = true;
+    }
+
+    const accountMaterial = await reissueAccountJwt(
+      ACCOUNT_NAME,
+      accountSeed,
+      operatorKp,
+    );
+
+    // Ensure account JWT/public key in Vault match what we just signed —
+    // rendering uses these and the conf must reference the live values.
+    await kv.write(NATS_ACCOUNT_KV_PATH, {
+      [FIELD_ACCOUNT_SEED]: accountSeed,
+      [FIELD_ACCOUNT_JWT]: accountMaterial.jwt,
+      [FIELD_ACCOUNT_PUBLIC]: accountMaterial.publicKey,
+    });
+    await kv.write(NATS_OPERATOR_KV_PATH, {
+      [FIELD_OPERATOR_SEED]: operatorSeed,
+      [FIELD_OPERATOR_JWT]: operatorMaterial.jwt,
+      [FIELD_OPERATOR_PUBLIC]: operatorMaterial.publicKey,
+    });
+
+    const conf = renderNatsConfig({
+      operatorJwt: operatorMaterial.jwt,
+      accountPublicKey: accountMaterial.publicKey,
+      accountJwt: accountMaterial.jwt,
+      jetStream: true,
+    });
+    await kv.write(NATS_CONFIG_KV_PATH, { [FIELD_CONFIG]: conf });
+
+    log.info(
+      {
+        operatorPublic: operatorMaterial.publicKey,
+        accountPublic: accountMaterial.publicKey,
+        generatedSeeds,
+      },
+      "NATS bootstrap complete",
+    );
+
+    return {
+      generatedSeeds,
+      operatorPublic: operatorMaterial.publicKey,
+      accountPublic: accountMaterial.publicKey,
+    };
+  }
+
+  /**
+   * Mint a user `.creds` string scoped to the supplied permissions. Caller
+   * is responsible for storing or transporting the result — this method
+   * does not persist the creds anywhere.
+   */
+  async mintCreds(
+    userName: string,
+    perms: NatsPermissions,
+    ttlSeconds: number,
+  ): Promise<string> {
+    const accountSeed = await getVaultKVService().readField(
+      NATS_ACCOUNT_KV_PATH,
+      FIELD_ACCOUNT_SEED,
+    );
+    const accountKp = loadKeyPair(accountSeed);
+    return mintUserCreds(userName, accountKp, perms, ttlSeconds);
+  }
+
+  private async tryReadField(path: string, field: string): Promise<string | null> {
+    try {
+      return await getVaultKVService().readField(path, field);
+    } catch (err) {
+      if (err instanceof VaultKVError) {
+        if (err.code === "path_not_found" || err.code === "field_not_found") {
+          return null;
+        }
+      }
+      throw err;
+    }
+  }
+}
+
+let singleton: NatsBootstrapService | null = null;
+
+export function getNatsBootstrapService(): NatsBootstrapService {
+  if (!singleton) singleton = new NatsBootstrapService();
+  return singleton;
+}
+
+/** Test-only reset. */
+export function __resetNatsBootstrapServiceForTests(): void {
+  singleton = null;
+}

--- a/server/src/services/nats/nats-config-renderer.ts
+++ b/server/src/services/nats/nats-config-renderer.ts
@@ -24,6 +24,9 @@ export function renderNatsConfig(inputs: NatsConfigInputs): string {
   const lines: string[] = [];
   lines.push("# Managed by mini-infra — regenerated on every NATS bootstrap.");
   lines.push(`operator: ${inputs.operatorJwt}`);
+  if (inputs.jetStream) {
+    lines.push(`system_account: ${inputs.accountPublicKey}`);
+  }
   lines.push("");
   lines.push("resolver: MEMORY");
   lines.push("");

--- a/server/src/services/nats/nats-config-renderer.ts
+++ b/server/src/services/nats/nats-config-renderer.ts
@@ -1,0 +1,43 @@
+// Renders the nats.conf body served to the NATS container.
+//
+// The container fetches this string from Vault KV at apply time (via a
+// `vault-kv` dynamicEnv source) and writes it to /etc/nats/nats.conf
+// before invoking nats-server. Keeping the renderer in one place lets the
+// bootstrap step regenerate the conf any time the operator/account JWTs
+// rotate without re-deriving the layout in two places.
+
+export interface NatsConfigInputs {
+  operatorJwt: string;
+  accountPublicKey: string;
+  accountJwt: string;
+  /** Enable JetStream persistence. The NATS container mounts /data, so the
+   *  store directory points there. */
+  jetStream: boolean;
+  /** Server-side store directory for JetStream. Defaults to /data/jetstream. */
+  jetStreamStoreDir?: string;
+  /** Soft cap on JetStream disk usage. Omitted by default — NATS uses 75%
+   *  of free disk on the volume. */
+  jetStreamMaxStore?: string;
+}
+
+export function renderNatsConfig(inputs: NatsConfigInputs): string {
+  const lines: string[] = [];
+  lines.push("# Managed by mini-infra — regenerated on every NATS bootstrap.");
+  lines.push(`operator: ${inputs.operatorJwt}`);
+  lines.push("");
+  lines.push("resolver: MEMORY");
+  lines.push("");
+  lines.push("resolver_preload: {");
+  lines.push(`  ${inputs.accountPublicKey}: ${inputs.accountJwt}`);
+  lines.push("}");
+  if (inputs.jetStream) {
+    lines.push("");
+    lines.push("jetstream {");
+    lines.push(`  store_dir: "${inputs.jetStreamStoreDir ?? "/data/jetstream"}"`);
+    if (inputs.jetStreamMaxStore) {
+      lines.push(`  max_file_store: ${inputs.jetStreamMaxStore}`);
+    }
+    lines.push("}");
+  }
+  return lines.join("\n") + "\n";
+}

--- a/server/src/services/nats/nats-key-manager.ts
+++ b/server/src/services/nats/nats-key-manager.ts
@@ -1,0 +1,143 @@
+// Operator/account/user NKey + JWT primitives for NATS.
+//
+// Mirrors the slackbot-agent-sdk approach: an operator NKey signs an account
+// JWT, the account NKey signs user JWTs, and `.creds` files combine a user
+// JWT with the user NKey seed. NATS clients use those `.creds` to authenticate.
+//
+// The operator and account NKey *seeds* are the only true secrets — they
+// stay in Vault. Operator/account JWTs are public (they're embedded in
+// nats.conf and visible to any NATS client). User JWTs are short-lived and
+// scoped to a permission allow-list passed in by the caller.
+
+import {
+  createOperator,
+  createAccount,
+  createUser,
+  fromSeed,
+  type KeyPair,
+} from "nkeys.js";
+import { encodeOperator, encodeAccount, encodeUser, fmtCreds } from "nats-jwt";
+
+export interface NatsPermissions {
+  pub: string[];
+  sub: string[];
+}
+
+export interface OperatorMaterial {
+  seed: string;
+  publicKey: string;
+  jwt: string;
+}
+
+export interface AccountMaterial {
+  seed: string;
+  publicKey: string;
+  jwt: string;
+}
+
+const TEXT_DECODER = new TextDecoder();
+const TEXT_ENCODER = new TextEncoder();
+
+/**
+ * Wide-open account limits. We use NATS auth to scope individual users via
+ * pub/sub allow-lists; account-level caps would just add noise here.
+ */
+const DEFAULT_ACCOUNT_LIMITS = {
+  conn: -1,
+  subs: -1,
+  data: -1,
+  payload: -1,
+  imports: -1,
+  exports: -1,
+  wildcards: true,
+  leaf: -1,
+  disallow_bearer: false,
+};
+
+/** Decode an NKey seed string into a KeyPair. */
+export function loadKeyPair(seed: string): KeyPair {
+  return fromSeed(TEXT_ENCODER.encode(seed));
+}
+
+/** Generate a fresh operator key pair and sign its JWT. */
+export async function generateOperator(name: string): Promise<OperatorMaterial> {
+  const kp = createOperator();
+  const seed = TEXT_DECODER.decode(kp.getSeed());
+  const publicKey = kp.getPublicKey();
+  const jwt = await encodeOperator(name, kp);
+  return { seed, publicKey, jwt };
+}
+
+/** Re-sign an existing operator's JWT (e.g. after restart from a stored seed). */
+export async function reissueOperatorJwt(
+  name: string,
+  operatorSeed: string,
+): Promise<OperatorMaterial> {
+  const kp = loadKeyPair(operatorSeed);
+  const publicKey = kp.getPublicKey();
+  const jwt = await encodeOperator(name, kp);
+  return { seed: operatorSeed, publicKey, jwt };
+}
+
+/** Generate a fresh account key pair and sign its JWT with the operator. */
+export async function generateAccount(
+  name: string,
+  operatorKp: KeyPair,
+): Promise<AccountMaterial> {
+  const kp = createAccount();
+  const seed = TEXT_DECODER.decode(kp.getSeed());
+  const publicKey = kp.getPublicKey();
+  const jwt = await encodeAccount(
+    name,
+    kp,
+    { limits: DEFAULT_ACCOUNT_LIMITS },
+    { signer: operatorKp },
+  );
+  return { seed, publicKey, jwt };
+}
+
+/** Re-sign an existing account's JWT from its stored seed. */
+export async function reissueAccountJwt(
+  name: string,
+  accountSeed: string,
+  operatorKp: KeyPair,
+): Promise<AccountMaterial> {
+  const kp = loadKeyPair(accountSeed);
+  const publicKey = kp.getPublicKey();
+  const jwt = await encodeAccount(
+    name,
+    kp,
+    { limits: DEFAULT_ACCOUNT_LIMITS },
+    { signer: operatorKp },
+  );
+  return { seed: accountSeed, publicKey, jwt };
+}
+
+/**
+ * Mint a `.creds` string for a NATS client. The user JWT is signed by the
+ * account, scoped to the supplied permissions, and expires after `ttlSeconds`.
+ * Pass `0` for `ttlSeconds` to mint a non-expiring JWT.
+ */
+export async function mintUserCreds(
+  name: string,
+  accountKp: KeyPair,
+  perms: NatsPermissions,
+  ttlSeconds: number,
+): Promise<string> {
+  const userKp = createUser();
+  const opts: { exp?: number } = {};
+  if (ttlSeconds > 0) {
+    opts.exp = Math.floor(Date.now() / 1000) + ttlSeconds;
+  }
+  const jwt = await encodeUser(
+    name,
+    userKp,
+    accountKp,
+    {
+      pub: { allow: perms.pub, deny: [] },
+      sub: { allow: perms.sub, deny: [] },
+    },
+    opts,
+  );
+  return TEXT_DECODER.decode(fmtCreds(jwt, userKp));
+}

--- a/server/src/services/stacks/post-install-actions/index.ts
+++ b/server/src/services/stacks/post-install-actions/index.ts
@@ -14,6 +14,7 @@ type ActionHandler = (ctx: PostInstallContext) => Promise<void>;
 const templateHandlers: Record<string, ActionHandler[]> = {
   postgres: [registerPostgresServer],
   vault: [registerVaultAddress],
+  'vault-nats': [registerVaultAddress],
 };
 
 /**

--- a/server/src/services/stacks/stack-reconciler.ts
+++ b/server/src/services/stacks/stack-reconciler.ts
@@ -271,8 +271,16 @@ export class StackReconciler {
       // conceptually complete (handled inside prepareServiceContainer) and
       // before any container is created, so wrapped secret_ids have the
       // tightest possible lifetime around container start.
+      const activeServiceNames = new Set(actions.map((a) => a.serviceName));
       const { overrides: resolvedEnvOverrides, serviceBindingsToRecord: serviceBindingsToRecordApply } =
-        await this.resolveVaultEnv(stack, stack.services, resolvedDefinitions, poolTokens, log);
+        await this.resolveVaultEnv(
+          stack,
+          stack.services,
+          resolvedDefinitions,
+          poolTokens,
+          activeServiceNames,
+          log,
+        );
 
       for (const action of actions) {
         const actionStart = Date.now();
@@ -527,8 +535,16 @@ export class StackReconciler {
         stackId,
         recreatedCallers,
       );
+      const activeServiceNames = new Set(actions.map((a) => a.serviceName));
       const { overrides: resolvedEnvOverrides, serviceBindingsToRecord: serviceBindingsToRecordUpdate } =
-        await this.resolveVaultEnv(stack, stack.services, resolvedDefinitions, poolTokens, log);
+        await this.resolveVaultEnv(
+          stack,
+          stack.services,
+          resolvedDefinitions,
+          poolTokens,
+          activeServiceNames,
+          log,
+        );
 
       for (const action of actions) {
         const svc = serviceMap.get(action.serviceName);
@@ -650,6 +666,7 @@ export class StackReconciler {
     }>,
     resolvedDefinitions: Map<string, StackServiceDefinition>,
     poolTokens: Record<string, string>,
+    activeServiceNames: Set<string>,
     log: Logger,
   ): Promise<{
     overrides: Map<string, Record<string, string>>;
@@ -663,6 +680,7 @@ export class StackReconciler {
     const injector = vaultReady ? new VaultCredentialInjector(this.prisma) : null;
 
     for (const [serviceName, serviceDef] of resolvedDefinitions.entries()) {
+      if (!activeServiceNames.has(serviceName)) continue;
       // Pool services never get a container at apply time — skip resolution
       // entirely so we don't waste a Vault mint on something we won't use.
       if (serviceDef.serviceType === 'Pool') continue;

--- a/server/src/services/vault/vault-admin-service.ts
+++ b/server/src/services/vault/vault-admin-service.ts
@@ -5,6 +5,7 @@ import { VaultHttpClient } from "./vault-http-client";
 import type { VaultAuthResponse } from "./vault-http-client";
 import { VaultStateService } from "./vault-state-service";
 import { getLogger } from "../../lib/logger-factory";
+import { getNatsBootstrapService } from "../nats/nats-bootstrap-service";
 import { emitToChannel } from "../../lib/socket";
 import { Channel, ServerEvent } from "@mini-infra/types";
 import type { OperationStep } from "@mini-infra/types";
@@ -306,6 +307,19 @@ export class VaultAdminService {
     );
 
     await this.stateService.markBootstrapped();
+
+    // Provision NATS NKey material in Vault now that the admin token is live.
+    // Non-fatal: NATS is optional and a missing nats-config KV path just
+    // means the vault-nats stack's NATS service won't apply until a future
+    // bootstrap call succeeds. Re-runs at boot via authenticateAsAdmin.
+    try {
+      await getNatsBootstrapService().bootstrap();
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "NATS bootstrap after Vault init failed (non-fatal)",
+      );
+    }
 
     return {
       unsealKeys,

--- a/server/src/services/vault/vault-health-watcher.ts
+++ b/server/src/services/vault/vault-health-watcher.ts
@@ -1,6 +1,7 @@
 import { OperatorPassphraseService } from "../../lib/operator-passphrase-service";
 import { VaultAdminService, UNSEAL_STEP_NAMES } from "./vault-admin-service";
 import { VaultStateService } from "./vault-state-service";
+import { getNatsBootstrapService } from "../nats/nats-bootstrap-service";
 import { emitToChannel } from "../../lib/socket";
 import { Channel, ServerEvent } from "@mini-infra/types";
 import type { VaultStatus } from "@mini-infra/types";
@@ -176,6 +177,18 @@ export class VaultHealthWatcher {
         }
       });
       log.info("Auto-unseal succeeded");
+      // Vault is now usable — make sure NATS KV state is current. Requires
+      // an authenticated admin token; re-auth first since unseal alone does
+      // not refresh it. Non-fatal so a NATS hiccup never blocks Vault.
+      try {
+        await this.admin.authenticateAsAdmin();
+        await getNatsBootstrapService().bootstrap();
+      } catch (natsErr) {
+        log.warn(
+          { err: natsErr instanceof Error ? natsErr.message : String(natsErr) },
+          "NATS bootstrap after auto-unseal failed (non-fatal)",
+        );
+      }
     } catch (err) {
       success = false;
       const msg = err instanceof Error ? err.message : String(err);

--- a/server/templates/vault-nats/template.json
+++ b/server/templates/vault-nats/template.json
@@ -1,0 +1,133 @@
+{
+  "name": "vault-nats",
+  "displayName": "Vault + NATS",
+  "builtinVersion": 1,
+  "scope": "host",
+  "category": "infrastructure",
+  "description": "OpenBao vault paired with a NATS messaging server. NATS uses Vault-managed NKey/JWT auth and JetStream persistence. Cannot coexist with the standalone 'vault' template — install one or the other.",
+  "parameters": [
+    {
+      "name": "vault-host-port",
+      "type": "number",
+      "default": 8200,
+      "description": "Bind the Vault API on the host at this port."
+    },
+    {
+      "name": "nats-host-port",
+      "type": "number",
+      "default": 4222,
+      "description": "Bind the NATS client port on the host."
+    },
+    {
+      "name": "nats-monitor-port",
+      "type": "number",
+      "default": 8222,
+      "description": "Bind the NATS HTTP monitoring port on the host."
+    }
+  ],
+  "resourceOutputs": [
+    { "type": "docker-network", "purpose": "vault", "joinSelf": true },
+    { "type": "docker-network", "purpose": "nats", "joinSelf": true }
+  ],
+  "networks": [],
+  "volumes": [
+    { "name": "openbao_data" },
+    { "name": "nats_data" }
+  ],
+  "services": [
+    {
+      "serviceName": "vault",
+      "serviceType": "Stateful",
+      "dockerImage": "openbao/openbao",
+      "dockerTag": "2.5.2",
+      "containerConfig": {
+        "command": ["server"],
+        "capAdd": ["IPC_LOCK"],
+        "env": {
+          "BAO_LOCAL_CONFIG": "{\"storage\":{\"file\":{\"path\":\"/openbao/file\"}},\"listener\":[{\"tcp\":{\"address\":\"0.0.0.0:8200\",\"tls_disable\":true}}],\"ui\":true,\"api_addr\":\"http://mini-infra-vault-nats-vault:8200\"}"
+        },
+        "ports": [
+          {
+            "containerPort": 8200,
+            "hostPort": "{{params.vault-host-port}}",
+            "protocol": "tcp",
+            "exposeOnHost": true
+          }
+        ],
+        "mounts": [
+          {
+            "source": "openbao_data",
+            "target": "/openbao/file",
+            "type": "volume"
+          }
+        ],
+        "restartPolicy": "unless-stopped",
+        "joinResourceNetworks": ["vault"],
+        "logConfig": {
+          "type": "json-file",
+          "maxSize": "10m",
+          "maxFile": "3"
+        }
+      },
+      "dependsOn": [],
+      "order": 1
+    },
+    {
+      "serviceName": "nats",
+      "serviceType": "Stateful",
+      "dockerImage": "nats",
+      "dockerTag": "2.12.8-alpine",
+      "containerConfig": {
+        "entrypoint": [
+          "sh",
+          "-c",
+          "mkdir -p /etc/nats && printf '%s' \"$NATS_CONF\" > /etc/nats/nats.conf && exec nats-server -c /etc/nats/nats.conf -m 8222"
+        ],
+        "dynamicEnv": {
+          "NATS_CONF": {
+            "kind": "vault-kv",
+            "path": "shared/nats-config",
+            "field": "conf"
+          }
+        },
+        "ports": [
+          {
+            "containerPort": 4222,
+            "hostPort": "{{params.nats-host-port}}",
+            "protocol": "tcp",
+            "exposeOnHost": true
+          },
+          {
+            "containerPort": 8222,
+            "hostPort": "{{params.nats-monitor-port}}",
+            "protocol": "tcp",
+            "exposeOnHost": true
+          }
+        ],
+        "mounts": [
+          {
+            "source": "nats_data",
+            "target": "/data",
+            "type": "volume"
+          }
+        ],
+        "restartPolicy": "unless-stopped",
+        "joinResourceNetworks": ["vault", "nats"],
+        "healthcheck": {
+          "test": ["CMD", "wget", "-qO-", "http://localhost:8222/healthz"],
+          "interval": 10,
+          "timeout": 3,
+          "retries": 5,
+          "startPeriod": 10
+        },
+        "logConfig": {
+          "type": "json-file",
+          "maxSize": "10m",
+          "maxFile": "3"
+        }
+      },
+      "dependsOn": ["vault"],
+      "order": 2
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- New built-in `vault-nats` stack template bundling OpenBao + NATS 2.12.8-alpine in one install (`server/templates/vault-nats/template.json`).
- `NatsBootstrapService` generates and persists the operator/account NKey material in Vault KV, then renders `nats.conf` to `secret/shared/nats-config/conf`. The NATS service in the stack pulls that config at apply time via the existing `dynamicEnv` `vault-kv` source — a tiny entrypoint wrapper writes it to `/etc/nats/nats.conf` before invoking `nats-server`. No new schema/config-file plumbing required.
- Hooked into Vault lifecycle: end of `VaultAdminService.bootstrap()`, the boot-time `authenticateAsAdmin` path in `server.ts`, and post-auto-unseal in `VaultHealthWatcher`. All hooks are idempotent and non-fatal — never block Vault on a NATS hiccup.

## Why
Mini Infra has more components that need to talk to each other (auth-proxy sidecar, agent sidecar, egress agent, pool workers). NATS provides a proper async messaging layer with strong scoped auth via Vault-managed NKey/JWTs — same pattern that's working well in the slackbot-agent-sdk project.

## Notes
- The existing `vault` template still ships. Users pick one or the other (both deploy OpenBao); documented in the new template's description.
- `mintCreds()` exists on `NatsBootstrapService` but no REST/UI surface yet — adding the route + UI for issuing per-service creds is a follow-up.
- NATS 2.12.8 is the latest stable Alpine tag at time of writing.

## Test plan
- [x] `pnpm --filter mini-infra-server exec vitest run src/services/nats/` — 13 new tests pass (key round-trips, config renderer, bootstrap idempotency).
- [x] `pnpm --filter mini-infra-server test` — full server suite (1944 tests) passes.
- [x] `pnpm --filter mini-infra-server build` + `lint` — clean.
- [x] `pnpm --filter mini-infra-client build` — clean.
- [x] Template loads via `loadTemplateFromDirectory('./templates/vault-nats')`.
- [ ] End-to-end in dev worktree: install `vault-nats`, bootstrap Vault via UI, confirm NATS container becomes healthy and `curl http://<host>:8222/healthz` returns 200.
- [ ] Confirm JetStream is on: `curl http://<host>:8222/jsz` returns non-empty state.
- [ ] Restart server and confirm operator seed in Vault KV is unchanged (no rotation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)