### PR TITLE
feat(vault): auto-apply system policies on bootstrap, guard system rows

### DIFF
--- a/deployment/development/lib/seeder.ts
+++ b/deployment/development/lib/seeder.ts
@@ -758,51 +758,6 @@ export async function ensureVaultUnlocked(api: ApiClient): Promise<void> {
   }
 }
 
-interface VaultPolicySummary {
-  id?: string;
-  name?: string;
-  publishedVersion?: number;
-}
-
-/**
- * Publish the two system Vault policies (`mini-infra-admin` and
- * `mini-infra-operator`) so the DB tracks them as published. The bootstrap
- * flow already writes the HCL to Vault directly, but leaves the DB rows in
- * draft state — without this step they show as unpublished in the UI on a
- * fresh dev environment. Idempotent: skips policies already at version >= 1.
- */
-async function publishSystemVaultPolicies(api: ApiClient): Promise<void> {
-  const SYSTEM_POLICY_NAMES = ['mini-infra-admin', 'mini-infra-operator'];
-
-  const res = await api.get<unknown>('/api/vault/policies');
-  if (res.status !== 200) {
-    logSkip(`Vault policies list returned ${res.status} — skipping system policy publish`);
-    return;
-  }
-  const policies = pickItems<VaultPolicySummary>(res.body);
-
-  for (const name of SYSTEM_POLICY_NAMES) {
-    const policy = policies.find((p) => p.name === name);
-    if (!policy?.id) {
-      logSkip(`System Vault policy '${name}' not found — skipping publish`);
-      continue;
-    }
-    if ((policy.publishedVersion ?? 0) > 0) {
-      logSkip(`Vault policy '${name}' already published (v${policy.publishedVersion})`);
-      continue;
-    }
-    logInfo(`Publishing Vault policy '${name}'`);
-    const publishRes = await api.post(`/api/vault/policies/${policy.id}/publish`);
-    if (publishRes.status === 200 || publishRes.status === 201) {
-      logOk(`Vault policy '${name}' published`);
-    } else {
-      logError(
-        `Publishing Vault policy '${name}' returned ${publishRes.status}: ${publishRes.bodyText}`,
-      );
-    }
-  }
-}
-
 async function markOnboardingComplete(api: ApiClient): Promise<void> {
   logInfo('Marking onboarding complete');
   const res = await api.post('/api/onboarding/complete', {});
@@ -880,7 +835,6 @@ export async function seed(input: SeederInput): Promise<SeederOutput> {
     });
   }
   await ensureVaultUnlocked(api);
-  await publishSystemVaultPolicies(api);
   if (vaultNatsStackId) {
     await applyAndWaitForSynced(api, vaultNatsStackId, 'NATS service', {
       serviceNames: ['nats'],

--- a/server/src/routes/vault/policies.ts
+++ b/server/src/routes/vault/policies.ts
@@ -10,6 +10,7 @@ import { getLogger } from "../../lib/logger-factory";
 import {
   VaultPolicyService,
   PolicyInUseError,
+  SystemPolicyError,
 } from "../../services/vault/vault-policy-service";
 import { getVaultServices } from "../../services/vault/vault-services";
 import { emitToChannel } from "../../lib/socket";
@@ -105,6 +106,9 @@ router.put(
       );
       res.json({ success: true, data: policy });
     } catch (err) {
+      if (err instanceof SystemPolicyError) {
+        return res.status(409).json({ success: false, message: err.message });
+      }
       next(err);
     }
   }) as RequestHandler,
@@ -146,6 +150,9 @@ router.delete(
           message: err.message,
           details: { appRoles: err.appRoleNames },
         });
+      }
+      if (err instanceof SystemPolicyError) {
+        return res.status(409).json({ success: false, message: err.message });
       }
       next(err);
     }

--- a/server/src/services/vault/vault-admin-service.ts
+++ b/server/src/services/vault/vault-admin-service.ts
@@ -10,10 +10,10 @@ import { emitToChannel } from "../../lib/socket";
 import { Channel, ServerEvent } from "@mini-infra/types";
 import type { OperationStep } from "@mini-infra/types";
 import type { VaultBootstrapResult } from "@mini-infra/types";
