### PR TITLE
fix(env): clip overflowing template descriptions; guard worktree-env start at 4 distros

### DIFF
--- a/client/src/components/environments/stacks-list.tsx
+++ b/client/src/components/environments/stacks-list.tsx
@@ -251,7 +251,7 @@ export function StacksList({ environmentId, scope, className }: StacksListProps)
                   <p className="text-sm font-medium text-muted-foreground mb-3">
                     Available templates for this environment
                   </p>
-                  <div className="grid gap-2">
+                  <div className="grid grid-cols-1 gap-2">
                     {availableTemplates.map((t) => (
                       <div
                         key={t.id}

--- a/deployment/development/lib/wsl.ts
+++ b/deployment/development/lib/wsl.ts
@@ -70,6 +70,16 @@ export function listRunningDistros(): string[] {
     .map((d) => d.name);
 }
 
+/**
+ * Subset of `listRunningDistros()` filtered to mini-infra-prefixed distros —
+ * the ones we know each run their own dockerd and contend for Docker's
+ * default address pool. Used by `worktree-start` to refuse new instances
+ * once too many daemons are already running.
+ */
+export function listRunningMiniInfraDistros(): string[] {
+  return listRunningDistros().filter((d) => d.startsWith(DISTRO_PREFIX));
+}
+
 export interface WslImportOpts {
   name: string;
   baseTarball: string;

--- a/deployment/development/worktree-start.ts
+++ b/deployment/development/worktree-start.ts
@@ -40,6 +40,7 @@ import {
   ensureDockerReady,
   importDistro,
   isDistroRunning,
+  listRunningMiniInfraDistros,
   startDocker as startWslDocker,
 } from './lib/wsl.js';
 import { seed, ensureVaultUnlocked } from './lib/seeder.js';
@@ -51,6 +52,15 @@ const COMPOSE_FILE = path.join(SCRIPT_DIR, 'docker-compose.worktree.yaml');
 
 const COLIMA_CPUS = 2;
 const COLIMA_MEMORY_GIB = 8;
+
+// Each running mini-infra WSL distro runs its own dockerd, and every dockerd
+// carves bridge subnets out of Docker's default address pool. Past ~4
+// concurrent daemons, new network creation starts failing with
+// `(HTTP code 400) unexpected - all predefined address pools have been
+// fully subnetted`, which surfaces in the UI as a stuck dataplane sync.
+// Refuse to start a *new* instance once this many are already running;
+// re-running an already-running profile stays allowed.
+const MAX_RUNNING_WSL_INSTANCES = 4;
 
 type Driver = 'colima' | 'wsl';
 
@@ -226,6 +236,23 @@ export async function run(argv: string[]): Promise<void> {
       assertWslAvailable();
     } catch (err) {
       logError(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+    const targetDistro = distroName(profile);
+    const runningMini = listRunningMiniInfraDistros();
+    const startingNew = !runningMini.includes(targetDistro);
+    if (startingNew && runningMini.length >= MAX_RUNNING_WSL_INSTANCES) {
+      logError(
+        `Refusing to start: ${runningMini.length} mini-infra WSL distros are already running ` +
+          `(max ${MAX_RUNNING_WSL_INSTANCES}). Each runs its own dockerd and contends for ` +
+          `Docker's default address pool — adding another typically triggers ` +
+          `'all predefined address pools have been fully subnetted' on network creation.`,
+      );
+      logError('Currently running:');
+      for (const d of runningMini) logError(`  - ${d}`);
+      logError('');
+      logError('Tear one down with:  pnpm worktree-env delete <profile> --force');
+      logError('See all profiles:    pnpm worktree-env list');
       process.exit(1);
     }
   }


### PR DESCRIPTION
## Summary

Two unrelated changes that landed together on this worktree branch.

### `fix(env)` — Available-templates overflow on environment detail page
- The list used `grid gap-2` with no explicit column track. Tailwind's bare `grid` only sets `display: grid`, so the implicit single column was `auto`-sized to its widest content. A long template description (e.g. the Hello Vault demo) made that column exceed the viewport, the cards stretched to fill it, and the existing `truncate` classes never fired because their parent had unbounded width.
- Fix: `grid` → `grid grid-cols-1`. Tailwind's `grid-cols-1` is `grid-template-columns: repeat(1, minmax(0, 1fr))`; the `minmax(0, 1fr)` caps the column at the parent width so `truncate` actually clips.
- One-line diff in [client/src/components/environments/stacks-list.tsx:254](client/src/components/environments/stacks-list.tsx).

### `feat(worktree-env)` — refuse to start at 4 running mini-infra distros
- Each running mini-infra WSL distro hosts its own dockerd. WSL2's default NAT networking shares one kernel netns across distros, so the daemons contend for Docker's default address-pool subnets. Past ~4 concurrent daemons, network creation starts failing with `(HTTP code 400) unexpected - all predefined address pools have been fully subnetted`, which surfaces in the UI as a stuck dataplane sync. (Hit IRL while spinning up a fifth worktree.)
- New `listRunningMiniInfraDistros()` helper in `deployment/development/lib/wsl.ts`.
- Guard in `worktree-env start` (`deployment/development/worktree-start.ts`) that bails with a helpful error listing what's running and pointing at `pnpm worktree-env delete` / `list`. Re-running an already-running profile stays allowed; only *new* instances trip the guard.

## Test plan

- [x] `pnpm --filter mini-infra-client lint` — clean.
- [x] Rebuilt the worktree image, navigated to `/environments/<id>`, confirmed:
  - Page no longer has horizontal overflow (`document.body.scrollWidth === clientWidth === 1280`).
  - Long Hello Vault description now ends with `…` ellipsis.
  - Add buttons all visible within viewport. (Before/after screenshots in `screenshots/available-templates.png` and `screenshots/fix-verified.png`.)
- [ ] Manual: spin up a 5th worktree to confirm the guard fires (intentionally untested in this PR — the guard's failure path is an `process.exit(1)` with `logError` calls and was inspected by reading the code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)