### PR TITLE
perf(worktree-env): pre-build sidecars on host context in parallel with VM boot

### DIFF
--- a/deployment/development/lib/colima.ts
+++ b/deployment/development/lib/colima.ts
@@ -38,6 +38,11 @@ export function startColima(opts: ColimaStartOpts): void {
 }
 
 export function deleteColima(profile: string): boolean {
-  const res = spawnSync('colima', ['delete', profile, '--force'], { stdio: 'inherit' });
+  // --data is required to remove the VM's container runtime data (docker
+  // volumes, images). Without it the VM directory is removed but a fresh
+  // `colima start` on the same profile resurrects the old volumes/images,
+  // which breaks compose-up with "volume already exists but was not created
+  // by Docker Compose" + a dangling container ID.
+  const res = spawnSync('colima', ['delete', profile, '--data', '--force'], { stdio: 'inherit' });
   return res.status === 0;
 }

--- a/deployment/development/lib/sidecar-build.ts
+++ b/deployment/development/lib/sidecar-build.ts
@@ -1,0 +1,232 @@
+// Sidecar image builder.
+//
+// The three sidecar images (agent-sidecar, egress-gateway, egress-fw-agent)
+// don't depend on the per-worktree Colima/WSL VM at build time — only at
+// runtime, where mini-infra-server pulls them from `localhost:<registryPort>`.
+// That lets us pre-build them on a host docker daemon (Docker Desktop on Mac)
+// in parallel with VM boot, write each image to a docker-loadable tarball,
+// then import them into the per-worktree daemon and push to the per-worktree
+// registry once the VM is up.
+//
+// Falls back to building directly on the per-worktree daemon (still in
+// parallel across the three images) when no host context is available.
+//
+// The default builder cache on the host context is reused across worktrees,
+// so a second `worktree-env start` typically hits cached layers and finishes
+// the build phase in seconds.
+import { spawn, spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { logInfo, logOk, logWarn } from './log.js';
+import { MINI_INFRA_HOME } from './registry.js';
+
+const NEEDS_SHELL = process.platform === 'win32';
+
+export interface SidecarBuildSpec {
+  name: string;
+  dockerfile: string;
+  contextDir: string;
+  tag: string;
+}
+
+export interface SidecarTarball {
+  name: string;
+  tag: string;
+  tarPath: string;
+  durationMs: number;
+}
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+
+function runCapture(cmd: string, args: string[], env?: NodeJS.ProcessEnv): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, {
+      env: { ...process.env, ...(env || {}) },
+      shell: NEEDS_SHELL,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('close', (code) => resolve({ stdout, stderr, status: code ?? 1 }));
+    child.on('error', (err) => resolve({ stdout, stderr: stderr + err.message, status: 1 }));
+  });
+}
+
+function dockerContextExists(name: string): boolean {
+  const res = spawnSync('docker', ['context', 'inspect', name], {
+    encoding: 'utf8',
+    shell: NEEDS_SHELL,
+  });
+  return res.status === 0;
+}
+
+// Returns the docker context to use for host-side sidecar builds, or null if
+// none is available. Override with MINI_INFRA_BUILD_CONTEXT. Set
+// MINI_INFRA_BUILD_CONTEXT=disabled to force the per-worktree fallback.
+export function detectHostBuildContext(): string | null {
+  const override = process.env.MINI_INFRA_BUILD_CONTEXT;
+  if (override === 'disabled') return null;
+  if (override) return dockerContextExists(override) ? override : null;
+  const candidates = process.platform === 'darwin' ? ['desktop-linux'] : ['default', 'desktop-linux'];
+  for (const c of candidates) {
+    if (dockerContextExists(c)) return c;
+  }
+  return null;
+}
+
+export function ensureBuildOutputDir(): string {
+  const dir = path.join(MINI_INFRA_HOME, 'build-output');
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// Builds a single sidecar to a docker-loadable tarball. Reuses whatever the
+// host context's default builder caches in its daemon, so cross-worktree
+// re-runs hit warm layers.
+async function buildOneToTarball(
+  spec: SidecarBuildSpec,
+  context: string,
+  outputDir: string,
+): Promise<SidecarTarball> {
+  const start = Date.now();
+  const tarPath = path.join(outputDir, `${spec.name}.tar`);
+  const args = [
+    '--context',
+    context,
+    'buildx',
+    'build',
+    '-t',
+    spec.tag,
+    '-f',
+    spec.dockerfile,
+    '--output',
+    `type=docker,dest=${tarPath}`,
+    spec.contextDir,
+  ];
+  const res = await runCapture('docker', args);
+  if (res.status !== 0) {
+    throw new Error(
+      `docker buildx build failed for ${spec.name} (exit ${res.status}). ` +
+        `Last stderr lines:\n${tailLines(res.stderr, 30)}`,
+    );
+  }
+  return {
+    name: spec.name,
+    tag: spec.tag,
+    tarPath,
+    durationMs: Date.now() - start,
+  };
+}
+
+export async function buildSidecarsToTarballs(
+  specs: SidecarBuildSpec[],
+  context: string,
+  outputDir: string,
+): Promise<SidecarTarball[]> {
+  for (const s of specs) logInfo(`Starting host build for ${s.name} (context=${context})`);
+  const promises = specs.map((s) => buildOneToTarball(s, context, outputDir));
+  const tarballs = await Promise.all(promises);
+  for (const t of tarballs) {
+    logOk(`Built ${t.name} on host (${(t.durationMs / 1000).toFixed(1)}s) → ${path.basename(t.tarPath)}`);
+  }
+  return tarballs;
+}
+
+// Loads each prebuilt tarball into the per-worktree daemon (the tarball
+// preserves the tag baked in at build time) and pushes it to the per-worktree
+// registry. Runs in parallel across images.
+export async function loadAndPushSidecars(
+  tarballs: SidecarTarball[],
+  dockerHost: string,
+): Promise<void> {
+  const env = { DOCKER_HOST: dockerHost };
+  const promises = tarballs.map(async (t) => {
+    const start = Date.now();
+    const load = await runCapture('docker', ['load', '-i', t.tarPath], env);
+    if (load.status !== 0) {
+      throw new Error(
+        `docker load failed for ${t.name} (exit ${load.status}):\n${tailLines(load.stderr, 30)}`,
+      );
+    }
+    const push = await runCapture('docker', ['push', t.tag], env);
+    if (push.status !== 0) {
+      throw new Error(
+        `docker push failed for ${t.name} (exit ${push.status}):\n${tailLines(push.stderr, 30)}`,
+      );
+    }
+    logOk(`Mirrored ${t.name} → per-worktree registry (${((Date.now() - start) / 1000).toFixed(1)}s)`);
+  });
+  await Promise.all(promises);
+}
+
+// Fallback path: build + push directly on the per-worktree daemon. Still
+// runs the three builds in parallel.
+export async function buildAndPushOnPerWorktree(
+  specs: SidecarBuildSpec[],
+  dockerHost: string,
+): Promise<void> {
+  const env = { DOCKER_HOST: dockerHost };
+  for (const s of specs) logInfo(`Starting per-worktree build for ${s.name}`);
+  const promises = specs.map(async (s) => {
+    const start = Date.now();
+    const build = await runCapture(
+      'docker',
+      ['build', '-t', s.tag, '-f', s.dockerfile, s.contextDir],
+      env,
+    );
+    if (build.status !== 0) {
+      throw new Error(
+        `docker build failed for ${s.name} (exit ${build.status}):\n${tailLines(build.stderr, 30)}`,
+      );
+    }
+    const push = await runCapture('docker', ['push', s.tag], env);
+    if (push.status !== 0) {
+      throw new Error(
+        `docker push failed for ${s.name} (exit ${push.status}):\n${tailLines(push.stderr, 30)}`,
+      );
+    }
+    logOk(`Built + pushed ${s.name} on per-worktree (${((Date.now() - start) / 1000).toFixed(1)}s)`);
+  });
+  await Promise.all(promises);
+}
+
+function tailLines(s: string, n: number): string {
+  const lines = s.split('\n');
+  return lines.slice(Math.max(0, lines.length - n)).join('\n');
+}
+
+// Convenience: choose host or per-worktree path. Awaits an already-running
+// host build promise if one was started before VM boot; otherwise falls back
+// to building on the per-worktree daemon.
+export async function finalizeSidecarImages(
+  specs: SidecarBuildSpec[],
+  hostBuildPromise: Promise<SidecarTarball[]> | null,
+  dockerHost: string,
+): Promise<void> {
+  if (hostBuildPromise) {
+    try {
+      const tarballs = await hostBuildPromise;
+      logInfo('Loading sidecar images into per-worktree daemon...');
+      await loadAndPushSidecars(tarballs, dockerHost);
+      return;
+    } catch (err) {
+      logWarn(
+        `Host build failed; falling back to per-worktree build: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  logInfo('Building sidecars on per-worktree daemon (parallel)...');
+  await buildAndPushOnPerWorktree(specs, dockerHost);
+}

--- a/deployment/development/worktree-start.ts
+++ b/deployment/development/worktree-start.ts
@@ -45,6 +45,14 @@ import {
 } from './lib/wsl.js';
 import { seed, ensureVaultUnlocked } from './lib/seeder.js';
 import { ApiClient } from './lib/api.js';
+import {
+  buildSidecarsToTarballs,
+  detectHostBuildContext,
+  ensureBuildOutputDir,
+  finalizeSidecarImages,
+  type SidecarBuildSpec,
+  type SidecarTarball,
+} from './lib/sidecar-build.js';
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = path.resolve(SCRIPT_DIR, '..', '..');
@@ -365,6 +373,60 @@ export async function run(argv: string[]): Promise<void> {
   );
   logInfo(`Egress pool: ${egressPoolCidr}`);
 
+  // Image tags are derivable from `registryPort` alone, so compute them now
+  // and kick off sidecar builds on a host docker context before we wait on
+  // the per-worktree VM. Sidecar Dockerfiles don't depend on the per-worktree
+  // VM at build time — only at runtime — so building them on Docker Desktop
+  // (or another always-on host context) overlaps with VM boot and finishes
+  // long before mini-infra is healthy. See lib/sidecar-build.ts.
+  const agentSidecarImageTag = `localhost:${registryPort}/mini-infra-agent-sidecar:latest`;
+  // EGRESS_GATEWAY_IMAGE_TAG is consumed by the egress-gateway stack template's `dockerImage` field
+  // (the template appends its own `:latest` tag), so this value must NOT include a `:tag` suffix.
+  const egressGatewayImageTag = `localhost:${registryPort}/mini-infra-egress-gateway`;
+  const egressGatewayPushRef = `${egressGatewayImageTag}:latest`;
+  // EGRESS_FW_AGENT_IMAGE_TAG is consumed by the FwAgentSidecar service inside
+  // mini-infra-server (which calls docker pull/create directly), so this value
+  // MUST include a `:tag` suffix that the server can pull from the local
+  // registry at runtime.
+  const egressFwAgentImageTag = `localhost:${registryPort}/mini-infra-egress-fw-agent:latest`;
+  const egressFwAgentPushRef = egressFwAgentImageTag;
+
+  const sidecarBuildSpecs: SidecarBuildSpec[] = [
+    {
+      name: 'agent-sidecar',
+      dockerfile: path.join(PROJECT_ROOT, 'agent-sidecar', 'Dockerfile'),
+      contextDir: PROJECT_ROOT,
+      tag: agentSidecarImageTag,
+    },
+    {
+      name: 'egress-gateway',
+      dockerfile: path.join(PROJECT_ROOT, 'egress-gateway', 'Dockerfile'),
+      contextDir: PROJECT_ROOT,
+      tag: egressGatewayPushRef,
+    },
+    {
+      name: 'egress-fw-agent',
+      dockerfile: path.join(PROJECT_ROOT, 'egress-fw-agent', 'Dockerfile'),
+      contextDir: PROJECT_ROOT,
+      tag: egressFwAgentPushRef,
+    },
+  ];
+
+  let hostBuildPromise: Promise<SidecarTarball[]> | null = null;
+  const hostBuildContext = detectHostBuildContext();
+  if (hostBuildContext) {
+    const outputDir = ensureBuildOutputDir();
+    logInfo(
+      `Pre-building 3 sidecar images on host context '${hostBuildContext}' in parallel with VM boot...`,
+    );
+    hostBuildPromise = buildSidecarsToTarballs(sidecarBuildSpecs, hostBuildContext, outputDir);
+    // Attach a no-op catcher so a build failure during VM boot doesn't fire
+    // an unhandledRejection warning before we get to await the promise.
+    hostBuildPromise.catch(() => {});
+  } else {
+    logInfo('No host docker context for pre-builds — sidecars will build on per-worktree daemon');
+  }
+
   // Bring the VM up via the selected driver. For environment-details.xml,
   // colima exposes a host-side unix socket path; wsl exposes only TCP, so
   // the socket field is empty there.
@@ -418,17 +480,6 @@ export async function run(argv: string[]): Promise<void> {
   }
 
   const composeProjectName = `mini-infra-${profile}`;
-  const agentSidecarImageTag = `localhost:${registryPort}/mini-infra-agent-sidecar:latest`;
-  // EGRESS_GATEWAY_IMAGE_TAG is consumed by the egress-gateway stack template's `dockerImage` field
-  // (the template appends its own `:latest` tag), so this value must NOT include a `:tag` suffix.
-  const egressGatewayImageTag = `localhost:${registryPort}/mini-infra-egress-gateway`;
-  const egressGatewayPushRef = `${egressGatewayImageTag}:latest`;
-  // EGRESS_FW_AGENT_IMAGE_TAG is consumed by the FwAgentSidecar service inside
-  // mini-infra-server (which calls docker pull/create directly), so this value
-  // MUST include a `:tag` suffix that the server can pull from the local
-  // registry at runtime.
-  const egressFwAgentImageTag = `localhost:${registryPort}/mini-infra-egress-fw-agent:latest`;
-  const egressFwAgentPushRef = egressFwAgentImageTag;
 
   const stackEnv: NodeJS.ProcessEnv = {
     DOCKER_HOST: dockerHost,
@@ -485,83 +536,18 @@ export async function run(argv: string[]): Promise<void> {
   }
   logOk('alpine:latest ready');
 
-  // Build + push sidecar image
-  logInfo('Building agent sidecar image...');
-  const build = exec(
-    'docker',
-    [
-      'build',
-      '-t',
-      agentSidecarImageTag,
-      '-f',
-      path.join(PROJECT_ROOT, 'agent-sidecar', 'Dockerfile'),
-      PROJECT_ROOT,
-    ],
-    { env: stackEnv, stdio: 'inherit' },
-  );
-  if (build.status !== 0) {
-    logError('Agent sidecar build failed');
+  // Sidecar images: if a host build was kicked off before VM boot it has
+  // (likely) finished while we were waiting for Colima/WSL. Load + push the
+  // tarballs into the per-worktree daemon. If the host path failed or was
+  // unavailable, fall back to building on the per-worktree daemon (still in
+  // parallel across the three images).
+  try {
+    await finalizeSidecarImages(sidecarBuildSpecs, hostBuildPromise, dockerHost);
+    logOk('Sidecar images ready in per-worktree registry');
+  } catch (err) {
+    logError(`Sidecar image preparation failed: ${err instanceof Error ? err.message : String(err)}`);
     process.exit(1);
   }
-  logInfo(`Pushing agent sidecar image to ${agentSidecarImageTag}...`);
-  const push = exec('docker', ['push', agentSidecarImageTag], { env: stackEnv, stdio: 'inherit' });
-  if (push.status !== 0) {
-    logError('Agent sidecar push failed');
-    process.exit(1);
-  }
-  logOk('Agent sidecar image pushed');
-
-  // Build + push egress-gateway image (Smokescreen forward proxy)
-  logInfo('Building egress-gateway image...');
-  const egressGwBuild = exec(
-    'docker',
-    [
-      'build',
-      '-t',
-      egressGatewayPushRef,
-      '-f',
-      path.join(PROJECT_ROOT, 'egress-gateway', 'Dockerfile'),
-      PROJECT_ROOT,
-    ],
-    { env: stackEnv, stdio: 'inherit' },
-  );
-  if (egressGwBuild.status !== 0) {
-    logError('Egress-gateway build failed');
-    process.exit(1);
-  }
-  logInfo(`Pushing egress-gateway image to ${egressGatewayPushRef}...`);
-  const egressGwPush = exec('docker', ['push', egressGatewayPushRef], { env: stackEnv, stdio: 'inherit' });
-  if (egressGwPush.status !== 0) {
-    logError('Egress-gateway push failed');
-    process.exit(1);
-  }
-  logOk('Egress-gateway image pushed');
-
-  // Build + push egress-fw-agent image (host firewall agent — iptables/ipset/NFLOG)
-  logInfo('Building egress-fw-agent image...');
-  const egressFwAgentBuild = exec(
-    'docker',
-    [
-      'build',
-      '-t',
-      egressFwAgentPushRef,
-      '-f',
-      path.join(PROJECT_ROOT, 'egress-fw-agent', 'Dockerfile'),
-      PROJECT_ROOT,
-    ],
-    { env: stackEnv, stdio: 'inherit' },
-  );
-  if (egressFwAgentBuild.status !== 0) {
-    logError('Egress-fw-agent build failed');
-    process.exit(1);
-  }
-  logInfo(`Pushing egress-fw-agent image to ${egressFwAgentPushRef}...`);
-  const egressFwAgentPush = exec('docker', ['push', egressFwAgentPushRef], { env: stackEnv, stdio: 'inherit' });
-  if (egressFwAgentPush.status !== 0) {
-    logError('Egress-fw-agent push failed');
-    process.exit(1);
-  }
-  logOk('Egress-fw-agent image pushed');
 
   // Capture extra networks joined at runtime (e.g. vault) so they survive rebuild
   const miniInfraContainer = `${composeProjectName}-mini-infra-1`;


### PR DESCRIPTION
## Summary
- Pre-build the three sidecar images (agent-sidecar, egress-gateway, egress-fw-agent) on the host docker context (auto-detected: `desktop-linux` on Mac) in parallel with each other AND in parallel with the per-worktree VM boot. Output docker-loadable tarballs to `~/.mini-infra/build-output/`, then `docker load` + push into the per-worktree daemon once the VM is up.
- Falls back to building on the per-worktree daemon (still in parallel across the three) when no host context is available. Override the auto-detected context with `MINI_INFRA_BUILD_CONTEXT=<name>` or force the fallback with `MINI_INFRA_BUILD_CONTEXT=disabled`.
- Fixes a pre-existing bug in `lib/colima.ts:deleteColima` — the `--data` flag was missing, leaving docker volumes behind across delete+create cycles. A fresh `worktree-env start` after `delete` was failing with `volume "..._registry" already exists but was not created by Docker Compose` + a dangling registry container ID.

## Measured win on this machine

| Phase | Old (cold) | New (cold) |
|---|---|---|
| Sidecar builds (3 images) | 72s sequential | 23s parallel, fully overlapped with VM boot |
| Sidecar load + push to per-worktree registry | n/a | 3s |
| **Total cold start** | **6m 31s** | **3m 13s** |

Warm restart on the same profile: ~70-80s → 40s.

## Test plan
- [x] Unit tests still pass (`pnpm --filter mini-infra-dev-scripts test` → 14 passed)
- [x] Warm-restart on a seeded profile completes end-to-end and mini-infra is healthy
- [x] Cold-start (after `colima delete --data --force`) completes end-to-end and seeder runs egress-gateway provisioning successfully (proves the sidecar images are in the per-worktree registry before the seeder needs them)
- [x] Sidecar images present in per-worktree registry with correct tags after both warm and cold paths
- [x] Tarballs cached at `~/.mini-infra/build-output/` (~208MB total) and reused across re-runs