### PR TITLE
feat(nats): app-roles, signers, prefix allowlist, and cross-stack imports/exports

### DIFF
--- a/docs/planning/not-shipped/nats-app-roles-followups.md
+++ b/docs/planning/not-shipped/nats-app-roles-followups.md
@@ -1,0 +1,206 @@
+# NATS App Roles & Subject Scoping — Deferred Follow-Ups
+
+**Status:** Tracking doc for work intentionally not in the initial PR.
+**Companion to:** [`docs/planning/shipped/nats-app-roles-plan.md`](../shipped/nats-app-roles-plan.md)
+
+The first PR landed Phases 1, 2, 3, and 5 of the design — the type surface,
+validation, prefix allowlist, role materialization, and cross-stack
+imports/exports. The items below were either explicitly out of scope, blocked
+on a discrete prerequisite, or surfaced as code-level TODOs during
+implementation. Each is sized so it can be picked up independently.
+
+---
+
+## Phase 0 — Live account-JWT propagation (PREREQUISITE for Phase 4)
+
+**Why it's blocking.** The current `vault-nats` stack runs NATS with
+`resolver: MEMORY` and a static `resolver_preload` block written into
+`nats.conf`. Account JWTs in this mode load once at process start and **do
+not hot-reload**. Scoped signing keys (the cryptographic primitive that
+makes `signers` safe) live inside the account JWT, so adding/rotating/
+revoking a signer means re-issuing the account JWT and getting the live
+`nats-server` to load the new one. Today the only options are to restart
+the server (disruptive) or `SIGHUP` (still a reload event).
+
+**Recommended path.** Switch `vault-nats` to the full account resolver
+(`resolver: { type: full, dir: ... }`) and use the NATS account-server
+protocol (`$SYS.REQ.CLAIMS.UPDATE`) to push updated account JWTs over the
+wire. No reload, no downtime.
+
+**Touch points** (verified during planning):
+- [server/src/services/nats/nats-config-renderer.ts](../../../server/src/services/nats/nats-config-renderer.ts) — make resolver mode a parameter; render `dir` for full mode.
+- [server/src/services/nats/nats-control-plane-service.ts](../../../server/src/services/nats/nats-control-plane-service.ts) — add a system-account-authenticated connection (`mintSystemUserCreds()` + `withSystemNats()` helper) and `updateAccountClaim(publicKey, jwt)` method. **Zero existing system-account plumbing today** — must build from scratch.
+- [server/src/services/nats/nats-key-manager.ts](../../../server/src/services/nats/nats-key-manager.ts) — add `mintSystemUserCreds()` (sys account, broad `$SYS.>` permissions).
+- [server/templates/vault-nats/template.json](../../../server/templates/vault-nats/template.json) — bump version; mint system-user creds at apply; write account JWTs to `/data/accounts/` on the existing `nats_data` volume.
+- Apply orchestrator: after `reissueAccountJwt()`, call `updateAccountClaim()` instead of relying on config rewrite.
+
+**Verification (must run against a real NATS server):**
+- Account JWT changes propagate within <2s of `updateAccountClaim()`.
+- Revoking a scoped signing key (re-issuing the account JWT without it) invalidates user JWTs signed by that key on next connect.
+- Backwards-compat: existing system stacks that don't declare new fields still apply cleanly under the full resolver.
+
+**Estimated effort:** 2–3 engineer-days. The largest unknown in the plan.
+
+**Pause point.** End-of-phase review before starting Phase 4. If
+propagation latency turns out unacceptable or system-user plumbing is
+brittle, fall back to `SIGHUP` reload (option 2 in design §1.3) as the
+cheap path.
+
+---
+
+## Phase 4 — Signers materialization (depends on Phase 0)
+
+**Why deferred.** The Phase 1 type surface for `nats.signers[]` is shipped
+and validated, but the apply-time materialization is not. Without Phase 0,
+adding a scoped signing key to the shared account JWT can't be
+hot-reloaded into the live server, so a signer would be cryptographically
+inert until the next NATS restart.
+
+**What's still TBD when picked up:**
+- Extend `NatsKeyManager` with `generateScopedSigningKey()` distinct from `mintUserCreds`. Use `nats-jwt`'s `newScopedSigner(signingKey, role, { pub: { allow: [<scoped>] }, sub: { allow: [<scoped>, '_INBOX.>'] } })`.
+- For each signer at apply: compute `<prefix>.<subjectScope>.>`, generate ED25519 keypair, add to `Account.signing_keys`, re-issue account JWT, propagate via Phase 0 mechanism, persist seed in Vault KV at `shared/nats-signers/<stackId>-<signerName>`, persist `NatsSigningKey` row (model already shipped in Phase 1).
+- New `nats-signer-seed` branch in `NatsCredentialInjector.resolve()` that reads from Vault KV at the canonical path. The `maxTtlSeconds` cap is enforced by NATS itself via the scope template — no client-side policing.
+- Auto-inject `NATS_SIGNER_SEED` dynamicEnv when a service declares `natsSigner`.
+- Destroy path: delete `NatsSigningKey` row, delete seed from Vault KV, **and** re-issue account JWT with the signing key removed + propagate. Without the re-issue, a revoked signing key remains valid until the next account-JWT refresh.
+
+**Verification (real NATS server, not mocks):**
+- JWT minted by a scoped signer with permissions broader than its scope is silently trimmed by the server.
+- JWT with claimed TTL > `maxTtlSeconds` is rejected.
+- Seed redacted in logs (`getLogger("nats", ...)` filters).
+- Destroying a stack with a signer revokes the key end-to-end.
+
+---
+
+## Phase 6 — Slackbot migration (external repo)
+
+**Goal.** Validate the design end-to-end by porting the
+`slackbot-agent-sdk` repo's hand-rolled NATS plumbing onto the new
+`roles` + `signers` surface. Litmus test for whether the DSL covers a real
+third-party app's needs without escape hatches.
+
+**Tasks** (in `slackbot-agent-sdk`, not this repo):
+- Replace bespoke NKey/JWT minting in `manager/src/nats-jwt-minter.ts` with reads of `NATS_SIGNER_SEED` env var.
+- Update template to declare `roles: [gateway, manager]` and `signers: [worker-minter]` per the design's §2.3 example.
+- Decide between default `app.<stack-id>.*` prefix or admin-allowlisted `navi` retention.
+- Validate the ~686-line installer shrinks meaningfully (deletes NATS account material handling).
+
+**Verification:** existing slackbot integration tests pass; `_INBOX.>`
+request/reply round-trips work without explicit declaration.
+
+**Blocker:** Phase 4 (signers) must ship first — the slackbot's `manager`
+service is the canonical signer use case.
+
+---
+
+## Operational hardening — discovered during implementation
+
+These came up during code review of Phases 1–5. None are blocking, all are
+worth doing before the first non-trivial third-party app onboards.
+
+### Orphan profile cleanup on role rename
+
+**Problem.** A role is keyed by `<stackId>-<roleName>` in
+`NatsCredentialProfile`. Renaming `gateway` → `frontdoor` in a template
+leaves the old profile row in the DB; apply creates a new row but never
+deletes the old one. Same applies to deleting a role outright.
+
+**Where flagged:**
+- [server/src/services/stacks/stack-nats-apply-orchestrator.ts](../../../server/src/services/stacks/stack-nats-apply-orchestrator.ts) — TODO comment in `materializeRole`.
+
+**Approach.** Add a per-stack "desired roles" diff at the end of the apply
+phase: enumerate existing `NatsCredentialProfile` rows owned by this stack
+(via the `<stackId>-` prefix or, better, a `stackId` FK on the profile
+table — small migration), compare against the rendered `roles[]` set,
+delete any orphans. Same pattern would later cover signer rotation when
+Phase 4 ships.
+
+### Cycle detection in cross-stack imports
+
+**Problem.** Stack A imports from B; B imports from A. The Phase 5
+orchestrator has no cycle check. Both apply in some order: each generation
+sees the other's *prior* snapshot, so they ping-pong eventually-
+consistent rather than failing fast. This was acknowledged in the design
+(§6) but no implementation yet.
+
+**Where flagged:**
+- [server/src/services/stacks/stack-nats-apply-orchestrator.ts](../../../server/src/services/stacks/stack-nats-apply-orchestrator.ts) — TODO comment in `resolveImport`.
+
+**Approach.** Before resolving an import, walk the producer's `imports[]`
+recursively (DFS through `lastAppliedNatsSnapshot.imports`) looking for the
+consumer's stack name. Refuse to apply if found, surface the cycle path.
+Cheap because cross-stack import depth is small in practice.
+
+### Global NATS-apply lock (concurrency hardening)
+
+**Problem.** Phase 5's `resolveImport` is a plain Prisma read of the
+producer's `lastAppliedNatsSnapshot`. If producer + consumer apply
+simultaneously, the consumer can race on a stale snapshot. The design
+recommended a global NATS-apply lock; v1 takes the eventual-consistency
+tradeoff (consumer's next apply picks up the new snapshot).
+
+**Approach.** A single advisory lock keyed by `"nats-apply"` taken at
+the top of `runStackNatsApplyPhase`. Cheap, single-host system, contention
+is rare. Implementation note: keep the lock scope tight (don't hold across
+the legacy `applyConfig`/`applyJetStreamResources` since those touch a
+live NATS connection that may be slow).
+
+### Forced revocation path for in-flight JWTs
+
+**Open question from §5 of the design.** Re-applying with a changed
+`subjectScope` rotates the signing key (old removed from account JWT, new
+one added), but in-flight user JWTs minted by the old key remain valid
+until their TTL expires — NATS validation is stateless.
+
+**Approach (if a real compliance ask appears).** Track per-signer "epoch"
+in the account JWT's claim metadata; bump the epoch on rotation. The
+signer's connect-time check rejects JWTs from earlier epochs. Adds
+complexity (custom claim parsing on every connection) and trades latency
+for correctness — only worth it if compliance demands it.
+
+---
+
+## Ergonomics — nice-to-haves
+
+### CLI helper for the prefix allowlist
+
+The Phase 2 admin API works (POST/PUT/DELETE on
+`/api/nats/prefix-allowlist`), but a `mini-infra nats allowlist add ...`
+CLI helper would make the usual workflow (allowlist a non-default prefix
+for a specific template) one command instead of two API calls. Punted in
+favor of "ship the API, write the CLI when an admin asks."
+
+### Per-user credential observability UI
+
+The design's §2.1 explicitly opts out: mini-infra is intentionally blind
+once a signer's seed is delegated. NATS's own connection logs cover who
+connected with what JWT; the manager service is responsible for its own
+audit log if it needs one. Worth revisiting if a real compliance ask
+appears.
+
+### JetStream-for-apps (`roles[].streams`)
+
+V1 keeps `streams` as a legacy-only template field with absolute
+subjects, system-template-only path. Apps that want JetStream are blocked
+by the mixing rule. Slackbot doesn't need it, but the next NATS-using app
+might. Adding `roles[].streams` (relative subjects, auto-prefixed) is
+straightforward once a use case appears — the materialization path
+already exists, just needs prefix-prepending in
+`stack-nats-apply-orchestrator.ts` legacy-streams branch.
+
+### Drift detection in `lastAppliedNatsSnapshot`
+
+The snapshot writes accounts/credentials/streams/consumers/roles/exports/
+imports/resolved-prefix on every apply, but no consumer compares against
+it for drift. Once the orchestrator's snapshot is rich enough (it is now,
+post-Phase 5), the next planned change is a drift detector that compares
+the rendered roles + resolved prefix against the snapshot and surfaces
+"out of sync" in the stack list.
+
+---
+
+## How to pick something up
+
+1. **Read** [docs/planning/shipped/nats-app-roles-plan.md](../shipped/nats-app-roles-plan.md) §2 for the design rationale.
+2. **Find the relevant section above** for the entry point file and rough approach.
+3. **The shipped phases** ([server/src/services/stacks/stack-nats-apply-orchestrator.ts](../../../server/src/services/stacks/stack-nats-apply-orchestrator.ts), [server/src/services/nats/nats-prefix-allowlist-service.ts](../../../server/src/services/nats/nats-prefix-allowlist-service.ts), the schema/validator additions) are the closest patterns to follow.
+4. **Tests** — every phase added integration tests under `server/src/__tests__/`. Match that style. Real-NATS integration tests for Phase 4 are a hard requirement (the cryptographic guarantees can't be verified against mocks).

--- a/docs/planning/shipped/nats-app-roles-plan.md
+++ b/docs/planning/shipped/nats-app-roles-plan.md
@@ -1,6 +1,6 @@
 # NATS App Roles & Subject Scoping in the Stack Definition Language
 
-**Status:** Proposed
+**Status:** Phases 1, 2, 3, and 5 shipped. Phase 4 (signers) deferred until the Phase 0 prerequisite (live account-JWT propagation) lands.
 **Forcing function:** [slackbot-agent-sdk](https://github.com/) — a third-party app that wants to consume NATS via mini-infra without hand-rolling NKey/JWT minting and without colliding with other apps' subjects.
 **Builds on:** the NATS first-class primitives shipped in #320 / #322 (`vault-nats` built-in stack, `NatsControlPlaneService`, `TemplateNatsSection`).
 

--- a/docs/user/stack-definition-reference.md
+++ b/docs/user/stack-definition-reference.md
@@ -351,6 +351,138 @@ Reference note:
 | `containerName` | Yes | Name of the already-running Docker container to route to. | 1-253 chars. |
 | `listeningPort` | Yes | Port Mini Infra should target on that container. | Integer `1-65535`. |
 
+## `nats` — app-author surface (roles, signers, imports/exports)
+
+The `nats` section lets a stack template declare its NATS topology safely
+without hand-rolling NKey/JWT minting. Mini Infra materializes the
+declarations into `NatsCredentialProfile` rows at apply time and binds them
+to services via the symbolic refs below. This section is **separate** from
+the low-level `accounts` / `credentials` / `streams` / `consumers` shape used
+by built-in system templates — mixing the two within one template is
+rejected at validation time. App templates use the role/signer surface.
+
+### `nats.subjectPrefix`
+
+The subject namespace this stack lives under. Every relative subject in
+`roles[].publish` / `roles[].subscribe` / `exports[]` / `imports[].subjects`
+gets this prefix prepended at apply time.
+
+**Default:** `app.{{stack.id}}` — opaque but collision-free across stacks.
+
+A non-default prefix (e.g. `navi`, `events.platform`) requires an admin
+allowlist entry. POST `/api/nats/prefix-allowlist` with `{ prefix,
+allowedTemplateIds }` to grant a template the right to claim that prefix.
+The allowlist is CRUD-per-entry; subject-tree overlaps (e.g. `events` and
+`events.platform`) are rejected at write time.
+
+### `nats.roles[]`
+
+Symbolic role declarations. Each entry materializes into a
+`NatsCredentialProfile` row at apply time, with the resolved subjectPrefix
+prepended to every `publish` / `subscribe` entry.
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `name` | Yes | Symbolic name. Service-level `natsRole: <name>` resolves to this. |
+| `publish` | No | Subjects relative to the stack's subjectPrefix. Prepended at apply. |
+| `subscribe` | No | Same shape as `publish`, for the role's subscribe permissions. |
+| `inboxAuto` | No | Controls `_INBOX.>` auto-injection. Default `'both'` (right for roles that send AND respond to request/reply). Other values: `'reply'` (pub only), `'request'` (sub only), `'none'`. |
+| `ttlSeconds` | No | Credential JWT TTL. Defaults to system default (3600s). |
+
+**Subject pattern rules** (enforced at validation):
+- No `>` or `*` at the start of a relative subject (would shadow the whole prefix tree).
+- No leading `_INBOX.` — use `inboxAuto`.
+- No leading `$SYS.` — system-account namespace is reserved.
+- No empty tokens (`..` or leading/trailing dots).
+- Wildcards mid-pattern (e.g. `agent.*.in`, `events.>`) are fine.
+
+### `nats.signers[]`
+
+Scoped signing keys for in-process JWT minting (e.g. a manager service
+that mints per-user worker JWTs). The seed is delivered to the service via
+`NATS_SIGNER_SEED` env var. The NATS server cryptographically constrains
+anything signed with this key to the declared `subjectScope` — a
+compromised signer cannot escape its sub-tree.
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `name` | Yes | Symbolic name. Service-level `natsSigner: <name>` resolves to this. |
+| `subjectScope` | Yes | Subject sub-tree the key is constrained to, *relative* to the stack's subjectPrefix. E.g. `agent.worker` → minted JWTs cannot exceed `<prefix>.agent.worker.>`. No wildcards. |
+| `maxTtlSeconds` | No | Hard NATS-enforced cap on JWT TTL. Default 3600. |
+
+> **Note.** Signers depend on the live NATS account-JWT propagation
+> mechanism described in the design doc (Phase 0). Until that ships,
+> `signers[]` is accepted by validation but not yet materialized.
+
+### `nats.exports[]`
+
+Subjects relative to this stack's subjectPrefix that other stacks may
+import. After apply, the resolved (prefixed) form lands in the stack's
+`lastAppliedNatsSnapshot`; consumer stacks read from there.
+
+```yaml
+exports:
+  - "events.>"
+```
+
+### `nats.imports[]`
+
+Cross-stack subject sharing. Each entry resolves at apply time against the
+producer's last applied snapshot.
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `fromStack` | Yes | Producer stack name. Scoped to the consumer's environment (cross-environment imports are not supported in v1). |
+| `subjects` | Yes | Subjects relative to the *producer's* subjectPrefix. Must match one of the producer's `exports[]` patterns. |
+| `forRoles` | Yes | **Required.** Roles in *this* stack that get the imported subjects added to their `subscribe` list. Per-role binding only — security-critical so a "consumer" role doesn't accidentally pick up subjects intended for a specific gateway. |
+
+```yaml
+imports:
+  - fromStack: events-bus
+    subjects: ["events.user.>"]
+    forRoles: ["watcher"]
+```
+
+### Service bindings
+
+Symbolic refs on `services[].natsRole` and `services[].natsSigner` resolve
+at apply time:
+
+| Field | Effect |
+| --- | --- |
+| `services[].natsRole: <name>` | Binds `StackService.natsCredentialId` to the materialized role profile. The injector (`nats-credential-injector.ts`) auto-injects `NATS_CREDS` and `NATS_URL` env vars. |
+| `services[].natsSigner: <name>` | Auto-injects `NATS_SIGNER_SEED` env var into the service. Coexists with `natsRole` — a manager service typically has both. |
+
+A service with both `natsRole` and `natsCredentialRef` (legacy) prefers the
+role binding — but the validator rejects mixing the two surfaces in one
+template, so this only applies in degenerate / corrupted-template states.
+
+### Worked example (slackbot-style topology)
+
+```yaml
+nats:
+  # subjectPrefix omitted → defaults to "app.{{stack.id}}"
+  roles:
+    - name: gateway
+      publish:   ["agent.in"]
+      subscribe: ["slack.api", "askuser", "agent.reply.>"]
+      # inboxAuto defaults to 'both'
+    - name: manager
+      publish:   ["agent.worker.>"]
+      subscribe: ["agent.ensure", "agent.worker.ready.>"]
+  signers:
+    - name: worker-minter
+      subjectScope: "agent.worker"
+      maxTtlSeconds: 2400
+
+services:
+  - name: slack-gateway
+    natsRole: gateway
+  - name: manager
+    natsRole: manager           # → NATS_CREDS (connection)
+    natsSigner: worker-minter   # → NATS_SIGNER_SEED (in-process minting)
+```
+
 ## Templating notes
 
 Mini Infra resolves templates from a context that includes:

--- a/lib/types/permissions.ts
+++ b/lib/types/permissions.ts
@@ -541,7 +541,7 @@ export const PERMISSION_GROUPS: PermissionGroup[] = [
         domain: "nats",
         action: "write",
         label: "NATS Administration",
-        description: "Regenerate managed NATS configuration and reconcile JetStream resources",
+        description: "Regenerate managed NATS configuration, reconcile JetStream resources, and manage the subject-prefix allowlist",
       },
     ],
   },

