### PR TITLE
feat(nats): NatsBus foundation for app-to-app messaging (Phase 1, ALT-26)

### DIFF
--- a/.github/workflows/nats-constants.yml
+++ b/.github/workflows/nats-constants.yml
@@ -1,0 +1,35 @@
+name: NATS subject constants drift check
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "lib/types/nats-subjects.ts"
+      - "egress-shared/natsbus/**"
+      - "scripts/check-nats-subject-drift.mjs"
+      - ".github/workflows/nats-constants.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "lib/types/nats-subjects.ts"
+      - "egress-shared/natsbus/**"
+      - "scripts/check-nats-subject-drift.mjs"
+      - ".github/workflows/nats-constants.yml"
+  workflow_dispatch:
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Run drift check
+        run: node scripts/check-nats-subject-drift.mjs

--- a/docs/planning/not-shipped/internal-nats-messaging-plan.md
+++ b/docs/planning/not-shipped/internal-nats-messaging-plan.md
@@ -1,0 +1,241 @@
+# Internal NATS Messaging — Migrating App-to-App Comms onto the Bus
+
+**Status:** planned, not implemented. Phased rollout — each phase is a separate Linear issue.
+**Builds on:** the `vault-nats` stack and `NatsControlPlaneService` shipped in #320 / #322, plus the App Roles / Signers / Prefix Allowlist work shipped through #332 (see [shipped/nats-app-roles-plan.md](../shipped/nats-app-roles-plan.md)).
+**Excludes:** `agent-sidecar/` — a separate solution is in flight for that surface.
+
+---
+
+## 1. Background
+
+We now run our own NATS server (the managed `vault-nats` stack) with JetStream, account isolation, scoped credentials, and live JWT propagation. Every piece of plumbing needed to use NATS as the spine for system-internal messaging is in place — but none of our own server↔sidecar comms have been moved onto it yet.
+
+Today, server↔sidecar communication is a grab-bag of bespoke transports:
+
+| Pair | Transport | Issues |
+|---|---|---|
+| server ↔ `egress-fw-agent` | HTTP/1.1 over a Unix socket at `/var/run/mini-infra/fw.sock`, plus Docker log attach for NFLOG, plus 30 s health poll | Three transports per peer; bespoke framing; volume mount; polling |
+| server → `egress-gateway` | HTTP REST to admin port `:8054`, plus Docker log attach for proxy decisions | Log-attach is fragile across container restarts and loses messages |
+| server → `update-sidecar` | One-shot container, env-vars in, exit code out | Status visibility limited to `docker events` and stdout tail |
+| server → `pg-az-backup` | One-shot container, exit code + stdout tail | No live progress; structured result has to be parsed back out of stdout |
+| app containers → `auth-proxy` | Synchronous HTTP reverse proxy on the request path | Out of scope — see §6 |
+
+Each transport has its own framing, error handling, retry policy, and observability story. Adding a new sidecar means inventing a fourth one. NATS gives us a single transport with consistent semantics (req/reply, fan-out events, durable JetStream replay) and inherits the credential, audit, and isolation guarantees we already built.
+
+The goal of this plan is to move every system-internal app-to-app channel onto NATS, behind one shared client, with one well-known subject namespace. After it lands, "talking to a sidecar" stops being a transport-design exercise.
+
+## 2. Goals
+
+1. **One shared client.** A single `NatsBus` helper inside `server/` (and a thin Go equivalent for the egress sidecars) — every publish/subscribe goes through it. No raw `nats.connect()` outside the bus.
+2. **One namespace, no collisions.** A single `mini-infra` subject prefix, allowlisted once, with a documented sub-tree per subsystem.
+3. **Drop a transport per migration.** Each phase removes one bespoke channel (Unix socket, log-attach, health poll, admin-port HTTP) and replaces it with NATS subjects.
+4. **Keep the existing observability story.** Long-running operations still emit Socket.IO `*_STARTED → *_STEP → *_COMPLETED` events; NATS just feeds the server, which fans out to the client. The client doesn't subscribe to NATS directly.
+5. **Same code path for built-in and user stacks.** The bus injects credentials through the existing `nats-creds` / `nats-url` `dynamicEnv` plumbing — built-in sidecars are just stacks with `natsRole` declared.
+
+## 3. Non-goals
+
+- **Replacing Socket.IO.** Server↔client pushes stay on Socket.IO. Channel/event constants in [`lib/types/socket-events.ts`](../../../lib/types/socket-events.ts) remain the contract for the UI.
+- **`auth-proxy` migration.** Synchronous credential brokering on the request path — NATS req/reply adds latency and a second moving part. Stays HTTP. See §6.
+- **`agent-sidecar` migration.** Out of scope — separate solution incoming.
+- **Replacing the Docker socket.** The server still owns `/var/run/docker.sock`. Sidecars do not start dialing Docker over NATS — the architectural invariant in [ARCHITECTURE.md](../../../ARCHITECTURE.md#external-boundaries) holds.
+- **Cross-host NATS.** Single NATS instance on the managed host, same as today. No leaf nodes, no superclusters.
+
+## 4. Subject naming convention
+
+The NATS docs ([nats.io/subjects](https://docs.nats.io/nats-concepts/subjects)) prescribe hierarchy, reserved prefixes (`$SYS`, `$JS`, `$KV`, `_INBOX`), wildcard syntax, ≤16 tokens, ≤256 chars, case sensitivity, and `-`/`_` as delimiters within a token. They do **not** prescribe a verb/tense convention, so we adopt one.
+
+### 4.1 The single system prefix: `mini-infra`
+
+All system-internal subjects live under `mini-infra.>`. Anything else is application traffic and uses `app.<stack.id>.>` (the default), or an admin-allowlisted prefix per the App Roles work.
+
+`mini-infra` is added to the prefix allowlist as part of Phase 1 and bound to system templates only — application templates cannot claim it. The allowlist is the existing `nats-prefix-allowlist` Configuration category; no new mechanism.
+
+### 4.2 The shape
+
+```
+mini-infra.<subsystem>.<aggregate>.<verb-or-event>[.<id>]
+```
+
+| Token | Meaning | Examples |
+|---|---|---|
+| `mini-infra` | Always. The system namespace. | — |
+| `<subsystem>` | The owning area, matches the directory layout where possible. | `egress`, `backup`, `update`, `tls`, `stacks`, `haproxy` |
+| `<aggregate>` | A noun — the thing the subsystem is acting on. Optional if the subsystem has only one aggregate. | `fw`, `gw`, `cert`, `stack` |
+| `<verb-or-event>` | The discriminator. Verbs and events follow different rules — see §4.3. | `apply`, `health`, `applied`, `failed` |
+| `<id>` | Optional opaque correlator (UUID, stack id, container id) when fan-out targets need it. | `01HXYZ…` |
+
+Tokens are kebab-case (no PascalCase, no underscores). Every segment lowercase. No wildcards in published subjects — wildcards are subscription-side only.
+
+### 4.3 Commands vs events vs heartbeats
+
+Three idioms, one rule each, so a subject's shape tells you what it is.
+
+- **Commands — imperative verb, request/reply.**
+  Subject ends with the imperative verb: `mini-infra.egress.fw.rules.apply`, `mini-infra.backup.run`, `mini-infra.update.cancel`.
+  Always invoked via NATS request/reply (publisher waits for the responder on the auto-generated `_INBOX.>` subject; the bus handles inbox plumbing). Body is a typed command payload; reply is a typed result.
+- **Events — past-participle verb, fan-out publish.**
+  Subject ends with what already happened: `mini-infra.egress.fw.rules.applied`, `mini-infra.backup.completed`, `mini-infra.update.health-check-passed`.
+  Published once, may be consumed by zero or more subscribers, durable on JetStream when replay matters (backup history, audit). Past-tense is a hard rule — if a subscriber sees an event subject they know it's a historical fact.
+- **Heartbeats — the noun, no verb.**
+  Subject ends with the aggregate alone: `mini-infra.egress.fw.health`, `mini-infra.update.health`.
+  Periodic publish of current state. Subscribers latch the most recent value. Use a JetStream KV bucket if last-known state needs to survive a server restart; otherwise plain pub/sub with a short interval.
+
+### 4.4 Inboxes and JetStream
+
+- **Inboxes** are NATS-native (`_INBOX.>`). The bus auto-injects `_INBOX.>` into every role's subscribe allow list per the existing App Roles `inboxAuto` default. Don't hand-roll reply subjects.
+- **JetStream streams** are named after the wildcard they capture, in PascalCase, no `mini-infra.` prefix:
+  `EgressFwEvents` captures `mini-infra.egress.fw.>`, `BackupHistory` captures `mini-infra.backup.>.completed` and `.failed`. Stream names have no dots and live in their own NATS namespace, so the prefix would only be visual noise.
+- **Consumers** are durable, named `<stream>-<subscriber>` (e.g. `EgressFwEvents-server`, `BackupHistory-events-page`).
+
+### 4.5 Worked example
+
+Egress firewall rule push, end-to-end:
+
+```
+Server publishes:    mini-infra.egress.fw.rules.apply       (request, payload = ruleset)
+fw-agent replies on: _INBOX.<auto>                          (result = applied | rejected + reason)
+fw-agent publishes:  mini-infra.egress.fw.rules.applied     (event, fan-out, JetStream-durable)
+fw-agent publishes:  mini-infra.egress.fw.events            (NFLOG stream, JetStream-durable)
+fw-agent publishes:  mini-infra.egress.fw.health            (heartbeat, every 5 s)
+Server subscribes:   mini-infra.egress.fw.events            (durable consumer EgressFwEvents-server)
+                     mini-infra.egress.fw.health            (no consumer; latest-only)
+```
+
+Each subject's shape says what it is at a glance — apply/applied is a command/event pair, `events` is a stream of facts, `health` is a heartbeat.
+
+## 5. The shared `NatsBus` (DRY chokepoint)
+
+A single TypeScript module, mirrors the shape of `DockerService.getInstance()`. Lives at `server/src/services/nats/nats-bus.ts`.
+
+```ts
+class NatsBus {
+  static getInstance(): NatsBus
+  publish<T>(subject: string, payload: T): Promise<void>
+  request<Req, Res>(subject: string, payload: Req, opts?: { timeoutMs }): Promise<Res>
+  subscribe<T>(subject: string, handler: (msg: T, ctx) => Promise<void>): Subscription
+  jetstream: {
+    ensureStream(spec): Promise<void>
+    publish<T>(subject: string, payload: T): Promise<PubAck>
+    consume<T>(stream, consumer, handler): Subscription
+    kv(bucket): KV
+  }
+}
+```
+
+Hard rules — these are what keep messages from getting mixed up:
+
+1. **Singleton.** One connection per process. The bus owns reconnect/backoff. No service constructs its own `nats.connect()`.
+2. **Subject constants.** Every subject is a constant in [`lib/types/nats-subjects.ts`](../../../lib/types/nats-subjects.ts) (new file), grouped by subsystem:
+   ```ts
+   export const EgressFw = {
+     rulesApply: "mini-infra.egress.fw.rules.apply",
+     rulesApplied: "mini-infra.egress.fw.rules.applied",
+     events: "mini-infra.egress.fw.events",
+     health: "mini-infra.egress.fw.health",
+   } as const;
+   ```
+   No raw subject strings anywhere in `server/src`. Mirrors the Socket.IO `Channel.*` / `ServerEvent.*` rule from [ARCHITECTURE.md](../../../ARCHITECTURE.md#cross-cutting-concerns).
+3. **Typed payloads.** Each subject has a Zod schema in `lib/types/nats-payloads/<subsystem>.ts`. The bus validates on publish *and* receive. Schema mismatch = thrown error, not a silently-truncated message.
+4. **Logger discipline.** Every publish/subscribe carries the existing `getLogger("integrations", "nats-bus")` context plus the subject and (for req/reply) the inbox correlation id. NDJSON lines join cleanly with HTTP `requestId` and operation `operationId`.
+5. **Go counterpart.** A small `egress-shared/natsbus` Go package holds the same constants and the same publish/subscribe wrappers, so `egress-fw-agent` and `egress-gateway` use the same shape. Constants live in two places (TS + Go) by necessity — Phase 1 includes a build-time check that they don't drift.
+
+What the bus is **not**: a generic message broker abstraction with pluggable transports, retries, dead-letter queues, or schema registry. NATS handles those concerns natively. The bus is a thin adapter, not a framework.
+
+## 6. Phased rollout
+
+Each phase is a separate Linear issue (linked at the bottom of this doc). Phases land in order — every phase depends on Phase 1 — but later phases are otherwise independent of each other.
+
+### Phase 1 — Foundation: `NatsBus`, subject constants, prefix allowlist entry
+
+**Goal:** the shared client, the namespace, and one trivial round-trip working end to end. No production traffic yet.
+
+Deliverables:
+- `server/src/services/nats/nats-bus.ts` (singleton, publish/request/subscribe, JetStream wrappers).
+- `lib/types/nats-subjects.ts` and `lib/types/nats-payloads/` (Zod schemas).
+- `egress-shared/natsbus/` (Go counterpart) and a build-time drift check.
+- `mini-infra` added to the prefix allowlist via a migration; bound to a new system role on the `vault-nats` template (so the server has credentials to publish/subscribe under it).
+- Smoke subject: `mini-infra.system.ping` (request/reply) used by a server-side health check that asserts the bus is up. Wired into the existing `Connected Service` health UI.
+- Logger and metrics hooks (publish count, subscribe count, request latency p50/p99).
+
+Done when: an integration test publishes `mini-infra.system.ping` from the server bus and gets a typed reply from a test responder, with both ends going through the singleton.
+
+### Phase 2 — `egress-fw-agent` onto NATS
+
+**Goal:** delete the Unix socket, the 30 s health poll, and the Docker log-attach for NFLOG.
+
+Subjects:
+- `mini-infra.egress.fw.rules.apply` (cmd, req/reply).
+- `mini-infra.egress.fw.rules.applied` (evt, JetStream `EgressFwEvents`).
+- `mini-infra.egress.fw.events` (NFLOG stream, JetStream `EgressFwEvents`).
+- `mini-infra.egress.fw.health` (heartbeat, 5 s, KV bucket `egress-fw-health`).
+
+Migration shape:
+1. fw-agent template gains `nats.roles[]` so it gets `NATS_URL` + `NATS_CREDS` injected.
+2. Go agent imports `egress-shared/natsbus`, replaces the HTTP server on the Unix socket with a `subscribe` on `rules.apply`, replaces the stdout-NFLOG with a `publish` on `events`, replaces the on-demand health endpoint with a heartbeat publisher.
+3. Server-side: [`fw-agent-transport.ts`](../../../server/src/services/egress/fw-agent-transport.ts) becomes a thin wrapper over `NatsBus.request(EgressFw.rulesApply, …)`; [`fw-agent-sidecar.ts`](../../../server/src/services/egress/fw-agent-sidecar.ts) loses its 30 s poll, replaced by reading the latest `health` heartbeat from the KV bucket.
+4. The Unix socket mount comes off the fw-agent stack template.
+5. Old transport stays compiled for one release behind a feature flag for rollback; flag is removed in the follow-up clean-up issue.
+
+Done when: a fresh worktree boots without a Unix socket on the fw-agent stack, rule applies succeed via NATS, health UI reflects heartbeat freshness, NFLOG ingester reads from JetStream.
+
+### Phase 3 — `egress-gateway` onto NATS
+
+**Goal:** delete the `:8054` admin HTTP listener and the canonical-decisions log-tail.
+
+Subjects:
+- `mini-infra.egress.gw.rules.apply` (cmd, req/reply).
+- `mini-infra.egress.gw.rules.applied` (evt).
+- `mini-infra.egress.gw.decisions` (every proxy decision; JetStream `EgressGwDecisions`, work-queue retention bounded by size and age).
+- `mini-infra.egress.gw.health` (heartbeat).
+
+Migration shape mirrors Phase 2. The Go gateway imports the same `natsbus` helper; `egress-log-ingester.ts` switches from `docker logs` follow to a JetStream durable consumer. Acceptance criterion is the same: the admin port comes off the template and decisions survive a gateway container restart (today they don't — log-attach drops in-flight lines).
+
+### Phase 4 — `pg-az-backup` progress + result events
+
+**Goal:** make backup runs first-class on the bus and free the server from parsing stdout.
+
+Subjects:
+- `mini-infra.backup.run` (cmd, req/reply, fired by the scheduler).
+- `mini-infra.backup.progress.<runId>` (evt stream, plain pub/sub — short-lived, no replay needed).
+- `mini-infra.backup.completed` (evt, JetStream `BackupHistory`).
+- `mini-infra.backup.failed` (evt, JetStream `BackupHistory`).
+
+The exit-code path stays as a fallback so a hard crash mid-run still surfaces as a failed event published by the server's container watcher. The in-memory job queue inside [`backup-executor.ts`](../../../server/src/services/backup/backup-executor.ts) becomes a NATS request flight; concurrency stays at two, enforced by the executor, not by NATS.
+
+Done when: backup progress steps appear live in the events page (Socket.IO fan-out from a server subscription on `progress.>`); `BackupHistory` stream replays the last N runs into the events list on cold load.
+
+### Phase 5 — `update-sidecar` progress (optional)
+
+**Goal:** harmonise self-update status with the rest of the bus.
+
+Smaller payoff than Phase 4 — the sidecar runs to completion in seconds and the existing `docker events` probe works. Worth doing only because it lets us delete the bespoke watcher in [`server/src/services/self-update.ts`](../../../server/src/services/self-update.ts) and reuse the same `*_STARTED → *_STEP → *_COMPLETED` pattern as backups.
+
+Subjects:
+- `mini-infra.update.run` (cmd, req/reply).
+- `mini-infra.update.progress.<runId>` (evt).
+- `mini-infra.update.completed` (evt, JetStream `UpdateHistory`).
+- `mini-infra.update.failed` (evt).
+- `mini-infra.update.health-check-passed` (evt — for the swap-then-validate flow).
+
+Defer until Phase 4 has settled — same pattern, same subscribers; no surprise.
+
+## 7. Risks & open questions
+
+- **Bootstrap ordering.** The server publishes onto a NATS server that the server itself manages (the `vault-nats` stack). On a cold start, the bus must tolerate NATS being unavailable for the first few seconds without crashing the boot sequence. The existing `Connected Service` retry pattern should cover this — verify in Phase 1.
+- **Constants drift between TS and Go.** `lib/types/nats-subjects.ts` and `egress-shared/natsbus/subjects.go` need to stay in lockstep. Phase 1 adds a CI check that diffs the parsed constants — a generator is overkill at this scale.
+- **JetStream storage budget.** `BackupHistory`, `EgressFwEvents`, `EgressGwDecisions` need explicit byte/age limits in the stream spec. Default to `max-bytes: 1 GiB` and `max-age: 30 d`; revisit when we have real data.
+- **Authorization ergonomics.** Each system subsystem becomes a `natsRole` on `vault-nats` (or its own built-in stack). Three roles is fine; if we end up with ten, revisit consolidation.
+- **Schema evolution.** Zod schemas are versioned by adding optional fields. Renaming or removing a field requires a new subject token (`v2`), not a schema flag — easier to grep, harder to footgun.
+- **Replacing Unix socket is a behaviour change.** Some operators may have monitoring on the socket file. Document the removal in the release notes for the Phase 2 release.
+
+## 8. Linear tracking
+
+Phase issues in Linear (Altitude Devops team) — each links back to this doc:
+
+- Phase 1 — Foundation: `NatsBus`, subject constants, prefix allowlist
+- Phase 2 — `egress-fw-agent` onto NATS
+- Phase 3 — `egress-gateway` onto NATS
+- Phase 4 — `pg-az-backup` progress + result events
+- Phase 5 — `update-sidecar` progress (optional)
+
+Issue identifiers will be appended here once filed.

--- a/docs/planning/not-shipped/internal-nats-messaging-plan.md
+++ b/docs/planning/not-shipped/internal-nats-messaging-plan.md
@@ -230,12 +230,10 @@ Defer until Phase 4 has settled — same pattern, same subscribers; no surprise.
 
 ## 8. Linear tracking
 
-Phase issues in Linear (Altitude Devops team) — each links back to this doc:
+Phase issues in Linear (Altitude Devops team) — each links back to this doc. Phase 1 blocks all later phases; Phase 5 also blocks on Phase 4.
 
-- Phase 1 — Foundation: `NatsBus`, subject constants, prefix allowlist
-- Phase 2 — `egress-fw-agent` onto NATS
-- Phase 3 — `egress-gateway` onto NATS
-- Phase 4 — `pg-az-backup` progress + result events
-- Phase 5 — `update-sidecar` progress (optional)
-
-Issue identifiers will be appended here once filed.
+- [ALT-26](https://linear.app/altitude-devops/issue/ALT-26) — Phase 1: Foundation (`NatsBus`, subject constants, prefix allowlist)
+- [ALT-27](https://linear.app/altitude-devops/issue/ALT-27) — Phase 2: `egress-fw-agent` onto NATS
+- [ALT-28](https://linear.app/altitude-devops/issue/ALT-28) — Phase 3: `egress-gateway` onto NATS
+- [ALT-29](https://linear.app/altitude-devops/issue/ALT-29) — Phase 4: `pg-az-backup` progress + result events
+- [ALT-30](https://linear.app/altitude-devops/issue/ALT-30) — Phase 5: `update-sidecar` progress (optional)

--- a/docs/planning/not-shipped/internal-nats-messaging-plan.md
+++ b/docs/planning/not-shipped/internal-nats-messaging-plan.md
@@ -145,19 +145,26 @@ What the bus is **not**: a generic message broker abstraction with pluggable tra
 
 Each phase is a separate Linear issue (linked at the bottom of this doc). Phases land in order — every phase depends on Phase 1 — but later phases are otherwise independent of each other.
 
-### Phase 1 — Foundation: `NatsBus`, subject constants, prefix allowlist entry
+### Phase 1 — Foundation: `NatsBus`, subject constants, smoke ping
 
 **Goal:** the shared client, the namespace, and one trivial round-trip working end to end. No production traffic yet.
 
 Deliverables:
 - `server/src/services/nats/nats-bus.ts` (singleton, publish/request/subscribe, JetStream wrappers).
-- `lib/types/nats-subjects.ts` and `lib/types/nats-payloads/` (Zod schemas).
-- `egress-shared/natsbus/` (Go counterpart) and a build-time drift check.
-- `mini-infra` added to the prefix allowlist via a migration; bound to a new system role on the `vault-nats` template (so the server has credentials to publish/subscribe under it).
-- Smoke subject: `mini-infra.system.ping` (request/reply) used by a server-side health check that asserts the bus is up. Wired into the existing `Connected Service` health UI.
-- Logger and metrics hooks (publish count, subscribe count, request latency p50/p99).
+- `lib/types/nats-subjects.ts` (subject constants only — runtime-dep-free, per `lib/CLAUDE.md`).
+- `server/src/services/nats/payload-schemas.ts` (Zod schemas + inferred types — schemas live server-side because the lib package is types-only).
+- `egress-shared/natsbus/` (Go counterpart, constants only — Go client wrappers land in Phase 2 with the first real consumer).
+- A `mini-infra-server-bus` `.creds` blob, minted by `applyConfig()` into Vault KV (`shared/nats-server-bus-creds`) and bound to the default account with `pub: ["mini-infra.>"]` + `sub: ["mini-infra.>", "_INBOX.>"]`. Read by `NatsBus` at connect time and rotated on every apply.
+- Smoke subject: `mini-infra.system.ping` (request/reply). The server's bus connection registers a loopback responder; a `pingSelf()` helper measures round-trip latency.
+- A CI drift check (`scripts/check-nats-subject-drift.mjs`) that fails when the TS and Go subject constants diverge.
+- Logger context (`getLogger("integrations", "nats-bus")`).
 
-Done when: an integration test publishes `mini-infra.system.ping` from the server bus and gets a typed reply from a test responder, with both ends going through the singleton.
+Deferred to follow-ups (deliberately out of Phase 1 scope):
+- **Prefix allowlist entry.** The allowlist gates which *templates* may claim a non-default prefix; the server's own creds carry pub/sub permission directly and don't go through the allowlist. The first template that needs to claim `mini-infra.egress.fw.*` (Phase 2) will add the entry.
+- **Connected Service / ConnectivityScheduler integration.** The scheduler is wired around `ConfigurationService.validate()` and adding a fake settings category for the bus is real scope creep. Phase 1 exposes `bus.getHealth()` + `pingSelf()`; UI integration lands as a follow-up.
+- **Metrics hooks.** Publish/subscribe counters and request-latency histograms are easy to add but no consumer wires them up yet — log lines carry the same data on a per-call basis until a real metrics surface lands.
+
+Done when: an integration test boots a real `nats:2.12.8-alpine` container, the server bus connects through the testcontainers URL, the loopback ping round-trips with a matching nonce, and Zod validation rejects malformed publishes.
 
 ### Phase 2 — `egress-fw-agent` onto NATS
 

--- a/egress-shared/natsbus/subjects.go
+++ b/egress-shared/natsbus/subjects.go
@@ -1,0 +1,86 @@
+// Package natsbus mirrors the NATS subject constants declared in
+// `lib/types/nats-subjects.ts`. Both files describe the same contract for
+// system-internal app-to-app messaging on the `mini-infra.>` namespace; the
+// drift check at `scripts/check-nats-subject-drift.mjs` runs in CI to keep
+// them in lock-step.
+//
+// Phase 1 ships constants only — there is no NATS client wrapper here yet.
+// The first real Go consumer (the egress-fw-agent in Phase 2) will add
+// publish/subscribe helpers.
+//
+// Naming rules (kept terse here; see the TS file for the full rationale):
+//
+//	mini-infra.<subsystem>.<aggregate>.<verb-or-event>[.<id>]
+//
+//	  Commands: imperative verb, used with request/reply.
+//	  Events:   past-participle verb, fan-out publish.
+//	  Heartbeat: noun only, periodic publish.
+package natsbus
+
+// SystemPrefix is the single namespace under which every system-internal
+// subject lives. App stacks use the per-stack default `app.<stack-id>.>`
+// or an admin-allowlisted prefix — both are out of scope of this package.
+const SystemPrefix = "mini-infra"
+
+// System / smoke ping (Phase 1).
+const (
+	SubjectSystemPing = "mini-infra.system.ping"
+)
+
+// Egress firewall agent subjects (Phase 2).
+const (
+	SubjectEgressFwRulesApply   = "mini-infra.egress.fw.rules.apply"
+	SubjectEgressFwRulesApplied = "mini-infra.egress.fw.rules.applied"
+	SubjectEgressFwEvents       = "mini-infra.egress.fw.events"
+	SubjectEgressFwHealth       = "mini-infra.egress.fw.health"
+)
+
+// Egress gateway subjects (Phase 3).
+const (
+	SubjectEgressGwRulesApply   = "mini-infra.egress.gw.rules.apply"
+	SubjectEgressGwRulesApplied = "mini-infra.egress.gw.rules.applied"
+	SubjectEgressGwDecisions    = "mini-infra.egress.gw.decisions"
+	SubjectEgressGwHealth       = "mini-infra.egress.gw.health"
+)
+
+// PostgreSQL backup subjects (Phase 4).
+const (
+	SubjectBackupRun             = "mini-infra.backup.run"
+	SubjectBackupProgressPrefix  = "mini-infra.backup.progress"
+	SubjectBackupCompleted       = "mini-infra.backup.completed"
+	SubjectBackupFailed          = "mini-infra.backup.failed"
+)
+
+// Self-update sidecar subjects (Phase 5, optional).
+const (
+	SubjectUpdateRun                = "mini-infra.update.run"
+	SubjectUpdateProgressPrefix     = "mini-infra.update.progress"
+	SubjectUpdateCompleted          = "mini-infra.update.completed"
+	SubjectUpdateFailed             = "mini-infra.update.failed"
+	SubjectUpdateHealthCheckPassed  = "mini-infra.update.health-check-passed"
+)
+
+// AllSubjects is the flat list used by the TS↔Go drift check. Order matches
+// `ALL_NATS_SUBJECTS` in `lib/types/nats-subjects.ts` (subjects-as-set
+// equality is what the check enforces, but mirroring the order makes diffs
+// readable).
+var AllSubjects = []string{
+	SubjectSystemPing,
+	SubjectEgressFwRulesApply,
+	SubjectEgressFwRulesApplied,
+	SubjectEgressFwEvents,
+	SubjectEgressFwHealth,
+	SubjectEgressGwRulesApply,
+	SubjectEgressGwRulesApplied,
+	SubjectEgressGwDecisions,
+	SubjectEgressGwHealth,
+	SubjectBackupRun,
+	SubjectBackupProgressPrefix,
+	SubjectBackupCompleted,
+	SubjectBackupFailed,
+	SubjectUpdateRun,
+	SubjectUpdateProgressPrefix,
+	SubjectUpdateCompleted,
+	SubjectUpdateFailed,
+	SubjectUpdateHealthCheckPassed,
+}

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -89,6 +89,9 @@ export * from "./vault";
 // NATS types
 export * from "./nats";
 
+// NATS subject constants (system-internal app-to-app messaging)
+export * from "./nats-subjects";
+
 // Egress firewall types
 export * from "./egress";
 

--- a/lib/types/nats-subjects.ts
+++ b/lib/types/nats-subjects.ts
@@ -1,0 +1,138 @@
+/**
+ * NATS subject constants for system-internal app-to-app messaging.
+ *
+ * Every system-internal subject lives under `mini-infra.>`. Application stacks
+ * use the per-stack default `app.<stack-id>.>` or an admin-allowlisted prefix
+ * — those are out of scope for this file.
+ *
+ * Naming rules (see docs/planning/not-shipped/internal-nats-messaging-plan.md
+ * §4 for the rationale):
+ *
+ *   mini-infra.<subsystem>.<aggregate>.<verb-or-event>[.<id>]
+ *
+ *   - Commands: imperative verb, used with request/reply.
+ *       e.g. `mini-infra.egress.fw.rules.apply`
+ *   - Events: past-participle verb, fan-out publish.
+ *       e.g. `mini-infra.egress.fw.rules.applied`
+ *   - Heartbeats: noun only, periodic publish of current state.
+ *       e.g. `mini-infra.egress.fw.health`
+ *
+ * Tokens are kebab-case and lowercase. No wildcards in published subjects.
+ *
+ * **This file is the contract.** No raw subject strings are allowed in
+ * `server/src` — always import from here. There is a Go mirror at
+ * `egress-shared/natsbus/subjects.go`; the two are kept in sync by
+ * `scripts/check-nats-subject-drift.mjs` in CI.
+ */
+
+/**
+ * The single system prefix. Every subject below begins with this token. Adding
+ * `mini-infra` to the prefix allowlist (so app-authored templates can claim
+ * it) is deferred to Phase 2 — Phase 1 is server-only and the server's bus
+ * credential carries explicit pub/sub permission on `mini-infra.>` directly.
+ */
+export const NATS_SYSTEM_PREFIX = "mini-infra" as const;
+
+/** Phase 1: smoke-ping subjects used by the bus health-check loopback. */
+export const SystemSubject = {
+  /**
+   * Request/reply liveness probe. The server subscribes to this on its own
+   * bus connection (see `server/src/services/nats/nats-bus-ping.ts`) and
+   * replies with `SystemPingReply`. Phase 1 only. Phase 2+ may add
+   * subsystem-specific responders.
+   */
+  ping: "mini-infra.system.ping",
+} as const;
+
+/** Phase 2: egress firewall agent subjects. Reserved here so the constants
+ *  exist when the migration begins; the agent is not yet on the bus. */
+export const EgressFwSubject = {
+  /** Command (req/reply): server pushes a new ruleset to the agent. */
+  rulesApply: "mini-infra.egress.fw.rules.apply",
+  /** Event: ruleset successfully applied; durable on JetStream. */
+  rulesApplied: "mini-infra.egress.fw.rules.applied",
+  /** Event stream: NFLOG events; durable on JetStream. */
+  events: "mini-infra.egress.fw.events",
+  /** Heartbeat: current health snapshot, published every few seconds. */
+  health: "mini-infra.egress.fw.health",
+} as const;
+
+/** Phase 3: egress gateway subjects. Reserved. */
+export const EgressGwSubject = {
+  rulesApply: "mini-infra.egress.gw.rules.apply",
+  rulesApplied: "mini-infra.egress.gw.rules.applied",
+  /** Event stream: per-decision proxy verdicts; JetStream durable. */
+  decisions: "mini-infra.egress.gw.decisions",
+  health: "mini-infra.egress.gw.health",
+} as const;
+
+/** Phase 4: PostgreSQL backup subjects. Reserved. */
+export const BackupSubject = {
+  /** Command: scheduler invokes a backup run. */
+  run: "mini-infra.backup.run",
+  /** Event prefix: per-run progress (`...progress.<runId>`). Plain pub/sub. */
+  progressPrefix: "mini-infra.backup.progress",
+  /** Event: backup finished successfully; JetStream durable. */
+  completed: "mini-infra.backup.completed",
+  /** Event: backup failed; JetStream durable. */
+  failed: "mini-infra.backup.failed",
+} as const;
+
+/** Phase 5 (optional): self-update sidecar subjects. Reserved. */
+export const UpdateSubject = {
+  run: "mini-infra.update.run",
+  progressPrefix: "mini-infra.update.progress",
+  completed: "mini-infra.update.completed",
+  failed: "mini-infra.update.failed",
+  healthCheckPassed: "mini-infra.update.health-check-passed",
+} as const;
+
+/**
+ * Wildcard subjects used for stream/consumer subscriptions. Defined alongside
+ * the subjects they capture so the relationship is obvious at the call site.
+ */
+export const NatsWildcard = {
+  egressFwAll: "mini-infra.egress.fw.>",
+  egressGwAll: "mini-infra.egress.gw.>",
+  backupAll: "mini-infra.backup.>",
+  backupProgressAll: "mini-infra.backup.progress.>",
+  updateAll: "mini-infra.update.>",
+  updateProgressAll: "mini-infra.update.progress.>",
+} as const;
+
+/**
+ * JetStream stream names. Names live in their own NATS namespace so they do
+ * not carry the `mini-infra.` prefix; PascalCase per NATS convention.
+ */
+export const NatsStream = {
+  egressFwEvents: "EgressFwEvents",
+  egressGwDecisions: "EgressGwDecisions",
+  backupHistory: "BackupHistory",
+  updateHistory: "UpdateHistory",
+} as const;
+
+/**
+ * Flat array of every concrete subject this file declares. Used by the
+ * TS↔Go drift check to compare against the Go mirror without having to know
+ * the grouping shape.
+ */
+export const ALL_NATS_SUBJECTS: readonly string[] = [
+  SystemSubject.ping,
+  EgressFwSubject.rulesApply,
+  EgressFwSubject.rulesApplied,
+  EgressFwSubject.events,
+  EgressFwSubject.health,
+  EgressGwSubject.rulesApply,
+  EgressGwSubject.rulesApplied,
+  EgressGwSubject.decisions,
+  EgressGwSubject.health,
+  BackupSubject.run,
+  BackupSubject.progressPrefix,
+  BackupSubject.completed,
+  BackupSubject.failed,
+  UpdateSubject.run,
+  UpdateSubject.progressPrefix,
+  UpdateSubject.completed,
+  UpdateSubject.failed,
+  UpdateSubject.healthCheckPassed,
+] as const;

--- a/scripts/check-nats-subject-drift.mjs
+++ b/scripts/check-nats-subject-drift.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * Drift check between the TypeScript subject constants in
+ * `lib/types/nats-subjects.ts` and their Go mirror in
+ * `egress-shared/natsbus/subjects.go`.
+ *
+ * Both files declare the same contract for system-internal NATS subjects
+ * (the `mini-infra.>` namespace). They live in two languages because they
+ * are consumed by two runtimes (Node server + Go egress sidecars). This
+ * check parses both files and fails CI if the *set* of subject string
+ * literals diverges.
+ *
+ * Why parse instead of codegen: the TS file is `as const` literal-grouped
+ * objects that double as documentation; the Go file is plain top-level
+ * `const` blocks that the Go ecosystem expects. Generating either side
+ * loses readability, and a tiny parser is enough to enforce equivalence.
+ *
+ * Run via `node scripts/check-nats-subject-drift.mjs` (no deps). CI workflow
+ * is `.github/workflows/nats-constants.yml`.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+const TS_PATH = resolve(REPO_ROOT, "lib/types/nats-subjects.ts");
+const GO_PATH = resolve(REPO_ROOT, "egress-shared/natsbus/subjects.go");
+
+/**
+ * Extract `mini-infra.*` string literals from a source file. Both TS and Go
+ * use the same `"mini-infra.<...>"` literal form, so one regex covers both.
+ * Excluding `mini-infra.>` and similar (the wildcards file is separate in TS;
+ * Go currently has none) keeps the comparison to concrete subjects only.
+ */
+function extractSubjects(source) {
+  const re = /"(mini-infra\.[a-z0-9.\-]+)"/g;
+  const found = new Set();
+  for (const m of source.matchAll(re)) {
+    const subject = m[1];
+    if (subject.includes(">") || subject.includes("*")) continue;
+    found.add(subject);
+  }
+  return found;
+}
+
+function diff(setA, setB) {
+  const onlyInA = [...setA].filter((s) => !setB.has(s)).sort();
+  const onlyInB = [...setB].filter((s) => !setA.has(s)).sort();
+  return { onlyInA, onlyInB };
+}
+
+const ts = readFileSync(TS_PATH, "utf8");
+const go = readFileSync(GO_PATH, "utf8");
+
+const tsSubjects = extractSubjects(ts);
+const goSubjects = extractSubjects(go);
+
+const { onlyInA: onlyInTs, onlyInB: onlyInGo } = diff(tsSubjects, goSubjects);
+
+if (onlyInTs.length === 0 && onlyInGo.length === 0) {
+  console.log(
+    `OK — ${tsSubjects.size} subjects in lock-step between ${TS_PATH} and ${GO_PATH}`,
+  );
+  process.exit(0);
+}
+
+console.error("NATS subject constants drift detected.\n");
+if (onlyInTs.length > 0) {
+  console.error("Only in TypeScript (lib/types/nats-subjects.ts):");
+  for (const s of onlyInTs) console.error(`  + ${s}`);
+}
+if (onlyInGo.length > 0) {
+  console.error("Only in Go (egress-shared/natsbus/subjects.go):");
+  for (const s of onlyInGo) console.error(`  + ${s}`);
+}
+console.error(
+  "\nFix: add or remove the missing subject in the file that's behind, " +
+    "then re-run `node scripts/check-nats-subject-drift.mjs` locally.",
+);
+process.exit(1);

--- a/server/src/routes/nats.ts
+++ b/server/src/routes/nats.ts
@@ -6,6 +6,7 @@ import { getUserId } from "../lib/get-user-id";
 import { emitToChannel } from "../lib/socket";
 import { requirePermission } from "../middleware/auth";
 import { getNatsControlPlaneService } from "../services/nats/nats-control-plane-service";
+import { NatsBus } from "../services/nats/nats-bus";
 import { Channel, ServerEvent } from "@mini-infra/types";
 
 const router = Router();
@@ -94,6 +95,12 @@ router.post(
     try {
       await getNatsControlPlaneService().applyConfig();
       await getNatsControlPlaneService().applyJetStreamResources();
+      // applyConfig() rotated the server-bus creds blob in Vault KV; tell
+      // the live bus to reconnect and pick up the fresh creds. No-op if
+      // the bus hasn't been started yet (cold-boot path is wired in
+      // server.ts and short-circuits there). Same call site as the boot
+      // path — keeps the mint-then-invalidate pair consistent.
+      NatsBus.getInstance().invalidateCreds();
       emitToChannel(Channel.NATS, ServerEvent.NATS_APPLIED, { operationId, success: true });
       res.json({ success: true, data: { operationId } });
     } catch (err) {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -63,6 +63,8 @@ import { setupHAProxyCrashLoopWatcher } from "./services/haproxy/haproxy-crash-l
 import { initVaultServices } from "./services/vault/vault-services";
 import { seedVaultPolicies } from "./services/vault/vault-seed";
 import { getNatsControlPlaneService } from "./services/nats/nats-control-plane-service";
+import { NatsBus } from "./services/nats/nats-bus";
+import { registerPingResponder } from "./services/nats/nats-bus-ping";
 import {
   startEgressBackgroundServices,
   ensureFwAgent,
@@ -325,6 +327,10 @@ const initializeServices = async () => {
             // installed; the conf will simply sit unread in the KV.
             try {
               await getNatsControlPlaneService().applyConfig();
+              // applyConfig() rotates the server-bus creds blob in Vault KV
+              // every run; tell any already-connected bus to reconnect with
+              // the fresh creds. No-op on cold boot (bus not started yet).
+              NatsBus.getInstance().invalidateCreds();
             } catch (natsErr) {
               logger.warn(
                 { err: natsErr instanceof Error ? natsErr.message : String(natsErr) },
@@ -347,6 +353,32 @@ const initializeServices = async () => {
       logger.error(
         { err: err instanceof Error ? err.message : String(err) },
         "Failed to initialize Vault services (non-fatal)",
+      );
+    }
+
+    // Start the system NATS bus. Non-blocking — the connect loop runs in
+    // the background and tolerates vault-nats not being up yet (fresh
+    // worktree boot, or NATS container restart). Registering the ping
+    // responder before `ready()` is important: NatsBus subscriptions are
+    // durable across reconnects, so the responder is attached automatically
+    // whenever the bus first reaches `connected`.
+    try {
+      NatsBus.getInstance().start();
+      registerPingResponder();
+      try {
+        await NatsBus.getInstance().ready({ timeoutMs: 3_000 });
+        console.log("[STARTUP] ✓ NATS bus connected");
+      } catch (busErr) {
+        logger.info(
+          { err: busErr instanceof Error ? busErr.message : String(busErr) },
+          "NATS bus not connected at boot — will keep retrying in the background",
+        );
+        console.log("[STARTUP] NATS bus retrying in background (non-fatal)");
+      }
+    } catch (err) {
+      logger.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "NATS bus start failed (non-fatal)",
       );
     }
 
@@ -654,6 +686,16 @@ startServer()
       if (poolInstanceReaper) {
         poolInstanceReaper.stop();
         logger.info("Pool instance reaper stopped");
+      }
+
+      // Drain the system NATS bus before stopping containers — otherwise
+      // any in-flight publishes (including ping replies) get truncated and
+      // log noise spikes during shutdown.
+      try {
+        await NatsBus.getInstance().shutdown();
+        logger.info("NATS bus drained");
+      } catch (err) {
+        logger.warn({ err }, "NATS bus shutdown failed (non-fatal)");
       }
 
       // Shutdown agent service

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -328,8 +328,11 @@ const initializeServices = async () => {
             try {
               await getNatsControlPlaneService().applyConfig();
               // applyConfig() rotates the server-bus creds blob in Vault KV
-              // every run; tell any already-connected bus to reconnect with
-              // the fresh creds. No-op on cold boot (bus not started yet).
+              // every run. invalidateCreds() forces a reconnect when the bus
+              // is already running (subsequent applies). On the cold-boot
+              // path the bus hasn't started yet — see invalidateCreds()'s
+              // pre-start handling — and the first connect later in the
+              // boot sequence reads the fresh creds straight out of Vault.
               NatsBus.getInstance().invalidateCreds();
             } catch (natsErr) {
               logger.warn(

--- a/server/src/services/nats/__tests__/nats-bus.external.test.ts
+++ b/server/src/services/nats/__tests__/nats-bus.external.test.ts
@@ -1,0 +1,89 @@
+/**
+ * NatsBus integration test against a real `nats:2.12.8-alpine` container.
+ *
+ * Phase 1 verifies the smallest end-to-end loop: the server bus connects to
+ * NATS, registers the smoke-ping responder, and a `pingSelf()` call returns
+ * a typed reply with the same nonce. Schema validation is exercised on both
+ * the publish and reply paths.
+ *
+ * Named `*.external.test.ts` to match the convention in `nats-account-claim-
+ * update.external.test.ts` — these tests pull a Docker image and run a real
+ * server, so they're slower than the in-memory suite.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { GenericContainer, type StartedTestContainer, Wait } from "testcontainers";
+import { SystemSubject } from "@mini-infra/types";
+import { NatsBus } from "../nats-bus";
+import { pingSelf, registerPingResponder } from "../nats-bus-ping";
+
+const NATS_IMAGE = "nats:2.12.8-alpine";
+
+let container: StartedTestContainer;
+let bus: NatsBus;
+let url: string;
+
+describe("NatsBus (external)", () => {
+  beforeAll(async () => {
+    // Phase 1 smoke uses no auth — we're testing the bus mechanics, not the
+    // creds plumbing (covered by the existing nats-account-claim-update
+    // tests). The Phase 0 control-plane tests use a full operator/account
+    // setup; mixing that in here would add boot time without coverage value.
+    container = await new GenericContainer(NATS_IMAGE)
+      .withCommand(["-js", "-m", "8222"])
+      .withExposedPorts(4222, 8222)
+      .withWaitStrategy(Wait.forHttp("/healthz", 8222).forStatusCode(200))
+      .withStartupTimeout(20_000)
+      .start();
+    url = `nats://${container.getHost()}:${container.getMappedPort(4222)}`;
+    NatsBus.resetInstanceForTests();
+    bus = NatsBus.getInstance({ testOverride: { url } });
+    bus.start();
+    await bus.ready({ timeoutMs: 10_000 });
+    registerPingResponder();
+  }, 30_000);
+
+  afterAll(async () => {
+    if (bus) await bus.shutdown();
+    NatsBus.resetInstanceForTests();
+    if (container) {
+      try {
+        await container.stop({ timeout: 5_000 });
+      } catch {
+        // best-effort
+      }
+    }
+  });
+
+  it("connects via the test override URL", () => {
+    const health = bus.getHealth();
+    expect(health.state).toBe("connected");
+    expect(health.url).toBe(url);
+    expect(health.lastConnectedAtMs).not.toBeNull();
+  });
+
+  it("ping/pong round-trips with matching nonce", async () => {
+    const result = await pingSelf(2_000);
+    expect(result.reply.responder).toBe("server");
+    expect(typeof result.reply.nonce).toBe("string");
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(result.latencyMs).toBeLessThan(2_000);
+  });
+
+  it("rejects publishes with payloads that fail Zod validation", async () => {
+    await expect(
+      // Missing `nonce` and `sentAtMs` — schema requires both.
+      bus.request(SystemSubject.ping, {} as { nonce: string; sentAtMs: number }, {
+        timeoutMs: 1_000,
+      }),
+    ).rejects.toThrow(/nats payload validation failed/);
+  });
+
+  it("getHealth() reports a connected state and a recent connect timestamp", () => {
+    const before = Date.now();
+    const health = bus.getHealth();
+    expect(health.state).toBe("connected");
+    expect(health.lastConnectedAtMs).toBeLessThanOrEqual(before);
+    expect(health.lastErrorMessage).toBeNull();
+  });
+});

--- a/server/src/services/nats/nats-bus-ping.ts
+++ b/server/src/services/nats/nats-bus-ping.ts
@@ -1,0 +1,88 @@
+/**
+ * Smoke ping for the NatsBus.
+ *
+ * Phase 1 closes the bus loop by having the server reply to its own
+ * `mini-infra.system.ping` requests. Until Phase 2 wires the first real
+ * peer (egress-fw-agent), this is the only honest health-check the bus
+ * has — but it does prove a non-trivial set of guarantees end to end:
+ *
+ *   - the bus is connected to NATS
+ *   - server-bus credentials grant pub + sub on `mini-infra.>`
+ *   - JSON encode/decode and Zod validation are wired correctly
+ *   - request/reply round-trip latency is measurable
+ *
+ * `registerPingResponder()` runs once at boot. `pingSelf()` is the active
+ * probe — call it for a synthetic request/reply cycle that returns the
+ * round-trip latency. A future ConnectivityScheduler integration can poll
+ * `pingSelf()` on a timer; that's deliberately out of scope for Phase 1.
+ */
+
+import { randomUUID } from "node:crypto";
+import { SystemSubject } from "@mini-infra/types";
+import { getLogger } from "../../lib/logger-factory";
+import { NatsBus } from "./nats-bus";
+import type {
+  SystemPingReply,
+  SystemPingRequest,
+} from "./payload-schemas";
+
+const log = getLogger("integrations", "nats-bus-ping");
+
+const RESPONDER_ID = "server";
+
+let cancel: (() => void) | null = null;
+
+/**
+ * Subscribe the server's bus connection to `mini-infra.system.ping` and reply
+ * with a typed `SystemPingReply`. Idempotent — calling twice is a no-op. The
+ * subscription is durable across bus reconnects (NatsBus re-attaches it).
+ */
+export function registerPingResponder(): void {
+  if (cancel) return;
+  const bus = NatsBus.getInstance();
+  cancel = bus.respond<SystemPingRequest, SystemPingReply>(
+    SystemSubject.ping,
+    (req) => ({
+      nonce: req.nonce,
+      receivedAtMs: Date.now(),
+      responder: RESPONDER_ID,
+    }),
+  );
+  log.info({ subject: SystemSubject.ping }, "ping responder registered");
+}
+
+/** Tear down the responder. For tests; production never unregisters. */
+export function unregisterPingResponderForTests(): void {
+  if (cancel) {
+    cancel();
+    cancel = null;
+  }
+}
+
+export interface PingResult {
+  latencyMs: number;
+  reply: SystemPingReply;
+}
+
+/**
+ * Issue a `mini-infra.system.ping` request against the bus and return the
+ * round-trip latency. Throws if the bus is not connected or the reply fails
+ * validation.
+ */
+export async function pingSelf(timeoutMs = 2_000): Promise<PingResult> {
+  const bus = NatsBus.getInstance();
+  const sentAtMs = Date.now();
+  const nonce = randomUUID();
+  const reply = await bus.request<SystemPingRequest, SystemPingReply>(
+    SystemSubject.ping,
+    { nonce, sentAtMs },
+    { timeoutMs },
+  );
+  const latencyMs = Date.now() - sentAtMs;
+  if (reply.nonce !== nonce) {
+    throw new Error(
+      `ping reply nonce mismatch (expected ${nonce}, got ${reply.nonce})`,
+    );
+  }
+  return { latencyMs, reply };
+}

--- a/server/src/services/nats/nats-bus.ts
+++ b/server/src/services/nats/nats-bus.ts
@@ -1,0 +1,556 @@
+/**
+ * NatsBus — the singleton chokepoint for system-internal NATS messaging.
+ *
+ * One NATS connection per server process. All publish/request/subscribe goes
+ * through here so we get one set of guarantees instead of N: typed payloads,
+ * Zod validation on both ends, structured logging with subject correlation,
+ * a non-blocking reconnect loop, and a single shutdown path.
+ *
+ * Subjects are constants in `lib/types/nats-subjects.ts`. Schemas live in
+ * `./payload-schemas.ts`. **No raw subject strings or raw `nats.connect()`
+ * elsewhere in `server/src`** — see the rules in
+ * `docs/planning/not-shipped/internal-nats-messaging-plan.md` §5.
+ *
+ * Boot ordering (server/src/server.ts): `NatsBus.getInstance().start()` is
+ * fire-and-forget and returns immediately. The reconnect loop runs forever
+ * in the background, so a fresh worktree where `vault-nats` hasn't booted
+ * yet doesn't stall the parent process. Callers that genuinely need a
+ * connection use `await bus.ready({ timeoutMs })`.
+ */
+
+import { connect, credsAuthenticator, type NatsConnection, type Subscription } from "nats";
+import { z, type ZodType } from "zod";
+import { getLogger } from "../../lib/logger-factory";
+import { getVaultKVService } from "../vault/vault-kv-service";
+import { getNatsControlPlaneService } from "./nats-control-plane-service";
+import {
+  NATS_SERVER_BUS_CREDS_KV_PATH,
+} from "./nats-control-plane-service";
+import { payloadSchemas, type SubjectSchemaEntry } from "./payload-schemas";
+
+const log = getLogger("integrations", "nats-bus");
+
+const FIELD_SERVER_BUS_CREDS = "creds";
+const RECONNECT_BACKOFF_MIN_MS = 1_000;
+const RECONNECT_BACKOFF_MAX_MS = 30_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 5_000;
+
+export type BusState = "disconnected" | "connecting" | "connected" | "shutting-down";
+
+export interface BusHealth {
+  state: BusState;
+  /** Wall-clock time (ms since epoch) of the last successful connect. */
+  lastConnectedAtMs: number | null;
+  /** Last connection error message, cleared on successful connect. */
+  lastErrorMessage: string | null;
+  /** Server-reported URL the bus is connected to (or attempting). */
+  url: string | null;
+}
+
+export interface PublishOptions {
+  /**
+   * Skip Zod validation for this call. Use sparingly — only when the subject
+   * carries an opaque blob (e.g. NFLOG events) or routes through a wildcard
+   * for which no static schema is registered.
+   */
+  unchecked?: boolean;
+}
+
+export interface RequestOptions extends PublishOptions {
+  /** Request timeout in milliseconds. Defaults to 5 000. */
+  timeoutMs?: number;
+}
+
+export interface SubscribeOptions {
+  unchecked?: boolean;
+  /** Optional queue group for load-balanced delivery. */
+  queue?: string;
+}
+
+export type SubscribeHandler<T> = (
+  msg: T,
+  ctx: SubscribeContext,
+) => Promise<unknown> | unknown;
+
+export interface SubscribeContext {
+  /** The subject the message arrived on (may differ from subscription on wildcard subs). */
+  subject: string;
+  /** Reply subject when the message is a request, otherwise undefined. */
+  reply: string | undefined;
+}
+
+export interface NatsBusOptions {
+  /**
+   * Override the URL/credential resolution path. Used by integration tests
+   * to point at an ephemeral NATS container without going through Vault KV.
+   */
+  testOverride?: {
+    url: string;
+    creds?: string;
+  };
+}
+
+interface SubscriptionRegistration {
+  subject: string;
+  handler: SubscribeHandler<unknown>;
+  opts: SubscribeOptions;
+  /** Set to the live `Subscription` while the bus is connected; null otherwise. */
+  live: Subscription | null;
+}
+
+const ENCODER = new TextEncoder();
+const DECODER = new TextDecoder();
+
+export class NatsBus {
+  private static _instance: NatsBus | null = null;
+
+  static getInstance(opts?: NatsBusOptions): NatsBus {
+    if (!NatsBus._instance) {
+      NatsBus._instance = new NatsBus(opts);
+    }
+    return NatsBus._instance;
+  }
+
+  /** Reset the singleton — for tests only. */
+  static resetInstanceForTests(): void {
+    NatsBus._instance = null;
+  }
+
+  private state: BusState = "disconnected";
+  private nc: NatsConnection | null = null;
+  private connectAttempt = 0;
+  private lastConnectedAtMs: number | null = null;
+  private lastErrorMessage: string | null = null;
+  private currentUrl: string | null = null;
+  private readyWaiters: Array<{ resolve: () => void; reject: (e: Error) => void }> = [];
+  // Active subscriptions on the current connection. Replaced on reconnect.
+  private liveSubs: Subscription[] = [];
+  // Durable subscriber registrations. Re-attached after every reconnect so a
+  // caller can `bus.subscribe(...)` once at boot and keep receiving messages
+  // across NATS bounces without bookkeeping.
+  private registrations: SubscriptionRegistration[] = [];
+  private reconnectTimer: NodeJS.Timeout | null = null;
+  private started = false;
+
+  private constructor(private readonly opts: NatsBusOptions = {}) {}
+
+  /**
+   * Kick off the connect loop. Returns immediately — connection happens in
+   * the background. Safe to call repeatedly; subsequent calls are a no-op.
+   */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    this.scheduleReconnect(0);
+  }
+
+  /**
+   * Drain the connection and stop the reconnect loop. Idempotent.
+   */
+  async shutdown(): Promise<void> {
+    if (this.state === "shutting-down" || this.state === "disconnected") return;
+    this.state = "shutting-down";
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.rejectReadyWaiters(new Error("NatsBus shutting down"));
+    const nc = this.nc;
+    this.nc = null;
+    if (nc) {
+      try {
+        await nc.drain();
+      } catch (err) {
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err) },
+          "drain on shutdown failed",
+        );
+      }
+    }
+    this.state = "disconnected";
+  }
+
+  /**
+   * Block until the bus is connected, or reject after `timeoutMs`.
+   * Resolves immediately if already connected.
+   */
+  ready(opts: { timeoutMs?: number } = {}): Promise<void> {
+    if (this.state === "connected") return Promise.resolve();
+    if (this.state === "shutting-down") {
+      return Promise.reject(new Error("NatsBus shutting down"));
+    }
+    const timeoutMs = opts.timeoutMs ?? 10_000;
+    return new Promise<void>((resolve, reject) => {
+      const handle = setTimeout(() => {
+        this.readyWaiters = this.readyWaiters.filter((w) => w.resolve !== onResolve);
+        reject(new Error(`NatsBus.ready timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      const onResolve = () => {
+        clearTimeout(handle);
+        resolve();
+      };
+      const onReject = (err: Error) => {
+        clearTimeout(handle);
+        reject(err);
+      };
+      this.readyWaiters.push({ resolve: onResolve, reject: onReject });
+    });
+  }
+
+  getHealth(): BusHealth {
+    return {
+      state: this.state,
+      lastConnectedAtMs: this.lastConnectedAtMs,
+      lastErrorMessage: this.lastErrorMessage,
+      url: this.currentUrl,
+    };
+  }
+
+  /**
+   * Mark the cached credential as stale and force a reconnect. Called by
+   * `NatsControlPlaneService.applyConfig()` after rotating the bus creds
+   * blob in Vault KV.
+   */
+  invalidateCreds(): void {
+    if (!this.started) return;
+    log.info("creds invalidated, scheduling reconnect");
+    const nc = this.nc;
+    this.nc = null;
+    this.state = "connecting";
+    if (nc) {
+      // Best-effort drain; don't await so callers never block.
+      nc.drain().catch((err) => {
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err) },
+          "drain after creds invalidation failed",
+        );
+      });
+    }
+    this.scheduleReconnect(0);
+  }
+
+  // ============================================================
+  // Publish / request / subscribe
+  // ============================================================
+
+  async publish<T>(subject: string, payload: T, opts: PublishOptions = {}): Promise<void> {
+    const nc = this.requireConnected();
+    const validated = opts.unchecked ? payload : this.validateRequest(subject, payload);
+    nc.publish(subject, ENCODER.encode(JSON.stringify(validated)));
+  }
+
+  async request<Req, Res>(
+    subject: string,
+    payload: Req,
+    opts: RequestOptions = {},
+  ): Promise<Res> {
+    const nc = this.requireConnected();
+    const validated = opts.unchecked ? payload : this.validateRequest(subject, payload);
+    const reply = await nc.request(
+      subject,
+      ENCODER.encode(JSON.stringify(validated)),
+      { timeout: opts.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS },
+    );
+    const body = this.decodeBody<unknown>(reply.data);
+    return (opts.unchecked ? body : this.validateReply(subject, body)) as Res;
+  }
+
+  /**
+   * Subscribe to a subject. The handler runs once per message; errors are
+   * caught and logged so a misbehaving handler can't tear down the
+   * subscription. For wildcard subjects, pass `unchecked: true` and validate
+   * inside the handler.
+   *
+   * **Durable across reconnects.** The registration is remembered and the
+   * subscription is re-attached every time the bus reconnects to NATS, so
+   * callers register once at boot and don't have to re-register after
+   * `invalidateCreds()` or transient disconnects.
+   *
+   * Returns a cancel handle, not the underlying `Subscription`. Call it to
+   * permanently unregister (it removes from the durable list and unsubs the
+   * current live subscription if any).
+   */
+  subscribe<T>(
+    subject: string,
+    handler: SubscribeHandler<T>,
+    opts: SubscribeOptions = {},
+  ): () => void {
+    const reg: SubscriptionRegistration = {
+      subject,
+      handler: handler as SubscribeHandler<unknown>,
+      opts,
+      live: null,
+    };
+    this.registrations.push(reg);
+    if (this.state === "connected" && this.nc) {
+      this.attachRegistration(reg, this.nc);
+    }
+    return () => {
+      this.registrations = this.registrations.filter((r) => r !== reg);
+      if (reg.live) {
+        try {
+          reg.live.unsubscribe();
+        } catch {
+          // best-effort
+        }
+      }
+    };
+  }
+
+  /**
+   * Subscribe to a request/reply subject. The handler returns the reply
+   * payload (validated against the subject's reply schema) which the bus
+   * sends back on `msg.reply`.
+   *
+   * Durable across reconnects (see `subscribe`).
+   */
+  respond<Req, Res>(
+    subject: string,
+    handler: (req: Req, ctx: SubscribeContext) => Promise<Res> | Res,
+    opts: SubscribeOptions = {},
+  ): () => void {
+    return this.subscribe<Req>(
+      subject,
+      async (msg, ctx) => {
+        const result = await handler(msg, ctx);
+        if (!ctx.reply) {
+          log.warn({ subject: ctx.subject }, "respond handler called on non-request message");
+          return;
+        }
+        const validated = opts.unchecked ? result : this.validateReply(subject, result);
+        const nc = this.requireConnected();
+        nc.publish(ctx.reply, ENCODER.encode(JSON.stringify(validated)));
+      },
+      opts,
+    );
+  }
+
+  private attachRegistration(reg: SubscriptionRegistration, nc: NatsConnection): void {
+    const sub = nc.subscribe(
+      reg.subject,
+      reg.opts.queue ? { queue: reg.opts.queue } : undefined,
+    );
+    reg.live = sub;
+    this.liveSubs.push(sub);
+    void this.consume(reg.subject, sub, reg.handler, reg.opts);
+  }
+
+  private reattachAllRegistrations(nc: NatsConnection): void {
+    this.liveSubs = [];
+    for (const reg of this.registrations) {
+      reg.live = null;
+      this.attachRegistration(reg, nc);
+    }
+  }
+
+  // ============================================================
+  // Internals
+  // ============================================================
+
+  private requireConnected(): NatsConnection {
+    if (this.state !== "connected" || !this.nc) {
+      throw new Error(`NatsBus not connected (state=${this.state})`);
+    }
+    return this.nc;
+  }
+
+  private decodeBody<T>(buf: Uint8Array): T {
+    if (buf.length === 0) return undefined as unknown as T;
+    return JSON.parse(DECODER.decode(buf)) as T;
+  }
+
+  private getSchemaEntry(subject: string): SubjectSchemaEntry | undefined {
+    return payloadSchemas[subject];
+  }
+
+  private validateRequest(subject: string, payload: unknown): unknown {
+    const entry = this.getSchemaEntry(subject);
+    if (!entry) return payload;
+    return validateOrThrow(entry.request, subject, "request", payload);
+  }
+
+  private validateReply(subject: string, payload: unknown): unknown {
+    const entry = this.getSchemaEntry(subject);
+    if (!entry?.reply) return payload;
+    return validateOrThrow(entry.reply, subject, "reply", payload);
+  }
+
+  private async consume<T>(
+    subject: string,
+    sub: Subscription,
+    handler: SubscribeHandler<T>,
+    opts: SubscribeOptions,
+  ): Promise<void> {
+    for await (const msg of sub) {
+      const ctx: SubscribeContext = { subject: msg.subject, reply: msg.reply };
+      try {
+        const raw = this.decodeBody<unknown>(msg.data);
+        const body = opts.unchecked ? raw : this.validateRequest(subject, raw);
+        await handler(body as T, ctx);
+      } catch (err) {
+        log.error(
+          {
+            subject,
+            arrivedOn: msg.subject,
+            err: err instanceof Error ? err.message : String(err),
+          },
+          "nats subscriber handler failed",
+        );
+      }
+    }
+  }
+
+  // ============================================================
+  // Reconnect loop
+  // ============================================================
+
+  private scheduleReconnect(delayMs: number): void {
+    if (this.state === "shutting-down") return;
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    this.state = "connecting";
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.attemptConnect();
+    }, delayMs);
+  }
+
+  private async attemptConnect(): Promise<void> {
+    if (this.state === "shutting-down") return;
+    this.connectAttempt += 1;
+    let url: string | null = null;
+    let creds: string | undefined;
+    try {
+      const resolved = await this.resolveConnection();
+      url = resolved.url;
+      creds = resolved.creds;
+      this.currentUrl = url;
+      const nc = await connect({
+        servers: url,
+        ...(creds
+          ? { authenticator: credsAuthenticator(ENCODER.encode(creds)) }
+          : {}),
+        timeout: 5_000,
+        // The SDK's own reconnect handles transient drops once we're up.
+        reconnect: true,
+        maxReconnectAttempts: -1,
+        reconnectTimeWait: RECONNECT_BACKOFF_MIN_MS,
+      });
+      this.onConnected(nc, url);
+      // Wait for the connection to close, then schedule a fresh attempt.
+      void nc
+        .closed()
+        .then((err) => {
+          this.onDisconnected(err ?? null);
+        })
+        .catch((err) => {
+          this.onDisconnected(err instanceof Error ? err : new Error(String(err)));
+        });
+    } catch (err) {
+      this.lastErrorMessage = err instanceof Error ? err.message : String(err);
+      const delay = backoffDelayMs(this.connectAttempt);
+      log.warn(
+        {
+          url,
+          attempt: this.connectAttempt,
+          delayMs: delay,
+          err: this.lastErrorMessage,
+        },
+        "nats bus connect failed; will retry",
+      );
+      this.scheduleReconnect(delay);
+    }
+  }
+
+  private async resolveConnection(): Promise<{ url: string; creds?: string }> {
+    if (this.opts.testOverride) {
+      return {
+        url: this.opts.testOverride.url,
+        creds: this.opts.testOverride.creds,
+      };
+    }
+    const url = await getNatsControlPlaneService().getInternalUrl();
+    let creds: string | undefined;
+    try {
+      const kv = getVaultKVService();
+      const blob = await kv.read(NATS_SERVER_BUS_CREDS_KV_PATH);
+      const v = blob?.[FIELD_SERVER_BUS_CREDS];
+      if (typeof v === "string" && v.length > 0) creds = v;
+    } catch (err) {
+      log.debug(
+        {
+          path: NATS_SERVER_BUS_CREDS_KV_PATH,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "server bus creds not yet available — will connect anonymously and retry on next cycle",
+      );
+    }
+    if (!creds) {
+      throw new Error(
+        `server bus creds not present at ${NATS_SERVER_BUS_CREDS_KV_PATH}; ` +
+          `applyConfig() may not have run yet`,
+      );
+    }
+    return { url, creds };
+  }
+
+  private onConnected(nc: NatsConnection, url: string): void {
+    this.nc = nc;
+    this.state = "connected";
+    this.connectAttempt = 0;
+    this.lastConnectedAtMs = Date.now();
+    this.lastErrorMessage = null;
+    this.currentUrl = url;
+    log.info({ url, registrations: this.registrations.length }, "nats bus connected");
+    this.reattachAllRegistrations(nc);
+    this.resolveReadyWaiters();
+  }
+
+  private onDisconnected(err: Error | null): void {
+    if (this.state === "shutting-down") return;
+    this.nc = null;
+    this.lastErrorMessage = err?.message ?? null;
+    log.warn(
+      { err: err?.message ?? null },
+      "nats bus connection closed; reconnecting",
+    );
+    this.scheduleReconnect(backoffDelayMs(1));
+  }
+
+  private resolveReadyWaiters(): void {
+    const waiters = this.readyWaiters;
+    this.readyWaiters = [];
+    for (const w of waiters) w.resolve();
+  }
+
+  private rejectReadyWaiters(err: Error): void {
+    const waiters = this.readyWaiters;
+    this.readyWaiters = [];
+    for (const w of waiters) w.reject(err);
+  }
+}
+
+function backoffDelayMs(attempt: number): number {
+  const base = Math.min(
+    RECONNECT_BACKOFF_MAX_MS,
+    RECONNECT_BACKOFF_MIN_MS * 2 ** Math.max(0, attempt - 1),
+  );
+  // Full jitter — caps thundering herd if multiple processes restart at once.
+  return Math.floor(Math.random() * base);
+}
+
+function validateOrThrow<T>(
+  schema: ZodType<T>,
+  subject: string,
+  kind: "request" | "reply",
+  payload: unknown,
+): T {
+  const result = schema.safeParse(payload);
+  if (!result.success) {
+    const issues = result.error.issues
+      .slice(0, 3)
+      .map((i: z.ZodIssue) => `${i.path.join(".")}: ${i.message}`)
+      .join("; ");
+    throw new Error(`nats payload validation failed [${subject} ${kind}]: ${issues}`);
+  }
+  return result.data;
+}

--- a/server/src/services/nats/nats-bus.ts
+++ b/server/src/services/nats/nats-bus.ts
@@ -22,15 +22,14 @@ import { connect, credsAuthenticator, type NatsConnection, type Subscription } f
 import { z, type ZodType } from "zod";
 import { getLogger } from "../../lib/logger-factory";
 import { getVaultKVService } from "../vault/vault-kv-service";
-import { getNatsControlPlaneService } from "./nats-control-plane-service";
 import {
+  FIELD_SERVER_BUS_CREDS,
   NATS_SERVER_BUS_CREDS_KV_PATH,
+  getNatsControlPlaneService,
 } from "./nats-control-plane-service";
 import { payloadSchemas, type SubjectSchemaEntry } from "./payload-schemas";
 
 const log = getLogger("integrations", "nats-bus");
-
-const FIELD_SERVER_BUS_CREDS = "creds";
 const RECONNECT_BACKOFF_MIN_MS = 1_000;
 const RECONNECT_BACKOFF_MAX_MS = 30_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 5_000;
@@ -131,6 +130,17 @@ export class NatsBus {
   private registrations: SubscriptionRegistration[] = [];
   private reconnectTimer: NodeJS.Timeout | null = null;
   private started = false;
+  // Guard against overlapping connect attempts — `invalidateCreds` can fire
+  // while `attemptConnect` is mid-await, and without this two parallel
+  // `connect()` calls would race to write `this.nc`. The guard is set true
+  // when `attemptConnect` enters and cleared when it returns (success or
+  // failure). The reconnect scheduler skips queueing while `connecting` is
+  // true; once the in-flight attempt finishes it always reschedules itself.
+  private connecting = false;
+  // Track every in-flight handler Promise so `shutdown()` can wait for them
+  // to settle before draining the connection — prevents post-shutdown side
+  // effects in stateful Phase 2+ handlers.
+  private activeHandlers = new Set<Promise<unknown>>();
 
   private constructor(private readonly opts: NatsBusOptions = {}) {}
 
@@ -146,6 +156,12 @@ export class NatsBus {
 
   /**
    * Drain the connection and stop the reconnect loop. Idempotent.
+   *
+   * Stops accepting new work, then unsubscribes live subscriptions (which
+   * causes their `consume` loops to exit), waits for any in-flight handler
+   * Promises to settle, and finally drains the connection. Handlers that
+   * started before shutdown finish their work before the bus closes —
+   * critical for any future stateful consumer.
    */
   async shutdown(): Promise<void> {
     if (this.state === "shutting-down" || this.state === "disconnected") return;
@@ -155,6 +171,26 @@ export class NatsBus {
       this.reconnectTimer = null;
     }
     this.rejectReadyWaiters(new Error("NatsBus shutting down"));
+
+    // Stop subscription iterators so consume() loops fall through. We do
+    // this before draining so handlers that are blocked on `for await msg`
+    // don't see another message arriving during shutdown.
+    for (const sub of this.liveSubs) {
+      try {
+        sub.unsubscribe();
+      } catch {
+        // best-effort
+      }
+    }
+    this.liveSubs = [];
+    for (const reg of this.registrations) reg.live = null;
+
+    // Wait for in-flight handlers to settle. allSettled so a misbehaving
+    // handler can't block the rest of shutdown forever.
+    if (this.activeHandlers.size > 0) {
+      await Promise.allSettled([...this.activeHandlers]);
+    }
+
     const nc = this.nc;
     this.nc = null;
     if (nc) {
@@ -210,9 +246,18 @@ export class NatsBus {
    * Mark the cached credential as stale and force a reconnect. Called by
    * `NatsControlPlaneService.applyConfig()` after rotating the bus creds
    * blob in Vault KV.
+   *
+   * Safe to call before `start()`: in that case the bus has nothing to
+   * disconnect, but the next call to `start()` will re-read creds from
+   * Vault (which is what every cold connect does anyway), so the invalidate
+   * is implicitly satisfied without any extra state. Logged at info either
+   * way so the call is visible in the boot transcript.
    */
   invalidateCreds(): void {
-    if (!this.started) return;
+    if (!this.started) {
+      log.info("creds invalidated before bus start; first connect will pick up fresh creds");
+      return;
+    }
     log.info("creds invalidated, scheduling reconnect");
     const nc = this.nc;
     this.nc = null;
@@ -336,6 +381,21 @@ export class NatsBus {
   }
 
   private reattachAllRegistrations(nc: NatsConnection): void {
+    // Tear down old subs first. The async iterator inside each `consume()`
+    // loop terminates when its `Subscription` is unsubscribed, so calling
+    // unsubscribe here lets the old loop exit cleanly *before* a new one
+    // is started for the same registration. Without this, a brief window
+    // exists during which an old handler could process a stray message
+    // delivered by the dying connection's drain alongside the new sub —
+    // benign for the ping responder, a double-processing bug for any
+    // stateful Phase 2+ consumer.
+    for (const oldSub of this.liveSubs) {
+      try {
+        oldSub.unsubscribe();
+      } catch {
+        // best-effort
+      }
+    }
     this.liveSubs = [];
     for (const reg of this.registrations) {
       reg.live = null;
@@ -383,20 +443,31 @@ export class NatsBus {
   ): Promise<void> {
     for await (const msg of sub) {
       const ctx: SubscribeContext = { subject: msg.subject, reply: msg.reply };
-      try {
-        const raw = this.decodeBody<unknown>(msg.data);
-        const body = opts.unchecked ? raw : this.validateRequest(subject, raw);
-        await handler(body as T, ctx);
-      } catch (err) {
-        log.error(
-          {
-            subject,
-            arrivedOn: msg.subject,
-            err: err instanceof Error ? err.message : String(err),
-          },
-          "nats subscriber handler failed",
-        );
-      }
+      const work = (async () => {
+        try {
+          const raw = this.decodeBody<unknown>(msg.data);
+          const body = opts.unchecked ? raw : this.validateRequest(subject, raw);
+          await handler(body as T, ctx);
+        } catch (err) {
+          log.error(
+            {
+              subject,
+              arrivedOn: msg.subject,
+              err: err instanceof Error ? err.message : String(err),
+            },
+            "nats subscriber handler failed",
+          );
+        }
+      })();
+      // Track the in-flight Promise so shutdown() can wait for it. We
+      // remove on settle (regardless of outcome) so the Set never leaks.
+      this.activeHandlers.add(work);
+      void work.finally(() => this.activeHandlers.delete(work));
+      // Serialise per-subscription so a slow handler doesn't pile up
+      // unbounded message work — a single handler-instance-at-a-time per
+      // subscription matches typical req/reply expectations and keeps
+      // shutdown's wait set bounded by sub-count rather than message-rate.
+      await work;
     }
   }
 
@@ -406,7 +477,9 @@ export class NatsBus {
 
   private scheduleReconnect(delayMs: number): void {
     if (this.state === "shutting-down") return;
-    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    // Don't stack timers. If a connect is already in flight or queued, the
+    // running attempt will reschedule itself on completion.
+    if (this.connecting || this.reconnectTimer) return;
     this.state = "connecting";
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
@@ -416,6 +489,12 @@ export class NatsBus {
 
   private async attemptConnect(): Promise<void> {
     if (this.state === "shutting-down") return;
+    // Re-entrancy guard. `invalidateCreds` can call `scheduleReconnect(0)`
+    // while a previous attempt is still mid-await (waiting on `connect()`
+    // or `resolveConnection()`); without this guard two `connect()` calls
+    // would race to write `this.nc` and we'd orphan the loser's connection.
+    if (this.connecting) return;
+    this.connecting = true;
     this.connectAttempt += 1;
     let url: string | null = null;
     let creds: string | undefined;
@@ -436,6 +515,7 @@ export class NatsBus {
         reconnectTimeWait: RECONNECT_BACKOFF_MIN_MS,
       });
       this.onConnected(nc, url);
+      this.connecting = false;
       // Wait for the connection to close, then schedule a fresh attempt.
       void nc
         .closed()
@@ -457,6 +537,7 @@ export class NatsBus {
         },
         "nats bus connect failed; will retry",
       );
+      this.connecting = false;
       this.scheduleReconnect(delay);
     }
   }

--- a/server/src/services/nats/nats-bus.ts
+++ b/server/src/services/nats/nats-bus.ts
@@ -551,24 +551,23 @@ export class NatsBus {
     }
     const url = await getNatsControlPlaneService().getInternalUrl();
     let creds: string | undefined;
+    let readError: string | null = null;
     try {
       const kv = getVaultKVService();
       const blob = await kv.read(NATS_SERVER_BUS_CREDS_KV_PATH);
       const v = blob?.[FIELD_SERVER_BUS_CREDS];
       if (typeof v === "string" && v.length > 0) creds = v;
     } catch (err) {
-      log.debug(
-        {
-          path: NATS_SERVER_BUS_CREDS_KV_PATH,
-          err: err instanceof Error ? err.message : String(err),
-        },
-        "server bus creds not yet available — will connect anonymously and retry on next cycle",
-      );
+      readError = err instanceof Error ? err.message : String(err);
     }
     if (!creds) {
+      // Surface the actual cause (Vault sealed, no admin token, path 404,
+      // wrong field) instead of the boot-time-friendly fallback message.
+      // Without this you can't tell apart "applyConfig hasn't run yet" from
+      // "applyConfig wrote the blob but Vault auth has rotated underneath us".
       throw new Error(
-        `server bus creds not present at ${NATS_SERVER_BUS_CREDS_KV_PATH}; ` +
-          `applyConfig() may not have run yet`,
+        `server bus creds not usable at ${NATS_SERVER_BUS_CREDS_KV_PATH}: ` +
+          (readError ?? "KV read returned null or missing field"),
       );
     }
     return { url, creds };

--- a/server/src/services/nats/nats-control-plane-service.ts
+++ b/server/src/services/nats/nats-control-plane-service.ts
@@ -59,9 +59,13 @@ export const NATS_SIGNER_KV_PATH_PREFIX = "shared/nats-signers";
  * `.creds` blob for the server's own bus connection. Bound to the default
  * (non-system) account, scoped to `mini-infra.>` + `_INBOX.>`. Re-minted on
  * every `applyConfig()`; consumed by `NatsBus` at connect time.
+ *
+ * The path and field are exported together so the writer (this file) and the
+ * reader (`nats-bus.ts`) share one source of truth — a typo fix in one would
+ * silently break the other.
  */
 export const NATS_SERVER_BUS_CREDS_KV_PATH = "shared/nats-server-bus-creds";
-const FIELD_SERVER_BUS_CREDS = "creds";
+export const FIELD_SERVER_BUS_CREDS = "creds";
 
 const FIELD_OPERATOR_SEED = "operator_seed";
 const FIELD_OPERATOR_JWT = "operator_jwt";
@@ -423,6 +427,15 @@ export class NatsControlPlaneService {
       await kv.write(NATS_SERVER_BUS_CREDS_KV_PATH, {
         [FIELD_SERVER_BUS_CREDS]: serverBusCreds,
       });
+    } else {
+      // ensureDefaultAccount() at the top of this method should always
+      // create the row, so this branch only fires if someone manually
+      // deleted the account. Without creds the bus loops forever printing
+      // "server bus creds not present" — surface the cause loudly.
+      log.warn(
+        { defaultAccountName: DEFAULT_ACCOUNT_NAME },
+        "default NATS account not found during applyConfig; server-bus creds were not minted, NatsBus will be unable to connect",
+      );
     }
 
     // Phase 0: write the full set of account JWTs to a single Vault KV blob

--- a/server/src/services/nats/nats-control-plane-service.ts
+++ b/server/src/services/nats/nats-control-plane-service.ts
@@ -10,6 +10,7 @@ import {
   generateAccount,
   generateOperator,
   loadKeyPair,
+  mintServerBusUserCreds,
   mintSystemUserCreds,
   mintUserCreds,
   reissueAccountJwt,
@@ -54,6 +55,13 @@ export const NATS_DEFAULT_ACCOUNT_KV_PATH = "shared/nats-account";
 export const NATS_SYSTEM_CREDS_KV_PATH = "shared/nats-system-creds";
 export const NATS_ACCOUNTS_INDEX_KV_PATH = "shared/nats-accounts-index";
 export const NATS_SIGNER_KV_PATH_PREFIX = "shared/nats-signers";
+/**
+ * `.creds` blob for the server's own bus connection. Bound to the default
+ * (non-system) account, scoped to `mini-infra.>` + `_INBOX.>`. Re-minted on
+ * every `applyConfig()`; consumed by `NatsBus` at connect time.
+ */
+export const NATS_SERVER_BUS_CREDS_KV_PATH = "shared/nats-server-bus-creds";
+const FIELD_SERVER_BUS_CREDS = "creds";
 
 const FIELD_OPERATOR_SEED = "operator_seed";
 const FIELD_OPERATOR_JWT = "operator_jwt";
@@ -353,6 +361,7 @@ export class NatsControlPlaneService {
     const renderedAccounts: RenderedNatsAccount[] = [];
     let systemAccountPublic: string | null = null;
     let systemAccountSeed: string | null = null;
+    let defaultAccountSeed: string | null = null;
 
     for (const account of accounts) {
       let accountSeed = await this.tryReadField(account.seedKvPath, FIELD_ACCOUNT_SEED);
@@ -390,6 +399,9 @@ export class NatsControlPlaneService {
         systemAccountPublic = accountMaterial.publicKey;
         systemAccountSeed = accountSeed;
       }
+      if (account.name === DEFAULT_ACCOUNT_NAME) {
+        defaultAccountSeed = accountSeed;
+      }
     }
 
     // Phase 0: re-mint system-account user creds on every apply. The user
@@ -400,6 +412,17 @@ export class NatsControlPlaneService {
     if (systemAccountSeed) {
       const systemCreds = await mintSystemUserCreds(loadKeyPair(systemAccountSeed));
       await kv.write(NATS_SYSTEM_CREDS_KV_PATH, { [FIELD_SYSTEM_CREDS]: systemCreds });
+    }
+
+    // Phase 1 (internal-bus migration): mint a long-lived `.creds` for the
+    // server's own NATS bus connection, bound to the default account and
+    // scoped to `mini-infra.>` + `_INBOX.>`. Same rotate-every-apply rationale
+    // as the system creds above. NatsBus reads this on connect.
+    if (defaultAccountSeed) {
+      const serverBusCreds = await mintServerBusUserCreds(loadKeyPair(defaultAccountSeed));
+      await kv.write(NATS_SERVER_BUS_CREDS_KV_PATH, {
+        [FIELD_SERVER_BUS_CREDS]: serverBusCreds,
+      });
     }
 
     // Phase 0: write the full set of account JWTs to a single Vault KV blob

--- a/server/src/services/nats/nats-key-manager.ts
+++ b/server/src/services/nats/nats-key-manager.ts
@@ -174,6 +174,27 @@ export async function mintSystemUserCreds(
   );
 }
 
+/**
+ * Mint a long-lived `.creds` blob for the server's own NATS bus connection.
+ * The credential is bound to the default (non-system) account and scoped to
+ * the `mini-infra.>` system-internal namespace plus `_INBOX.>` for req/reply
+ * inboxes. Re-minted on every `applyConfig()` so a leaked KV blob is
+ * invalidated by the next apply rather than living until manual intervention.
+ */
+export async function mintServerBusUserCreds(
+  defaultAccountKp: KeyPair,
+): Promise<string> {
+  return mintUserCreds(
+    "mini-infra-server-bus",
+    defaultAccountKp,
+    {
+      pub: ["mini-infra.>"],
+      sub: ["mini-infra.>", "_INBOX.>"],
+    },
+    0,
+  );
+}
+
 export interface ScopedSigningKeyMaterial {
   seed: string;
   publicKey: string;

--- a/server/src/services/nats/payload-schemas.ts
+++ b/server/src/services/nats/payload-schemas.ts
@@ -1,0 +1,121 @@
+/**
+ * Zod schemas + inferred TypeScript types for every NATS subject in
+ * `lib/types/nats-subjects.ts`.
+ *
+ * Subjects are the contract (and live in `lib` so the client can see them);
+ * the runtime validators live here in the server because `@mini-infra/types`
+ * is a runtime-dependency-free types-only package (see lib/CLAUDE.md).
+ *
+ * Every subject in `ALL_NATS_SUBJECTS` SHOULD have a request schema and (for
+ * req/reply subjects) a reply schema registered in `payloadSchemas` below.
+ * The `NatsBus` validates outgoing publish/request bodies and incoming
+ * subscribe/reply bodies against this registry. A schema mismatch is a
+ * thrown error — never a silently-truncated message.
+ */
+
+import { z } from "zod";
+import {
+  BackupSubject,
+  EgressFwSubject,
+  EgressGwSubject,
+  SystemSubject,
+  UpdateSubject,
+} from "@mini-infra/types";
+
+// ====================================================================
+// System / smoke ping (Phase 1)
+// ====================================================================
+
+export const systemPingRequestSchema = z.object({
+  /** Free-form correlation token echoed back in the reply. */
+  nonce: z.string().min(1).max(128),
+  /** Caller's wall-clock time, ms since epoch. */
+  sentAtMs: z.number().int().nonnegative(),
+});
+export type SystemPingRequest = z.infer<typeof systemPingRequestSchema>;
+
+export const systemPingReplySchema = z.object({
+  /** Echoed `nonce` from the request. */
+  nonce: z.string().min(1).max(128),
+  /** Responder's wall-clock time, ms since epoch. */
+  receivedAtMs: z.number().int().nonnegative(),
+  /** Stable identifier of the responder (e.g. "server"). */
+  responder: z.string().min(1).max(64),
+});
+export type SystemPingReply = z.infer<typeof systemPingReplySchema>;
+
+// ====================================================================
+// Egress fw-agent (Phase 2 — schemas declared early so Phase 1 lands the
+// subject contract end-to-end; the agent is not yet wired)
+// ====================================================================
+
+export const egressFwRulesApplyRequestSchema = z.object({
+  /** Opaque correlation id for the apply, propagated into events. */
+  applyId: z.string().min(1).max(64),
+  /** Serialised ruleset; opaque to the bus, agent parses. */
+  ruleset: z.string(),
+});
+export type EgressFwRulesApplyRequest = z.infer<typeof egressFwRulesApplyRequestSchema>;
+
+export const egressFwRulesApplyReplySchema = z.object({
+  applyId: z.string(),
+  status: z.enum(["applied", "rejected"]),
+  /** Reason on rejection, free text. */
+  reason: z.string().optional(),
+});
+export type EgressFwRulesApplyReply = z.infer<typeof egressFwRulesApplyReplySchema>;
+
+// ====================================================================
+// Schema registry — used by NatsBus for validation lookups.
+// ====================================================================
+
+export interface SubjectSchemaEntry {
+  /** Schema for the published / request body on this subject. */
+  request: z.ZodType<unknown>;
+  /** Schema for the reply (only set for request/reply subjects). */
+  reply?: z.ZodType<unknown>;
+}
+
+/**
+ * Concrete subjects only — wildcards and per-id subjects (e.g. `progress.<id>`)
+ * are validated by the closest static parent subject's schema if present, or
+ * skipped if the bus call is marked `unchecked: true`.
+ */
+export const payloadSchemas: Record<string, SubjectSchemaEntry> = {
+  [SystemSubject.ping]: {
+    request: systemPingRequestSchema,
+    reply: systemPingReplySchema,
+  },
+  [EgressFwSubject.rulesApply]: {
+    request: egressFwRulesApplyRequestSchema,
+    reply: egressFwRulesApplyReplySchema,
+  },
+  // Phase 2+ subjects: schemas land alongside the migration that uses them.
+  [EgressFwSubject.rulesApplied]: {
+    // Stub: same shape as the apply reply for now; will be re-typed in Phase 2.
+    request: egressFwRulesApplyReplySchema,
+  },
+  [EgressFwSubject.events]: {
+    // Opaque blob in Phase 1 — Phase 2 will refine when fw-agent ships.
+    request: z.unknown(),
+  },
+  [EgressFwSubject.health]: {
+    request: z.object({
+      ok: z.boolean(),
+      reportedAtMs: z.number().int().nonnegative(),
+    }),
+  },
+  [EgressGwSubject.rulesApply]: { request: z.unknown() },
+  [EgressGwSubject.rulesApplied]: { request: z.unknown() },
+  [EgressGwSubject.decisions]: { request: z.unknown() },
+  [EgressGwSubject.health]: { request: z.unknown() },
+  [BackupSubject.run]: { request: z.unknown() },
+  [BackupSubject.progressPrefix]: { request: z.unknown() },
+  [BackupSubject.completed]: { request: z.unknown() },
+  [BackupSubject.failed]: { request: z.unknown() },
+  [UpdateSubject.run]: { request: z.unknown() },
+  [UpdateSubject.progressPrefix]: { request: z.unknown() },
+  [UpdateSubject.completed]: { request: z.unknown() },
+  [UpdateSubject.failed]: { request: z.unknown() },
+  [UpdateSubject.healthCheckPassed]: { request: z.unknown() },
+};

--- a/server/src/services/nats/payload-schemas.ts
+++ b/server/src/services/nats/payload-schemas.ts
@@ -15,6 +15,7 @@
 
 import { z } from "zod";
 import {
+  ALL_NATS_SUBJECTS,
   BackupSubject,
   EgressFwSubject,
   EgressGwSubject,
@@ -77,11 +78,20 @@ export interface SubjectSchemaEntry {
 }
 
 /**
+ * The set of subjects this registry knows about. Tied to `ALL_NATS_SUBJECTS`
+ * in `lib/types/nats-subjects.ts` so adding a new subject there forces an
+ * entry here at compile time — a typo in a key fails to type-check, and a
+ * forgotten schema surfaces as a missing-key compile error rather than a
+ * silent runtime skip.
+ */
+export type KnownNatsSubject = (typeof ALL_NATS_SUBJECTS)[number];
+
+/**
  * Concrete subjects only — wildcards and per-id subjects (e.g. `progress.<id>`)
  * are validated by the closest static parent subject's schema if present, or
  * skipped if the bus call is marked `unchecked: true`.
  */
-export const payloadSchemas: Record<string, SubjectSchemaEntry> = {
+export const payloadSchemas: Record<KnownNatsSubject, SubjectSchemaEntry> = {
   [SystemSubject.ping]: {
     request: systemPingRequestSchema,
     reply: systemPingReplySchema,


### PR DESCRIPTION
## Summary

Lays the foundation for migrating system-internal app-to-app communication onto the managed `vault-nats` bus. Combines two pieces:

1. **Plan doc** ([docs/planning/not-shipped/internal-nats-messaging-plan.md](docs/planning/not-shipped/internal-nats-messaging-plan.md)) — phased rollout (ALT-26 through ALT-30), subject naming convention, shared `NatsBus` design.
2. **Phase 1 implementation** ([ALT-26](https://linear.app/altitude-devops/issue/ALT-26)) — the shared chokepoint everything else builds on. No production traffic moved yet.

## Subject namespace and conventions

All system-internal subjects live under `mini-infra.>`. Three idioms whose shape tells you what they are:

- **Commands** — imperative verb, used with request/reply: `mini-infra.egress.fw.rules.apply`
- **Events** — past-participle, fan-out publish: `mini-infra.egress.fw.rules.applied`
- **Heartbeats** — noun only, periodic publish: `mini-infra.egress.fw.health`

## Phase 1 deliverables

- **`lib/types/nats-subjects.ts`** — typed constants for the whole namespace (system + Phases 2–5 reserved). Lib stays runtime-dep-free per `lib/CLAUDE.md`; Zod schemas live server-side.
- **`server/src/services/nats/payload-schemas.ts`** — Zod schemas + inferred types per subject. Bus validates on publish and receive.
- **`server/src/services/nats/nats-bus.ts`** — singleton client. Non-blocking connect loop with capped jittered backoff, durable-across-reconnect subscriptions (registrations re-attach on every connect), `publish` / `request` / `respond` with schema validation, JetStream wrappers stubbed for Phase 4. Test override hatch lets integration tests skip Vault KV.
- **`server/src/services/nats/nats-bus-ping.ts`** — `mini-infra.system.ping` loopback responder + `pingSelf()` helper. Phase 1's honest health-check.
- **Server-bus `.creds`** minted by `applyConfig()` into Vault KV at `shared/nats-server-bus-creds`. Bound to the default account with `pub: [\"mini-infra.>\"]` + `sub: [\"mini-infra.>\", \"_INBOX.>\"]`, rotated every apply (same pattern as the existing system creds). `applyConfig()` calls `NatsBus.invalidateCreds()` after the rotation so the live bus reconnects with fresh creds.
- **`egress-shared/natsbus/subjects.go`** — Go mirror of the subject set, constants only. Client wrappers land in Phase 2 with the first real Go consumer.
- **`scripts/check-nats-subject-drift.mjs`** + **`.github/workflows/nats-constants.yml`** — CI fails if the TS and Go subject literal sets diverge.
- **`server.ts` wire-up** — `NatsBus.getInstance().start()` is fire-and-forget; ping responder registered before `ready()` so it auto-attaches on first connect; bus drained on shutdown before container teardown.

## Deferred to follow-ups (called out in plan doc §6 Phase 1)

- **Prefix-allowlist seed entry.** The allowlist gates which *templates* may claim a non-default prefix — the server's own creds carry pub/sub directly and don't go through it. Lands with the first template in Phase 2.
- **ConnectivityScheduler integration.** Would need a fake settings category to slot in. `bus.getHealth()` + `pingSelf()` are exposed; UI integration is a clean follow-up.
- **Metrics hooks.** Log lines carry the same data per call until there's a real metrics surface to wire to.

## Test plan

- [x] `pnpm build:server` — clean
- [x] `pnpm --filter mini-infra-server lint` — clean
- [x] NATS unit tests — 14 passed
- [x] **External integration test** (`nats-bus.external.test.ts`) — 4 passed against a real `nats:2.12.8-alpine` container via testcontainers. Verifies connect, ping/pong with matching nonce, Zod rejection of malformed publish, `getHealth()` reporting.
- [x] `go build ./...` on `egress-shared`, `egress-fw-agent`, `egress-gateway` — clean
- [x] `node scripts/check-nats-subject-drift.mjs` — 18 subjects in lock-step
- [ ] **Cold-boot worktree verification** — needs `pnpm worktree-env start` to confirm the bus retries patiently while `vault-nats` is coming up. Not done in-PR because the worktree env isn't currently running on this machine.

## Linear

- [ALT-26](https://linear.app/altitude-devops/issue/ALT-26) — Phase 1 (this PR). Will move to In Review when the PR opens.
- ALT-27 / ALT-28 / ALT-29 / ALT-30 — Phases 2–5, blocked on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)