-// Single source of truth for the admin policy HCL. Imported by the seeder so
-// the DB row, the bootstrap-time write, and the per-login self-heal all
-// publish the same body — no drift when capabilities are added or removed.
-import { MINI_INFRA_ADMIN_HCL } from "./vault-policy-bodies";
+// Bootstrap and per-login self-heal both read system policy bodies from the
+// seeded DB rows (`isSystem: true`), which `seedVaultPolicies` keeps pinned
+// to the codebase constants in `vault-policy-bodies.ts`. No HCL import here.
+import { seedVaultPolicies } from "./vault-seed";
 
 const log = getLogger("platform", "vault-admin-service");
 
@@ -33,57 +33,13 @@ const MINI_INFRA_OPERATOR_POLICY_NAME = "mini-infra-operator";
 const MINI_INFRA_ADMIN_APPROLE_NAME = "mini-infra-admin";
 const MINI_INFRA_OPERATOR_USERPASS_NAME = "mini-infra-operator";
 
-const ADMIN_POLICY_HCL = MINI_INFRA_ADMIN_HCL;
-
-const OPERATOR_POLICY_HCL = `# mini-infra-operator — userpass policy for human operator logging into the
-# Vault UI to inspect state and debug. Deliberately NOT admin-equivalent: all
-# write paths are delegated to the mini-infra-admin AppRole via the Mini Infra
-# API. If a human operator needs admin capability, grant them the vault:admin
-# scope on Mini Infra and drive Vault through the UI there.
-
-# Read-only visibility into seal, mounts, policies, audit config
-path "sys/health" { capabilities = ["read", "list"] }
-path "sys/seal-status" { capabilities = ["read", "list"] }
-path "sys/mounts" { capabilities = ["read", "list"] }
-path "sys/mounts/*" { capabilities = ["read", "list"] }
-path "sys/auth" { capabilities = ["read", "list"] }
-path "sys/auth/*" { capabilities = ["read", "list"] }
-path "sys/policies/acl" { capabilities = ["read", "list"] }
-path "sys/policies/acl/*" { capabilities = ["read", "list"] }
-path "sys/capabilities-self" { capabilities = ["update"] }
-
-# List and read AppRoles to see which apps are configured
-path "auth/approle/role" { capabilities = ["read", "list"] }
-path "auth/approle/role/*" { capabilities = ["read", "list"] }
-
-# Let the operator change their own userpass password. Others' passwords and
-# new user creation are NOT allowed — use the admin AppRole via Mini Infra.
-path "auth/userpass/users/mini-infra-operator/password" {
-  capabilities = ["update"]
-}
-
-# Read and write secrets under secret/ — the operator needs this to debug
-# what apps are reading at runtime. KV v2 requires both data/ and metadata/.
-path "secret/data/*" {
-  capabilities = ["create", "read", "update", "delete", "list"]
-}
-path "secret/metadata/*" {
-  capabilities = ["read", "list", "delete"]
-}
-
-# Token lifecycle for own session
-path "auth/token/lookup-self" { capabilities = ["read"] }
-path "auth/token/renew-self" { capabilities = ["update"] }
-path "auth/token/revoke-self" { capabilities = ["update"] }
-`;
-
 const BOOTSTRAP_STEPS = [
   "Initialise Vault (sys/init)",
   "Persist and unseal with operator passphrase",
   "Enable auth methods (approle, userpass)",
   "Enable KV v2 at secret/",
-  "Write mini-infra-admin policy + AppRole",
-  "Write mini-infra-operator policy + userpass user",
+  "Apply system policies + admin AppRole",
+  "Create operator userpass user",
   "Rotate root token",
 ] as const;
 