--- a/lib/types/settings.ts
+++ b/lib/types/settings.ts
@@ -40,7 +40,7 @@ export interface SystemSettingsInfo {
 // Settings Categories
 // ====================
 
-export const SETTINGS_CATEGORIES = ["docker", "cloudflare", "azure", "system", "deployments", "haproxy", "tls", "github", "github-app", "agent", "self-backup", "vault", "nats"] as const;
+export const SETTINGS_CATEGORIES = ["docker", "cloudflare", "azure", "system", "deployments", "haproxy", "tls", "github", "github-app", "agent", "self-backup", "vault", "nats", "nats-prefix-allowlist"] as const;
 export type SettingsCategory = typeof SETTINGS_CATEGORIES[number];
 
 export const VALIDATION_STATUSES = ["valid", "invalid", "pending", "error"] as const;

--- a/lib/types/stack-templates.ts
+++ b/lib/types/stack-templates.ts
@@ -215,7 +215,72 @@ export interface TemplateNatsConsumer {
   scope: 'host' | 'environment' | 'stack';
 }
 
+/**
+ * App-author-facing role declaration. Materializes into a NatsCredentialProfile
+ * row at apply time, with the stack's resolved subjectPrefix prepended to every
+ * publish/subscribe entry. Subject patterns are written *relative* to the
+ * prefix — the orchestrator does the prepend.
+ */
+export interface TemplateNatsRole {
+  name: string;
+  publish?: string[];
+  subscribe?: string[];
+  /**
+   * Controls `_INBOX.>` auto-injection for NATS request/reply ergonomics.
+   * Default `'both'` injects in pub and sub (right for roles that initiate
+   * AND respond to request/reply). `'reply'` = pub only (pure responder).
+   * `'request'` = sub only (pure requester). `'none'` = no injection.
+   */
+  inboxAuto?: 'both' | 'reply' | 'request' | 'none';
+  /** Credential JWT TTL. Defaults to NatsCredentialProfile system default (3600s). */
+  ttlSeconds?: number;
+}
+
+/**
+ * App-author-facing signer declaration. Materializes a scoped signing key on
+ * the shared NATS account; the seed is injected into the named service via
+ * the `nats-signer-seed` dynamicEnv kind so the service can mint per-user
+ * JWTs in-process. The server cryptographically constrains anything signed
+ * with this key to the declared subject scope.
+ */
+export interface TemplateNatsSigner {
+  name: string;
+  /**
+   * Subject sub-tree the signing key is constrained to, *relative* to the
+   * stack's subjectPrefix. E.g. `agent.worker` → minted JWTs cannot exceed
+   * `<prefix>.agent.worker.>`.
+   */
+  subjectScope: string;
+  /** Hard cap (NATS-enforced) on TTL of any JWT the signer can mint. Defaults to 3600s. */
+  maxTtlSeconds?: number;
+}
+
+/**
+ * App-author-facing cross-stack subject import. Resolved at apply time
+ * against the producer stack's latest applied version's exports.
+ */
+export interface TemplateNatsImport {
+  /** Structural reference to another stack (by name). Resolved at apply time. */
+  fromStack: string;
+  /** Subjects relative to the *producer's* subjectPrefix. Must match producer's exports. */
+  subjects: string[];
+  /** Roles in *this* stack that get the imported subjects added to their subscribe list. Required (per-role binding only). */
+  forRoles: string[];
+}
+
 export interface TemplateNatsSection {
+  // App-author surface (safe-by-default; auto-prefixed; validated at publish).
+  /** Defaults to `app.{{stack.id}}`. Non-default values require an admin allowlist entry. */
+  subjectPrefix?: string;
+  roles?: TemplateNatsRole[];
+  signers?: TemplateNatsSigner[];
+  /** Subjects relative to subjectPrefix that this stack publishes for cross-app consumption. */
+  exports?: string[];
+  imports?: TemplateNatsImport[];
+
+  // Low-level surface (system templates and advanced/internal use).
+  // App templates use the role/signer surface above; mixing the two within
+  // one template is rejected at validation time.
   accounts?: TemplateNatsAccount[];
   credentials?: TemplateNatsCredential[];
   streams?: TemplateNatsStream[];
@@ -267,6 +332,10 @@ export interface StackTemplateServiceInfo {
   natsCredentialId?: string | null;
   /** Symbolic credential name from nats.credentials[]; resolved to natsCredentialId at apply time. */
   natsCredentialRef?: string | null;
+  /** Symbolic role name from nats.roles[]; resolved to a materialized NatsCredentialProfile at apply time. */
+  natsRole?: string | null;
+  /** Symbolic signer name from nats.signers[]; auto-injects NATS_SIGNER_SEED dynamicEnv at apply time. */
+  natsSigner?: string | null;
 }
 
 export interface StackTemplateConfigFileInfo {

--- a/lib/types/stacks.ts
+++ b/lib/types/stacks.ts
@@ -55,7 +55,20 @@ export type DynamicEnvSource =
    * env var — no Vault client SDK or AppRole needed by the running app.
    * Apply re-runs re-read; KV updates do not propagate until the next apply.
    */
-  | { kind: 'vault-kv'; path: string; field: string };
+  | { kind: 'vault-kv'; path: string; field: string }
+  /**
+   * Seed (NKey, base32) of a *scoped signing key* on the shared NATS account.
+   * Distinct from `nats-creds` — this is NOT used to connect to NATS; it is
+   * used by the service to mint downstream user JWTs in-process. Server-side
+   * NATS enforces the signer's subjectScope at JWT-validation time, so a
+   * compromised signer cannot escape its declared sub-tree.
+   *
+   * Auto-wired by the apply orchestrator when a service declares
+   * `natsSigner: '<name>'` against a `nats.signers[]` entry — apps don't write
+   * this dynamicEnv kind by hand. Resolved at apply time from Vault KV at
+   * `shared/nats-signers/<stackId>-<signerName>`.
+   */
+  | { kind: 'nats-signer-seed'; signer: string };
 
 /**
  * Per-service configuration for a `Pool` service. Pools are container
@@ -372,6 +385,12 @@ export interface StackServiceDefinition {
   /** Symbolic reference to a nats.credentials[].name in the owning template draft.
    *  Resolved to a concrete natsCredentialId at apply time. */
   natsCredentialRef?: string | null;
+  /** Symbolic reference to a nats.roles[].name. Resolved at apply time to a
+   *  materialized NatsCredentialProfile (auto-prefixed permissions). */
+  natsRole?: string | null;
+  /** Symbolic reference to a nats.signers[].name. Causes NATS_SIGNER_SEED to
+   *  be auto-injected as dynamicEnv at apply time. */
+  natsSigner?: string | null;
 }
 
 export interface StackDefinition {

--- a/server/prisma/migrations/20260501100000_nats_app_roles_phase1/migration.sql
+++ b/server/prisma/migrations/20260501100000_nats_app_roles_phase1/migration.sql
@@ -1,0 +1,143 @@
+-- AlterTable
+ALTER TABLE "stack_template_services" ADD COLUMN "natsRole" TEXT;
+ALTER TABLE "stack_template_services" ADD COLUMN "natsSigner" TEXT;
+
+-- AlterTable
+ALTER TABLE "stack_template_versions" ADD COLUMN "natsExports" JSONB;
+ALTER TABLE "stack_template_versions" ADD COLUMN "natsImports" JSONB;
+ALTER TABLE "stack_template_versions" ADD COLUMN "natsRoles" JSONB;
+ALTER TABLE "stack_template_versions" ADD COLUMN "natsSigners" JSONB;
+ALTER TABLE "stack_template_versions" ADD COLUMN "natsSubjectPrefix" TEXT;
+
+-- CreateTable
+CREATE TABLE "nats_signing_keys" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "accountId" TEXT NOT NULL,
+    "stackId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "scope" TEXT NOT NULL,
+    "scopedSubject" TEXT NOT NULL,
+    "publicKey" TEXT NOT NULL,
+    "seedKvPath" TEXT NOT NULL,
+    "maxTtlSeconds" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "nats_signing_keys_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "nats_accounts" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "nats_signing_keys_stackId_fkey" FOREIGN KEY ("stackId") REFERENCES "stacks" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_nats_accounts" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "description" TEXT,
+    "isSystem" BOOLEAN NOT NULL DEFAULT false,
+    "seedKvPath" TEXT NOT NULL,
+    "publicKey" TEXT,
+    "jwt" TEXT,
+    "lastAppliedAt" DATETIME,
+    "createdById" TEXT,
+    "updatedById" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_nats_accounts" ("createdAt", "createdById", "description", "displayName", "id", "isSystem", "jwt", "lastAppliedAt", "name", "publicKey", "seedKvPath", "updatedAt", "updatedById") SELECT "createdAt", "createdById", "description", "displayName", "id", "isSystem", "jwt", "lastAppliedAt", "name", "publicKey", "seedKvPath", "updatedAt", "updatedById" FROM "nats_accounts";
+DROP TABLE "nats_accounts";
+ALTER TABLE "new_nats_accounts" RENAME TO "nats_accounts";
+CREATE UNIQUE INDEX "nats_accounts_name_key" ON "nats_accounts"("name");
+CREATE INDEX "nats_accounts_isSystem_idx" ON "nats_accounts"("isSystem");
+CREATE TABLE "new_nats_consumers" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "streamId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "durableName" TEXT,
+    "description" TEXT,
+    "filterSubject" TEXT,
+    "deliverPolicy" TEXT NOT NULL DEFAULT 'all',
+    "ackPolicy" TEXT NOT NULL DEFAULT 'explicit',
+    "maxDeliver" INTEGER,
+    "ackWaitSeconds" INTEGER,
+    "lastAppliedAt" DATETIME,
+    "createdById" TEXT,
+    "updatedById" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "nats_consumers_streamId_fkey" FOREIGN KEY ("streamId") REFERENCES "nats_streams" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_nats_consumers" ("ackPolicy", "ackWaitSeconds", "createdAt", "createdById", "deliverPolicy", "description", "durableName", "filterSubject", "id", "lastAppliedAt", "maxDeliver", "name", "streamId", "updatedAt", "updatedById") SELECT "ackPolicy", "ackWaitSeconds", "createdAt", "createdById", "deliverPolicy", "description", "durableName", "filterSubject", "id", "lastAppliedAt", "maxDeliver", "name", "streamId", "updatedAt", "updatedById" FROM "nats_consumers";
+DROP TABLE "nats_consumers";
+ALTER TABLE "new_nats_consumers" RENAME TO "nats_consumers";
+CREATE INDEX "nats_consumers_streamId_idx" ON "nats_consumers"("streamId");
+CREATE UNIQUE INDEX "nats_consumers_streamId_name_key" ON "nats_consumers"("streamId", "name");
+CREATE TABLE "new_nats_credential_profiles" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "description" TEXT,
+    "accountId" TEXT NOT NULL,
+    "publishAllow" JSONB NOT NULL,
+    "subscribeAllow" JSONB NOT NULL,
+    "ttlSeconds" INTEGER NOT NULL DEFAULT 3600,
+    "lastAppliedAt" DATETIME,
+    "createdById" TEXT,
+    "updatedById" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "nats_credential_profiles_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "nats_accounts" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_nats_credential_profiles" ("accountId", "createdAt", "createdById", "description", "displayName", "id", "lastAppliedAt", "name", "publishAllow", "subscribeAllow", "ttlSeconds", "updatedAt", "updatedById") SELECT "accountId", "createdAt", "createdById", "description", "displayName", "id", "lastAppliedAt", "name", "publishAllow", "subscribeAllow", "ttlSeconds", "updatedAt", "updatedById" FROM "nats_credential_profiles";
+DROP TABLE "nats_credential_profiles";
+ALTER TABLE "new_nats_credential_profiles" RENAME TO "nats_credential_profiles";
+CREATE UNIQUE INDEX "nats_credential_profiles_name_key" ON "nats_credential_profiles"("name");
+CREATE INDEX "nats_credential_profiles_accountId_idx" ON "nats_credential_profiles"("accountId");
+CREATE TABLE "new_nats_state" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "kind" TEXT NOT NULL,
+    "stackId" TEXT,
+    "clientUrl" TEXT,
+    "monitorUrl" TEXT,
+    "bootstrappedAt" DATETIME,
+    "lastAppliedAt" DATETIME,
+    "operatorPublic" TEXT,
+    "systemAccountPublic" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_nats_state" ("bootstrappedAt", "clientUrl", "createdAt", "id", "kind", "lastAppliedAt", "monitorUrl", "operatorPublic", "stackId", "systemAccountPublic", "updatedAt") SELECT "bootstrappedAt", "clientUrl", "createdAt", "id", "kind", "lastAppliedAt", "monitorUrl", "operatorPublic", "stackId", "systemAccountPublic", "updatedAt" FROM "nats_state";
+DROP TABLE "nats_state";
+ALTER TABLE "new_nats_state" RENAME TO "nats_state";
+CREATE UNIQUE INDEX "nats_state_kind_key" ON "nats_state"("kind");
+CREATE TABLE "new_nats_streams" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "accountId" TEXT NOT NULL,
+    "description" TEXT,
+    "subjects" JSONB NOT NULL,
+    "retention" TEXT NOT NULL DEFAULT 'limits',
+    "storage" TEXT NOT NULL DEFAULT 'file',
+    "maxMsgs" INTEGER,
+    "maxBytes" INTEGER,
+    "maxAgeSeconds" INTEGER,
+    "lastAppliedAt" DATETIME,
+    "createdById" TEXT,
+    "updatedById" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "nats_streams_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "nats_accounts" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_nats_streams" ("accountId", "createdAt", "createdById", "description", "id", "lastAppliedAt", "maxAgeSeconds", "maxBytes", "maxMsgs", "name", "retention", "storage", "subjects", "updatedAt", "updatedById") SELECT "accountId", "createdAt", "createdById", "description", "id", "lastAppliedAt", "maxAgeSeconds", "maxBytes", "maxMsgs", "name", "retention", "storage", "subjects", "updatedAt", "updatedById" FROM "nats_streams";
+DROP TABLE "nats_streams";
+ALTER TABLE "new_nats_streams" RENAME TO "nats_streams";
+CREATE UNIQUE INDEX "nats_streams_name_key" ON "nats_streams"("name");
+CREATE INDEX "nats_streams_accountId_idx" ON "nats_streams"("accountId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE INDEX "nats_signing_keys_accountId_idx" ON "nats_signing_keys"("accountId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "nats_signing_keys_stackId_name_key" ON "nats_signing_keys"("stackId", "name");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1119,6 +1119,7 @@ model Stack {
 
   vaultResources       StackVaultResource[]
   natsResources        StackNatsResource[]
+  natsSigningKeys      NatsSigningKey[]     @relation("StackNatsSigningKey")
   egressPolicies       EgressPolicy[]
 
   @@index([environmentId])
@@ -1270,6 +1271,7 @@ model NatsAccount {
 
   credentialProfiles NatsCredentialProfile[]
   streams             NatsStream[]
+  signingKeys         NatsSigningKey[]
 
   @@index([isSystem])
   @@map("nats_accounts")
@@ -1346,6 +1348,32 @@ model NatsConsumer {
   @@unique([streamId, name])
   @@index([streamId])
   @@map("nats_consumers")
+}
+
+/// NatsSigningKey - Scoped signing keys bound to a stack via the new
+/// `nats.signers[]` template surface. The seed itself is stored in Vault KV
+/// at `seedKvPath`; this row indexes the stack-scoped binding so the
+/// destroy path can revoke + propagate cleanly. The server-side cryptographic
+/// guarantee (a JWT minted with this key cannot exceed `scopedSubject`) is
+/// enforced by NATS via the scope template embedded in the account JWT.
+model NatsSigningKey {
+  id             String      @id @default(cuid())
+  accountId      String
+  account        NatsAccount @relation(fields: [accountId], references: [id], onDelete: Cascade)
+  stackId        String
+  stack          Stack       @relation("StackNatsSigningKey", fields: [stackId], references: [id], onDelete: Cascade)
+  name           String      // template-author symbol, e.g. "worker-minter"
+  scope          String      // relative scope as declared, e.g. "agent.worker"
+  scopedSubject  String      // resolved absolute subject, e.g. "app.<stackId>.agent.worker.>"
+  publicKey      String      // for cross-checking server-side validation
+  seedKvPath     String      // shared/nats-signers/<stackId>-<name>
+  maxTtlSeconds  Int
+  createdAt      DateTime    @default(now())
+  updatedAt      DateTime    @updatedAt
+
+  @@unique([stackId, name])
+  @@index([accountId])
+  @@map("nats_signing_keys")
 }
 
 // StackService - Individual service within a stack
@@ -1543,6 +1571,15 @@ model StackTemplateVersion {
   natsStreams            Json?                       // TemplateNatsStream[]
   natsConsumers          Json?                       // TemplateNatsConsumer[]
 
+  // Phase 1 — NATS app-author surface (roles/signers/imports/exports + prefix).
+  // Persisted on the version row so apply-time orchestrator and cross-stack
+  // consumers can resolve against the latest applied snapshot.
+  natsSubjectPrefix      String?                     // e.g. "app.{{stack.id}}" or allowlisted "navi"
+  natsRoles              Json?                       // TemplateNatsRole[]
+  natsSigners            Json?                       // TemplateNatsSigner[]
+  natsExports            Json?                       // string[] — *resolved* (prefixed) export subjects
+  natsImports            Json?                       // TemplateNatsImport[]
+
   // Relations
   services               StackTemplateService[]
   configFiles            StackTemplateConfigFile[]
@@ -1580,6 +1617,12 @@ model StackTemplateService {
   natsCredentialId  String?
   natsCredential    NatsCredentialProfile? @relation("TemplateServiceNatsCredential", fields: [natsCredentialId], references: [id], onDelete: SetNull)
   natsCredentialRef String?
+  // Phase 1 — symbolic refs into nats.roles[] and nats.signers[] declared on
+  // the same StackTemplateVersion. Resolved at apply time: natsRole → bound
+  // NatsCredentialProfile (auto-prefixed); natsSigner → auto-injected
+  // NATS_SIGNER_SEED dynamicEnv. Mutually exclusive with natsCredentialRef.
+  natsRole          String?
+  natsSigner        String?
 
   @@unique([versionId, serviceName])
   @@index([versionId])

--- a/server/src/__tests__/nats-app-roles-schema.test.ts
+++ b/server/src/__tests__/nats-app-roles-schema.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Phase 1 — Zod-level coverage for the new NATS app-author surface
+ * (`roles`, `signers`, `imports`, `exports`, `subjectPrefix`).
+ *
+ * Tests both the file-loader path (templateFileSchema) and the HTTP draft
+ * path (draftVersionSchema) since they share the `validateNatsSectionShape`
+ * cross-validator and must both reject the same shapes (per `service-schema-
+ * drift.test.ts` invariant).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { templateFileSchema } from '../services/stacks/template-file-loader';
+import { draftVersionSchema } from '../services/stacks/stack-template-schemas';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function fileBody(over: Record<string, unknown>) {
+  return {
+    name: 'tpl',
+    displayName: 'Test',
+    builtinVersion: 1,
+    scope: 'environment' as const,
+    networks: [],
+    volumes: [],
+    services: [],
+    ...over,
+  };
+}
+
+function draftBody(over: Record<string, unknown>) {
+  return {
+    networks: [],
+    volumes: [],
+    services: [],
+    ...over,
+  };
+}
+
+// ─── Per-pattern escape-attempt rejection ────────────────────────────────────
+
+describe('templateNatsRoleSchema — relative subject pattern guards', () => {
+  it('rejects publish: ">" (would shadow whole prefix)', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: { roles: [{ name: 'gateway', publish: ['>'] }] },
+    }));
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects publish: "*" at root', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: { roles: [{ name: 'gateway', publish: ['*.in'] }] },
+    }));
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects subscribe: "_INBOX.>" (must use inboxAuto)', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: { roles: [{ name: 'gateway', subscribe: ['_INBOX.>'] }] },
+    }));
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects publish: "$SYS.foo"', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: { roles: [{ name: 'gateway', publish: ['$SYS.foo'] }] },
+    }));
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects publish: "agent..in" (empty token)', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: { roles: [{ name: 'gateway', publish: ['agent..in'] }] },
+    }));
+    expect(r.success).toBe(false);
+  });
+
+  it('accepts a normal relative subject', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: { roles: [{ name: 'gateway', publish: ['agent.in'], subscribe: ['agent.reply.>'] }] },
+    }));
+    expect(r.success).toBe(true);
+  });
+});
+
+// ─── Signer subjectScope guards ──────────────────────────────────────────────
+
+describe('templateNatsSignerSchema — subjectScope guards', () => {
+  it('rejects scope containing wildcards', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: { signers: [{ name: 'minter', subjectScope: 'agent.worker.>' }] },
+    }));
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects scope with empty tokens', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: { signers: [{ name: 'minter', subjectScope: 'agent..worker' }] },
+    }));
+    expect(r.success).toBe(false);
+  });
+
+  it('accepts a concrete dotted scope', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: { signers: [{ name: 'minter', subjectScope: 'agent.worker' }] },
+    }));
+    expect(r.success).toBe(true);
+  });
+});
+
+// ─── Mixing rule: legacy credentials and new roles cannot coexist ────────────
+
+describe('NATS mixing rule (legacy credentials + new roles)', () => {
+  const legacyOnly = {
+    nats: {
+      accounts: [{ name: 'app', scope: 'host' as const }],
+      credentials: [
+        {
+          name: 'app-cred',
+          account: 'app',
+          publishAllow: ['app.>'],
+          subscribeAllow: ['app.>'],
+        },
+      ],
+    },
+  };
+  const newOnly = {
+    nats: { roles: [{ name: 'gateway', publish: ['agent.in'] }] },
+  };
+  const mixed = {
+    nats: {
+      ...legacyOnly.nats,
+      roles: [{ name: 'gateway', publish: ['agent.in'] }],
+    },
+  };
+
+  it('legacy-only is accepted (file loader)', () => {
+    const r = templateFileSchema.safeParse(fileBody(legacyOnly));
+    expect(r.success).toBe(true);
+  });
+
+  it('new-only is accepted (file loader)', () => {
+    const r = templateFileSchema.safeParse(fileBody(newOnly));
+    expect(r.success).toBe(true);
+  });
+
+  it('mixed is rejected (file loader)', () => {
+    const r = templateFileSchema.safeParse(fileBody(mixed));
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const msg = r.error.issues.map((i) => i.message).join('|');
+      expect(msg).toContain('cannot be declared in the same template');
+    }
+  });
+
+  it('mixed is rejected (HTTP draft)', () => {
+    const r = draftVersionSchema.safeParse(draftBody(mixed));
+    expect(r.success).toBe(false);
+  });
+});
+
+// ─── Name uniqueness ─────────────────────────────────────────────────────────
+
+describe('NATS role/signer name uniqueness', () => {
+  it('duplicate role names rejected', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: {
+        roles: [
+          { name: 'gateway', publish: ['a.in'] },
+          { name: 'gateway', publish: ['b.in'] },
+        ],
+      },
+    }));
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const msg = r.error.issues.map((i) => i.message).join('|');
+      expect(msg).toContain('Duplicate NATS role');
+    }
+  });
+
+  it('duplicate signer names rejected', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: {
+        signers: [
+          { name: 'minter', subjectScope: 'a' },
+          { name: 'minter', subjectScope: 'b' },
+        ],
+      },
+    }));
+    expect(r.success).toBe(false);
+  });
+});
+
+// ─── imports[].forRoles must reference declared roles ────────────────────────
+
+describe('NATS imports[].forRoles role-resolution', () => {
+  it('forRoles referencing an undeclared role is rejected', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: {
+        roles: [{ name: 'watcher', subscribe: ['x.>'] }],
+        imports: [
+          { fromStack: 'producer', subjects: ['events.>'], forRoles: ['notARealRole'] },
+        ],
+      },
+    }));
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const msg = r.error.issues.map((i) => i.message).join('|');
+      expect(msg).toContain("references unknown role 'notARealRole'");
+    }
+  });
+
+  it('forRoles referencing a declared role is accepted', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: {
+        roles: [{ name: 'watcher', subscribe: ['x.>'] }],
+        imports: [
+          { fromStack: 'producer', subjects: ['events.>'], forRoles: ['watcher'] },
+        ],
+      },
+    }));
+    expect(r.success).toBe(true);
+  });
+
+  it('forRoles must be non-empty (required, per security decision)', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: {
+        roles: [{ name: 'watcher', subscribe: ['x.>'] }],
+        imports: [{ fromStack: 'producer', subjects: ['events.>'], forRoles: [] }],
+      },
+    }));
+    expect(r.success).toBe(false);
+  });
+});
+
+// ─── Service-level natsRole / natsSigner refs must resolve ───────────────────
+
+describe('service.natsRole / service.natsSigner reference resolution', () => {
+  function svc(extra: Record<string, unknown>) {
+    return {
+      serviceName: 'manager',
+      serviceType: 'Stateful' as const,
+      dockerImage: 'app',
+      dockerTag: 'latest',
+      containerConfig: {},
+      dependsOn: [],
+      order: 1,
+      ...extra,
+    };
+  }
+
+  it('natsRole referencing an undeclared role is rejected (file loader)', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      services: [svc({ natsRole: 'gateway' })],
+      nats: { roles: [{ name: 'manager-role', publish: ['x'] }] },
+    }));
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const msg = r.error.issues.map((i) => i.message).join('|');
+      expect(msg).toContain("natsRole 'gateway' references unknown role");
+    }
+  });
+
+  it('natsSigner referencing an undeclared signer is rejected (HTTP draft)', () => {
+    const r = draftVersionSchema.safeParse(draftBody({
+      services: [svc({ natsSigner: 'absent' })],
+      nats: { signers: [{ name: 'minter', subjectScope: 'a' }] },
+    }));
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const msg = r.error.issues.map((i) => i.message).join('|');
+      expect(msg).toContain("natsSigner 'absent' references unknown signer");
+    }
+  });
+
+  it('correct natsRole + natsSigner round-trip on a service', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      services: [svc({ natsRole: 'manager-role', natsSigner: 'minter' })],
+      nats: {
+        roles: [{ name: 'manager-role', publish: ['x'] }],
+        signers: [{ name: 'minter', subjectScope: 'agent.worker' }],
+      },
+    }));
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.services[0].natsRole).toBe('manager-role');
+      expect(r.data.services[0].natsSigner).toBe('minter');
+    }
+  });
+});
+
+// ─── DynamicEnvSource: nats-signer-seed parses ───────────────────────────────
+
+describe('dynamicEnvSourceSchema — nats-signer-seed', () => {
+  // Inline-import to keep the file's primary focus on the section schema.
+  it('nats-signer-seed dynamicEnv parses', async () => {
+    const { stackContainerConfigSchema } = await import('../services/stacks/schemas');
+    const r = stackContainerConfigSchema.safeParse({
+      dynamicEnv: { NATS_SIGNER_SEED: { kind: 'nats-signer-seed', signer: 'minter' } },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('nats-signer-seed with empty signer rejected', async () => {
+    const { stackContainerConfigSchema } = await import('../services/stacks/schemas');
+    const r = stackContainerConfigSchema.safeParse({
+      dynamicEnv: { NATS_SIGNER_SEED: { kind: 'nats-signer-seed', signer: '' } },
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/server/src/__tests__/nats-prefix-allowlist-route.integration.test.ts
+++ b/server/src/__tests__/nats-prefix-allowlist-route.integration.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Integration tests for the NATS subject-prefix allowlist (Phase 2).
+ *
+ * These exercise the full HTTP → service → SystemSettings round-trip plus
+ * every validation rule from the design (§2.6). The route uses CRUD-per-
+ * entry, NOT blob PUT — verified here by deletion of one entry leaving
+ * others untouched.
+ */
+
+import supertest from 'supertest';
+import express, { type Request, type Response, type NextFunction } from 'express';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { testPrisma } from './integration-test-helpers';
+
+vi.mock('../middleware/auth', () => ({
+  requirePermission: () => (req: Request, _res: Response, next: NextFunction) => {
+    (req as Request & { user?: { id: string } }).user = { id: 'session-user' };
+    next();
+  },
+}));
+
+vi.mock('../lib/prisma', () => ({ default: testPrisma }));
+
+import natsPrefixAllowlistRoutes from '../routes/nats-prefix-allowlist';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/nats/prefix-allowlist', natsPrefixAllowlistRoutes);
+  return app;
+}
+
+async function createUserTemplate(name?: string): Promise<string> {
+  const id = createId();
+  await testPrisma.stackTemplate.create({
+    data: {
+      id,
+      name: name ?? `tpl-${id.slice(0, 6)}`,
+      displayName: 'Allowlist Test Template',
+      source: 'user',
+      scope: 'environment',
+      currentVersionId: null,
+      draftVersionId: null,
+    },
+  });
+  return id;
+}
+
+describe('NATS prefix allowlist route — happy paths', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('GET / returns empty array by default', async () => {
+    const res = await supertest(buildApp()).get('/api/nats/prefix-allowlist').expect(200);
+    expect(res.body).toEqual({ success: true, data: [] });
+  });
+
+  it('POST → GET round-trips an entry (default state was empty)', async () => {
+    const tplId = await createUserTemplate();
+
+    const created = await supertest(buildApp())
+      .post('/api/nats/prefix-allowlist')
+      .send({ prefix: 'navi', allowedTemplateIds: [tplId] })
+      .expect(201);
+    expect(created.body.success).toBe(true);
+    expect(created.body.data.prefix).toBe('navi');
+    expect(created.body.data.allowedTemplateIds).toEqual([tplId]);
+
+    const list = await supertest(buildApp()).get('/api/nats/prefix-allowlist').expect(200);
+    expect(list.body.data).toHaveLength(1);
+    expect(list.body.data[0].prefix).toBe('navi');
+
+    const single = await supertest(buildApp()).get('/api/nats/prefix-allowlist/navi').expect(200);
+    expect(single.body.data.prefix).toBe('navi');
+  });
+
+  it('PUT updates allowedTemplateIds without changing prefix or createdAt', async () => {
+    const tplA = await createUserTemplate();
+    const tplB = await createUserTemplate();
+
+    const created = await supertest(buildApp())
+      .post('/api/nats/prefix-allowlist')
+      .send({ prefix: 'navi', allowedTemplateIds: [tplA] })
+      .expect(201);
+    const createdAt = created.body.data.createdAt;
+
+    const updated = await supertest(buildApp())
+      .put('/api/nats/prefix-allowlist/navi')
+      .send({ allowedTemplateIds: [tplA, tplB] })
+      .expect(200);
+    expect(updated.body.data.allowedTemplateIds).toEqual([tplA, tplB]);
+    expect(updated.body.data.createdAt).toBe(createdAt);
+  });
+
+  it('DELETE removes only the specified entry', async () => {
+    const tplA = await createUserTemplate();
+    const tplB = await createUserTemplate();
+
+    await supertest(buildApp())
+      .post('/api/nats/prefix-allowlist')
+      .send({ prefix: 'navi', allowedTemplateIds: [tplA] })
+      .expect(201);
+    await supertest(buildApp())
+      .post('/api/nats/prefix-allowlist')
+      .send({ prefix: 'platform-events', allowedTemplateIds: [tplB] })
+      .expect(201);
+
+    await supertest(buildApp()).delete('/api/nats/prefix-allowlist/navi').expect(200);
+
+    const list = await supertest(buildApp()).get('/api/nats/prefix-allowlist').expect(200);
+    expect(list.body.data).toHaveLength(1);
+    expect(list.body.data[0].prefix).toBe('platform-events');
+  });
+
+  it('DELETE on a missing prefix returns 404', async () => {
+    await supertest(buildApp()).delete('/api/nats/prefix-allowlist/nope').expect(404);
+  });
+
+  it('GET on a missing prefix returns 404', async () => {
+    await supertest(buildApp()).get('/api/nats/prefix-allowlist/nope').expect(404);
+  });
+});
+
+describe('NATS prefix allowlist route — validation rejection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects empty prefix', async () => {
+    await supertest(buildApp())
+      .post('/api/nats/prefix-allowlist')
+      .send({ prefix: '', allowedTemplateIds: ['tpl1'] })
+      .expect(400);
+  });
+
+  it.each([
+    ['contains >', 'navi.>'],
+    ['contains *', 'navi.*'],
+    ['leading dot', '.navi'],
+    ['trailing dot', 'navi.'],
+    ['starts with $SYS.', '$SYS.foo'],
+    ['equals $SYS', '$SYS'],
+    ['has empty token', 'navi..foo'],
+  ])('rejects prefix that %s', async (_label, prefix) => {
+    const tpl = await createUserTemplate();
+    const res = await supertest(buildApp())
+      .post('/api/nats/prefix-allowlist')
+      .send({ prefix, allowedTemplateIds: [tpl] });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects empty allowedTemplateIds', async () => {
+    const res = await supertest(buildApp())
+      .post('/api/nats/prefix-allowlist')
+      .send({ prefix: 'navi', allowedTemplateIds: [] });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects allowedTemplateIds that reference a nonexistent template', async () => {
+    const res = await supertest(buildApp())
+      .post('/api/nats/prefix-allowlist')
+      .send({ prefix: 'navi', allowedTemplateIds: ['does-not-exist'] });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/unknown template/);
+  });
+
+  it('rejects an entry whose prefix is a strict ancestor of an existing entry', async () => {
+    const tpl = await createUserTemplate();
+    await supertest(buildApp())
+      .post('/api/nats/prefix-allowlist')
+      .send({ prefix: 'events.platform', allowedTemplateIds: [tpl] })
+      .expect(201);
+
+    const res = await supertest(buildApp())
+      .post('/api/nats/prefix-allowlist')
+      .send({ prefix: 'events', allowedTemplateIds: [tpl] });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/overlap/);
+  });
+
+  it('rejects an entry whose prefix is a strict descendant of an existing entry', async () => {
+    const tpl = await createUserTemplate();
+    await supertest(buildApp())
+      .post('/api/nats/prefix-allowlist')
+      .send({ prefix: 'events', allowedTemplateIds: [tpl] })
+      .expect(201);
+
+    const res = await supertest(buildApp())
+      .post('/api/nats/prefix-allowlist')
+      .send({ prefix: 'events.platform', allowedTemplateIds: [tpl] });
+    expect(res.status).toBe(409);
+  });
+
+  it('rejects creating a duplicate prefix', async () => {
+    const tpl = await createUserTemplate();
+    await supertest(buildApp())
+      .post('/api/nats/prefix-allowlist')
+      .send({ prefix: 'navi', allowedTemplateIds: [tpl] })
+      .expect(201);
+
+    const res = await supertest(buildApp())
+      .post('/api/nats/prefix-allowlist')
+      .send({ prefix: 'navi', allowedTemplateIds: [tpl] });
+    expect(res.status).toBe(409);
+  });
+
+  it('PUT rejects allowedTemplateIds that reference a nonexistent template', async () => {
+    const tpl = await createUserTemplate();
+    await supertest(buildApp())
+      .post('/api/nats/prefix-allowlist')
+      .send({ prefix: 'navi', allowedTemplateIds: [tpl] })
+      .expect(201);
+
+    const res = await supertest(buildApp())
+      .put('/api/nats/prefix-allowlist/navi')
+      .send({ allowedTemplateIds: ['does-not-exist'] });
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT on a missing prefix returns 404', async () => {
+    const tpl = await createUserTemplate();
+    const res = await supertest(buildApp())
+      .put('/api/nats/prefix-allowlist/nope')
+      .send({ allowedTemplateIds: [tpl] });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects duplicate templateIds in allowedTemplateIds', async () => {
+    const tpl = await createUserTemplate();
+    const res = await supertest(buildApp())
+      .post('/api/nats/prefix-allowlist')
+      .send({ prefix: 'navi', allowedTemplateIds: [tpl, tpl] });
+    expect(res.status).toBe(400);
+  });
+});

--- a/server/src/__tests__/service-schema-drift.test.ts
+++ b/server/src/__tests__/service-schema-drift.test.ts
@@ -61,6 +61,9 @@ const COMMON_FIELDS = [
   'order',
   'routing',
   'vaultAppRoleRef',
+  'natsCredentialRef',
+  'natsRole',
+  'natsSigner',
 ] as const;
 
 // Every key in COMMON_FIELDS must also be a key of the shared base. If

--- a/server/src/__tests__/stack-nats-apply-orchestrator-imports.integration.test.ts
+++ b/server/src/__tests__/stack-nats-apply-orchestrator-imports.integration.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Integration tests for Phase 5 — cross-stack imports/exports in
+ * `runStackNatsApplyPhase`.
+ *
+ * Coverage:
+ *   - Producer applies with `nats.exports[]` → resolved (prefixed) exports
+ *     land in `lastAppliedNatsSnapshot`.
+ *   - Consumer with `nats.imports[]` → matching subject lands on the
+ *     `forRoles` role's subscribeAllow (and ONLY those roles, per design).
+ *   - Producer not yet applied → consumer apply fails clean.
+ *   - Producer doesn't export a matching pattern → consumer apply fails clean.
+ *   - Self-import (consumer === producer) → rejected.
+ *   - Subject-pattern matcher unit checks (>, *, equality, mismatch).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { testPrisma } from './integration-test-helpers';
+
+vi.mock('../services/nats/nats-control-plane-service', async (orig) => {
+  const real = await orig<typeof import('../services/nats/nats-control-plane-service')>();
+  return {
+    ...real,
+    getNatsControlPlaneService: (db: unknown) => ({
+      getStatus: async () => ({ configured: true }),
+      ensureDefaultAccount: async () => {
+        const prisma = db as typeof testPrisma;
+        const existing = await prisma.natsAccount.findUnique({ where: { name: 'default' } });
+        if (existing) return { id: existing.id, name: existing.name, isSystem: true };
+        const created = await prisma.natsAccount.create({
+          data: {
+            name: 'default',
+            displayName: 'Default',
+            isSystem: true,
+            seedKvPath: 'shared/nats-default',
+          },
+        });
+        return { id: created.id, name: created.name, isSystem: true };
+      },
+      applyConfig: async () => undefined,
+      applyJetStreamResources: async () => undefined,
+    }),
+  };
+});
+
+import {
+  runStackNatsApplyPhase,
+  __testing,
+} from '../services/stacks/stack-nats-apply-orchestrator';
+
+interface SeedStackInput {
+  natsRoles?: unknown;
+  natsExports?: unknown;
+  natsImports?: unknown;
+  natsSubjectPrefix?: string | null;
+  templateName?: string;
+  stackName?: string;
+}
+
+async function seedStack(input: SeedStackInput): Promise<{ stackId: string; templateId: string }> {
+  const templateId = createId();
+  const stackId = createId();
+  const versionId = createId();
+
+  await testPrisma.stackTemplate.create({
+    data: {
+      id: templateId,
+      name: input.templateName ?? `tpl-${templateId.slice(0, 6)}`,
+      displayName: 'Phase 5 test template',
+      source: 'user',
+      scope: 'host',
+    },
+  });
+  await testPrisma.stackTemplateVersion.create({
+    data: {
+      id: versionId,
+      templateId,
+      version: 1,
+      status: 'published',
+      parameters: [],
+      defaultParameterValues: {},
+      networkTypeDefaults: {},
+      networks: [],
+      volumes: [],
+      natsRoles: input.natsRoles ?? null,
+      natsExports: input.natsExports ?? null,
+      natsImports: input.natsImports ?? null,
+      natsSubjectPrefix: input.natsSubjectPrefix ?? null,
+    },
+  });
+  await testPrisma.stack.create({
+    data: {
+      id: stackId,
+      name: input.stackName ?? `stack-${stackId.slice(0, 6)}`,
+      version: 1,
+      networks: [],
+      volumes: [],
+      templateId,
+      templateVersion: 1,
+      lastAppliedVersion: 1,
+    },
+  });
+  return { stackId, templateId };
+}
+
+// ─── Subject matcher unit checks ─────────────────────────────────────────────
+
+describe('Phase 5 — natsSubjectMatches', () => {
+  const m = __testing.natsSubjectMatches;
+
+  it('exact match', () => expect(m('a.b.c', 'a.b.c')).toBe(true));
+  it('exact mismatch', () => expect(m('a.b.c', 'a.b.d')).toBe(false));
+  it('* matches one token', () => expect(m('a.*.c', 'a.b.c')).toBe(true));
+  it('* does not match two tokens', () => expect(m('a.*.c', 'a.b.x.c')).toBe(false));
+  it('> matches one or more tail tokens', () => expect(m('a.>', 'a.b')).toBe(true));
+  it('> matches multi-token tail', () => expect(m('a.>', 'a.b.c.d')).toBe(true));
+  it('> does not match shorter subject', () => expect(m('a.>', 'a')).toBe(false));
+  it('> only valid at end (treats midway as no-match)', () =>
+    expect(m('a.>.c', 'a.b.c')).toBe(false));
+  it('subject longer than pattern without > → no match', () =>
+    expect(m('a.b', 'a.b.c')).toBe(false));
+});
+
+// ─── Cross-stack apply flow ──────────────────────────────────────────────────
+
+describe('runStackNatsApplyPhase — Phase 5 imports/exports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('producer apply writes resolved exports to lastAppliedNatsSnapshot', async () => {
+    const { stackId } = await seedStack({
+      natsRoles: [{ name: 'gateway', publish: ['x'] }],
+      natsExports: ['events.>'],
+      stackName: `producer-${Date.now()}`,
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('applied');
+    const stack = await testPrisma.stack.findUnique({ where: { id: stackId } });
+    const snap = JSON.parse(stack!.lastAppliedNatsSnapshot!);
+    expect(snap.subjectPrefix).toBe(`app.${stackId}`);
+    expect(snap.resolvedExports).toEqual([`app.${stackId}.events.>`]);
+  });
+
+  it('consumer import lands on only the forRoles role and is absolute (producer-prefixed)', async () => {
+    const producer = await seedStack({
+      natsRoles: [{ name: 'pub', publish: ['x'] }],
+      natsExports: ['events.>'],
+      stackName: `producer-imp-${Date.now()}`,
+    });
+    await runStackNatsApplyPhase(testPrisma, producer.stackId, { triggeredBy: undefined });
+
+    const producerName = (await testPrisma.stack.findUnique({ where: { id: producer.stackId } }))!.name;
+
+    const consumer = await seedStack({
+      natsRoles: [
+        { name: 'watcher', subscribe: ['internal'] },
+        { name: 'admin', subscribe: ['internal'] },
+      ],
+      natsImports: [{ fromStack: producerName, subjects: ['events.foo'], forRoles: ['watcher'] }],
+      stackName: `consumer-${Date.now()}`,
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, consumer.stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('applied');
+
+    const watcherProfile = await testPrisma.natsCredentialProfile.findFirst({
+      where: { name: { contains: 'watcher' } },
+    });
+    const adminProfile = await testPrisma.natsCredentialProfile.findFirst({
+      where: { name: { contains: 'admin' } },
+    });
+    const watcherSub = watcherProfile!.subscribeAllow as unknown as string[];
+    const adminSub = adminProfile!.subscribeAllow as unknown as string[];
+
+    // watcher gets the imported subject (absolute, producer-prefixed).
+    expect(watcherSub).toContain(`app.${producer.stackId}.events.foo`);
+    // admin does NOT get it — per-role binding only.
+    expect(adminSub).not.toContain(`app.${producer.stackId}.events.foo`);
+  });
+
+  it('consumer can also import a wildcard pattern that the producer exported', async () => {
+    const producer = await seedStack({
+      natsRoles: [{ name: 'pub', publish: ['x'] }],
+      natsExports: ['events.>'],
+      stackName: `producer-wild-${Date.now()}`,
+    });
+    await runStackNatsApplyPhase(testPrisma, producer.stackId, { triggeredBy: undefined });
+
+    const producerName = (await testPrisma.stack.findUnique({ where: { id: producer.stackId } }))!.name;
+    const consumer = await seedStack({
+      natsRoles: [{ name: 'watcher', subscribe: ['x'] }],
+      natsImports: [{ fromStack: producerName, subjects: ['events.>'], forRoles: ['watcher'] }],
+      stackName: `consumer-wild-${Date.now()}`,
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, consumer.stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('applied');
+
+    const profile = await testPrisma.natsCredentialProfile.findFirst({
+      where: { name: { contains: 'watcher' } },
+    });
+    const sub = profile!.subscribeAllow as unknown as string[];
+    expect(sub).toContain(`app.${producer.stackId}.events.>`);
+  });
+
+  it('producer not applied → consumer apply fails clean', async () => {
+    const producer = await seedStack({
+      natsExports: ['events.>'],
+      stackName: `producer-unapplied-${Date.now()}`,
+    });
+    // NOTE: producer is intentionally not applied
+    const producerName = (await testPrisma.stack.findUnique({ where: { id: producer.stackId } }))!.name;
+
+    const consumer = await seedStack({
+      natsRoles: [{ name: 'watcher', subscribe: ['x'] }],
+      natsImports: [{ fromStack: producerName, subjects: ['events.foo'], forRoles: ['watcher'] }],
+      stackName: `consumer-noapply-${Date.now()}`,
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, consumer.stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/no applied NATS snapshot|did not export any subjects/);
+  });
+
+  it('producer does not export a matching pattern → consumer apply fails with structured error', async () => {
+    const producer = await seedStack({
+      natsRoles: [{ name: 'pub', publish: ['x'] }],
+      natsExports: ['metrics.>'],  // exports metrics, not events
+      stackName: `producer-mismatch-${Date.now()}`,
+    });
+    await runStackNatsApplyPhase(testPrisma, producer.stackId, { triggeredBy: undefined });
+
+    const producerName = (await testPrisma.stack.findUnique({ where: { id: producer.stackId } }))!.name;
+    const consumer = await seedStack({
+      natsRoles: [{ name: 'watcher', subscribe: ['x'] }],
+      natsImports: [{ fromStack: producerName, subjects: ['events.foo'], forRoles: ['watcher'] }],
+      stackName: `consumer-mismatch-${Date.now()}`,
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, consumer.stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/does not match any export/);
+  });
+
+  it('non-existent producer → consumer apply fails clean', async () => {
+    const consumer = await seedStack({
+      natsRoles: [{ name: 'watcher', subscribe: ['x'] }],
+      natsImports: [{ fromStack: 'no-such-stack', subjects: ['events.foo'], forRoles: ['watcher'] }],
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, consumer.stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/not found/);
+  });
+
+  it('a stack can both export AND import in the same apply (mixed producer+consumer)', async () => {
+    // Producer A exports events.>; consumer B imports from A AND also
+    // exports its own metrics.>; consumer C imports from B's metrics.
+    // Verifies the resolved-exports + imports paths run together cleanly
+    // for a stack acting as both endpoints.
+    const aProducer = await seedStack({
+      natsRoles: [{ name: 'pub', publish: ['x'] }],
+      natsExports: ['events.>'],
+      stackName: `chain-a-${Date.now()}`,
+    });
+    await runStackNatsApplyPhase(testPrisma, aProducer.stackId, { triggeredBy: undefined });
+    const aName = (await testPrisma.stack.findUnique({ where: { id: aProducer.stackId } }))!.name;
+
+    const bMixed = await seedStack({
+      natsRoles: [{ name: 'watcher', subscribe: ['internal'] }],
+      natsImports: [{ fromStack: aName, subjects: ['events.foo'], forRoles: ['watcher'] }],
+      natsExports: ['metrics.>'],
+      stackName: `chain-b-${Date.now()}`,
+    });
+    const bResult = await runStackNatsApplyPhase(testPrisma, bMixed.stackId, { triggeredBy: undefined });
+    expect(bResult.status).toBe('applied');
+
+    const bSnap = JSON.parse(
+      (await testPrisma.stack.findUnique({ where: { id: bMixed.stackId } }))!.lastAppliedNatsSnapshot!,
+    );
+    // B's own export landed in its snapshot.
+    expect(bSnap.resolvedExports).toEqual([`app.${bMixed.stackId}.metrics.>`]);
+    // B's watcher role gets A's events.foo on subscribe (absolute, A-prefixed).
+    const bWatcherProfile = await testPrisma.natsCredentialProfile.findFirst({
+      where: { name: { contains: 'watcher' } },
+    });
+    const bSub = bWatcherProfile!.subscribeAllow as unknown as string[];
+    expect(bSub).toContain(`app.${aProducer.stackId}.events.foo`);
+
+    // A third stack C imports from B's metrics — verifies B's resolvedExports
+    // is consumable by another stack.
+    const bName = (await testPrisma.stack.findUnique({ where: { id: bMixed.stackId } }))!.name;
+    const cConsumer = await seedStack({
+      natsRoles: [{ name: 'metrics-watcher', subscribe: ['x'] }],
+      natsImports: [
+        { fromStack: bName, subjects: ['metrics.cpu'], forRoles: ['metrics-watcher'] },
+      ],
+      stackName: `chain-c-${Date.now()}`,
+    });
+    const cResult = await runStackNatsApplyPhase(testPrisma, cConsumer.stackId, { triggeredBy: undefined });
+    expect(cResult.status).toBe('applied');
+    const cWatcherProfile = await testPrisma.natsCredentialProfile.findFirst({
+      where: { name: { contains: 'metrics-watcher' } },
+    });
+    const cSub = cWatcherProfile!.subscribeAllow as unknown as string[];
+    expect(cSub).toContain(`app.${bMixed.stackId}.metrics.cpu`);
+  });
+
+  it('imports[].forRoles referencing an undeclared role → apply fails (defense in depth)', async () => {
+    const producer = await seedStack({
+      natsRoles: [{ name: 'pub', publish: ['x'] }],
+      natsExports: ['events.>'],
+      stackName: `producer-bad-forroles-${Date.now()}`,
+    });
+    await runStackNatsApplyPhase(testPrisma, producer.stackId, { triggeredBy: undefined });
+
+    const producerName = (await testPrisma.stack.findUnique({ where: { id: producer.stackId } }))!.name;
+    const consumer = await seedStack({
+      // Note: declares no roles, but imports[].forRoles references one.
+      natsRoles: [{ name: 'watcher', subscribe: ['x'] }],
+      natsImports: [{ fromStack: producerName, subjects: ['events.foo'], forRoles: ['notARealRole'] }],
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, consumer.stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/undeclared role/);
+  });
+});

--- a/server/src/__tests__/stack-nats-apply-orchestrator-roles.integration.test.ts
+++ b/server/src/__tests__/stack-nats-apply-orchestrator-roles.integration.test.ts
@@ -1,0 +1,452 @@
+/**
+ * Integration tests for Phase 3 — role materialization in
+ * `runStackNatsApplyPhase`. The control-plane service is mocked because we
+ * don't want to talk to a real NATS server in unit/integration suite, but
+ * everything else (Prisma writes, allowlist read, prefix resolution,
+ * template engine) is real.
+ *
+ * What's covered:
+ *   - Default prefix `app.<stack.id>` materializes roles with prefixed perms
+ *   - `inboxAuto: 'both' | 'reply' | 'request' | 'none'` injects `_INBOX.>`
+ *     in the right list(s)
+ *   - Service `natsRole` resolves to the materialized NatsCredentialProfile
+ *   - Non-default prefix without an allowlist entry → apply fails
+ *   - Non-default prefix WITH an allowlist entry → apply succeeds
+ *   - Two stacks with overlapping role names get distinct profiles + prefixes
+ *   - Legacy `nats.credentials` path still works unchanged
+ *   - Defense-in-depth: a corrupted (escape-pattern) role permission stored
+ *     in the DB is rejected at apply
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { testPrisma } from './integration-test-helpers';
+
+// Mock the NATS control plane: tests don't need a live server. We only care
+// about what gets written to Prisma.
+vi.mock('../services/nats/nats-control-plane-service', async (orig) => {
+  const real = await orig<typeof import('../services/nats/nats-control-plane-service')>();
+  return {
+    ...real,
+    getNatsControlPlaneService: (db: unknown) => ({
+      getStatus: async () => ({ configured: true }),
+      ensureDefaultAccount: async () => {
+        // Use the test prisma's record if it exists; else create one.
+        const prisma = db as typeof testPrisma;
+        const existing = await prisma.natsAccount.findUnique({ where: { name: 'default' } });
+        if (existing) return { id: existing.id, name: existing.name, isSystem: true };
+        const created = await prisma.natsAccount.create({
+          data: {
+            name: 'default',
+            displayName: 'Default',
+            isSystem: true,
+            seedKvPath: 'shared/nats-default',
+          },
+        });
+        return { id: created.id, name: created.name, isSystem: true };
+      },
+      applyConfig: async () => undefined,
+      applyJetStreamResources: async () => undefined,
+    }),
+  };
+});
+
+import { runStackNatsApplyPhase } from '../services/stacks/stack-nats-apply-orchestrator';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+interface SeedStackInput {
+  natsRoles?: unknown;
+  natsSubjectPrefix?: string | null;
+  natsCredentials?: unknown;
+  natsAccounts?: unknown;
+  serviceNatsRole?: string | null;
+  serviceNatsCredentialRef?: string | null;
+  templateName?: string;
+  stackName?: string;
+}
+
+async function seedStack(input: SeedStackInput): Promise<{ stackId: string; templateId: string; serviceId: string }> {
+  const templateId = createId();
+  const stackId = createId();
+  const versionId = createId();
+  const serviceId = createId();
+
+  await testPrisma.stackTemplate.create({
+    data: {
+      id: templateId,
+      name: input.templateName ?? `tpl-${templateId.slice(0, 6)}`,
+      displayName: 'Phase 3 test template',
+      source: 'user',
+      scope: 'host',
+    },
+  });
+  await testPrisma.stackTemplateVersion.create({
+    data: {
+      id: versionId,
+      templateId,
+      version: 1,
+      status: 'published',
+      parameters: [],
+      defaultParameterValues: {},
+      networkTypeDefaults: {},
+      networks: [],
+      volumes: [],
+      natsAccounts: input.natsAccounts ?? null,
+      natsCredentials: input.natsCredentials ?? null,
+      natsRoles: input.natsRoles ?? null,
+      natsSubjectPrefix: input.natsSubjectPrefix ?? null,
+    },
+  });
+  await testPrisma.stackTemplateService.create({
+    data: {
+      versionId,
+      serviceName: 'manager',
+      serviceType: 'Stateful',
+      dockerImage: 'app',
+      dockerTag: 'latest',
+      containerConfig: {},
+      dependsOn: [],
+      order: 0,
+      natsRole: input.serviceNatsRole ?? null,
+      natsCredentialRef: input.serviceNatsCredentialRef ?? null,
+    },
+  });
+  await testPrisma.stack.create({
+    data: {
+      id: stackId,
+      name: input.stackName ?? `stack-${stackId.slice(0, 6)}`,
+      version: 1,
+      networks: [],
+      volumes: [],
+      templateId,
+      templateVersion: 1,
+      lastAppliedVersion: 1,
+      services: {
+        create: {
+          id: serviceId,
+          serviceName: 'manager',
+          serviceType: 'Stateful',
+          dockerImage: 'app',
+          dockerTag: 'latest',
+          containerConfig: {},
+          configFiles: [],
+          dependsOn: [],
+          order: 0,
+        },
+      },
+    },
+  });
+  return { stackId, templateId, serviceId };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('runStackNatsApplyPhase — Phase 3 role materialization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('default prefix `app.<stackId>` is auto-applied; role permissions are prefix-prepended', async () => {
+    const { stackId } = await seedStack({
+      natsRoles: [
+        {
+          name: 'gateway',
+          publish: ['agent.in'],
+          subscribe: ['slack.api'],
+          inboxAuto: 'both',
+        },
+      ],
+      serviceNatsRole: 'gateway',
+    });
+
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: 'test-user' });
+    expect(result.status).toBe('applied');
+
+    const profile = await testPrisma.natsCredentialProfile.findFirst({
+      where: { name: { contains: 'gateway' } },
+    });
+    expect(profile).not.toBeNull();
+    const expectedPrefix = `app.${stackId}`;
+    expect(profile!.publishAllow).toEqual([`${expectedPrefix}.agent.in`, '_INBOX.>']);
+    expect(profile!.subscribeAllow).toEqual([`${expectedPrefix}.slack.api`, '_INBOX.>']);
+  });
+
+  it('service.natsRole binds the materialized credential profile', async () => {
+    const { stackId, serviceId } = await seedStack({
+      natsRoles: [{ name: 'gateway', publish: ['x'] }],
+      serviceNatsRole: 'gateway',
+    });
+
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: 'test-user' });
+    expect(result.status).toBe('applied');
+    expect(result.servicesBound).toBe(1);
+
+    const svc = await testPrisma.stackService.findUnique({ where: { id: serviceId } });
+    expect(svc!.natsCredentialId).not.toBeNull();
+    const profile = await testPrisma.natsCredentialProfile.findUnique({
+      where: { id: svc!.natsCredentialId! },
+    });
+    expect(profile!.name).toContain('gateway');
+  });
+
+  it.each([
+    ['both', { pubInbox: true, subInbox: true }],
+    ['reply', { pubInbox: true, subInbox: false }],
+    ['request', { pubInbox: false, subInbox: true }],
+    ['none', { pubInbox: false, subInbox: false }],
+  ])('inboxAuto=%s injects _INBOX.> correctly', async (inboxAuto, expected) => {
+    const { stackId } = await seedStack({
+      natsRoles: [
+        { name: 'gateway', publish: ['agent.in'], subscribe: ['slack.api'], inboxAuto },
+      ],
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: null as never });
+    expect(result.status).toBe('applied');
+
+    const profile = await testPrisma.natsCredentialProfile.findFirst({
+      where: { name: { contains: 'gateway' } },
+    });
+    const pub = profile!.publishAllow as unknown as string[];
+    const sub = profile!.subscribeAllow as unknown as string[];
+    expect(pub.includes('_INBOX.>')).toBe(expected.pubInbox);
+    expect(sub.includes('_INBOX.>')).toBe(expected.subInbox);
+  });
+
+  it('two stacks with the same role name get distinct profiles with non-overlapping prefixes', async () => {
+    const a = await seedStack({
+      natsRoles: [{ name: 'gateway', publish: ['x'] }],
+      stackName: `stack-a-${Date.now()}`,
+    });
+    const b = await seedStack({
+      natsRoles: [{ name: 'gateway', publish: ['x'] }],
+      stackName: `stack-b-${Date.now()}`,
+    });
+
+    await runStackNatsApplyPhase(testPrisma, a.stackId, { triggeredBy: undefined });
+    await runStackNatsApplyPhase(testPrisma, b.stackId, { triggeredBy: undefined });
+
+    const profileA = await testPrisma.natsCredentialProfile.findFirst({
+      where: { name: { contains: a.stackId.slice(0, 8).toLowerCase() } },
+    });
+    const profileB = await testPrisma.natsCredentialProfile.findFirst({
+      where: { name: { contains: b.stackId.slice(0, 8).toLowerCase() } },
+    });
+    expect(profileA).not.toBeNull();
+    expect(profileB).not.toBeNull();
+    expect(profileA!.id).not.toBe(profileB!.id);
+    const pubA = profileA!.publishAllow as unknown as string[];
+    const pubB = profileB!.publishAllow as unknown as string[];
+    expect(pubA[0]).toContain(`app.${a.stackId}`);
+    expect(pubB[0]).toContain(`app.${b.stackId}`);
+    expect(pubA[0]).not.toBe(pubB[0]);
+  });
+});
+
+describe('runStackNatsApplyPhase — Phase 3 prefix allowlist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('non-default subjectPrefix without an allowlist entry → apply fails with structured error', async () => {
+    const { stackId } = await seedStack({
+      natsSubjectPrefix: 'navi-no-allowlist',
+      natsRoles: [{ name: 'gateway', publish: ['x'] }],
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('allowlist');
+  });
+
+  it('non-default subjectPrefix WITH an allowlist entry that names this template → succeeds', async () => {
+    const { stackId, templateId } = await seedStack({
+      natsSubjectPrefix: 'navi-allowlisted',
+      natsRoles: [{ name: 'gateway', publish: ['x'] }],
+    });
+    await testPrisma.systemSettings.create({
+      data: {
+        category: 'nats-prefix-allowlist',
+        key: 'navi-allowlisted',
+        value: JSON.stringify({ allowedTemplateIds: [templateId] }),
+        isEncrypted: false,
+        isActive: true,
+        createdBy: 'test',
+        updatedBy: 'test',
+      },
+    });
+
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('applied');
+
+    const profile = await testPrisma.natsCredentialProfile.findFirst({
+      where: { name: { contains: 'gateway' } },
+    });
+    const pub = profile!.publishAllow as unknown as string[];
+    expect(pub[0]).toBe('navi-allowlisted.x');
+  });
+
+  it('non-default subjectPrefix WITH allowlist entry that does NOT name this template → fails', async () => {
+    const { stackId } = await seedStack({
+      natsSubjectPrefix: 'navi-other-template',
+      natsRoles: [{ name: 'gateway', publish: ['x'] }],
+    });
+    // Allowlist entry exists but for a different template ID.
+    await testPrisma.systemSettings.create({
+      data: {
+        category: 'nats-prefix-allowlist',
+        key: 'navi-other-template',
+        value: JSON.stringify({ allowedTemplateIds: ['some-other-template-id'] }),
+        isEncrypted: false,
+        isActive: true,
+        createdBy: 'test',
+        updatedBy: 'test',
+      },
+    });
+
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('not in its allowedTemplateIds');
+  });
+});
+
+describe('runStackNatsApplyPhase — Phase 3 escape-pattern defense in depth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects a role.publish entry that escapes the prefix even if it slipped past validation', async () => {
+    // Simulate corrupted DB state: role with `>` that the validator should
+    // have caught earlier. Apply must reject defensively rather than emit
+    // a permission that shadows the prefix.
+    const { stackId } = await seedStack({
+      natsRoles: [{ name: 'gateway', publish: ['>'] }],
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/escapes the prefix/);
+  });
+
+  it('rejects a role.subscribe entry that targets _INBOX.> directly', async () => {
+    const { stackId } = await seedStack({
+      natsRoles: [{ name: 'gateway', subscribe: ['_INBOX.foo'] }],
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('_INBOX');
+  });
+
+  it('rejects a corrupt subjectPrefix containing wildcards', async () => {
+    const { stackId } = await seedStack({
+      natsSubjectPrefix: 'broken.*',
+      natsRoles: [{ name: 'gateway', publish: ['x'] }],
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('subjectPrefix');
+  });
+});
+
+describe('runStackNatsApplyPhase — Phase 3 legacy passthrough', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('templates using only legacy `nats.credentials` still bind correctly', async () => {
+    const accountName = `legacy-acct-${Date.now()}`;
+    const credName = `legacy-cred-${Date.now()}`;
+    const { stackId, serviceId } = await seedStack({
+      natsAccounts: [{ name: accountName, scope: 'host' }],
+      natsCredentials: [
+        {
+          name: credName,
+          account: accountName,
+          publishAllow: ['legacy.>'],
+          subscribeAllow: ['legacy.>'],
+          scope: 'host',
+        },
+      ],
+      serviceNatsCredentialRef: credName,
+    });
+
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: 'test-user' });
+    expect(result.status).toBe('applied');
+    expect(result.servicesBound).toBe(1);
+
+    const svc = await testPrisma.stackService.findUnique({ where: { id: serviceId } });
+    expect(svc!.natsCredentialId).not.toBeNull();
+    const profile = await testPrisma.natsCredentialProfile.findUnique({
+      where: { id: svc!.natsCredentialId! },
+    });
+    expect(profile!.publishAllow).toEqual(['legacy.>']);
+  });
+
+  it('an empty NATS section returns "skipped"', async () => {
+    const { stackId } = await seedStack({});
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('skipped');
+  });
+});
+
+describe('runStackNatsApplyPhase — Phase 3 reviewer-flagged gaps', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('a service with both natsRole and natsCredentialRef set prefers the role binding', async () => {
+    // The Phase 1 validator rejects mixed templates, but the orchestrator
+    // also has a defense-in-depth preference: role wins over credentialRef
+    // if both are somehow set. This test pins that behavior.
+    const accountName = `dual-acct-${Date.now()}`;
+    const credName = `dual-cred-${Date.now()}`;
+    const { stackId, serviceId } = await seedStack({
+      // Both surfaces declared (corrupt-template scenario)
+      natsAccounts: [{ name: accountName, scope: 'host' }],
+      natsCredentials: [
+        {
+          name: credName,
+          account: accountName,
+          publishAllow: ['legacy.>'],
+          subscribeAllow: ['legacy.>'],
+          scope: 'host',
+        },
+      ],
+      natsRoles: [{ name: 'gateway', publish: ['agent.in'] }],
+      serviceNatsRole: 'gateway',
+      serviceNatsCredentialRef: credName,
+    });
+
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('applied');
+
+    const svc = await testPrisma.stackService.findUnique({ where: { id: serviceId } });
+    const profile = await testPrisma.natsCredentialProfile.findUnique({
+      where: { id: svc!.natsCredentialId! },
+    });
+    // Role-derived profile wins. Permissions are prefix-prepended, not the
+    // bare 'legacy.>' from the legacy credential.
+    const pub = profile!.publishAllow as unknown as string[];
+    expect(pub.some((s) => s.endsWith('.agent.in'))).toBe(true);
+    expect(pub.some((s) => s === 'legacy.>')).toBe(false);
+  });
+
+  it('credentialsMapped counts both legacy creds and role-materialized profiles', async () => {
+    const { stackId } = await seedStack({
+      natsRoles: [
+        { name: 'a', publish: ['x'] },
+        { name: 'b', publish: ['y'] },
+      ],
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('applied');
+    expect(result.credentialsMapped).toBe(2);
+  });
+
+  it('rejects a relative subject containing empty tokens (..) at apply time', async () => {
+    const { stackId } = await seedStack({
+      natsRoles: [{ name: 'gateway', publish: ['agent..in'] }],
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/empty tokens/);
+  });
+});

--- a/server/src/__tests__/stack-templates-draft-route-nats.integration.test.ts
+++ b/server/src/__tests__/stack-templates-draft-route-nats.integration.test.ts
@@ -1,0 +1,227 @@
+/**
+ * HTTP regression test for POST /api/stack-templates/:templateId/draft —
+ * Phase 1 NATS app-roles surface (`natsRole`, `natsSigner`, plus the new
+ * version-level `subjectPrefix`/`roles`/`signers`/`exports`/`imports` fields).
+ *
+ * Mirrors the `vaultAppRoleRef` regression test (see
+ * `stack-templates-draft-route.integration.test.ts`). A reviewer flagged that
+ * `toTemplateServiceCreate`, `serializeTemplateService`, `buildNatsSection`,
+ * and `upsertBuiltinTemplate` were all silently dropping these fields on the
+ * way to / from Prisma — the exact same bug class as `vaultAppRoleRef`. These
+ * tests post a real body via supertest and assert the columns are persisted
+ * AND echoed back through the GET path.
+ */
+
+import supertest from 'supertest';
+import express, { type Request, type Response, type NextFunction } from 'express';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { testPrisma } from './integration-test-helpers';
+
+vi.mock('../middleware/auth', () => ({
+  requirePermission: () => (req: Request, _res: Response, next: NextFunction) => {
+    (req as Request & { user?: { id: string } }).user = { id: 'session-user' };
+    next();
+  },
+}));
+
+vi.mock('../lib/prisma', () => ({ default: testPrisma }));
+
+import stackTemplateRouter from '../routes/stack-templates';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/stack-templates', stackTemplateRouter);
+  return app;
+}
+
+async function createUserTemplateRow(): Promise<string> {
+  const templateId = createId();
+  await testPrisma.stackTemplate.create({
+    data: {
+      id: templateId,
+      name: `tpl-${templateId.slice(0, 6)}`,
+      displayName: 'NATS Draft Route Test Template',
+      source: 'user',
+      scope: 'environment',
+      currentVersionId: null,
+      draftVersionId: null,
+    },
+  });
+  return templateId;
+}
+
+const baseService = {
+  serviceName: 'manager',
+  serviceType: 'Stateful',
+  dockerImage: 'app',
+  dockerTag: 'latest',
+  containerConfig: {},
+  dependsOn: [],
+  order: 0,
+};
+
+describe('POST /api/stack-templates/:templateId/draft — NATS Phase 1 persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('persists service.natsRole and service.natsSigner on the StackTemplateService row', async () => {
+    const templateId = await createUserTemplateRow();
+
+    const draftBody = {
+      networks: [],
+      volumes: [],
+      services: [
+        { ...baseService, natsRole: 'manager-role', natsSigner: 'worker-minter' },
+      ],
+      nats: {
+        roles: [{ name: 'manager-role', publish: ['agent.worker.>'] }],
+        signers: [{ name: 'worker-minter', subjectScope: 'agent.worker' }],
+      },
+    };
+
+    const res = await supertest(buildApp())
+      .post(`/api/stack-templates/${templateId}/draft`)
+      .send(draftBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const tmpl = await testPrisma.stackTemplate.findUnique({ where: { id: templateId } });
+    expect(tmpl?.draftVersionId).not.toBeNull();
+
+    const row = await testPrisma.stackTemplateService.findFirst({
+      where: { versionId: tmpl!.draftVersionId! },
+    });
+    expect(row).not.toBeNull();
+    expect(row!.natsRole).toBe('manager-role');
+    expect(row!.natsSigner).toBe('worker-minter');
+  });
+
+  it('persists subjectPrefix / roles / signers / exports / imports on the StackTemplateVersion row', async () => {
+    const templateId = await createUserTemplateRow();
+
+    const draftBody = {
+      networks: [],
+      volumes: [],
+      services: [],
+      nats: {
+        subjectPrefix: 'app.{{stack.id}}',
+        roles: [
+          { name: 'gateway', publish: ['agent.in'], subscribe: ['slack.api'] },
+        ],
+        signers: [{ name: 'minter', subjectScope: 'agent.worker', maxTtlSeconds: 1800 }],
+        exports: ['events.>'],
+        imports: [{ fromStack: 'producer', subjects: ['x.>'], forRoles: ['gateway'] }],
+      },
+    };
+
+    const res = await supertest(buildApp())
+      .post(`/api/stack-templates/${templateId}/draft`)
+      .send(draftBody);
+
+    expect(res.status).toBe(200);
+
+    const tmpl = await testPrisma.stackTemplate.findUnique({ where: { id: templateId } });
+    const versionRow = await testPrisma.stackTemplateVersion.findUnique({
+      where: { id: tmpl!.draftVersionId! },
+    });
+    expect(versionRow).not.toBeNull();
+    expect(versionRow!.natsSubjectPrefix).toBe('app.{{stack.id}}');
+    expect(versionRow!.natsRoles).toEqual([
+      { name: 'gateway', publish: ['agent.in'], subscribe: ['slack.api'] },
+    ]);
+    expect(versionRow!.natsSigners).toEqual([
+      { name: 'minter', subjectScope: 'agent.worker', maxTtlSeconds: 1800 },
+    ]);
+    expect(versionRow!.natsExports).toEqual(['events.>']);
+    expect(versionRow!.natsImports).toEqual([
+      { fromStack: 'producer', subjects: ['x.>'], forRoles: ['gateway'] },
+    ]);
+  });
+
+  it('returns 400 when natsRole references an undeclared role', async () => {
+    const templateId = await createUserTemplateRow();
+
+    const res = await supertest(buildApp())
+      .post(`/api/stack-templates/${templateId}/draft`)
+      .send({
+        networks: [],
+        volumes: [],
+        services: [{ ...baseService, natsRole: 'absent' }],
+        nats: { roles: [{ name: 'gateway', publish: ['x'] }] },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('GET /api/stack-templates/:id echoes Phase 1 NATS fields in the version response', async () => {
+    const templateId = await createUserTemplateRow();
+
+    await supertest(buildApp())
+      .post(`/api/stack-templates/${templateId}/draft`)
+      .send({
+        networks: [],
+        volumes: [],
+        services: [{ ...baseService, natsRole: 'manager-role', natsSigner: 'minter' }],
+        nats: {
+          subjectPrefix: 'navi-test',
+          roles: [{ name: 'manager-role', publish: ['agent.worker.>'] }],
+          signers: [{ name: 'minter', subjectScope: 'agent.worker' }],
+          exports: ['events.>'],
+          imports: [{ fromStack: 'producer', subjects: ['x.>'], forRoles: ['manager-role'] }],
+        },
+      })
+      .expect(200);
+
+    const res = await supertest(buildApp())
+      .get(`/api/stack-templates/${templateId}`)
+      .expect(200);
+
+    const draft = res.body.data.draftVersion;
+    expect(draft).not.toBeNull();
+    expect(draft.nats).toBeDefined();
+    expect(draft.nats.subjectPrefix).toBe('navi-test');
+    expect(draft.nats.roles).toEqual([
+      { name: 'manager-role', publish: ['agent.worker.>'] },
+    ]);
+    expect(draft.nats.signers).toEqual([
+      { name: 'minter', subjectScope: 'agent.worker' },
+    ]);
+    expect(draft.nats.exports).toEqual(['events.>']);
+    expect(draft.nats.imports).toEqual([
+      { fromStack: 'producer', subjects: ['x.>'], forRoles: ['manager-role'] },
+    ]);
+
+    expect(draft.services).toBeDefined();
+    const svc = draft.services.find((s: { serviceName: string }) => s.serviceName === 'manager');
+    expect(svc?.natsRole).toBe('manager-role');
+    expect(svc?.natsSigner).toBe('minter');
+  });
+
+  it('returns 400 when legacy `nats.credentials` and new `nats.roles` are both declared (mixing rule)', async () => {
+    const templateId = await createUserTemplateRow();
+
+    const res = await supertest(buildApp())
+      .post(`/api/stack-templates/${templateId}/draft`)
+      .send({
+        networks: [],
+        volumes: [],
+        services: [],
+        nats: {
+          accounts: [{ name: 'app', scope: 'host' }],
+          credentials: [
+            { name: 'cred', account: 'app', publishAllow: ['x'], subscribeAllow: ['y'] },
+          ],
+          roles: [{ name: 'gateway', publish: ['x'] }],
+        },
+      });
+
+    expect(res.status).toBe(400);
+    const issueMessages = (res.body.issues as Array<{ message: string }> | undefined)?.map((i) => i.message) ?? [];
+    expect(issueMessages.join('|')).toContain('cannot be declared in the same template');
+  });
+});

--- a/server/src/__tests__/template-substitution-validator-nats.test.ts
+++ b/server/src/__tests__/template-substitution-validator-nats.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Phase 1 — substitution validator coverage for the new NATS app-author
+ * surface (subjectPrefix, roles[].publish/subscribe, signers[].subjectScope,
+ * exports[], imports[]). Same allowed namespaces as the vault section: the
+ * `inputs` namespace is KV-only and must NOT be accepted in NATS fields.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateTemplateSubstitutions } from '../services/stacks/template-substitution-validator';
+
+function make(over: Partial<Parameters<typeof validateTemplateSubstitutions>[0]> = {}) {
+  return {
+    scope: 'environment' as const,
+    parameterNames: new Set<string>(),
+    inputNames: new Set<string>(),
+    services: [],
+    configFiles: [],
+    networks: [],
+    volumes: [],
+    resourceInputs: [],
+    resourceOutputs: [],
+    ...over,
+  };
+}
+
+describe('validateTemplateSubstitutions — nats.subjectPrefix', () => {
+  it('accepts {{stack.id}} in subjectPrefix', () => {
+    const issues = validateTemplateSubstitutions(
+      make({ natsSubjectPrefix: 'app.{{stack.id}}' }),
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('rejects unknown stack key', () => {
+    const issues = validateTemplateSubstitutions(
+      make({ natsSubjectPrefix: 'app.{{stack.uuid}}' }),
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].path).toBe('nats.subjectPrefix');
+    expect(issues[0].message).toContain("unknown stack key 'uuid'");
+  });
+
+  it('rejects {{environment.*}} on host-scoped template', () => {
+    const issues = validateTemplateSubstitutions(
+      make({ scope: 'host', natsSubjectPrefix: 'app.{{environment.name}}' }),
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].path).toBe('nats.subjectPrefix');
+    expect(issues[0].message).toContain('host-scoped');
+  });
+});
+
+describe('validateTemplateSubstitutions — nats.roles', () => {
+  it('accepts {{params.x}} inside role publish/subscribe patterns', () => {
+    const issues = validateTemplateSubstitutions(
+      make({
+        parameterNames: new Set(['tenant']),
+        natsRoles: [
+          {
+            name: 'gateway',
+            publish: ['agent.{{params.tenant}}.in'],
+            subscribe: ['agent.{{params.tenant}}.out'],
+          },
+        ],
+      }),
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('flags unknown parameter inside role pattern', () => {
+    const issues = validateTemplateSubstitutions(
+      make({
+        parameterNames: new Set(['tenant']),
+        natsRoles: [{ name: 'gateway', publish: ['agent.{{params.tenat}}.in'] }],
+      }),
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].token).toBe('{{params.tenat}}');
+    expect(issues[0].path).toContain('nats.roles');
+  });
+
+  it('rejects {{inputs.*}} inside role pattern (inputs namespace is KV-only)', () => {
+    const issues = validateTemplateSubstitutions(
+      make({
+        inputNames: new Set(['tenant']),
+        natsRoles: [{ name: 'gateway', subscribe: ['agent.{{inputs.tenant}}.out'] }],
+      }),
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].token).toBe('{{inputs.tenant}}');
+    expect(issues[0].message).toContain('inputs');
+  });
+});
+
+describe('validateTemplateSubstitutions — nats.signers', () => {
+  it('accepts {{stack.id}} inside signer subjectScope', () => {
+    const issues = validateTemplateSubstitutions(
+      make({
+        natsSigners: [
+          { name: 'worker-minter', subjectScope: 'agent.worker.{{stack.id}}' },
+        ],
+      }),
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('rejects unknown namespace in signer subjectScope', () => {
+    const issues = validateTemplateSubstitutions(
+      make({
+        natsSigners: [
+          { name: 'worker-minter', subjectScope: 'agent.worker.{{user.name}}' },
+        ],
+      }),
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].token).toBe('{{user.name}}');
+    expect(issues[0].path).toContain('nats.signers');
+  });
+});
+
+describe('validateTemplateSubstitutions — nats.exports / nats.imports', () => {
+  it('accepts substitutions in export subjects', () => {
+    const issues = validateTemplateSubstitutions(
+      make({
+        parameterNames: new Set(['tenant']),
+        natsExports: ['events.{{params.tenant}}.>'],
+      }),
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('flags unknown parameter in import subjects', () => {
+    const issues = validateTemplateSubstitutions(
+      make({
+        parameterNames: new Set([]),
+        natsImports: [
+          { fromStack: 'producer', subjects: ['events.{{params.tenant}}.>'], forRoles: ['watcher'] },
+        ],
+      }),
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].token).toBe('{{params.tenant}}');
+    expect(issues[0].path).toContain('nats.imports');
+  });
+
+  it('environment-scoped imports accept {{environment.name}}', () => {
+    const issues = validateTemplateSubstitutions(
+      make({
+        scope: 'environment',
+        natsImports: [
+          { fromStack: 'producer-{{environment.name}}', subjects: ['events.>'], forRoles: ['watcher'] },
+        ],
+      }),
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('host-scoped imports rejecting {{environment.name}}', () => {
+    const issues = validateTemplateSubstitutions(
+      make({
+        scope: 'host',
+        natsImports: [
+          { fromStack: 'producer-{{environment.name}}', subjects: ['events.>'], forRoles: ['watcher'] },
+        ],
+      }),
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain('host-scoped');
+  });
+});

--- a/server/src/app-factory.ts
+++ b/server/src/app-factory.ts
@@ -79,6 +79,7 @@ import vaultPolicyRoutes from "./routes/vault/policies";
 import vaultAppRoleRoutes from "./routes/vault/approles";
 import vaultKvRoutes from "./routes/vault/kv";
 import natsRoutes from "./routes/nats";
+import natsPrefixAllowlistRoutes from "./routes/nats-prefix-allowlist";
 import egressRoutes from "./routes/egress";
 import egressFwAgentRoutes from "./routes/egress-fw-agent";
 import { listRouteMeta } from "./lib/openapi-registry";
@@ -192,6 +193,9 @@ function getRouteDefinitions(): RouteDefinition[] {
     // shared status/bootstrap router.
     { id: "vaultKv", path: "/api/vault/kv", name: "vaultKvRoutes", getRouter: () => vaultKvRoutes },
     { id: "vault", path: "/api/vault", name: "vaultRoutes", getRouter: () => vaultRoutes },
+    // Allowlist must be mounted BEFORE the catch-all `/api/nats` router so
+    // requests to `/api/nats/prefix-allowlist/...` reach this router instead.
+    { id: "natsPrefixAllowlist", path: "/api/nats/prefix-allowlist", name: "natsPrefixAllowlistRoutes", getRouter: () => natsPrefixAllowlistRoutes },
     { id: "nats", path: "/api/nats", name: "natsRoutes", getRouter: () => natsRoutes },
     // Dev-only: exchange admin credentials for a full-admin API key. Only
     // registered when ENABLE_DEV_API_KEY_ENDPOINT=true — otherwise getRouter

--- a/server/src/routes/nats-prefix-allowlist.ts
+++ b/server/src/routes/nats-prefix-allowlist.ts
@@ -1,0 +1,160 @@
+/**
+ * NATS subject-prefix allowlist (Phase 2).
+ *
+ * Per the design doc (§2.6), this route uses **CRUD per entry** rather than
+ * a single PUT-the-whole-blob API — a stale blob write would otherwise wipe
+ * the whole allowlist atomically. Each prefix is its own row keyed in
+ * `SystemSettings` under category `nats-prefix-allowlist`.
+ *
+ * Endpoints:
+ *   GET    /                — list all allowlist entries
+ *   GET    /:prefix         — get one entry
+ *   POST   /                — create a new entry
+ *   PUT    /:prefix         — update an existing entry's allowedTemplateIds
+ *   DELETE /:prefix         — remove an entry
+ *
+ * Permissions: read = `nats:read`; write = `nats:admin` (admin-only — the
+ * allowlist gates which templates can claim non-default subject prefixes).
+ */
+
+import { Router } from "express";
+import { z } from "zod";
+import { asyncHandler } from "../lib/async-handler";
+import { getUserId } from "../lib/get-user-id";
+import { requirePermission } from "../middleware/auth";
+import prisma from "../lib/prisma";
+import {
+  NatsPrefixAllowlistService,
+  NatsPrefixAllowlistError,
+  toEntryInfo,
+} from "../services/nats/nats-prefix-allowlist-service";
+
+const router = Router();
+
+const allowlistService = new NatsPrefixAllowlistService(prisma);
+
+// `:prefix` route param accepts dotted segments — `events.platform`,
+// `navi`, etc. Validation of the prefix itself happens inside the service.
+const prefixParamSchema = z.string().min(1).max(120);
+
+const upsertBodySchema = z.object({
+  prefix: z.string().min(1).max(120),
+  allowedTemplateIds: z.array(z.string().min(1)).min(1),
+});
+
+const updateBodySchema = z.object({
+  allowedTemplateIds: z.array(z.string().min(1)).min(1),
+});
+
+function handleError(err: unknown, res: import("express").Response, next: import("express").NextFunction): void {
+  if (err instanceof NatsPrefixAllowlistError) {
+    res.status(err.statusCode).json({ success: false, error: err.message });
+    return;
+  }
+  next(err);
+}
+
+// ─── GET / ────────────────────────────────────────────────────────────────
+
+router.get(
+  "/",
+  requirePermission("nats:read"),
+  asyncHandler(async (_req, res) => {
+    const entries = await allowlistService.list();
+    res.json({ success: true, data: entries.map(toEntryInfo) });
+  }),
+);
+
+// ─── GET /:prefix ─────────────────────────────────────────────────────────
+
+router.get(
+  "/:prefix",
+  requirePermission("nats:read"),
+  asyncHandler(async (req, res, next) => {
+    const parsed = prefixParamSchema.safeParse(req.params.prefix);
+    if (!parsed.success) {
+      res.status(400).json({ success: false, error: "Invalid prefix parameter" });
+      return;
+    }
+    try {
+      const entry = await allowlistService.get(parsed.data);
+      if (!entry) {
+        res.status(404).json({ success: false, error: `Prefix '${parsed.data}' not found in allowlist` });
+        return;
+      }
+      res.json({ success: true, data: toEntryInfo(entry) });
+    } catch (err) {
+      handleError(err, res, next);
+    }
+  }),
+);
+
+// ─── POST / ───────────────────────────────────────────────────────────────
+
+router.post(
+  "/",
+  requirePermission("nats:admin"),
+  asyncHandler(async (req, res, next) => {
+    const parsed = upsertBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ success: false, error: "Validation error", issues: parsed.error.issues });
+      return;
+    }
+    const userId = getUserId(req) ?? "unknown";
+    try {
+      const created = await allowlistService.create(parsed.data, userId);
+      res.status(201).json({ success: true, data: toEntryInfo(created) });
+    } catch (err) {
+      handleError(err, res, next);
+    }
+  }),
+);
+
+// ─── PUT /:prefix ─────────────────────────────────────────────────────────
+
+router.put(
+  "/:prefix",
+  requirePermission("nats:admin"),
+  asyncHandler(async (req, res, next) => {
+    const paramParsed = prefixParamSchema.safeParse(req.params.prefix);
+    if (!paramParsed.success) {
+      res.status(400).json({ success: false, error: "Invalid prefix parameter" });
+      return;
+    }
+    const bodyParsed = updateBodySchema.safeParse(req.body);
+    if (!bodyParsed.success) {
+      res.status(400).json({ success: false, error: "Validation error", issues: bodyParsed.error.issues });
+      return;
+    }
+    const userId = getUserId(req) ?? "unknown";
+    try {
+      const updated = await allowlistService.update(paramParsed.data, bodyParsed.data, userId);
+      res.json({ success: true, data: toEntryInfo(updated) });
+    } catch (err) {
+      handleError(err, res, next);
+    }
+  }),
+);
+
+// ─── DELETE /:prefix ──────────────────────────────────────────────────────
+
+router.delete(
+  "/:prefix",
+  requirePermission("nats:admin"),
+  asyncHandler(async (req, res, next) => {
+    const parsed = prefixParamSchema.safeParse(req.params.prefix);
+    if (!parsed.success) {
+      res.status(400).json({ success: false, error: "Invalid prefix parameter" });
+      return;
+    }
+    const userId = getUserId(req) ?? "unknown";
+    try {
+      await allowlistService.remove(parsed.data, userId);
+      res.json({ success: true });
+    } catch (err) {
+      handleError(err, res, next);
+    }
+  }),
+);
+
+export default router;

--- a/server/src/services/nats/nats-prefix-allowlist-service.ts
+++ b/server/src/services/nats/nats-prefix-allowlist-service.ts
@@ -1,0 +1,288 @@
+/**
+ * NATS subject-prefix allowlist (Phase 2).
+ *
+ * The Phase 1+3 design defaults every stack's `nats.subjectPrefix` to
+ * `app.<stack-id>` — opaque but collision-free. Templates that want a
+ * human-readable prefix (e.g. the slackbot's `navi.*`) need an explicit
+ * admin opt-in: an allowlist entry naming the prefix and the template IDs
+ * that may claim it. Without an entry, apply rejects any non-default prefix.
+ *
+ * **Storage shape.** One `SystemSettings` row per allowlist entry. Category
+ * is a dedicated `nats-prefix-allowlist`. Key is the prefix string itself;
+ * value is JSON `{ allowedTemplateIds: string[] }`. CRUD-per-entry — never a
+ * blob PUT — so a stale write can't wipe everyone's allowlist (one of the
+ * design's named footguns).
+ *
+ * **Validation, all enforced at write time** (so a corrupt entry can never
+ * reach the apply orchestrator):
+ *   - prefix non-empty, no wildcards (`>` / `*`), no leading/trailing dot,
+ *     not `$SYS.*`, syntactically dotted-segment of `[a-zA-Z0-9_-]`
+ *   - prefix has no overlap (strict subset/superset) with any other entry —
+ *     prevents "events" silently shadowing "events.platform"
+ *   - allowedTemplateIds non-empty and every entry references a real
+ *     `StackTemplate.id`
+ *
+ * The apply orchestrator (Phase 3) reads this via `lookupAllowedTemplateIds`
+ * and rejects an apply when the resolved subjectPrefix is non-default and
+ * the template's ID is not in the entry's allowlist.
+ */
+
+import { PrismaClient } from "../../lib/prisma";
+import { getLogger } from "../../lib/logger-factory";
+
+export interface NatsPrefixAllowlistEntry {
+  prefix: string;
+  allowedTemplateIds: string[];
+  createdAt: Date;
+  updatedAt: Date;
+  createdBy: string;
+  updatedBy: string;
+}
+
+export interface NatsPrefixAllowlistEntryInfo {
+  prefix: string;
+  allowedTemplateIds: string[];
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+  updatedBy: string;
+}
+
+export interface UpsertNatsPrefixAllowlistEntryInput {
+  prefix: string;
+  allowedTemplateIds: string[];
+}
+
+export class NatsPrefixAllowlistError extends Error {
+  constructor(message: string, public statusCode: number) {
+    super(message);
+    this.name = "NatsPrefixAllowlistError";
+  }
+}
+
+const CATEGORY = "nats-prefix-allowlist";
+const log = getLogger("integrations", "nats-prefix-allowlist");
+
+// Dotted segments of [a-zA-Z0-9_-]. Must contain no wildcards, no leading/
+// trailing dot. The regex matches the `templateNatsSubjectPrefixSchema` in
+// `stack-template-schemas.ts` — keep them in sync.
+const PREFIX_REGEX = /^[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*$/;
+
+function validatePrefixSyntax(prefix: string): void {
+  if (!prefix || prefix.length === 0) {
+    throw new NatsPrefixAllowlistError("prefix must be non-empty", 400);
+  }
+  if (prefix.length > 120) {
+    throw new NatsPrefixAllowlistError("prefix must be ≤120 characters", 400);
+  }
+  if (/[>*]/.test(prefix)) {
+    throw new NatsPrefixAllowlistError("prefix must not contain wildcards ('>' or '*')", 400);
+  }
+  if (prefix.startsWith(".") || prefix.endsWith(".")) {
+    throw new NatsPrefixAllowlistError("prefix must not start or end with '.'", 400);
+  }
+  if (prefix === "$SYS" || prefix.startsWith("$SYS.")) {
+    throw new NatsPrefixAllowlistError("prefix must not target the '$SYS' system-account namespace", 400);
+  }
+  if (!PREFIX_REGEX.test(prefix)) {
+    throw new NatsPrefixAllowlistError(
+      "prefix must be dotted segments of [a-zA-Z0-9_-] (e.g. 'navi' or 'events.platform')",
+      400,
+    );
+  }
+}
+
+/**
+ * `a` is a strict ancestor or descendant of `b` (in the dotted-segment subject
+ * tree). E.g. "events" is an ancestor of "events.platform". Equality returns
+ * true so callers can decide whether duplicates should error out separately.
+ */
+function isSubjectTreeOverlap(a: string, b: string): boolean {
+  if (a === b) return true;
+  return a.startsWith(b + ".") || b.startsWith(a + ".");
+}
+
+function entryFromRow(row: {
+  key: string;
+  value: string;
+  createdAt: Date;
+  updatedAt: Date;
+  createdBy: string;
+  updatedBy: string;
+}): NatsPrefixAllowlistEntry {
+  let allowedTemplateIds: string[] = [];
+  try {
+    const parsed = JSON.parse(row.value);
+    if (parsed && Array.isArray(parsed.allowedTemplateIds)) {
+      allowedTemplateIds = parsed.allowedTemplateIds.filter((s: unknown): s is string => typeof s === "string");
+    }
+  } catch {
+    log.warn({ prefix: row.key }, "nats-prefix-allowlist row had unparseable value");
+  }
+  return {
+    prefix: row.key,
+    allowedTemplateIds,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    createdBy: row.createdBy,
+    updatedBy: row.updatedBy,
+  };
+}
+
+export function toEntryInfo(entry: NatsPrefixAllowlistEntry): NatsPrefixAllowlistEntryInfo {
+  return {
+    prefix: entry.prefix,
+    allowedTemplateIds: entry.allowedTemplateIds,
+    createdAt: entry.createdAt.toISOString(),
+    updatedAt: entry.updatedAt.toISOString(),
+    createdBy: entry.createdBy,
+    updatedBy: entry.updatedBy,
+  };
+}
+
+export class NatsPrefixAllowlistService {
+  constructor(private prisma: PrismaClient) {}
+
+  async list(): Promise<NatsPrefixAllowlistEntry[]> {
+    const rows = await this.prisma.systemSettings.findMany({
+      where: { category: CATEGORY, isActive: true },
+      orderBy: { key: "asc" },
+    });
+    return rows.map(entryFromRow);
+  }
+
+  async get(prefix: string): Promise<NatsPrefixAllowlistEntry | null> {
+    const row = await this.prisma.systemSettings.findUnique({
+      where: { category_key: { category: CATEGORY, key: prefix } },
+    });
+    if (!row || !row.isActive) return null;
+    return entryFromRow(row);
+  }
+
+  /**
+   * Read-only lookup used by the apply orchestrator: returns the allowlist
+   * entry for an exact-match prefix, or null. The orchestrator then checks
+   * that the candidate templateId is in `allowedTemplateIds`.
+   */
+  async lookupAllowedTemplateIds(prefix: string): Promise<string[] | null> {
+    const entry = await this.get(prefix);
+    return entry ? entry.allowedTemplateIds : null;
+  }
+
+  /**
+   * Create a new allowlist entry. Rejects duplicates (use `update` to change
+   * an existing entry) and any prefix that overlaps an existing entry's
+   * subject tree.
+   */
+  async create(input: UpsertNatsPrefixAllowlistEntryInput, userId: string): Promise<NatsPrefixAllowlistEntry> {
+    await this.validateForWrite(input, { isUpdate: false });
+    await this.prisma.systemSettings.create({
+      data: {
+        category: CATEGORY,
+        key: input.prefix,
+        value: JSON.stringify({ allowedTemplateIds: input.allowedTemplateIds }),
+        isEncrypted: false,
+        isActive: true,
+        createdBy: userId,
+        updatedBy: userId,
+      },
+    });
+    log.info({ prefix: input.prefix, userId, count: input.allowedTemplateIds.length }, "nats-prefix-allowlist entry created");
+    const created = await this.get(input.prefix);
+    if (!created) throw new NatsPrefixAllowlistError("failed to load created entry", 500);
+    return created;
+  }
+
+  /**
+   * Update an existing entry's `allowedTemplateIds`. The prefix itself is
+   * the immutable key — to rename, delete + create.
+   */
+  async update(prefix: string, input: { allowedTemplateIds: string[] }, userId: string): Promise<NatsPrefixAllowlistEntry> {
+    const existing = await this.get(prefix);
+    if (!existing) {
+      throw new NatsPrefixAllowlistError(`allowlist entry for prefix '${prefix}' not found`, 404);
+    }
+    // Re-validate the new template IDs (overlap rules don't apply on update —
+    // the prefix string isn't changing — but we do re-check that every
+    // templateId references a real template).
+    await this.validateForWrite({ prefix, allowedTemplateIds: input.allowedTemplateIds }, { isUpdate: true });
+    await this.prisma.systemSettings.update({
+      where: { category_key: { category: CATEGORY, key: prefix } },
+      data: {
+        value: JSON.stringify({ allowedTemplateIds: input.allowedTemplateIds }),
+        updatedBy: userId,
+        updatedAt: new Date(),
+      },
+    });
+    log.info({ prefix, userId, count: input.allowedTemplateIds.length }, "nats-prefix-allowlist entry updated");
+    const updated = await this.get(prefix);
+    if (!updated) throw new NatsPrefixAllowlistError("failed to load updated entry", 500);
+    return updated;
+  }
+
+  async remove(prefix: string, userId: string): Promise<void> {
+    const existing = await this.get(prefix);
+    if (!existing) {
+      throw new NatsPrefixAllowlistError(`allowlist entry for prefix '${prefix}' not found`, 404);
+    }
+    await this.prisma.systemSettings.delete({
+      where: { category_key: { category: CATEGORY, key: prefix } },
+    });
+    log.info({ prefix, userId }, "nats-prefix-allowlist entry deleted");
+  }
+
+  // ─── Validation helpers ────────────────────────────────────────────────────
+
+  /**
+   * Full per-write validation: prefix syntax + overlap (create only) +
+   * non-empty allowedTemplateIds + every templateId references a real row.
+   */
+  private async validateForWrite(
+    input: UpsertNatsPrefixAllowlistEntryInput,
+    opts: { isUpdate: boolean },
+  ): Promise<void> {
+    validatePrefixSyntax(input.prefix);
+
+    if (!Array.isArray(input.allowedTemplateIds) || input.allowedTemplateIds.length === 0) {
+      throw new NatsPrefixAllowlistError("allowedTemplateIds must be a non-empty array", 400);
+    }
+    const seen = new Set<string>();
+    for (const id of input.allowedTemplateIds) {
+      if (typeof id !== "string" || id.length === 0) {
+        throw new NatsPrefixAllowlistError("allowedTemplateIds entries must be non-empty strings", 400);
+      }
+      if (seen.has(id)) {
+        throw new NatsPrefixAllowlistError(`duplicate templateId in allowedTemplateIds: '${id}'`, 400);
+      }
+      seen.add(id);
+    }
+
+    // Verify every templateId references a real template. One DB hit; cheap.
+    const templates = await this.prisma.stackTemplate.findMany({
+      where: { id: { in: input.allowedTemplateIds } },
+      select: { id: true },
+    });
+    const realIds = new Set(templates.map((t) => t.id));
+    const missing = input.allowedTemplateIds.filter((id) => !realIds.has(id));
+    if (missing.length > 0) {
+      throw new NatsPrefixAllowlistError(
+        `allowedTemplateIds references unknown template${missing.length === 1 ? "" : "s"}: ${missing.join(", ")}`,
+        400,
+      );
+    }
+
+    // Overlap check — only on create. Update keeps the same prefix string
+    // so overlap with itself is fine.
+    if (!opts.isUpdate) {
+      const existing = await this.list();
+      for (const e of existing) {
+        if (isSubjectTreeOverlap(e.prefix, input.prefix)) {
+          throw new NatsPrefixAllowlistError(
+            `prefix '${input.prefix}' overlaps existing allowlist entry '${e.prefix}' (one is a subject-tree ancestor or duplicate of the other)`,
+            409,
+          );
+        }
+      }
+    }
+  }
+}

--- a/server/src/services/stacks/schemas.ts
+++ b/server/src/services/stacks/schemas.ts
@@ -101,6 +101,10 @@ const dynamicEnvSourceSchema = z.discriminatedUnion("kind", [
     path: kvPathSchema,
     field: z.string().min(1).max(100).regex(/^[a-zA-Z0-9_-]+$/, "vault-kv field may only contain letters, numbers, '_', '-'"),
   }),
+  z.object({
+    kind: z.literal("nats-signer-seed"),
+    signer: z.string().min(1).max(100).regex(/^[a-zA-Z0-9_-]+$/, "nats signer name may only contain letters, numbers, '_', '-'"),
+  }),
 ]);
 
 export const poolConfigSchema = z.object({
@@ -350,6 +354,12 @@ export const stackServiceCommonFieldsSchema = z.object({
   // Symbolic reference to a nats.credentials[].name declared in the same draft
   // / template. Resolved to a concrete natsCredentialId at apply time.
   natsCredentialRef: z.string().min(1).optional(),
+  // Symbolic reference to a nats.roles[].name. Resolved at apply time to a
+  // materialized NatsCredentialProfile (subjectPrefix-prepended permissions).
+  natsRole: z.string().min(1).optional(),
+  // Symbolic reference to a nats.signers[].name. Causes NATS_SIGNER_SEED to
+  // be auto-injected as dynamicEnv at apply time.
+  natsSigner: z.string().min(1).optional(),
 });
 
 export const stackServiceDefinitionSchema = stackServiceCommonFieldsSchema

--- a/server/src/services/stacks/stack-nats-apply-orchestrator.ts
+++ b/server/src/services/stacks/stack-nats-apply-orchestrator.ts
@@ -7,6 +7,8 @@ import {
 } from "./template-engine";
 import { mergeParameterValues } from "./utils";
 import { getNatsControlPlaneService } from "../nats/nats-control-plane-service";
+import { NatsPrefixAllowlistService } from "../nats/nats-prefix-allowlist-service";
+import { getLogger } from "../../lib/logger-factory";
 import type {
   EnvironmentNetworkType,
   EnvironmentType,
@@ -15,6 +17,8 @@ import type {
   TemplateNatsAccount,
   TemplateNatsConsumer,
   TemplateNatsCredential,
+  TemplateNatsImport,
+  TemplateNatsRole,
   TemplateNatsStream,
 } from "@mini-infra/types";
 
@@ -53,7 +57,21 @@ export async function runStackNatsApplyPhase(
       natsCredentials: true,
       natsStreams: true,
       natsConsumers: true,
-      services: { select: { serviceName: true, natsCredentialRef: true } },
+      // Phase 1 fields (app-author surface). Phase 3 materializes `roles`
+      // and reads `subjectPrefix`; Phase 4 will use `signers`; Phase 5 will
+      // use `imports`/`exports`.
+      natsSubjectPrefix: true,
+      natsRoles: true,
+      natsExports: true,
+      natsImports: true,
+      services: {
+        select: {
+          serviceName: true,
+          natsCredentialRef: true,
+          natsRole: true,
+          natsSigner: true,
+        },
+      },
     },
   });
   if (!templateVersion) return { status: "skipped" };
@@ -62,7 +80,22 @@ export async function runStackNatsApplyPhase(
   const credentials = (templateVersion.natsCredentials as TemplateNatsCredential[] | null) ?? [];
   const streams = (templateVersion.natsStreams as TemplateNatsStream[] | null) ?? [];
   const consumers = (templateVersion.natsConsumers as TemplateNatsConsumer[] | null) ?? [];
-  const hasNats = accounts.length > 0 || credentials.length > 0 || streams.length > 0 || consumers.length > 0;
+  const roles = (templateVersion.natsRoles as TemplateNatsRole[] | null) ?? [];
+  const exportsRelative = (templateVersion.natsExports as string[] | null) ?? [];
+  const imports = (templateVersion.natsImports as TemplateNatsImport[] | null) ?? [];
+  // Phase 3 expands the guard to include the new app-author surface so
+  // pure-roles templates still trigger the apply phase. Mixing is rejected
+  // at validation (Phase 1's `validateNatsSectionShape`), so legacy and new
+  // paths run side-by-side without colliding. Phase 5 adds exports/imports
+  // to the guard for cross-stack subject sharing.
+  const hasNats =
+    accounts.length > 0 ||
+    credentials.length > 0 ||
+    streams.length > 0 ||
+    consumers.length > 0 ||
+    roles.length > 0 ||
+    exportsRelative.length > 0 ||
+    imports.length > 0;
   if (!hasNats) return { status: "skipped" };
 
   const status = await getNatsControlPlaneService(prisma).getStatus();
@@ -221,18 +254,103 @@ export async function runStackNatsApplyPhase(
       resources.push({ type: "consumer", concreteName: name, scope: consumer.scope });
     }
 
+    // ─── Phase 3 + 5: app-author roles materialization + cross-stack imports ──
+    // Roles share the system-default account (prefix-only isolation, see
+    // design §2.1 decision 1). Each role becomes a NatsCredentialProfile
+    // with `<resolvedSubjectPrefix>.` prepended to every publish/subscribe
+    // entry, plus `_INBOX.>` injection per the role's `inboxAuto` setting.
+    // The mixing rule (Phase 1) prevents `roles` and legacy `credentials`
+    // from coexisting in one template, so the maps below stay disjoint.
+    //
+    // Phase 5 adds cross-stack imports: for each `nats.imports[]` entry, the
+    // producer's resolved exports are looked up and the matched subjects
+    // get appended (in absolute form) to the subscribe list of every role
+    // named in `forRoles`. The producer's snapshot (`lastAppliedNatsSnapshot`)
+    // is the source of truth — written by the producer's own apply phase.
+    let resolvedSubjectPrefix: string | null = null;
+    const roleCredentialIdByName = new Map<string, string>();
+    let resolvedExports: string[] = [];
+    if (roles.length > 0 || exportsRelative.length > 0 || imports.length > 0) {
+      const defaultAccount = await service.ensureDefaultAccount();
+      resolvedSubjectPrefix = await resolveAndValidateSubjectPrefix({
+        prisma,
+        rawPrefix: templateVersion.natsSubjectPrefix ?? null,
+        ctx,
+        stackId,
+        templateId: stack.templateId,
+      });
+
+      // Resolve our own exports for snapshot consumption by other stacks.
+      resolvedExports = exportsRelative.map((s) => `${resolvedSubjectPrefix}.${s}`);
+
+      // Resolve imports: per-role additional subscribe subjects (absolute,
+      // already prefixed by the *producer's* prefix). Validate fromStack
+      // exists + is applied + actually exports a matching pattern.
+      const declaredRoleNames = new Set(roles.map((r) => r.name));
+      const importedSubscribeByRole = new Map<string, string[]>();
+      for (const imp of imports) {
+        for (const r of imp.forRoles) {
+          if (!declaredRoleNames.has(r)) {
+            // Phase 1 validator should have caught this; fail loud at apply
+            // if a corrupt template made it through.
+            throw new Error(`NATS apply: imports[].forRoles references undeclared role '${r}'`);
+          }
+        }
+        const resolved = await resolveImport({
+          prisma,
+          imp,
+          consumerStackId: stackId,
+          consumerEnvironmentId: stack.environmentId,
+        });
+        for (const r of imp.forRoles) {
+          const list = importedSubscribeByRole.get(r) ?? [];
+          list.push(...resolved);
+          importedSubscribeByRole.set(r, list);
+        }
+      }
+
+      for (const role of roles) {
+        const profile = await materializeRole({
+          prisma,
+          role,
+          accountId: defaultAccount.id,
+          subjectPrefix: resolvedSubjectPrefix,
+          stackId,
+          stackName: stack.name,
+          triggeredBy: opts.triggeredBy,
+          additionalSubscribeAbsolute: importedSubscribeByRole.get(role.name) ?? [],
+        });
+        roleCredentialIdByName.set(role.name, profile.id);
+        resources.push({ type: "credential", concreteName: profile.name, scope: "stack" });
+      }
+    }
+
     await service.applyConfig();
     await service.applyJetStreamResources();
 
-    const refByService = new Map(
+    const credentialRefByService = new Map(
       templateVersion.services
         .filter((s) => s.natsCredentialRef != null)
         .map((s) => [s.serviceName, s.natsCredentialRef as string]),
     );
+    const roleRefByService = new Map(
+      templateVersion.services
+        .filter((s) => s.natsRole != null)
+        .map((s) => [s.serviceName, s.natsRole as string]),
+    );
     const serviceUpdates = stack.services
       .map((svc) => {
-        const ref = refByService.get(svc.serviceName);
-        const concreteId = ref ? credentialIdByName.get(ref) : undefined;
+        // Legacy `natsCredentialRef` and new `natsRole` are mutually
+        // exclusive (template-level mixing rule + service-level "either or"
+        // by convention). Prefer role binding when both happen to exist —
+        // a defensive choice; the validator should have already rejected.
+        const roleRef = roleRefByService.get(svc.serviceName);
+        const credRef = credentialRefByService.get(svc.serviceName);
+        const concreteId = roleRef
+          ? roleCredentialIdByName.get(roleRef)
+          : credRef
+            ? credentialIdByName.get(credRef)
+            : undefined;
         return concreteId ? { id: svc.id, natsCredentialId: concreteId } : null;
       })
       .filter((item): item is { id: string; natsCredentialId: string } => item !== null);
@@ -241,7 +359,22 @@ export async function runStackNatsApplyPhase(
       prisma.stack.update({
         where: { id: stackId },
         data: {
-          lastAppliedNatsSnapshot: JSON.stringify({ accounts, credentials, streams, consumers, resources }),
+          lastAppliedNatsSnapshot: JSON.stringify({
+            accounts,
+            credentials,
+            streams,
+            consumers,
+            resources,
+            // Phase 3: snapshot the resolved prefix and the materialized
+            // role permissions so drift detection can compare cleanly.
+            subjectPrefix: resolvedSubjectPrefix,
+            roles,
+            // Phase 5: snapshot the resolved (prefixed) exports so consumer
+            // stacks can read them directly without re-resolving the
+            // producer's prefix at consumer-apply time.
+            resolvedExports,
+            imports,
+          }),
           lastFailureReason: null,
         },
       }),
@@ -267,7 +400,9 @@ export async function runStackNatsApplyPhase(
     return {
       status: "applied",
       servicesBound: serviceUpdates.length,
-      credentialsMapped: credentialIdByName.size,
+      // Count both legacy and Phase 3 role-derived profiles so a pure-roles
+      // stack reports a non-zero figure in logs/Socket.IO progress.
+      credentialsMapped: credentialIdByName.size + roleCredentialIdByName.size,
     };
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
@@ -292,3 +427,317 @@ function concreteName(base: string, scope: string, stackName: string, environmen
         : environmentName ?? stackName;
   return `${prefix}-${base}`.toLowerCase().replace(/[^a-z0-9_-]/g, "-").replace(/-+/g, "-").replace(/^-+|-+$/g, "");
 }
+
+// =====================================================================
+// Phase 3 helpers — subject prefix resolution + role materialization
+// =====================================================================
+
+/** Default subject-prefix template applied when a template doesn't set one. */
+const DEFAULT_SUBJECT_PREFIX_TEMPLATE = "app.{{stack.id}}";
+
+/**
+ * Resolve and validate the stack's NATS subject prefix.
+ *
+ * Defaults to `app.<stack.id>` (opaque but collision-free). A non-default
+ * prefix requires the templateId to appear in the matching `nats-prefix-
+ * allowlist` entry — without that gate any template author could grab a
+ * shared namespace like `events` and shadow another stack's subjects (the
+ * design's named footgun).
+ *
+ * Returns the resolved (substituted) prefix string. Throws on:
+ *   - escape attempts that the static validator should have caught earlier
+ *     (defense in depth — a corrupt JSON column, a future schema drift, etc.)
+ *   - non-default prefix without an allowlist entry
+ *   - allowlist entry exists but doesn't list this template
+ */
+async function resolveAndValidateSubjectPrefix(args: {
+  prisma: PrismaClient;
+  rawPrefix: string | null;
+  ctx: Parameters<typeof resolveTemplate>[1];
+  stackId: string;
+  templateId: string;
+}): Promise<string> {
+  const rawTemplate = args.rawPrefix ?? DEFAULT_SUBJECT_PREFIX_TEMPLATE;
+  const resolved = render(rawTemplate, args.ctx);
+  const defaultResolved = render(DEFAULT_SUBJECT_PREFIX_TEMPLATE, args.ctx);
+
+  // Defense-in-depth: re-check the prefix shape at apply time. Phase 1's
+  // schema validator already enforces these, but a corrupt natsSubjectPrefix
+  // column (e.g. via a future direct-Prisma write) would otherwise reach the
+  // permission renderer with a wildcard and shadow the prefix tree.
+  if (!resolved || /[>*]/.test(resolved) || resolved.startsWith(".") || resolved.endsWith(".") || resolved === "$SYS" || resolved.startsWith("$SYS.")) {
+    throw new Error(
+      `NATS apply: invalid subjectPrefix '${resolved}' (must be non-empty, no wildcards, no leading/trailing dot, not $SYS)`,
+    );
+  }
+
+  if (resolved === defaultResolved) {
+    return resolved;
+  }
+
+  // Non-default → must be admin-allowlisted for this template ID.
+  const allowlist = new NatsPrefixAllowlistService(args.prisma);
+  const allowedTemplateIds = await allowlist.lookupAllowedTemplateIds(resolved);
+  if (!allowedTemplateIds) {
+    throw new Error(
+      `NATS apply: subjectPrefix '${resolved}' is not in the prefix allowlist. ` +
+        `Either remove the explicit subjectPrefix to use the default (${defaultResolved}), ` +
+        `or add an allowlist entry via POST /api/nats/prefix-allowlist.`,
+    );
+  }
+  if (!allowedTemplateIds.includes(args.templateId)) {
+    throw new Error(
+      `NATS apply: subjectPrefix '${resolved}' is allowlisted but template '${args.templateId}' is not in its allowedTemplateIds.`,
+    );
+  }
+
+  getLogger("integrations", "nats-apply-orchestrator").info(
+    { stackId: args.stackId, templateId: args.templateId, subjectPrefix: resolved },
+    "applied non-default NATS subject prefix",
+  );
+  return resolved;
+}
+
+/**
+ * Materialize a single `roles[]` entry into a `NatsCredentialProfile` row.
+ * Permissions are auto-prefixed with the resolved subjectPrefix and (per
+ * `inboxAuto`) `_INBOX.>` is injected on publish, subscribe, both, or
+ * neither — defaulting to `'both'` so the slackbot's request/reply pattern
+ * works without explicit `_INBOX` declarations (design §1.4 calls this out
+ * as the team's recurring footgun).
+ */
+async function materializeRole(args: {
+  prisma: PrismaClient;
+  role: TemplateNatsRole;
+  accountId: string;
+  subjectPrefix: string;
+  stackId: string;
+  stackName: string;
+  triggeredBy: string | undefined;
+  /**
+   * Phase 5: subjects from cross-stack imports already in absolute form
+   * (prefixed by the *producer's* subject prefix). These get added to the
+   * subscribe list as-is — never run through the prefix-prepend or relative-
+   * subject validators.
+   */
+  additionalSubscribeAbsolute?: string[];
+}): Promise<{ id: string; name: string }> {
+  const { role, subjectPrefix } = args;
+  const inboxAuto = role.inboxAuto ?? "both";
+
+  // Defense-in-depth at apply time. The static validator
+  // (`natsRelativeSubjectSchema` in stack-template-schemas.ts) is the
+  // primary gate; this is here so a corrupt DB column or future schema
+  // drift can't sneak a malformed subject through to the permission
+  // renderer. Keep the rules in sync with the static schema.
+  const validateRelative = (s: string): void => {
+    if (!s || s.startsWith(">") || s.startsWith("*")) {
+      throw new Error(`NATS apply: role '${role.name}' has subject '${s}' that escapes the prefix`);
+    }
+    if (s.startsWith("_INBOX.")) {
+      throw new Error(`NATS apply: role '${role.name}' subject '${s}' uses _INBOX.> directly — use inboxAuto`);
+    }
+    if (s.startsWith("$SYS.") || s === "$SYS") {
+      throw new Error(`NATS apply: role '${role.name}' subject '${s}' targets the $SYS namespace`);
+    }
+    if (s.includes("..") || s.split(".").some((tok) => tok.length === 0)) {
+      throw new Error(`NATS apply: role '${role.name}' subject '${s}' has empty tokens (leading/trailing dot or '..')`);
+    }
+  };
+
+  const buildList = (relative: string[] | undefined, includeInbox: boolean): string[] => {
+    const list: string[] = [];
+    for (const r of relative ?? []) {
+      validateRelative(r);
+      list.push(`${subjectPrefix}.${r}`);
+    }
+    if (includeInbox) list.push("_INBOX.>");
+    return list;
+  };
+
+  const publishAllow = buildList(role.publish, inboxAuto === "both" || inboxAuto === "reply");
+  const subscribeAllow = buildList(role.subscribe, inboxAuto === "both" || inboxAuto === "request");
+  // Phase 5: imports-derived subjects are already absolute (producer-prefixed)
+  // — append after the relative→absolute prepend pass.
+  if (args.additionalSubscribeAbsolute && args.additionalSubscribeAbsolute.length > 0) {
+    subscribeAllow.push(...args.additionalSubscribeAbsolute);
+  }
+
+  // Profile name: `<stackId>-<roleName>`. `stack.id` is opaque but
+  // collision-free — two stacks with the same `name` (host scope) would
+  // otherwise clobber each other (design §2.1 decision 2). UI can render
+  // a friendlier `<stackName>-<roleName>` derived from this row.
+  //
+  // TODO: orphan profiles on role rename. Renaming a role leaves the old
+  // `<stackId>-<oldName>` profile in the DB; we upsert the new one but
+  // never delete the previous. A drift reconciler / cleanup pass should
+  // diff the rendered roles against existing per-stack profiles and prune
+  // anything no longer declared.
+  const profileName = concreteName(role.name, "stack", args.stackId, null);
+
+  const existing = await args.prisma.natsCredentialProfile.findUnique({ where: { name: profileName } });
+  const data = {
+    accountId: args.accountId,
+    displayName: `${args.stackName}-${role.name}`,
+    description: `Phase 3 materialized role for stack ${args.stackName}`,
+    publishAllow: publishAllow as unknown as Prisma.InputJsonValue,
+    subscribeAllow: subscribeAllow as unknown as Prisma.InputJsonValue,
+    ttlSeconds: role.ttlSeconds ?? 3600,
+    updatedById: args.triggeredBy ?? null,
+  };
+  const row = existing
+    ? await args.prisma.natsCredentialProfile.update({ where: { id: existing.id }, data })
+    : await args.prisma.natsCredentialProfile.create({
+        data: {
+          name: profileName,
+          ...data,
+          createdById: args.triggeredBy ?? null,
+        },
+      });
+  return { id: row.id, name: profileName };
+}
+
+// =====================================================================
+// Phase 5 helpers — cross-stack imports
+// =====================================================================
+
+/**
+ * Resolve a single `imports[]` entry against a producer stack.
+ *
+ * Steps:
+ *   1. Find producer stack by `fromStack` name (the design treats this as
+ *      a structural reference; on a single-host system stack names are
+ *      unique within an environment scope, and the design defers cross-
+ *      environment imports to a future iteration).
+ *   2. Verify producer is applied (has `lastAppliedAt` set + a snapshot).
+ *   3. Read producer's resolved exports + subjectPrefix from its
+ *      `lastAppliedNatsSnapshot`. Source of truth, not the template's raw
+ *      authored exports — the snapshot reflects what's actually live.
+ *   4. For each requested subject (relative to producer's prefix), build
+ *      the absolute form `<producerPrefix>.<subject>`. Verify it matches
+ *      one of the producer's exported patterns using NATS subject-match
+ *      semantics (`>` = many tokens at end, `*` = exactly one token).
+ *
+ * Returns the absolute (producer-prefixed) subjects to add to subscribe
+ * lists. Throws with a structured error if the producer is missing,
+ * un-applied, or the import doesn't match any export.
+ *
+ * **Concurrency note.** This is a plain Prisma read; no global lock is
+ * taken. If producer + consumer apply simultaneously, the consumer might
+ * see an in-flight or stale snapshot. The design (§6) acknowledges this:
+ * cross-stack apply contention is rare on a single-host system, and the
+ * consumer's next apply will pick up any drift. A global NATS-apply lock
+ * is the recommended hardening when contention is proven to matter.
+ */
+async function resolveImport(args: {
+  prisma: PrismaClient;
+  imp: TemplateNatsImport;
+  consumerStackId: string;
+  consumerEnvironmentId: string | null;
+}): Promise<string[]> {
+  if (args.imp.fromStack === "") {
+    throw new Error(`NATS apply: imports[].fromStack is empty`);
+  }
+  // Scope the lookup to the consumer's environment. A host-scoped consumer
+  // (`environmentId === null`) only sees host-scoped producers; an
+  // environment-scoped consumer only sees stacks in the same environment.
+  // Without this scope filter, two stacks with the same name (one host-
+  // scoped, one in environment X) would resolve to whichever row Prisma's
+  // default ordering picks — effectively random and a privilege-escalation
+  // surface (a malicious stack named "events-bus" in one environment could
+  // intercept imports targeting a host-level "events-bus").
+  //
+  // Cross-environment imports are explicitly out of scope for v1 per the
+  // design's §2.1 ("Out of scope: cross-environment imports").
+  //
+  // TODO: detect circular import dependencies (A imports B imports A).
+  // Currently the orchestrator allows ping-pong eventual consistency: each
+  // apply uses the other's prior snapshot. Phase-5+ should add a cycle
+  // check and refuse to apply, surfacing the cycle to the operator.
+  const producer = await args.prisma.stack.findFirst({
+    where: {
+      name: args.imp.fromStack,
+      removedAt: null,
+      environmentId: args.consumerEnvironmentId,
+    },
+    select: {
+      id: true,
+      name: true,
+      lastAppliedNatsSnapshot: true,
+    },
+  });
+  if (!producer) {
+    throw new Error(
+      `NATS apply: imports[].fromStack '${args.imp.fromStack}' not found — apply the producer stack first`,
+    );
+  }
+  if (producer.id === args.consumerStackId) {
+    throw new Error(`NATS apply: imports[].fromStack cannot reference the consumer stack itself`);
+  }
+  // Source of truth is the NATS snapshot itself, not stack.lastAppliedAt — the
+  // orchestrator only writes the snapshot, the reconciler sets lastAppliedAt
+  // for the broader apply. A populated snapshot is sufficient to know the
+  // producer's NATS phase ran successfully.
+  if (!producer.lastAppliedNatsSnapshot) {
+    throw new Error(
+      `NATS apply: producer stack '${args.imp.fromStack}' has no applied NATS snapshot — apply it before importing`,
+    );
+  }
+
+  let snapshot: { subjectPrefix?: string; resolvedExports?: string[] };
+  try {
+    snapshot = JSON.parse(producer.lastAppliedNatsSnapshot);
+  } catch {
+    throw new Error(
+      `NATS apply: producer stack '${args.imp.fromStack}' has a corrupt NATS snapshot — re-apply the producer`,
+    );
+  }
+  const producerPrefix = snapshot.subjectPrefix;
+  const producerExports = snapshot.resolvedExports ?? [];
+  if (!producerPrefix || producerExports.length === 0) {
+    throw new Error(
+      `NATS apply: producer stack '${args.imp.fromStack}' did not export any subjects in its last apply`,
+    );
+  }
+
+  const resolved: string[] = [];
+  for (const subject of args.imp.subjects) {
+    const absolute = `${producerPrefix}.${subject}`;
+    const matches = producerExports.some((pattern) => natsSubjectMatches(pattern, absolute));
+    if (!matches) {
+      throw new Error(
+        `NATS apply: imports[].subjects '${subject}' does not match any export of producer '${args.imp.fromStack}' (exports: ${producerExports.join(", ")})`,
+      );
+    }
+    resolved.push(absolute);
+  }
+  return resolved;
+}
+
+/**
+ * NATS subject-pattern match. `*` matches exactly one token at any
+ * position; `>` matches one-or-more tokens at the end (and only at the
+ * end). Mirrors the server-side semantics so the consumer's import
+ * is rejected pre-apply if the producer's export wouldn't actually
+ * grant access at runtime.
+ */
+function natsSubjectMatches(pattern: string, subject: string): boolean {
+  const pt = pattern.split(".");
+  const st = subject.split(".");
+  for (let i = 0; i < pt.length; i++) {
+    const seg = pt[i];
+    if (seg === ">") {
+      // `>` is only valid at the end of the pattern. Treat anywhere else
+      // as no-match defensively.
+      return i === pt.length - 1 && st.length > i;
+    }
+    if (i >= st.length) return false;
+    if (seg === "*") continue;
+    if (seg !== st[i]) return false;
+  }
+  return pt.length === st.length;
+}
+
+// Exported for unit tests. Internal — the orchestrator's main entrypoint
+// is `runStackNatsApplyPhase`.
+export const __testing = { natsSubjectMatches };

--- a/server/src/services/stacks/stack-template-schemas.ts
+++ b/server/src/services/stacks/stack-template-schemas.ts
@@ -71,6 +71,45 @@ const templateVaultSectionSchema = z.object({
 
 const natsSubjectSchema = z.string().min(1).max(255).regex(/^[A-Za-z0-9_$*>\-.]+$/);
 
+// Subjects in app-author roles[].publish/subscribe are *relative* to the stack's
+// subjectPrefix and the orchestrator prepends. Wildcards inside the relative
+// path are fine; what's forbidden is breaking out of the prefix or hitting
+// reserved namespaces. Static rules:
+//   - cannot start with `>` or `*` (would shadow whole prefix tree)
+//   - cannot start with `_INBOX.` (use inboxAuto instead)
+//   - cannot start with `$SYS.` (system-account namespace)
+//   - cannot contain `..` or empty tokens
+//
+// Exported so the file-loader path can reuse the same strict shape.
+export const natsRelativeSubjectSchema = z
+  .string()
+  .min(1)
+  .max(255)
+  .regex(/^[A-Za-z0-9_*>\-.]+$/, "subject must contain only letters, numbers, '_', '-', '.', '*', '>'")
+  .refine((s) => !s.startsWith(">") && !s.startsWith("*"), {
+    message: "relative subject must not start with a wildcard ('>' or '*') — that would shadow the entire stack prefix",
+  })
+  .refine((s) => !s.startsWith("_INBOX."), {
+    message: "relative subject must not target '_INBOX.>' directly — use the inboxAuto field on the role",
+  })
+  .refine((s) => !s.startsWith("$SYS.") && s !== "$SYS", {
+    message: "relative subject must not target the '$SYS.>' system-account namespace",
+  })
+  .refine((s) => !s.includes("..") && !s.split(".").some((tok) => tok.length === 0), {
+    message: "relative subject must not contain empty tokens ('..' or leading/trailing dots)",
+  });
+
+// Subject scope for a signer: a relative path with no wildcards (the signing
+// key is constrained to `<prefix>.<scope>.>`; scope itself must be concrete).
+const natsSubjectScopeSchema = z
+  .string()
+  .min(1)
+  .max(255)
+  .regex(/^[A-Za-z0-9_\-.]+$/, "signer subjectScope must contain only letters, numbers, '_', '-', '.'")
+  .refine((s) => !s.includes("..") && !s.split(".").some((tok) => tok.length === 0), {
+    message: "signer subjectScope must not contain empty tokens ('..' or leading/trailing dots)",
+  });
+
 export const templateNatsAccountSchema = z.object({
   name: z.string().min(1).max(100),
   displayName: z.string().max(200).optional(),
@@ -115,7 +154,58 @@ export const templateNatsConsumerSchema = z.object({
   scope: z.enum(["host", "environment", "stack"]).default("environment"),
 });
 
+// ----- Phase 1: app-author role / signer / import surface -----
+
+export const templateNatsRoleSchema = z.object({
+  name: z.string().min(1).max(100).regex(nameRegex, "role name can only contain letters, numbers, '_', '-'"),
+  publish: z.array(natsRelativeSubjectSchema).optional(),
+  subscribe: z.array(natsRelativeSubjectSchema).optional(),
+  inboxAuto: z.enum(["both", "reply", "request", "none"]).optional(),
+  ttlSeconds: z.number().int().min(0).optional(),
+});
+
+export const templateNatsSignerSchema = z.object({
+  name: z.string().min(1).max(100).regex(nameRegex, "signer name can only contain letters, numbers, '_', '-'"),
+  subjectScope: natsSubjectScopeSchema,
+  maxTtlSeconds: z.number().int().min(1).optional(),
+});
+
+export const templateNatsImportSchema = z.object({
+  fromStack: z.string().min(1).max(100),
+  subjects: z.array(natsRelativeSubjectSchema).min(1),
+  /** Required: per-role binding only — security-critical to prevent broadcast. */
+  forRoles: z.array(z.string().min(1)).min(1),
+});
+
+// Subject prefix syntax: dotted segments of [a-zA-Z0-9_-]; `{{...}}` template
+// substitutions are walked separately by the substitution validator. Can't
+// contain wildcards or root-level traversal; allowlist enforces the human-
+// readable case (e.g. "navi") at apply time.
+//
+// Exported alongside `natsRelativeSubjectSchema` so the file-loader path uses
+// the same strict shapes — otherwise system-template files could sneak in
+// wildcards or `$SYS.*` prefixes that the HTTP draft path rejects.
+export const templateNatsSubjectPrefixSchema = z
+  .string()
+  .min(1)
+  .max(120)
+  .refine((s) => !/[>*]/.test(s), { message: "subjectPrefix must not contain wildcards" })
+  .refine((s) => !s.startsWith(".") && !s.endsWith("."), {
+    message: "subjectPrefix must not start or end with '.'",
+  })
+  .refine((s) => !s.startsWith("$SYS"), {
+    message: "subjectPrefix must not target the system-account namespace",
+  });
+
 const templateNatsSectionSchema = z.object({
+  // Phase 1 additions (app-author surface)
+  subjectPrefix: templateNatsSubjectPrefixSchema.optional(),
+  roles: z.array(templateNatsRoleSchema).optional(),
+  signers: z.array(templateNatsSignerSchema).optional(),
+  exports: z.array(natsRelativeSubjectSchema).optional(),
+  imports: z.array(templateNatsImportSchema).optional(),
+
+  // Existing low-level surface (system templates / advanced)
   accounts: z.array(templateNatsAccountSchema).optional(),
   credentials: z.array(templateNatsCredentialSchema).optional(),
   streams: z.array(templateNatsStreamSchema).optional(),
@@ -184,6 +274,48 @@ export const createTemplateSchema = z.object({
   inputs: z.array(templateInputDeclSchema).optional(),
   vault: templateVaultSectionSchema.optional(),
   nats: templateNatsSectionSchema.optional(),
+}).superRefine((data, ctx) => {
+  // Mirror draftVersionSchema: vaultAppRoleRef / natsCredentialRef / natsRole /
+  // natsSigner must resolve, the legacy/new mixing rule applies, and role +
+  // signer names must be unique. Without this, a POST /stack-templates that
+  // mixes legacy `nats.credentials` with new `nats.roles` would persist on the
+  // initial v0 draft and only fail later on the first /draft save.
+  const appRoleNames = new Set((data.vault?.appRoles ?? []).map((a) => a.name));
+  const credentialNames = new Set((data.nats?.credentials ?? []).map((c) => c.name));
+  const roleNames = new Set((data.nats?.roles ?? []).map((r) => r.name));
+  const signerNames = new Set((data.nats?.signers ?? []).map((s) => s.name));
+  for (let i = 0; i < data.services.length; i++) {
+    const svc = data.services[i];
+    if (svc.vaultAppRoleRef !== undefined && !appRoleNames.has(svc.vaultAppRoleRef)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Service '${svc.serviceName}' vaultAppRoleRef '${svc.vaultAppRoleRef}' references unknown appRole (defined: ${formatNameSet(appRoleNames)})`,
+        path: ['services', i, 'vaultAppRoleRef'],
+      });
+    }
+    if (svc.natsCredentialRef !== undefined && !credentialNames.has(svc.natsCredentialRef)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Service '${svc.serviceName}' natsCredentialRef '${svc.natsCredentialRef}' references unknown credential (defined: ${formatNameSet(credentialNames)})`,
+        path: ['services', i, 'natsCredentialRef'],
+      });
+    }
+    if (svc.natsRole !== undefined && !roleNames.has(svc.natsRole)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Service '${svc.serviceName}' natsRole '${svc.natsRole}' references unknown role (defined: ${formatNameSet(roleNames)})`,
+        path: ['services', i, 'natsRole'],
+      });
+    }
+    if (svc.natsSigner !== undefined && !signerNames.has(svc.natsSigner)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Service '${svc.serviceName}' natsSigner '${svc.natsSigner}' references unknown signer (defined: ${formatNameSet(signerNames)})`,
+        path: ['services', i, 'natsSigner'],
+      });
+    }
+  }
+  validateNatsSectionShape(data.nats, ctx);
 });
 
 export const updateTemplateMetaSchema = z.object({
@@ -225,6 +357,8 @@ export const draftVersionSchema = z.object({
     }
   }
   const credentialNames = new Set((data.nats?.credentials ?? []).map((c) => c.name));
+  const roleNames = new Set((data.nats?.roles ?? []).map((r) => r.name));
+  const signerNames = new Set((data.nats?.signers ?? []).map((s) => s.name));
   for (let i = 0; i < data.services.length; i++) {
     const svc = data.services[i];
     if (svc.natsCredentialRef !== undefined && !credentialNames.has(svc.natsCredentialRef)) {
@@ -234,8 +368,94 @@ export const draftVersionSchema = z.object({
         path: ['services', i, 'natsCredentialRef'],
       });
     }
+    if (svc.natsRole !== undefined && !roleNames.has(svc.natsRole)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Service '${svc.serviceName}' natsRole '${svc.natsRole}' references unknown role (defined: ${formatNameSet(roleNames)})`,
+        path: ['services', i, 'natsRole'],
+      });
+    }
+    if (svc.natsSigner !== undefined && !signerNames.has(svc.natsSigner)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Service '${svc.serviceName}' natsSigner '${svc.natsSigner}' references unknown signer (defined: ${formatNameSet(signerNames)})`,
+        path: ['services', i, 'natsSigner'],
+      });
+    }
   }
+  validateNatsSectionShape(data.nats, ctx);
 });
+
+/**
+ * Reusable cross-section validator for the NATS section. Catches the
+ * legacy/new mixing rule, name collisions inside roles/signers, and the
+ * per-role `imports[].forRoles` resolution. Called from both
+ * `draftVersionSchema` and `templateFileSchema` so the rules apply uniformly
+ * to HTTP draft submissions and bundled file-loaded templates.
+ */
+export function validateNatsSectionShape(
+  nats: { accounts?: unknown[]; credentials?: unknown[]; streams?: unknown[]; consumers?: unknown[];
+          roles?: Array<{ name: string }>; signers?: Array<{ name: string }>;
+          imports?: Array<{ forRoles?: string[] }>; exports?: unknown[]; subjectPrefix?: unknown } | undefined,
+  ctx: z.RefinementCtx,
+): void {
+  if (!nats) return;
+  const hasLegacy = (nats.credentials?.length ?? 0) > 0;
+  const hasNewRoles = (nats.roles?.length ?? 0) > 0;
+  // Mixing rule: a single template must not mix the legacy `credentials`
+  // surface with the new `roles` surface. System templates use legacy;
+  // app templates use roles. Forces an explicit migration step.
+  if (hasLegacy && hasNewRoles) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "nats.credentials (legacy) and nats.roles (new) cannot be declared in the same template — pick one surface",
+      path: ["nats", "roles"],
+    });
+  }
+
+  // Unique role names
+  const seenRoleNames = new Set<string>();
+  for (let i = 0; i < (nats.roles?.length ?? 0); i++) {
+    const r = nats.roles![i];
+    if (seenRoleNames.has(r.name)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Duplicate NATS role name: '${r.name}'`,
+        path: ["nats", "roles", i, "name"],
+      });
+    }
+    seenRoleNames.add(r.name);
+  }
+
+  // Unique signer names
+  const seenSignerNames = new Set<string>();
+  for (let i = 0; i < (nats.signers?.length ?? 0); i++) {
+    const s = nats.signers![i];
+    if (seenSignerNames.has(s.name)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Duplicate NATS signer name: '${s.name}'`,
+        path: ["nats", "signers", i, "name"],
+      });
+    }
+    seenSignerNames.add(s.name);
+  }
+
+  // imports[].forRoles must reference declared roles (per-role binding only).
+  for (let i = 0; i < (nats.imports?.length ?? 0); i++) {
+    const imp = nats.imports![i];
+    for (let j = 0; j < (imp.forRoles?.length ?? 0); j++) {
+      const r = imp.forRoles![j];
+      if (!seenRoleNames.has(r)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `nats.imports[${i}].forRoles references unknown role '${r}' (defined: ${formatNameSet(seenRoleNames)})`,
+          path: ["nats", "imports", i, "forRoles", j],
+        });
+      }
+    }
+  }
+}
 
 function formatNameSet(set: Set<string>): string {
   if (set.size === 0) return 'none defined';

--- a/server/src/services/stacks/stack-template-service.ts
+++ b/server/src/services/stacks/stack-template-service.ts
@@ -76,6 +76,11 @@ const versionSummary = {
   natsCredentials: true,
   natsStreams: true,
   natsConsumers: true,
+  natsSubjectPrefix: true,
+  natsRoles: true,
+  natsSigners: true,
+  natsExports: true,
+  natsImports: true,
   publishedAt: true,
   createdAt: true,
   createdById: true,
@@ -295,6 +300,11 @@ export class StackTemplateService {
       vaultPolicies: input.vault?.policies,
       vaultAppRoles: input.vault?.appRoles,
       vaultKvPaths: (input.vault?.kv ?? []).map((k) => k.path),
+      natsSubjectPrefix: input.nats?.subjectPrefix,
+      natsRoles: input.nats?.roles,
+      natsSigners: input.nats?.signers,
+      natsExports: input.nats?.exports,
+      natsImports: input.nats?.imports,
     });
     if (issues.length > 0) {
       const summary = issues
@@ -363,10 +373,7 @@ export class StackTemplateService {
           vaultPolicies: input.vault?.policies ? (input.vault.policies as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
           vaultAppRoles: input.vault?.appRoles ? (input.vault.appRoles as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
           vaultKv: input.vault?.kv ? (input.vault.kv as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
-          natsAccounts: input.nats?.accounts ? (input.nats.accounts as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
-          natsCredentials: input.nats?.credentials ? (input.nats.credentials as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
-          natsStreams: input.nats?.streams ? (input.nats.streams as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
-          natsConsumers: input.nats?.consumers ? (input.nats.consumers as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
+          ...natsSectionToVersionWrite(input.nats),
           createdById: createdById ?? null,
           services: {
             create: input.services.map((s, i) =>
@@ -485,6 +492,11 @@ export class StackTemplateService {
       vaultPolicies: input.vault?.policies,
       vaultAppRoles: input.vault?.appRoles,
       vaultKvPaths: (input.vault?.kv ?? []).map((k) => k.path),
+      natsSubjectPrefix: input.nats?.subjectPrefix,
+      natsRoles: input.nats?.roles,
+      natsSigners: input.nats?.signers,
+      natsExports: input.nats?.exports,
+      natsImports: input.nats?.imports,
     });
     if (issues.length > 0) {
       const summary = issues
@@ -526,10 +538,7 @@ export class StackTemplateService {
           vaultPolicies: input.vault?.policies ? (input.vault.policies as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
           vaultAppRoles: input.vault?.appRoles ? (input.vault.appRoles as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
           vaultKv: input.vault?.kv ? (input.vault.kv as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
-          natsAccounts: input.nats?.accounts ? (input.nats.accounts as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
-          natsCredentials: input.nats?.credentials ? (input.nats.credentials as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
-          natsStreams: input.nats?.streams ? (input.nats.streams as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
-          natsConsumers: input.nats?.consumers ? (input.nats.consumers as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
+          ...natsSectionToVersionWrite(input.nats),
           createdById: createdById ?? null,
           services: {
             create: input.services.map((s, i) =>
@@ -768,10 +777,7 @@ export class StackTemplateService {
             resourceInputs: definition.resourceInputs ? (definition.resourceInputs as unknown as Prisma.InputJsonValue) : undefined,
             networks: definition.networks as unknown as Prisma.InputJsonValue,
             volumes: definition.volumes as unknown as Prisma.InputJsonValue,
-            natsAccounts: nats?.accounts ? (nats.accounts as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
-            natsCredentials: nats?.credentials ? (nats.credentials as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
-            natsStreams: nats?.streams ? (nats.streams as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
-            natsConsumers: nats?.consumers ? (nats.consumers as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
+            ...natsSectionToVersionWrite(nats),
             publishedAt: new Date(),
           },
         });
@@ -791,10 +797,7 @@ export class StackTemplateService {
             resourceInputs: definition.resourceInputs ? (definition.resourceInputs as unknown as Prisma.InputJsonValue) : undefined,
             networks: definition.networks as unknown as Prisma.InputJsonValue,
             volumes: definition.volumes as unknown as Prisma.InputJsonValue,
-            natsAccounts: nats?.accounts ? (nats.accounts as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
-            natsCredentials: nats?.credentials ? (nats.credentials as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
-            natsStreams: nats?.streams ? (nats.streams as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
-            natsConsumers: nats?.consumers ? (nats.consumers as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
+            ...natsSectionToVersionWrite(nats),
             publishedAt: new Date(),
           },
         });
@@ -1207,6 +1210,8 @@ function serializeTemplateService(svc: Prisma.StackTemplateServiceGetPayload<tru
     vaultAppRoleRef: svc.vaultAppRoleRef ?? null,
     natsCredentialId: svc.natsCredentialId ?? null,
     natsCredentialRef: svc.natsCredentialRef ?? null,
+    natsRole: svc.natsRole ?? null,
+    natsSigner: svc.natsSigner ?? null,
   };
 }
 
@@ -1247,6 +1252,8 @@ function toTemplateServiceCreate(
     vaultAppRoleRef: s.vaultAppRoleRef ?? null,
     natsCredentialId: s.natsCredentialId ?? null,
     natsCredentialRef: s.natsCredentialRef ?? null,
+    natsRole: s.natsRole ?? null,
+    natsSigner: s.natsSigner ?? null,
   };
 }
 
@@ -1264,14 +1271,63 @@ function buildVaultSection(version: Record<string, unknown>): StackTemplateVersi
   };
 }
 
+/**
+ * Map a `TemplateNatsSection` (or undefined) to the NATS-shaped Prisma write
+ * fields on `StackTemplateVersion`. Centralised so create/update/builtin
+ * write paths can't drift on individual columns. Phase 1 added the
+ * subjectPrefix/roles/signers/exports/imports columns.
+ */
+function natsSectionToVersionWrite(nats: TemplateNatsSection | undefined): {
+  natsAccounts: Prisma.InputJsonValue | typeof Prisma.DbNull;
+  natsCredentials: Prisma.InputJsonValue | typeof Prisma.DbNull;
+  natsStreams: Prisma.InputJsonValue | typeof Prisma.DbNull;
+  natsConsumers: Prisma.InputJsonValue | typeof Prisma.DbNull;
+  natsSubjectPrefix: string | null;
+  natsRoles: Prisma.InputJsonValue | typeof Prisma.DbNull;
+  natsSigners: Prisma.InputJsonValue | typeof Prisma.DbNull;
+  natsExports: Prisma.InputJsonValue | typeof Prisma.DbNull;
+  natsImports: Prisma.InputJsonValue | typeof Prisma.DbNull;
+} {
+  return {
+    natsAccounts: nats?.accounts ? (nats.accounts as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
+    natsCredentials: nats?.credentials ? (nats.credentials as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
+    natsStreams: nats?.streams ? (nats.streams as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
+    natsConsumers: nats?.consumers ? (nats.consumers as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
+    natsSubjectPrefix: nats?.subjectPrefix ?? null,
+    natsRoles: nats?.roles ? (nats.roles as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
+    natsSigners: nats?.signers ? (nats.signers as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
+    natsExports: nats?.exports ? (nats.exports as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
+    natsImports: nats?.imports ? (nats.imports as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
+  };
+}
+
 function buildNatsSection(version: Record<string, unknown>): StackTemplateVersionInfo['nats'] {
-  if (!version['natsAccounts'] && !version['natsCredentials'] && !version['natsStreams'] && !version['natsConsumers']) return undefined;
+  // Phase 1 fields are checked alongside the legacy fields so a pure-roles
+  // template returns a non-undefined nats section.
+  if (
+    !version['natsAccounts'] &&
+    !version['natsCredentials'] &&
+    !version['natsStreams'] &&
+    !version['natsConsumers'] &&
+    !version['natsSubjectPrefix'] &&
+    !version['natsRoles'] &&
+    !version['natsSigners'] &&
+    !version['natsExports'] &&
+    !version['natsImports']
+  ) {
+    return undefined;
+  }
   type NatsSection = NonNullable<StackTemplateVersionInfo['nats']>;
   return {
     accounts: (version['natsAccounts'] as unknown as NatsSection['accounts']) ?? undefined,
     credentials: (version['natsCredentials'] as unknown as NatsSection['credentials']) ?? undefined,
     streams: (version['natsStreams'] as unknown as NatsSection['streams']) ?? undefined,
     consumers: (version['natsConsumers'] as unknown as NatsSection['consumers']) ?? undefined,
+    subjectPrefix: (version['natsSubjectPrefix'] as string | undefined) ?? undefined,
+    roles: (version['natsRoles'] as unknown as NatsSection['roles']) ?? undefined,
+    signers: (version['natsSigners'] as unknown as NatsSection['signers']) ?? undefined,
+    exports: (version['natsExports'] as unknown as NatsSection['exports']) ?? undefined,
+    imports: (version['natsImports'] as unknown as NatsSection['imports']) ?? undefined,
   };
 }
 
@@ -1397,6 +1453,10 @@ function buildServiceDefinitionsFromVersion(version: {
       poolConfig: (svc.poolConfig as unknown as StackServiceDefinition['poolConfig']) ?? undefined,
       vaultAppRoleId: svc.vaultAppRoleId ?? undefined,
       vaultAppRoleRef: svc.vaultAppRoleRef ?? undefined,
+      natsCredentialId: svc.natsCredentialId ?? undefined,
+      natsCredentialRef: svc.natsCredentialRef ?? undefined,
+      natsRole: svc.natsRole ?? undefined,
+      natsSigner: svc.natsSigner ?? undefined,
     };
   });
 }

--- a/server/src/services/stacks/template-file-loader.ts
+++ b/server/src/services/stacks/template-file-loader.ts
@@ -21,6 +21,12 @@ import {
   templateNatsCredentialSchema,
   templateNatsStreamSchema,
   templateNatsConsumerSchema,
+  templateNatsRoleSchema,
+  templateNatsSignerSchema,
+  templateNatsImportSchema,
+  templateNatsSubjectPrefixSchema,
+  natsRelativeSubjectSchema,
+  validateNatsSectionShape,
 } from "./stack-template-schemas";
 import type { StackTemplateConfigFileInput } from "@mini-infra/types";
 import { STACK_SERVICE_TYPES } from "@mini-infra/types";
@@ -71,6 +77,15 @@ const templateVaultSchema = z.object({
 });
 
 const templateNatsSchema = z.object({
+  // App-author surface (Phase 1 additions). Reuse canonical strict shapes
+  // from stack-template-schemas.ts so file-loaded templates can't sneak in
+  // wildcards or `$SYS.*` prefixes that the HTTP draft path rejects.
+  subjectPrefix: templateNatsSubjectPrefixSchema.optional(),
+  roles: z.array(templateNatsRoleSchema).optional(),
+  signers: z.array(templateNatsSignerSchema).optional(),
+  exports: z.array(natsRelativeSubjectSchema).optional(),
+  imports: z.array(templateNatsImportSchema).optional(),
+  // Legacy / system surface
   accounts: z.array(templateNatsAccountSchema).optional(),
   credentials: z.array(templateNatsCredentialSchema).optional(),
   streams: z.array(templateNatsStreamSchema).optional(),
@@ -212,6 +227,9 @@ export const templateFileSchema = z.object({
     }
   }
 
+  const natsRoleNames = new Set((data.nats?.roles ?? []).map((r) => r.name));
+  const natsSignerNames = new Set((data.nats?.signers ?? []).map((s) => s.name));
+
   for (const svc of data.services) {
     if (svc.natsCredentialRef !== undefined && !natsCredentialNames.has(svc.natsCredentialRef)) {
       ctx.addIssue({
@@ -220,8 +238,23 @@ export const templateFileSchema = z.object({
         path: ["services"],
       });
     }
+    if (svc.natsRole !== undefined && !natsRoleNames.has(svc.natsRole)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Service '${svc.serviceName}' natsRole '${svc.natsRole}' references unknown role (defined: ${formatNameSet(natsRoleNames)})`,
+        path: ["services"],
+      });
+    }
+    if (svc.natsSigner !== undefined && !natsSignerNames.has(svc.natsSigner)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Service '${svc.serviceName}' natsSigner '${svc.natsSigner}' references unknown signer (defined: ${formatNameSet(natsSignerNames)})`,
+        path: ["services"],
+      });
+    }
   }
 
+  validateNatsSectionShape(data.nats, ctx);
 });
 
 export type TemplateFileDefinition = z.infer<typeof templateFileSchema>;
@@ -298,6 +331,8 @@ export interface LoadedTemplate {
       routing?: z.infer<typeof stackServiceRoutingSchema>;
       vaultAppRoleRef?: string;
       natsCredentialRef?: string;
+      natsRole?: string;
+      natsSigner?: string;
     }>;
   };
   configFiles: StackTemplateConfigFileInput[];
@@ -417,6 +452,8 @@ export function loadTemplateFromObject(
       routing: svc.routing,
       vaultAppRoleRef: svc.vaultAppRoleRef,
       natsCredentialRef: svc.natsCredentialRef,
+      natsRole: svc.natsRole,
+      natsSigner: svc.natsSigner,
     };
   });
 

--- a/server/src/services/stacks/template-substitution-validator.ts
+++ b/server/src/services/stacks/template-substitution-validator.ts
@@ -45,6 +45,12 @@ export interface ValidateInput {
   vaultPolicies?: unknown;
   vaultAppRoles?: unknown;
   vaultKvPaths?: string[];
+  /** NATS section — subjectPrefix, role pub/sub patterns, signer scopes, exports, and import subjects support substitution. */
+  natsSubjectPrefix?: string;
+  natsRoles?: unknown;
+  natsSigners?: unknown;
+  natsExports?: unknown;
+  natsImports?: unknown;
 }
 
 export function validateTemplateSubstitutions(input: ValidateInput): TemplateSubstitutionIssue[] {
@@ -77,6 +83,26 @@ export function validateTemplateSubstitutions(input: ValidateInput): TemplateSub
     for (let i = 0; i < input.vaultKvPaths.length; i++) {
       walk(input.vaultKvPaths[i], `vault.kv[${i}].path`, kvCtx);
     }
+  }
+
+  // NATS section — params/stack/environment substitutions allowed in
+  // subjectPrefix, role pub/sub patterns, signer scopes, export subjects,
+  // and import subjects. Same allowed namespaces as the Vault section
+  // (no `{{inputs.*}}` — that namespace is KV-only).
+  if (input.natsSubjectPrefix !== undefined) {
+    walk(input.natsSubjectPrefix, 'nats.subjectPrefix', ctx);
+  }
+  if (input.natsRoles) {
+    walk(input.natsRoles, 'nats.roles', ctx);
+  }
+  if (input.natsSigners) {
+    walk(input.natsSigners, 'nats.signers', ctx);
+  }
+  if (input.natsExports) {
+    walk(input.natsExports, 'nats.exports', ctx);
+  }
+  if (input.natsImports) {
+    walk(input.natsImports, 'nats.imports', ctx);
   }
 
   return issues;


### PR DESCRIPTION
## Summary

Layers a safe-by-default surface on top of the NATS primitives shipped in #320/#322 so third-party stack templates can declare NATS topology without hand-rolling NKey/JWT minting or colliding with other apps' subjects. The forcing function is [`slackbot-agent-sdk`](https://github.com/) — this PR ships everything needed to port it except the signer materialization (Phase 4), which depends on a separate live account-JWT propagation spike (Phase 0). Both are tracked in [`docs/planning/not-shipped/nats-app-roles-followups.md`](docs/planning/not-shipped/nats-app-roles-followups.md).

Design doc: [`docs/planning/shipped/nats-app-roles-plan.md`](docs/planning/shipped/nats-app-roles-plan.md) (moved from `not-shipped/`).

## What's in this PR

**Phase 1 — types, validator, schema migration.** New `TemplateNatsRole` / `TemplateNatsSigner` / `TemplateNatsImport` interfaces. `nats-signer-seed` `DynamicEnvSource` variant. New columns on `StackTemplateVersion` (`natsSubjectPrefix` / `natsRoles` / `natsSigners` / `natsExports` / `natsImports`); `natsRole` / `natsSigner` on `StackTemplateService`; new `NatsSigningKey` model. Substitution validator extended with the new NATS fields (inputs namespace stays KV-only). `validateNatsSectionShape()` centralises the legacy/new mixing rule + name uniqueness + per-role import binding across both the HTTP draft path and the file-loader path. `natsSectionToVersionWrite()` helper closes the same silent-drop bug class that hit `vaultAppRoleRef` (now caught by the schema-drift pin test).

**Phase 2 — admin-only prefix allowlist** at `/api/nats/prefix-allowlist`. CRUD-per-entry (not blob PUT, per design §2.6). Validation rejects wildcards, leading/trailing dots, `$SYS` prefixes, subject-tree overlaps (both ancestor and descendant), and references to nonexistent template IDs. Mounted before the catch-all `/api/nats` router.

**Phase 3 — roles materialisation in the apply orchestrator.** Resolves `subjectPrefix` (default `app.<stack.id>`); validates non-default prefixes against the Phase 2 allowlist. For each role: prepends the prefix, auto-injects `_INBOX.>` per `inboxAuto` (default `'both'`), upserts a `NatsCredentialProfile` keyed by `stackId`. `service.natsRole` resolves to the materialised profile via `natsCredentialId`. Defense-in-depth re-validates escape patterns at apply time, matching the static schema. Legacy `nats.credentials` path runs unchanged side-by-side (mixing rule prevents collisions).

**Phase 5 — cross-stack imports / exports.** Producer apply writes resolved (prefixed) exports + the resolved `subjectPrefix` into `lastAppliedNatsSnapshot`. Consumer apply scopes the producer lookup by `environmentId` (closes a cross-scope name-collision attack), validates each imported subject matches a producer-exported pattern via `natsSubjectMatches()` (NATS subject-pattern semantics: `>` matches one-or-more trailing tokens; `*` matches exactly one token), and adds the absolute subject to the subscribe list of only the `forRoles` roles. Self-imports rejected.

**Phase 7 — docs.** New "NATS app roles" section in [`docs/user/stack-definition-reference.md`](docs/user/stack-definition-reference.md) with the slackbot worked example.

## What's NOT in this PR (deferred follow-ups)

Tracked in [`docs/planning/not-shipped/nats-app-roles-followups.md`](docs/planning/not-shipped/nats-app-roles-followups.md):

- **Phase 0** — live account-JWT propagation via `$SYS.REQ.CLAIMS.UPDATE` over the full account resolver. Discrete spike, 2-3 engineer-days. Blocks Phase 4.
- **Phase 4** — signer materialisation. Type surface is shipped; apply-time wiring depends on Phase 0.
- **Phase 6** — slackbot-agent-sdk migration (separate repo). Depends on Phase 4.
- **Operational hardening**: orphan-profile cleanup on role rename (TODO comment in `materializeRole`); cycle detection in cross-stack imports (TODO comment in `resolveImport`); global NATS-apply lock; forced revocation path for in-flight JWTs.
- **Ergonomics**: CLI helper for the allowlist; per-user credential observability UI; `roles[].streams` for app-author JetStream; drift detection in `lastAppliedNatsSnapshot`.

## Review process

Each phase was reviewed by an independent sonnet subagent. Findings:

- **Phase 1** — six silent-drop bugs, all of the same `vaultAppRoleRef` regression class: `toTemplateServiceCreate`, `serializeTemplateService`, `buildNatsSection`, `upsertBuiltinTemplate`, `buildServiceDefinitionsFromVersion`, `createTemplateSchema` missing superRefine. All fixed.
- **Phase 2** — clean. One cosmetic improvement to the `nats:admin` permission description, applied.
- **Phase 3** — three minor cleanups: `credentialsMapped` accounting, apply-time `..` validation, orphan-on-rename TODO. All addressed.
- **Phase 5** — one real correctness bug: cross-scope name collision in producer lookup (`findFirst` was global; now scoped to `consumer.environmentId`). Plus a mixed producer+consumer integration test added.

## Test plan

- [x] `pnpm --filter mini-infra-server build` — clean
- [x] `pnpm --filter mini-infra-client build` — clean
- [x] `pnpm --filter mini-infra-server lint` — clean
- [x] `pnpm --filter mini-infra-server test` — **133 files / 2037 tests passing** (78 new tests added across 6 files):
  - `template-substitution-validator-nats.test.ts` — NATS-field substitution coverage
  - `nats-app-roles-schema.test.ts` — escape-pattern guards, mixing rule, name uniqueness, forRoles resolution
  - `stack-templates-draft-route-nats.integration.test.ts` — supertest HTTP round-trip persistence + GET-echo (catches the silent-drop bug class)
  - `nats-prefix-allowlist-route.integration.test.ts` — CRUD round-trip + every validation rule
  - `stack-nats-apply-orchestrator-roles.integration.test.ts` — default prefix, all four `inboxAuto` modes, two-stack isolation, allowlist enforcement, defense-in-depth, legacy passthrough, dual-binding preference, `credentialsMapped` accounting
  - `stack-nats-apply-orchestrator-imports.integration.test.ts` — `natsSubjectMatches` unit checks, producer snapshot writeback, per-role binding isolation, mixed producer+consumer chain, error paths (missing producer, no matching export, undeclared role)
- [ ] Spin up dev environment (`pnpm worktree-env start`) and apply a roles-bearing stack end-to-end. Phase 4 integration tests against a real NATS server are required before signers ship — not before this PR.

## Migration

`server/prisma/migrations/20260501100000_nats_app_roles_phase1/migration.sql` — additive only:
- `ALTER TABLE stack_template_services ADD COLUMN natsRole / natsSigner`
- `ALTER TABLE stack_template_versions ADD COLUMN natsExports / natsImports / natsRoles / natsSigners / natsSubjectPrefix`
- `CREATE TABLE nats_signing_keys` (FK to `nats_accounts` + `stacks`)
- SQLite redefinition blocks for `nats_accounts` / `nats_consumers` / `nats_credential_profiles` / `nats_state` / `nats_streams` (full-column-preserving — no data loss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)