### PR TITLE
feat(nats): expose account public key via nats-account-public dynamicEnv

### DIFF
--- a/client/src/user-docs/nats/nats-app-integration.md
+++ b/client/src/user-docs/nats/nats-app-integration.md
@@ -163,7 +163,8 @@ A **signer** lets your service mint its own short-lived NATS JWTs --- useful for
         "dynamicEnv": {
           "NATS_URL": { "kind": "nats-url" },
           "NATS_CREDS": { "kind": "nats-creds" },
-          "NATS_SIGNER_SEED": { "kind": "nats-signer-seed", "signer": "worker-minter" }
+          "NATS_SIGNER_SEED": { "kind": "nats-signer-seed", "signer": "worker-minter" },
+          "NATS_ACCOUNT_PUB": { "kind": "nats-account-public", "signer": "worker-minter" }
         }
       }
     }
@@ -171,13 +172,34 @@ A **signer** lets your service mint its own short-lived NATS JWTs --- useful for
 }
 ```
 
-At apply time, the seed is read from Vault KV at `shared/nats-signers/<stackId>-worker-minter` and injected into the container as `NATS_SIGNER_SEED` (NKey, base32). Your service uses any standard nkeys library to mint user JWTs whose `pub`/`sub` permissions are *subsets* of `<prefix>.agent.worker.>`.
+At apply time, the seed is read from Vault KV at `shared/nats-signers/<stackId>-worker-minter` and injected into the container as `NATS_SIGNER_SEED` (NKey, base32). The matching account public key lands in `NATS_ACCOUNT_PUB` --- you need it as the `issuer_account` claim when minting JWTs (see below). Your service uses any standard nkeys library to mint user JWTs whose `pub`/`sub` permissions are *subsets* of `<prefix>.agent.worker.>`.
+
+### Minting JWTs in-process
+
+```ts
+import { encodeUser, fmtCreds } from "nats-jwt";
+import { createUser, fromSeed } from "nkeys.js";
+
+const signerKp = fromSeed(new TextEncoder().encode(process.env.NATS_SIGNER_SEED!));
+const accountPub = process.env.NATS_ACCOUNT_PUB!;
+
+const userKp = createUser();
+const userJwt = await encodeUser(
+  "worker-job-42",
+  userKp,
+  signerKp,
+  { issuer_account: accountPub }, // required when signing with a scoped key
+  { exp: Math.floor(Date.now() / 1000) + 60, scopedUser: true },
+);
+const creds = new TextDecoder().decode(fmtCreds(userJwt, userKp));
+// hand `creds` to the worker; the server trims its permissions to the scope envelope.
+```
 
 ### Signer fields
 
 | Field | Required | Default | Description |
 |---|---|---|---|
-| `name` | yes | --- | Identifier; referenced from `services[].natsSigner` and the `nats-signer-seed` dynamicEnv. |
+| `name` | yes | --- | Identifier; referenced from `services[].natsSigner` and from `nats-signer-seed` / `nats-account-public` dynamicEnv entries. |
 | `subjectScope` | yes | --- | Sub-tree (relative to prefix) the signing key is constrained to. NATS-enforced. |
 | `maxTtlSeconds` | no | `3600` | Hard cap on TTL of any JWT the signer can mint. |
 

--- a/docs/user/stack-definition-reference.md
+++ b/docs/user/stack-definition-reference.md
@@ -228,6 +228,8 @@ Each key is an environment variable name. Each value must be one of:
 | `{ kind: "vault-addr" }` | Inject the Vault address. | Exact object shape. |
 | `{ kind: "vault-role-id" }` | Inject the bound Vault AppRole role ID. | Exact object shape. |
 | `{ kind: "vault-wrapped-secret-id", ttlSeconds: 300 }` | Inject a wrapped secret ID minted at apply time. | `ttlSeconds` is optional, integer `> 0`. If omitted, runtime default is `300`. |
+| `{ kind: "nats-signer-seed", signer: "<name>" }` | NKey seed (base32) of the named scoped signing key, for in-process JWT minting. | `signer` must match a `nats.signers[].name` on the stack template. |
+| `{ kind: "nats-account-public", signer: "<name>" }` | Public key of the NATS account that owns the named signer. Pair with `nats-signer-seed`; `nats-jwt`'s `encodeUser` requires it as the `issuer_account` claim. | `signer` must match a `nats.signers[].name` on the stack template. |
 
 Runtime notes:
 

--- a/lib/types/stacks.ts
+++ b/lib/types/stacks.ts
@@ -68,7 +68,15 @@ export type DynamicEnvSource =
    * this dynamicEnv kind by hand. Resolved at apply time from Vault KV at
    * `shared/nats-signers/<stackId>-<signerName>`.
    */
-  | { kind: 'nats-signer-seed'; signer: string };
+  | { kind: 'nats-signer-seed'; signer: string }
+  /**
+   * Public key of the NATS account that owns the named signing key. Required
+   * by `nats-jwt`'s `encodeUser` as the `issuer_account` claim whenever a
+   * scoped signing key (rather than the account key itself) signs a user JWT
+   * — without it the server rejects the JWT. Pair with `nats-signer-seed`
+   * for any service that mints user JWTs in-process.
+   */
+  | { kind: 'nats-account-public'; signer: string };
 
 /**
  * Per-service configuration for a `Pool` service. Pools are container

--- a/server/src/__tests__/nats-app-roles-schema.test.ts
+++ b/server/src/__tests__/nats-app-roles-schema.test.ts
@@ -308,3 +308,31 @@ describe('dynamicEnvSourceSchema — nats-signer-seed', () => {
     expect(r.success).toBe(false);
   });
 });
+
+// ─── DynamicEnvSource: nats-account-public parses ────────────────────────────
+
+describe('dynamicEnvSourceSchema — nats-account-public', () => {
+  it('nats-account-public dynamicEnv parses', async () => {
+    const { stackContainerConfigSchema } = await import('../services/stacks/schemas');
+    const r = stackContainerConfigSchema.safeParse({
+      dynamicEnv: { NATS_ACCOUNT_PUB: { kind: 'nats-account-public', signer: 'minter' } },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('nats-account-public with empty signer rejected', async () => {
+    const { stackContainerConfigSchema } = await import('../services/stacks/schemas');
+    const r = stackContainerConfigSchema.safeParse({
+      dynamicEnv: { NATS_ACCOUNT_PUB: { kind: 'nats-account-public', signer: '' } },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('nats-account-public with invalid signer name rejected', async () => {
+    const { stackContainerConfigSchema } = await import('../services/stacks/schemas');
+    const r = stackContainerConfigSchema.safeParse({
+      dynamicEnv: { NATS_ACCOUNT_PUB: { kind: 'nats-account-public', signer: 'has spaces' } },
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/server/src/__tests__/nats-credential-injector.test.ts
+++ b/server/src/__tests__/nats-credential-injector.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { StackContainerConfig } from '@mini-infra/types';
+
+// Stub the heavy collaborators so the unit test isolates the injector. The
+// account-public path doesn't touch Vault or the control plane, but importing
+// the injector pulls them in so they need module-level stubs.
+vi.mock('../services/vault/vault-kv-service', () => ({
+  getVaultKVService: () => ({ read: vi.fn() }),
+}));
+vi.mock('../services/nats/nats-control-plane-service', () => ({
+  getNatsControlPlaneService: () => ({
+    getInternalUrl: vi.fn(),
+    mintCredentials: vi.fn(),
+  }),
+}));
+
+import {
+  NatsCredentialInjector,
+  __clearNatsSignerCacheForTests,
+} from '../services/nats/nats-credential-injector';
+
+type SigningKeyRow = {
+  publicKey: string;
+  account: { publicKey: string | null };
+};
+
+function makePrismaWithSigner(row: SigningKeyRow | null) {
+  return {
+    natsSigningKey: {
+      findUnique: vi.fn().mockResolvedValue(row),
+    },
+  } as unknown as ConstructorParameters<typeof NatsCredentialInjector>[0];
+}
+
+const containerConfigWithAccountPublic = (signer = 'minter'): StackContainerConfig => ({
+  dynamicEnv: {
+    NATS_ACCOUNT_PUB: { kind: 'nats-account-public', signer },
+  },
+});
+
+describe('NatsCredentialInjector — nats-account-public', () => {
+  beforeEach(() => {
+    __clearNatsSignerCacheForTests();
+  });
+
+  it('resolves the account public key from the signing-key row', async () => {
+    const prisma = makePrismaWithSigner({
+      publicKey: 'SIGNER_PUB',
+      account: { publicKey: 'AAAAAAAAAACCOUNTPUB' },
+    });
+    const injector = new NatsCredentialInjector(prisma);
+
+    const out = await injector.resolve(null, containerConfigWithAccountPublic('minter'), {
+      stackId: 'stack-1',
+    });
+
+    expect(out).toEqual({ NATS_ACCOUNT_PUB: 'AAAAAAAAAACCOUNTPUB' });
+  });
+
+  it('throws if no stackId is provided', async () => {
+    const prisma = makePrismaWithSigner({
+      publicKey: 'SIGNER_PUB',
+      account: { publicKey: 'ACC_PUB' },
+    });
+    const injector = new NatsCredentialInjector(prisma);
+
+    await expect(
+      injector.resolve(null, containerConfigWithAccountPublic('minter'), {}),
+    ).rejects.toThrow(/no stackId was provided/);
+  });
+
+  it('throws if the signing-key row does not exist', async () => {
+    const prisma = makePrismaWithSigner(null);
+    const injector = new NatsCredentialInjector(prisma);
+
+    await expect(
+      injector.resolve(null, containerConfigWithAccountPublic('ghost'), { stackId: 'stack-1' }),
+    ).rejects.toThrow(/no NatsSigningKey row exists/);
+  });
+
+  it('throws if the bound account has no publicKey set', async () => {
+    const prisma = makePrismaWithSigner({
+      publicKey: 'SIGNER_PUB',
+      account: { publicKey: null },
+    });
+    const injector = new NatsCredentialInjector(prisma);
+
+    await expect(
+      injector.resolve(null, containerConfigWithAccountPublic('minter'), { stackId: 'stack-1' }),
+    ).rejects.toThrow(/no publicKey set/);
+  });
+
+  it('caches across calls — second resolve does not re-hit Prisma', async () => {
+    const prisma = makePrismaWithSigner({
+      publicKey: 'SIGNER_PUB',
+      account: { publicKey: 'ACC_PUB' },
+    });
+    const injector = new NatsCredentialInjector(prisma);
+
+    await injector.resolve(null, containerConfigWithAccountPublic('minter'), { stackId: 'stack-1' });
+    await injector.resolve(null, containerConfigWithAccountPublic('minter'), { stackId: 'stack-1' });
+
+    // findUnique called exactly once across both resolves.
+    expect((prisma as unknown as { natsSigningKey: { findUnique: { mock: { calls: unknown[] } } } })
+      .natsSigningKey.findUnique.mock.calls.length).toBe(1);
+  });
+});

--- a/server/src/services/nats/nats-credential-injector.ts
+++ b/server/src/services/nats/nats-credential-injector.ts
@@ -21,9 +21,18 @@ const SIGNER_CACHE_TTL_MS = 60_000;
 type SignerCacheEntry = { publicKey: string; seed: string; expiresAt: number };
 const signerSeedCache = new Map<string, SignerCacheEntry>();
 
+// Mirrors the seed cache. Account public keys are stable for the life of an
+// account (only an orphan-cleanup-driven account regeneration would change
+// them), so the TTL is the dominant invalidator. Keyed the same way as the
+// seed cache so a service declaring both kinds for one signer hits both
+// caches predictably.
+type AccountPublicCacheEntry = { signerPublicKey: string; accountPublicKey: string; expiresAt: number };
+const signerAccountPublicCache = new Map<string, AccountPublicCacheEntry>();
+
 /** Exposed for tests; production code never needs to call this. */
 export function __clearNatsSignerCacheForTests(): void {
   signerSeedCache.clear();
+  signerAccountPublicCache.clear();
 }
 
 export class NatsCredentialInjector {
@@ -47,6 +56,11 @@ export class NatsCredentialInjector {
       throw new Error("Service declares nats-signer-seed but no stackId was provided to the injector");
     }
 
+    const hasAccountPublic = Object.values(dynamicEnv).some((src) => src.kind === "nats-account-public");
+    if (hasAccountPublic && !ctx.stackId) {
+      throw new Error("Service declares nats-account-public but no stackId was provided to the injector");
+    }
+
     const service = getNatsControlPlaneService(this.prisma);
     const values: Record<string, string> = {};
     let mintedCreds: string | null = null;
@@ -68,6 +82,9 @@ export class NatsCredentialInjector {
       }
       if (src.kind === "nats-signer-seed") {
         values[key] = await this.resolveSignerSeed(ctx.stackId!, src.signer);
+      }
+      if (src.kind === "nats-account-public") {
+        values[key] = await this.resolveSignerAccountPublic(ctx.stackId!, src.signer);
       }
     }
 
@@ -120,5 +137,55 @@ export class NatsCredentialInjector {
       expiresAt: now + SIGNER_CACHE_TTL_MS,
     });
     return seed;
+  }
+
+  /**
+   * Resolve the public key of the NATS account that owns the named signer.
+   * Required as the `issuer_account` claim by `nats-jwt`'s `encodeUser`
+   * whenever a scoped signing key signs a user JWT — without it the server
+   * rejects the JWT with "issuer_account required" / similar.
+   *
+   * Caching matches `resolveSignerSeed`: the (stackId, signer) → SigningKey
+   * row mapping is stable across rotations, and an account regeneration
+   * (which would change the publicKey) is rare enough that TTL eviction is
+   * sufficient. Stored under a parallel cache so a service declaring both
+   * `nats-signer-seed` and `nats-account-public` hits independently.
+   */
+  private async resolveSignerAccountPublic(stackId: string, signer: string): Promise<string> {
+    const cacheKey = `${stackId}/${signer}`;
+    const now = Date.now();
+    const cached = signerAccountPublicCache.get(cacheKey);
+    if (cached && cached.expiresAt > now) {
+      return cached.accountPublicKey;
+    }
+
+    const row = await this.prisma.natsSigningKey.findUnique({
+      where: { stackId_name: { stackId, name: signer } },
+      select: {
+        publicKey: true,
+        account: { select: { publicKey: true } },
+      },
+    });
+    if (!row) {
+      throw new Error(
+        `Service declares nats-account-public for signer '${signer}' but no NatsSigningKey row exists for stackId=${stackId} — has the apply phase materialized signers yet?`,
+      );
+    }
+    if (!row.account.publicKey) {
+      throw new Error(
+        `NatsSigningKey for signer '${signer}' (stackId=${stackId}) is bound to an account with no publicKey set — has the account been applied?`,
+      );
+    }
+
+    if (cached && cached.signerPublicKey !== row.publicKey) {
+      signerAccountPublicCache.delete(cacheKey);
+    }
+
+    signerAccountPublicCache.set(cacheKey, {
+      signerPublicKey: row.publicKey,
+      accountPublicKey: row.account.publicKey,
+      expiresAt: now + SIGNER_CACHE_TTL_MS,
+    });
+    return row.account.publicKey;
   }
 }

--- a/server/src/services/stacks/pool-spawner.ts
+++ b/server/src/services/stacks/pool-spawner.ts
@@ -173,7 +173,11 @@ export async function spawnPoolInstance(
   if (
     containerConfig.dynamicEnv &&
     Object.values(containerConfig.dynamicEnv).some(
-      (src) => src.kind === 'nats-url' || src.kind === 'nats-creds' || src.kind === 'nats-signer-seed',
+      (src) =>
+        src.kind === 'nats-url' ||
+        src.kind === 'nats-creds' ||
+        src.kind === 'nats-signer-seed' ||
+        src.kind === 'nats-account-public',
     )
   ) {
     try {

--- a/server/src/services/stacks/schemas.ts
+++ b/server/src/services/stacks/schemas.ts
@@ -105,6 +105,10 @@ const dynamicEnvSourceSchema = z.discriminatedUnion("kind", [
     kind: z.literal("nats-signer-seed"),
     signer: z.string().min(1).max(100).regex(/^[a-zA-Z0-9_-]+$/, "nats signer name may only contain letters, numbers, '_', '-'"),
   }),
+  z.object({
+    kind: z.literal("nats-account-public"),
+    signer: z.string().min(1).max(100).regex(/^[a-zA-Z0-9_-]+$/, "nats signer name may only contain letters, numbers, '_', '-'"),
+  }),
 ]);
 
 export const poolConfigSchema = z.object({

--- a/server/src/services/stacks/stack-reconciler.ts
+++ b/server/src/services/stacks/stack-reconciler.ts
@@ -699,7 +699,11 @@ export class StackReconciler {
         (src) => src.kind === 'vault-addr' || src.kind === 'vault-role-id' || src.kind === 'vault-wrapped-secret-id' || src.kind === 'vault-kv',
       );
       const hasNatsEntries = Object.values(dynamicEnv).some(
-        (src) => src.kind === 'nats-url' || src.kind === 'nats-creds' || src.kind === 'nats-signer-seed',
+        (src) =>
+          src.kind === 'nats-url' ||
+          src.kind === 'nats-creds' ||
+          src.kind === 'nats-signer-seed' ||
+          src.kind === 'nats-account-public',
       );
       const hasPoolTokenEntries = Object.values(dynamicEnv).some(
         (src) => src.kind === 'pool-management-token',

--- a/server/templates/_smoke-signer/template.json
+++ b/server/templates/_smoke-signer/template.json
@@ -45,7 +45,8 @@
         "dynamicEnv": {
           "NATS_URL": { "kind": "nats-url" },
           "NATS_CREDS": { "kind": "nats-creds" },
-          "NATS_SIGNER_SEED": { "kind": "nats-signer-seed", "signer": "worker-minter" }
+          "NATS_SIGNER_SEED": { "kind": "nats-signer-seed", "signer": "worker-minter" },
+          "ACCOUNT_PUB": { "kind": "nats-account-public", "signer": "worker-minter" }
         },
         "restartPolicy": "unless-stopped",
         "joinResourceNetworks": ["nats"],


### PR DESCRIPTION
## Summary

Adds a new `nats-account-public` dynamicEnv kind that resolves to the public key of the NATS account that owns a named scoped signer. Apps that mint user JWTs in-process need this as the `issuer_account` claim on `encodeUser` — without it the NATS server rejects the JWT.

The `_smoke-signer` template already referenced `\$ACCOUNT_PUB` in its echo command but never defined it; this gap is what surfaced the issue.

## What changed

- **Type + schema** ([lib/types/stacks.ts](lib/types/stacks.ts), [server/src/services/stacks/schemas.ts](server/src/services/stacks/schemas.ts)) — new `{ kind: 'nats-account-public', signer: string }` variant with the same signer-name validation as `nats-signer-seed`.
- **Resolver** ([server/src/services/nats/nats-credential-injector.ts](server/src/services/nats/nats-credential-injector.ts)) — sibling `resolveSignerAccountPublic()` that joins `NatsSigningKey` to its account row. Parallel cache to the seed cache (60s TTL, same `(stackId, signer)` key, rotation-aware via the signer's publicKey). Throws cleanly when the row is missing or the bound account has no `publicKey` set.
- **Apply-path predicates** ([stack-reconciler.ts](server/src/services/stacks/stack-reconciler.ts), [pool-spawner.ts](server/src/services/stacks/pool-spawner.ts)) — `hasNatsEntries` extended so a service declaring only `nats-account-public` still routes through the NATS injector.
- **Smoke fixture** ([server/templates/_smoke-signer/template.json](server/templates/_smoke-signer/template.json)) — adds the missing `ACCOUNT_PUB` dynamicEnv entry it was already echoing.
- **Docs** — [stack-definition-reference.md](docs/user/stack-definition-reference.md) dynamicEnv table grows two rows (the missing `nats-signer-seed` plus the new `nats-account-public`), and [nats-app-integration.md](client/src/user-docs/nats/nats-app-integration.md)'s worked example pulls both env vars and gains a runnable `encodeUser` snippet showing the `issuer_account` wiring.

## Why this approach

Two options were on the table: a new explicit dynamicEnv kind, or piggybacking on `nats-signer-seed` to also populate a paired `<NAME>_ACCOUNT_PUBLIC` env var. Went with the explicit kind — symmetric with the rest of the dynamicEnv surface, discoverable in template.json, validated at parse time, no magic naming convention.

## Test plan

- [x] `pnpm build:lib` ✓
- [x] `pnpm --filter mini-infra-server build` (tsc) ✓
- [x] `pnpm --filter mini-infra-server lint` ✓
- [x] `pnpm --filter mini-infra-client build` ✓
- [x] Vitest unit run on touched files (3 files, 36 tests pass) — covers schema parse (valid / empty signer / invalid name) and injector behaviour (resolve, missing stackId, missing row, null account.publicKey, cache hit)
- [ ] End-to-end exercise via the `_smoke-signer` smoke test in a worktree dev env to verify `\$ACCOUNT_PUB` is now populated in the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)