@@ -131,6 +87,54 @@ export class VaultAdminService {
 
   getClient(): VaultHttpClient | null {
     return this.client;
+  }
+
+  /**
+   * Write every `isSystem: true` VaultPolicy from the DB to Vault and mark the
+   * row as published. Idempotent: re-running re-syncs the body and refreshes
+   * `lastAppliedAt`. Used by `bootstrap()` to apply admin + operator (and any
+   * future system policies) in one place driven by the seed.
+   *
+   * Reads `draftHclBody` (not `publishedHclBody`): the seed pins
+   * `draftHclBody` to the codebase constant for system rows on every boot,
+   * so `draftHclBody` is the authoritative current body. Reading
+   * `publishedHclBody` would push the previous deployment's HCL after a
+   * capability upgrade.
+   *
+   * `publishedVersion` is intentionally not bumped on re-apply — this is a
+   * re-assertion of the existing version, not a new publish. The UI's
+   * "Publish" path (`VaultPolicyService.publish`) is what bumps the version
+   * when an operator deliberately publishes user-edited HCL.
+   */
+  private async publishSystemPolicies(client: VaultHttpClient): Promise<void> {
+    const policies = await this.prisma.vaultPolicy.findMany({
+      where: { isSystem: true },
+    });
+    for (const p of policies) {
+      const body = p.draftHclBody;
+      if (!body) {
+        log.warn(
+          { policy: p.name },
+          "System Vault policy has no HCL body; skipping",
+        );
+        continue;
+      }
+      await client.writePolicy(p.name, body);
+      await this.prisma.vaultPolicy.update({
+        where: { id: p.id },
+        data: {
+          publishedHclBody: body,
+          publishedVersion:
+            p.publishedVersion === 0 ? 1 : p.publishedVersion,
+          publishedAt: p.publishedAt ?? new Date(),
+          lastAppliedAt: new Date(),
+        },
+      });
+      log.info(
+        { policy: p.name },
+        "System Vault policy applied from DB",
+      );
+    }
   }
 
   /**
@@ -233,11 +237,18 @@ export class VaultAdminService {
       total,
     );
 
-    // 5. Admin policy + AppRole
+    // 5. Apply all system policies from the DB, then create the admin AppRole
+    //    bound to mini-infra-admin. The DB rows are the source of truth: any
+    //    policy with isSystem=true gets written to Vault and marked published.
+    //    Re-seed first so a freshly-installed instance always has the
+    //    mini-infra-admin and mini-infra-operator rows present even if the
+    //    boot-time seed call hasn't run yet (e.g. tests instantiating the
+    //    service directly).
     const { adminRoleId, adminSecretId } = await this.wrapStep(
       BOOTSTRAP_STEPS[4],
       async () => {
-        await client.writePolicy(MINI_INFRA_ADMIN_POLICY_NAME, ADMIN_POLICY_HCL);
+        await seedVaultPolicies(this.prisma);
+        await this.publishSystemPolicies(client);
         await client.writeAppRole(MINI_INFRA_ADMIN_APPROLE_NAME, {
           token_policies: MINI_INFRA_ADMIN_POLICY_NAME,
           token_period: "1h",
@@ -256,15 +267,11 @@ export class VaultAdminService {
       total,
     );
 
-    // 6. Operator policy + userpass user
+    // 6. Operator userpass user — the policy itself was applied in step 5.
     const operatorPassword = generateRandomPassword();
     await this.wrapStep(
       BOOTSTRAP_STEPS[5],
       async () => {
-        await client.writePolicy(
-          MINI_INFRA_OPERATOR_POLICY_NAME,
-          OPERATOR_POLICY_HCL,
-        );
         await client.createUserpassUser(
           MINI_INFRA_OPERATOR_USERPASS_NAME,
           operatorPassword,
@@ -408,19 +415,20 @@ export class VaultAdminService {
     const secretId = await this.stateService.readAdminSecretId();
     const res = await this.client.appRoleLogin(roleId, secretId);
     this.adoptAuthResponse(res);
-    // Reconcile the admin policy with the source-of-truth HCL on every
-    // successful login. Idempotent overwrite — keeps policy capabilities in
-    // sync with the codebase even after upgrades that add new capabilities
-    // (e.g. KV `patch` for the brokered Vault KV API).
+    // Reconcile every system policy with the source-of-truth HCL on every
+    // successful login. Idempotent — keeps Vault in sync with the codebase
+    // even after upgrades that add new capabilities (e.g. KV `patch` for the
+    // brokered Vault KV API). Driven entirely off the seeded DB rows so the
+    // bootstrap path and the per-login self-heal can't drift.
     try {
-      await this.client.writePolicy(MINI_INFRA_ADMIN_POLICY_NAME, ADMIN_POLICY_HCL);
+      await this.publishSystemPolicies(this.client);
     } catch (err) {
-      // Non-fatal — apply will surface a clearer error if the policy is
+      // Non-fatal — apply will surface a clearer error if a policy is
       // missing capabilities. We still want the login to succeed so the
       // operator can investigate via the UI.
       log.warn(
         { err: err instanceof Error ? err.message : String(err) },
-        "Failed to refresh admin policy on login (non-fatal)",
+        "Failed to refresh system policies on login (non-fatal)",
       );
     }
   }

--- a/server/src/services/vault/vault-policy-bodies.ts
+++ b/server/src/services/vault/vault-policy-bodies.ts
@@ -1,9 +1,8 @@
 /**
- * Source of truth for system policy HCL bodies. Both the bootstrap path
- * (`vault-admin-service.ts`) and the DB seed (`vault-seed.ts`) import from
- * here so updates land in lockstep — adding a capability in one place but
- * not the other was the bug that surfaced when the brokered Vault KV API
- * needed `patch`.
+ * Source of truth for system policy HCL bodies. Imported by `vault-seed.ts`
+ * (DB rows) and read back from the DB on bootstrap by `vault-admin-service.ts`.
+ * Keeping the bodies here means a capability change lands in one place — the
+ * seed re-applies it on next boot, and bootstrap re-publishes from the DB.
  */
 
 export const MINI_INFRA_ADMIN_HCL = `# mini-infra-admin — managed by Mini Infra. Do not edit directly.
@@ -24,4 +23,46 @@ path "secret/*" {
 path "identity/*" {
   capabilities = ["create", "read", "update", "delete", "list"]
 }
+`;
+
+export const MINI_INFRA_OPERATOR_HCL = `# mini-infra-operator — userpass policy for the human operator logging into
+# the Vault UI to inspect state and debug. Deliberately NOT admin-equivalent:
+# all write paths are delegated to the mini-infra-admin AppRole via the Mini
+# Infra API. If a human operator needs admin capability, grant them the
+# vault:admin scope on Mini Infra and drive Vault through the UI there.
+
+# Read-only visibility into seal, mounts, policies, audit config
+path "sys/health" { capabilities = ["read", "list"] }
+path "sys/seal-status" { capabilities = ["read", "list"] }
+path "sys/mounts" { capabilities = ["read", "list"] }
+path "sys/mounts/*" { capabilities = ["read", "list"] }
+path "sys/auth" { capabilities = ["read", "list"] }
+path "sys/auth/*" { capabilities = ["read", "list"] }
+path "sys/policies/acl" { capabilities = ["read", "list"] }
+path "sys/policies/acl/*" { capabilities = ["read", "list"] }
+path "sys/capabilities-self" { capabilities = ["update"] }
+
+# List and read AppRoles to see which apps are configured
+path "auth/approle/role" { capabilities = ["read", "list"] }
+path "auth/approle/role/*" { capabilities = ["read", "list"] }
+
+# Let the operator change their own userpass password. Others' passwords and
+# new user creation are NOT allowed — use the admin AppRole via Mini Infra.
+path "auth/userpass/users/mini-infra-operator/password" {
+  capabilities = ["update"]
+}
+
+# Read and write secrets under secret/ — the operator needs this to debug
+# what apps are reading at runtime. KV v2 requires both data/ and metadata/.
+path "secret/data/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+path "secret/metadata/*" {
+  capabilities = ["read", "list", "delete"]
+}
+
+# Token lifecycle for own session
+path "auth/token/lookup-self" { capabilities = ["read"] }
+path "auth/token/renew-self" { capabilities = ["update"] }
+path "auth/token/revoke-self" { capabilities = ["update"] }
 `;

--- a/server/src/services/vault/vault-policy-service.ts
+++ b/server/src/services/vault/vault-policy-service.ts
@@ -23,6 +23,14 @@ export class PolicyInUseError extends Error {
   }
 }
 
+/** Thrown when a caller tries to mutate a system-managed policy. */
+export class SystemPolicyError extends Error {
+  constructor(action: string) {
+    super(`Cannot ${action} a system-managed Vault policy`);
+    this.name = "SystemPolicyError";
+  }
+}
+
 export class VaultPolicyService {
   constructor(
     private readonly prisma: PrismaClient,
@@ -70,6 +78,10 @@ export class VaultPolicyService {
     input: UpdateVaultPolicyRequest,
     userId: string,
   ): Promise<VaultPolicyInfo> {
+    const existing = await this.prisma.vaultPolicy.findUnique({ where: { id } });
+    if (existing?.isSystem) {
+      throw new SystemPolicyError("edit");
+    }
     const row = await this.prisma.vaultPolicy.update({
       where: { id },
       data: {
@@ -92,6 +104,9 @@ export class VaultPolicyService {
     }
     const policy = await this.prisma.vaultPolicy.findUnique({ where: { id } });
     if (!policy) return;
+    if (policy.isSystem) {
+      throw new SystemPolicyError("delete");
+    }
 
     // Best-effort remove from Vault; continue on any failure. Use the
     // authenticated-client getter so we lazily re-login if the cached admin

--- a/server/src/services/vault/vault-seed.ts
+++ b/server/src/services/vault/vault-seed.ts
@@ -1,13 +1,17 @@
 import type { PrismaClient } from "../../lib/prisma";
 import { getLogger } from "../../lib/logger-factory";
-import { MINI_INFRA_ADMIN_HCL } from "./vault-policy-bodies";
+import {
+  MINI_INFRA_ADMIN_HCL,
+  MINI_INFRA_OPERATOR_HCL,
+} from "./vault-policy-bodies";
 
 const log = getLogger("platform", "vault-seed");
 
 /**
- * Seed system Vault policies. Called once at server boot — idempotent upsert.
- * Only writes rows into the DB; actual write-to-Vault happens when an operator
- * presses "Publish" in the UI, or on first bootstrap for `mini-infra-admin`.
+ * Seed built-in Vault policies. Called once at server boot — idempotent upsert.
+ * System policies (`isSystem: true`) are auto-published to Vault during the
+ * vault-nats stack bootstrap; user/example policies stay as drafts until an
+ * operator edits and publishes them via the UI.
  */
 export async function seedVaultPolicies(prisma: PrismaClient): Promise<void> {
   const policies: {
@@ -15,6 +19,7 @@ export async function seedVaultPolicies(prisma: PrismaClient): Promise<void> {
     displayName: string;
     description: string;
     draftHclBody: string;
+    isSystem: boolean;
   }[] = [
     {
       name: "mini-infra-admin",
@@ -22,6 +27,7 @@ export async function seedVaultPolicies(prisma: PrismaClient): Promise<void> {
       description:
         "Admin policy Mini Infra uses for platform-level Vault operations. Managed automatically — do not edit.",
       draftHclBody: MINI_INFRA_ADMIN_HCL,
+      isSystem: true,
     },
     {
       name: "mini-infra-operator",
@@ -29,6 +35,7 @@ export async function seedVaultPolicies(prisma: PrismaClient): Promise<void> {
       description:
         "Policy for the userpass `mini-infra-operator` account used for human Vault UI access.",
       draftHclBody: MINI_INFRA_OPERATOR_HCL,
+      isSystem: true,
     },
     {
       name: "user-self-service",
@@ -36,6 +43,7 @@ export async function seedVaultPolicies(prisma: PrismaClient): Promise<void> {
       description:
         "Example policy: lets a named user read/write their own secrets under secret/users/{{identity.entity.aliases.userpass.name}}/*.",
       draftHclBody: USER_SELF_SERVICE_HCL,
+      isSystem: false,
     },
     {
       name: "read-only-example",
@@ -43,6 +51,7 @@ export async function seedVaultPolicies(prisma: PrismaClient): Promise<void> {
       description:
         "Example read-only policy scoped to secret/shared/*. Copy, rename, and customise.",
       draftHclBody: READ_ONLY_EXAMPLE_HCL,
+      isSystem: false,
     },
   ];
 
@@ -55,13 +64,22 @@ export async function seedVaultPolicies(prisma: PrismaClient): Promise<void> {
           displayName: p.displayName,
           description: p.description,
           draftHclBody: p.draftHclBody,
-          isSystem: true,
+          isSystem: p.isSystem,
         },
         update: {
           displayName: p.displayName,
           description: p.description,
-          isSystem: true,
-          // Do NOT overwrite draftHclBody on upgrade — operators may have edited it
+          // Re-assert isSystem on every boot so previously mis-flagged rows
+          // (the two examples were originally seeded as isSystem: true) get
+          // corrected on upgrade.
+          isSystem: p.isSystem,
+          // For system policies, keep draftHclBody pinned to the codebase
+          // constant so capability changes (e.g. adding KV `patch`) flow
+          // through to Vault on the next bootstrap. The HCL header tells
+          // operators not to edit; update() in vault-policy-service also
+          // blocks edits via the API. For user/example policies, preserve
+          // any operator edits.
+          ...(p.isSystem ? { draftHclBody: p.draftHclBody } : {}),
         },
       });
     } catch (err) {
@@ -73,42 +91,6 @@ export async function seedVaultPolicies(prisma: PrismaClient): Promise<void> {
   }
   log.info({ count: policies.length }, "Vault policies seeded");
 }
-
-// MINI_INFRA_ADMIN_HCL imported from ./vault-policy-bodies — single source of
-// truth shared with vault-admin-service.ts (bootstrap + per-login self-heal).
-
-const MINI_INFRA_OPERATOR_HCL = `# mini-infra-operator — userpass human-operator access.
-# Read-only visibility + secret management + change own password. Keep in sync
-# with the policy installed during bootstrap in vault-admin-service.ts.
-
-path "sys/health" { capabilities = ["read", "list"] }
-path "sys/seal-status" { capabilities = ["read", "list"] }
-path "sys/mounts" { capabilities = ["read", "list"] }
-path "sys/mounts/*" { capabilities = ["read", "list"] }
-path "sys/auth" { capabilities = ["read", "list"] }
-path "sys/auth/*" { capabilities = ["read", "list"] }
-path "sys/policies/acl" { capabilities = ["read", "list"] }
-path "sys/policies/acl/*" { capabilities = ["read", "list"] }
-path "sys/capabilities-self" { capabilities = ["update"] }
-
-path "auth/approle/role" { capabilities = ["read", "list"] }
-path "auth/approle/role/*" { capabilities = ["read", "list"] }
-
-path "auth/userpass/users/mini-infra-operator/password" {
-  capabilities = ["update"]
-}
-
-path "secret/data/*" {
-  capabilities = ["create", "read", "update", "delete", "list"]
-}
-path "secret/metadata/*" {
-  capabilities = ["read", "list", "delete"]
-}
-
-path "auth/token/lookup-self" { capabilities = ["read"] }
-path "auth/token/renew-self" { capabilities = ["update"] }
-path "auth/token/revoke-self" { capabilities = ["update"] }
-`;
 
 const USER_SELF_SERVICE_HCL = `# User self-service — each authenticated user can manage their own secrets
 # under secret/users/<username>/*.


### PR DESCRIPTION
## Summary
- Bootstrap step 5 now seeds + publishes every `isSystem: true` VaultPolicy from the DB to Vault, so admin + operator land in Vault the moment the vault-nats stack finishes coming up — no dev-only second pass required.
- Reclassifies the two example policies (`user-self-service`, `read-only-example`) to `isSystem: false` so they show up in the UI as editable user policies (where they always belonged).
- Single source of truth for system policy HCL: `vault-policy-bodies.ts`. The seed pins `draftHclBody` to the constant on every boot for system rows, so capability changes (e.g. adding KV `patch`) flow through to Vault on the next bootstrap. Per-login self-heal (`authenticateAsAdminInner`) now routes through the same `publishSystemPolicies` path — no more divergent code paths.
- Hardens `VaultPolicyService.update` / `delete` with `isSystem` guards (return 409). The UI already disabled the buttons; the API now matches.
- Deletes the now-unused dev-only `publishSystemVaultPolicies` helper from the seeder.

## Why
On a fresh worktree the vault-nats stack would come up bootstrapped, but the two policies the platform actually relies on (`mini-infra-admin` for the admin AppRole, `mini-infra-operator` for the userpass UI login) only got into Vault via either (a) hard-coded `client.writePolicy` calls in `vault-admin-service.ts` or (b) a dev-seeder helper that POSTed `/api/vault/policies/{id}/publish` for the two known names. The DB rows stayed as drafts in production. With the same HCL hard-coded in two places, any capability change had to be duplicated to avoid drift. This PR makes the DB the source of truth.

## Code review pass
A Sonnet code-review pass surfaced 2 high + 4 medium findings. Addressed:
- **#1 (high) — stale HCL after capability upgrades.** Seed `update` branch now overwrites `draftHclBody` for system policies; `publishSystemPolicies` reads from `draftHclBody` (the seed-pinned authoritative source), not the previous `publishedHclBody`.
- **#4 (medium) — self-heal not DB-driven.** `authenticateAsAdminInner` now calls `publishSystemPolicies` instead of writing the hard-coded admin HCL constant. Single code path for both bootstrap and per-login self-heal.
- **#5 (medium) — no API-level `isSystem` guards.** Added `SystemPolicyError`; `update`/`delete` reject mutations on system rows with 409.
- **#3 (medium)** documented as comment (`publishedVersion` intentionally not bumped on re-apply — re-assertion, not a new publish).
- **#2 (high)** rejected: reviewer's premise was wrong; the deleted dev helper hard-coded `SYSTEM_POLICY_NAMES = ['mini-infra-admin', 'mini-infra-operator']`, so the examples never got `publishedVersion > 0` in any environment.
- **#6 (medium) — partial-failure retry.** Pre-existing fragility, not a regression from this PR.

## Out-of-scope: pre-existing publish-via-API issue
While smoke testing I noticed `POST /api/vault/policies/:id/publish` and `POST /api/vault/approles/:id/apply` return 500 with `permission denied` until `POST /api/vault/admin/reauthenticate` is hit, even though Vault has the correct policy attached to the admin AppRole. This is not introduced by this PR (the AppRole login path and admin policy contents are unchanged from `main`); it appears to be either an OpenBao 2.5.2 cache/policy-eval quirk on bootstrap-time-issued tokens or a long-standing bug in the bootstrap → admin-token-handover sequence. Filed as a separate concern.

## Test plan
- [x] `pnpm --filter mini-infra-server build` — clean
- [x] `pnpm --filter mini-infra-server test` — 1942/1942 pass
- [x] Fresh worktree via `pnpm worktree-env start` — vault-nats stack synced, Vault bootstrapped
- [x] Read `mini-infra-admin` and `mini-infra-operator` policy bodies directly from Vault (via operator userpass login) — both live, body matches seed HCL
- [x] `LIST sys/policies/acl/` in Vault — only `default`, `mini-infra-admin`, `mini-infra-operator`, `root` (examples correctly NOT pushed)
- [x] `DELETE /api/vault/policies/<admin>` → 409 with `Cannot delete a system-managed Vault policy`
- [x] `PUT /api/vault/policies/<admin>` with edited HCL → 409 with `Cannot edit a system-managed Vault policy`
- [x] `PUT /api/vault/policies/<user-policy>` → 200 (user policies unaffected)
- [x] DB state: admin/operator `isSystem=true`, `publishedVersion=1`, `lastAppliedAt` set; examples `isSystem=false`, `publishedVersion=0`, `lastAppliedAt=null`
- [x] Idempotency: re-running `pnpm worktree-env start` over an existing DB correctly flips previously-mis-flagged example rows to `isSystem: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)