### PR TITLE
docs(nats): set ttlSeconds:0 for long-running services; demote signer+callback to advanced

### DIFF
--- a/client/src/user-docs/nats/nats-app-integration.md
+++ b/client/src/user-docs/nats/nats-app-integration.md
@@ -45,7 +45,7 @@ Wildcards (`*` and `>`) work the same as regular NATS, e.g. `events.*` matches o
 | `publish` | no | `[]` | Subject patterns this role can publish to (relative to prefix). |
 | `subscribe` | no | `[]` | Subject patterns this role can subscribe to (relative to prefix). |
 | `inboxAuto` | no | `both` | Whether `_INBOX.>` is auto-injected for request/reply: `both`, `request`, `reply`, or `none`. |
-| `ttlSeconds` | no | `3600` | TTL (seconds) of the minted credential JWT. |
+| `ttlSeconds` | no | `3600` | TTL (seconds) of the minted credential JWT. **Set to `0` to mint a non-expiring JWT — the canonical pattern for long-running services.** The default of `3600` only suits short-lived containers (jobs, batch tasks). See the warning at the end of Step 2. |
 
 ## Step 2 --- Bind a service to the role
 
@@ -77,7 +77,15 @@ At apply time, the orchestrator:
 
 The values appear as plain environment variables to your container --- no SDK calls or AppRole flow needed for the connect itself.
 
-> **⚠ `NATS_CREDS` is a fixed-TTL static value.** The JWT in `NATS_CREDS` is minted once at apply time with the role's `ttlSeconds` (default `3600`). It is **not refreshed**. When the JWT expires, NATS closes the connection and rejects every reconnect attempt until the container is restarted or the stack re-applied. This pattern is fine for **one-shot containers** (jobs, init containers, batch tasks) whose lifetime is shorter than the TTL, but it is **not safe for long-running services**. For any service whose connection needs to outlive the TTL, jump to [Step 4](#step-4-optional-add-a-signer-for-in-process-jwt-minting) and use the signer pattern with an authenticator callback that mints a fresh user JWT on every (re)connect.
+> **⚠ `NATS_CREDS` is minted once at apply time and never refreshed.** Whatever `ttlSeconds` the role is configured with becomes the JWT's `exp`. When `exp` passes, NATS closes the connection and rejects every reconnect attempt until the container is restarted or the stack re-applied. The default of `3600` is suitable only for one-shot containers (jobs, init containers, batch tasks) whose lifetime is shorter than the TTL.
+>
+> **For long-running services, set `ttlSeconds: 0` on the role:**
+>
+> ```json
+> { "name": "worker", "publish": [...], "subscribe": [...], "ttlSeconds": 0 }
+> ```
+>
+> That mints a non-expiring JWT — the canonical NATS pattern for service-owned connections. Revocation is via the account's revocations list rather than expiry. **No app-side code changes needed.** Re-apply + restart the container if you ever change the role's permissions, since the cred is static once minted.
 
 ## Step 3 --- Connect from your app
 
@@ -144,13 +152,11 @@ const sub = nc.subscribe(`${process.env.NATS_SUBJECT_PREFIX}.jobs.queued`);
 
 If you'd like a stable, human-readable prefix (e.g. `myapp` instead of `app.cm0xyz`), ask an admin to add an entry to the [prefix allowlist](/nats/cross-stack-sharing#subject-prefix-allowlist).
 
-## Step 4 --- Use a signer for long-running connections
+## Step 4 (optional) --- Mint ephemeral per-tenant creds with a signer
 
-> **Long-running services should use this pattern, not `nats-creds`.** If your service stays connected for longer than the credential TTL — agents, gateways, control planes, anything that doesn't exit promptly — declare a signer and mint your own user JWT on connect. The seed is the durable secret; the user JWT is disposable and refreshed on every reconnect by the NATS client's authenticator callback.
+> **This is for the case where your service mints creds for *other* clients** — typically a manager/gateway that hands per-user, per-tenant, or per-job creds to downstream workers (the slackbot's worker-pool pattern is the canonical example). For the service's own NATS connection, use `ttlSeconds: 0` from Step 2 instead — that's the canonical NATS pattern for service-owned connections and needs no app-side code changes.
 
-A **signer** is a scoped NKey on your stack's NATS account. Your service holds the seed and uses it to mint user JWTs in-process. The server cryptographically constrains anything signed with the key to the declared subject sub-tree, so a leaked seed cannot escape its scope.
-
-This pattern also covers the original design goal: an agent gateway that hands one-shot credentials to per-user worker jobs.
+A **signer** is a scoped NKey on your stack's NATS account. Your service holds the seed and uses it to mint user JWTs in-process. The server cryptographically constrains anything signed with the key to the declared subject sub-tree, so a leaked seed cannot escape its scope --- which is what makes it safe to hand the seed to your service.
 
 ```json
 {
@@ -180,11 +186,36 @@ This pattern also covers the original design goal: an agent gateway that hands o
 
 At apply time, the seed is read from Vault KV at `shared/nats-signers/<stackId>-worker-minter` and injected into the container as `NATS_SIGNER_SEED` (NKey, base32). The matching account public key lands in `NATS_ACCOUNT_PUB` --- you need it as the `issuer_account` claim when minting JWTs. Your service uses any standard nkeys library to mint user JWTs whose `pub`/`sub` permissions are *subsets* of `<prefix>.agent.worker.>`.
 
-The seed itself never expires; the user JWTs you mint with it are short-lived and disposable. The connection refreshes by re-invoking the mint function on every reconnect — no rotation events, no extra mini-infra round-trip.
+The seed itself never expires; the user JWTs you mint with it are short-lived and disposable. Hand them to per-tenant clients; the server enforces the scope envelope cryptographically.
 
-### Connect with an authenticator callback (long-running service)
+### Minting a per-tenant cred
 
-Use this pattern for services like `manager`, `slack-gateway`, `agent-gateway` --- anything that stays connected. The callback fires on connect **and on every reconnect**, so when the current user JWT nears expiry, the NATS server drops the connection, the client's built-in reconnect kicks in, the callback mints a fresh JWT, and the connection resumes seamlessly.
+```ts
+import { encodeUser, fmtCreds } from "nats-jwt";
+import { createUser, fromSeed } from "nkeys.js";
+
+const signerKp = fromSeed(new TextEncoder().encode(process.env.NATS_SIGNER_SEED!));
+const accountPub = process.env.NATS_ACCOUNT_PUB!;
+
+const userKp = createUser();
+const userJwt = await encodeUser(
+  "worker-job-42",
+  userKp,
+  signerKp,
+  { issuer_account: accountPub }, // required when signing with a scoped key
+  { exp: Math.floor(Date.now() / 1000) + 60, scopedUser: true },
+);
+const creds = new TextDecoder().decode(fmtCreds(userJwt, userKp));
+// hand `creds` to the worker; the server trims its permissions to the scope envelope.
+```
+
+### Advanced: fast permission propagation via authenticator callback
+
+> **Niche.** Skip this unless you have a specific need: `ttlSeconds: 0` from Step 2 covers the long-running-service case, and the "mint a cred for a downstream worker" pattern above covers the per-tenant case.
+
+If you want a long-running service to pick up new role permissions **without restarting the container**, you can replace its static `nats-creds` with the signer pattern wired through your NATS client's authenticator callback. The callback fires on every (re)connect, so re-applying the stack (which updates the signer's scope template via `$SYS.REQ.CLAIMS.UPDATE`) makes the next reconnect pick up new permissions automatically.
+
+This adds app-side complexity and an extra NATS round-trip per reconnect; it's not the recommended default. Use it only when restart-on-permission-change is genuinely a problem.
 
 #### Node.js (`nats.js`)
 
@@ -207,8 +238,8 @@ async function mintFreshUserJwt(): Promise<string> {
     userPub,
     userKp,
     signerKp,
-    { issuer_account: accountPub }, // required when signing with a scoped key
-    { exp: Math.floor(Date.now() / 1000) + 600, scopedUser: true }, // 10 min — the lib refreshes well before this
+    { issuer_account: accountPub },
+    { exp: Math.floor(Date.now() / 1000) + 600, scopedUser: true },
   );
 }
 
@@ -241,7 +272,6 @@ mintJwt := func() (string, error) {
   uc := jwtv2.NewUserClaims(userPub)
   uc.IssuerAccount = accountPub
   uc.Expires = time.Now().Add(10 * time.Minute).Unix()
-  // mark the claim as scoped so the server applies the scope template
   return uc.Encode(signerKp) // signed with the scoped signer
 }
 
@@ -255,30 +285,7 @@ nc, err := nats.Connect(
 )
 ```
 
-> **Why the callback rather than `credsAuthenticator`/`UserCredentials` with a static creds string?** The static authenticator captures the JWT bytes once at connect time and reuses them on every internal reconnect. When the JWT expires, every reconnect attempt is rejected until the process restarts. The callback variant is what gives you continuous availability past the TTL.
-
-### Minting one-off creds for a downstream worker
-
-Same primitives, but you serialize the JWT + user nkey as a creds blob and hand it off:
-
-```ts
-import { encodeUser, fmtCreds } from "nats-jwt";
-import { createUser, fromSeed } from "nkeys.js";
-
-const signerKp = fromSeed(new TextEncoder().encode(process.env.NATS_SIGNER_SEED!));
-const accountPub = process.env.NATS_ACCOUNT_PUB!;
-
-const userKp = createUser();
-const userJwt = await encodeUser(
-  "worker-job-42",
-  userKp,
-  signerKp,
-  { issuer_account: accountPub },
-  { exp: Math.floor(Date.now() / 1000) + 60, scopedUser: true },
-);
-const creds = new TextDecoder().decode(fmtCreds(userJwt, userKp));
-// hand `creds` to the worker; the server trims its permissions to the scope envelope.
-```
+> **Why this works only with the callback variant.** Static authenticators (`credsAuthenticator` / `nats.UserCredentials`) capture the JWT bytes once at connect and reuse them on every internal reconnect. The callback variant is what makes the lib re-mint on each reconnect — that's how new permissions propagate without a container restart.
 
 ### Signer fields
 
@@ -299,7 +306,8 @@ A minimal complete example:
       {
         "name": "api",
         "publish": ["events.created", "events.updated"],
-        "subscribe": ["commands.>"]
+        "subscribe": ["commands.>"],
+        "ttlSeconds": 0
       }
     ]
   },
@@ -328,4 +336,4 @@ Apply, and your `api` container boots with everything it needs to talk to NATS.
 - **Subjects in role declarations are relative; your client code is absolute.** Read `NATS_SUBJECT_PREFIX` in your app and prepend it explicitly. Forgetting this is the #1 source of "permissions violation" errors.
 - **`inboxAuto` matters for RPC.** Default `'both'` is right for most services. Pick `'reply'` for pure responders and `'request'` for pure requesters if you want tighter permissions.
 - **Re-apply after editing roles.** Subject permission changes take effect when the orchestrator re-mints the credential. Container restarts alone don't pick up new permissions.
-- **`nats-creds` JWTs *are* enforced for the connection's lifetime.** When the JWT in `NATS_CREDS` expires, the NATS server closes the connection on the next protocol tick and rejects every reconnect attempt — your existing session does **not** get a grace period. The slackbot stack hit this in the wild: containers booted at 13:00, JWTs expired at 14:00, NATS started returning `authentication expired` at 14:06, and the dependent gateway → manager RPCs failed an hour later. Fix is the signer pattern in [Step 4](#step-4-use-a-signer-for-long-running-connections), not bumping the TTL.
+- **`nats-creds` JWTs *are* enforced for the connection's lifetime.** When the JWT in `NATS_CREDS` expires, the NATS server closes the connection on the next protocol tick and rejects every reconnect attempt — your existing session does **not** get a grace period. The slackbot stack hit this in the wild: containers booted at 13:00, JWTs expired at 14:00, NATS started returning `authentication expired` at 14:06, and the dependent gateway → manager RPCs failed an hour later. Fix: set `ttlSeconds: 0` on the role to mint a non-expiring JWT — the canonical NATS pattern for service-owned connections — and re-deploy.

--- a/client/src/user-docs/nats/nats-app-integration.md
+++ b/client/src/user-docs/nats/nats-app-integration.md
@@ -77,6 +77,8 @@ At apply time, the orchestrator:
 
 The values appear as plain environment variables to your container --- no SDK calls or AppRole flow needed for the connect itself.
 
+> **⚠ `NATS_CREDS` is a fixed-TTL static value.** The JWT in `NATS_CREDS` is minted once at apply time with the role's `ttlSeconds` (default `3600`). It is **not refreshed**. When the JWT expires, NATS closes the connection and rejects every reconnect attempt until the container is restarted or the stack re-applied. This pattern is fine for **one-shot containers** (jobs, init containers, batch tasks) whose lifetime is shorter than the TTL, but it is **not safe for long-running services**. For any service whose connection needs to outlive the TTL, jump to [Step 4](#step-4-optional-add-a-signer-for-in-process-jwt-minting) and use the signer pattern with an authenticator callback that mints a fresh user JWT on every (re)connect.
+
 ## Step 3 --- Connect from your app
 
 Most NATS clients accept a credentials file via `nats.credsAuthenticator` or an equivalent option. Two examples:
@@ -142,9 +144,13 @@ const sub = nc.subscribe(`${process.env.NATS_SUBJECT_PREFIX}.jobs.queued`);
 
 If you'd like a stable, human-readable prefix (e.g. `myapp` instead of `app.cm0xyz`), ask an admin to add an entry to the [prefix allowlist](/nats/cross-stack-sharing#subject-prefix-allowlist).
 
-## Step 4 (optional) --- Add a signer for in-process JWT minting
+## Step 4 --- Use a signer for long-running connections
 
-A **signer** lets your service mint its own short-lived NATS JWTs --- useful for an agent gateway that hands one-shot credentials to per-user worker jobs. The server constrains anything signed with this key to the declared sub-tree, so a leaked seed cannot escape its scope.
+> **Long-running services should use this pattern, not `nats-creds`.** If your service stays connected for longer than the credential TTL — agents, gateways, control planes, anything that doesn't exit promptly — declare a signer and mint your own user JWT on connect. The seed is the durable secret; the user JWT is disposable and refreshed on every reconnect by the NATS client's authenticator callback.
+
+A **signer** is a scoped NKey on your stack's NATS account. Your service holds the seed and uses it to mint user JWTs in-process. The server cryptographically constrains anything signed with the key to the declared subject sub-tree, so a leaked seed cannot escape its scope.
+
+This pattern also covers the original design goal: an agent gateway that hands one-shot credentials to per-user worker jobs.
 
 ```json
 {
@@ -172,9 +178,88 @@ A **signer** lets your service mint its own short-lived NATS JWTs --- useful for
 }
 ```
 
-At apply time, the seed is read from Vault KV at `shared/nats-signers/<stackId>-worker-minter` and injected into the container as `NATS_SIGNER_SEED` (NKey, base32). The matching account public key lands in `NATS_ACCOUNT_PUB` --- you need it as the `issuer_account` claim when minting JWTs (see below). Your service uses any standard nkeys library to mint user JWTs whose `pub`/`sub` permissions are *subsets* of `<prefix>.agent.worker.>`.
+At apply time, the seed is read from Vault KV at `shared/nats-signers/<stackId>-worker-minter` and injected into the container as `NATS_SIGNER_SEED` (NKey, base32). The matching account public key lands in `NATS_ACCOUNT_PUB` --- you need it as the `issuer_account` claim when minting JWTs. Your service uses any standard nkeys library to mint user JWTs whose `pub`/`sub` permissions are *subsets* of `<prefix>.agent.worker.>`.
 
-### Minting JWTs in-process
+The seed itself never expires; the user JWTs you mint with it are short-lived and disposable. The connection refreshes by re-invoking the mint function on every reconnect — no rotation events, no extra mini-infra round-trip.
+
+### Connect with an authenticator callback (long-running service)
+
+Use this pattern for services like `manager`, `slack-gateway`, `agent-gateway` --- anything that stays connected. The callback fires on connect **and on every reconnect**, so when the current user JWT nears expiry, the NATS server drops the connection, the client's built-in reconnect kicks in, the callback mints a fresh JWT, and the connection resumes seamlessly.
+
+#### Node.js (`nats.js`)
+
+```ts
+import { connect, jwtAuthenticator } from "nats";
+import { encodeUser } from "nats-jwt";
+import { createUser, fromSeed } from "nkeys.js";
+
+const signerKp = fromSeed(new TextEncoder().encode(process.env.NATS_SIGNER_SEED!));
+const accountPub = process.env.NATS_ACCOUNT_PUB!;
+
+// Stable user nkey for the lifetime of the process. The user JWT we mint
+// below is short-lived; the user nkey is not.
+const userKp = createUser();
+const userPub = userKp.getPublicKey();
+const userSeed = userKp.getSeed();
+
+async function mintFreshUserJwt(): Promise<string> {
+  return await encodeUser(
+    userPub,
+    userKp,
+    signerKp,
+    { issuer_account: accountPub }, // required when signing with a scoped key
+    { exp: Math.floor(Date.now() / 1000) + 600, scopedUser: true }, // 10 min — the lib refreshes well before this
+  );
+}
+
+const nc = await connect({
+  servers: process.env.NATS_URL!,
+  // jwtAuthenticator accepts a function for the JWT — called on every
+  // (re)connect, so the JWT is always freshly minted.
+  authenticator: jwtAuthenticator(() => mintFreshUserJwt(), userSeed),
+  reconnect: true,
+  maxReconnectAttempts: -1,
+});
+```
+
+#### Go (`nats.go`)
+
+```go
+import (
+  "github.com/nats-io/nats.go"
+  "github.com/nats-io/nkeys"
+  jwtv2 "github.com/nats-io/jwt/v2"
+)
+
+signerKp, _ := nkeys.FromSeed([]byte(os.Getenv("NATS_SIGNER_SEED")))
+accountPub := os.Getenv("NATS_ACCOUNT_PUB")
+
+userKp, _ := nkeys.CreateUser()
+userPub, _ := userKp.PublicKey()
+
+mintJwt := func() (string, error) {
+  uc := jwtv2.NewUserClaims(userPub)
+  uc.IssuerAccount = accountPub
+  uc.Expires = time.Now().Add(10 * time.Minute).Unix()
+  // mark the claim as scoped so the server applies the scope template
+  return uc.Encode(signerKp) // signed with the scoped signer
+}
+
+signCB := func(nonce []byte) ([]byte, error) { return userKp.Sign(nonce) }
+
+nc, err := nats.Connect(
+  os.Getenv("NATS_URL"),
+  // UserJWT's first arg is called on every (re)connect.
+  nats.UserJWT(mintJwt, signCB),
+  nats.MaxReconnects(-1),
+)
+```
+
+> **Why the callback rather than `credsAuthenticator`/`UserCredentials` with a static creds string?** The static authenticator captures the JWT bytes once at connect time and reuses them on every internal reconnect. When the JWT expires, every reconnect attempt is rejected until the process restarts. The callback variant is what gives you continuous availability past the TTL.
+
+### Minting one-off creds for a downstream worker
+
+Same primitives, but you serialize the JWT + user nkey as a creds blob and hand it off:
 
 ```ts
 import { encodeUser, fmtCreds } from "nats-jwt";
@@ -188,7 +273,7 @@ const userJwt = await encodeUser(
   "worker-job-42",
   userKp,
   signerKp,
-  { issuer_account: accountPub }, // required when signing with a scoped key
+  { issuer_account: accountPub },
   { exp: Math.floor(Date.now() / 1000) + 60, scopedUser: true },
 );
 const creds = new TextDecoder().decode(fmtCreds(userJwt, userKp));
@@ -243,4 +328,4 @@ Apply, and your `api` container boots with everything it needs to talk to NATS.
 - **Subjects in role declarations are relative; your client code is absolute.** Read `NATS_SUBJECT_PREFIX` in your app and prepend it explicitly. Forgetting this is the #1 source of "permissions violation" errors.
 - **`inboxAuto` matters for RPC.** Default `'both'` is right for most services. Pick `'reply'` for pure responders and `'request'` for pure requesters if you want tighter permissions.
 - **Re-apply after editing roles.** Subject permission changes take effect when the orchestrator re-mints the credential. Container restarts alone don't pick up new permissions.
-- **TTL = grant lifetime, not connection lifetime.** A connected client keeps its session even after the cred TTL expires (until it disconnects). Re-apply for new TTLs to take hold for fresh connections.
+- **`nats-creds` JWTs *are* enforced for the connection's lifetime.** When the JWT in `NATS_CREDS` expires, the NATS server closes the connection on the next protocol tick and rejects every reconnect attempt — your existing session does **not** get a grace period. The slackbot stack hit this in the wild: containers booted at 13:00, JWTs expired at 14:00, NATS started returning `authentication expired` at 14:06, and the dependent gateway → manager RPCs failed an hour later. Fix is the signer pattern in [Step 4](#step-4-use-a-signer-for-long-running-connections), not bumping the TTL.

--- a/docs/user/stack-definition-reference.md
+++ b/docs/user/stack-definition-reference.md
@@ -228,6 +228,8 @@ Each key is an environment variable name. Each value must be one of:
 | `{ kind: "vault-addr" }` | Inject the Vault address. | Exact object shape. |
 | `{ kind: "vault-role-id" }` | Inject the bound Vault AppRole role ID. | Exact object shape. |
 | `{ kind: "vault-wrapped-secret-id", ttlSeconds: 300 }` | Inject a wrapped secret ID minted at apply time. | `ttlSeconds` is optional, integer `> 0`. If omitted, runtime default is `300`. |
+| `{ kind: "nats-url" }` | URL of the managed NATS cluster reachable from the service's network. | Exact object shape. |
+| `{ kind: "nats-creds" }` | Multi-line credentials file (JWT + nkey seed) for the bound `natsRole`. **Fixed TTL — see warning below.** | Exact object shape. The service must declare a `natsRole`. |
 | `{ kind: "nats-signer-seed", signer: "<name>" }` | NKey seed (base32) of the named scoped signing key, for in-process JWT minting. | `signer` must match a `nats.signers[].name` on the stack template. |
 | `{ kind: "nats-account-public", signer: "<name>" }` | Public key of the NATS account that owns the named signer. Pair with `nats-signer-seed`; `nats-jwt`'s `encodeUser` requires it as the `issuer_account` claim. | `signer` must match a `nats.signers[].name` on the stack template. |
 
@@ -235,6 +237,7 @@ Runtime notes:
 
 - `dynamicEnv` values are resolved at apply time, not at plan time.
 - Their source definitions stay in the stack definition, but the secret values themselves are not part of the definition hash.
+- **`nats-creds` is fixed-TTL.** The JWT is minted once at apply time with the credential profile's `ttlSeconds` (default `3600`) and is **not refreshed**. When the JWT expires, NATS will close the connection on the next reconnect attempt and reject all reconnects until the container is restarted (or the stack re-applied). For any service whose connection is expected to outlive the TTL — i.e. virtually every long-running service — use the **signer pattern** (`nats-signer-seed` + `nats-account-public`) and an authenticator callback that mints a fresh user JWT on connect. See [Connecting your app to NATS](/nats/app-integration) for the recipe. Reserve `nats-creds` for one-shot containers (jobs, init containers, batch tasks) whose lifetime is shorter than the TTL.
 
 ## `services[].containerConfig.healthcheck`
 

--- a/docs/user/stack-definition-reference.md
+++ b/docs/user/stack-definition-reference.md
@@ -229,15 +229,17 @@ Each key is an environment variable name. Each value must be one of:
 | `{ kind: "vault-role-id" }` | Inject the bound Vault AppRole role ID. | Exact object shape. |
 | `{ kind: "vault-wrapped-secret-id", ttlSeconds: 300 }` | Inject a wrapped secret ID minted at apply time. | `ttlSeconds` is optional, integer `> 0`. If omitted, runtime default is `300`. |
 | `{ kind: "nats-url" }` | URL of the managed NATS cluster reachable from the service's network. | Exact object shape. |
-| `{ kind: "nats-creds" }` | Multi-line credentials file (JWT + nkey seed) for the bound `natsRole`. **Fixed TTL — see warning below.** | Exact object shape. The service must declare a `natsRole`. |
-| `{ kind: "nats-signer-seed", signer: "<name>" }` | NKey seed (base32) of the named scoped signing key, for in-process JWT minting. | `signer` must match a `nats.signers[].name` on the stack template. |
+| `{ kind: "nats-creds" }` | Multi-line credentials file (JWT + nkey seed) for the bound `natsRole`. **Fixed at apply time — see TTL note below.** | Exact object shape. The service must declare a `natsRole`. |
+| `{ kind: "nats-signer-seed", signer: "<name>" }` | NKey seed (base32) of the named scoped signing key, for in-process JWT minting. Used to mint **ephemeral per-tenant creds** (e.g. an agent gateway minting per-user worker creds), not for the service's own connection. | `signer` must match a `nats.signers[].name` on the stack template. |
 | `{ kind: "nats-account-public", signer: "<name>" }` | Public key of the NATS account that owns the named signer. Pair with `nats-signer-seed`; `nats-jwt`'s `encodeUser` requires it as the `issuer_account` claim. | `signer` must match a `nats.signers[].name` on the stack template. |
 
 Runtime notes:
 
 - `dynamicEnv` values are resolved at apply time, not at plan time.
 - Their source definitions stay in the stack definition, but the secret values themselves are not part of the definition hash.
-- **`nats-creds` is fixed-TTL.** The JWT is minted once at apply time with the credential profile's `ttlSeconds` (default `3600`) and is **not refreshed**. When the JWT expires, NATS will close the connection on the next reconnect attempt and reject all reconnects until the container is restarted (or the stack re-applied). For any service whose connection is expected to outlive the TTL — i.e. virtually every long-running service — use the **signer pattern** (`nats-signer-seed` + `nats-account-public`) and an authenticator callback that mints a fresh user JWT on connect. See [Connecting your app to NATS](/nats/app-integration) for the recipe. Reserve `nats-creds` for one-shot containers (jobs, init containers, batch tasks) whose lifetime is shorter than the TTL.
+- **`nats-creds` is minted once at apply time and never refreshed.** Whatever `ttlSeconds` the credential profile is configured with becomes the JWT's `exp`. When `exp` passes, NATS closes the connection and rejects reconnects until the container is restarted or the stack re-applied.
+  - **For long-running services, set `ttlSeconds: 0` on the role.** That mints a non-expiring JWT, which is the canonical NATS pattern for service-owned connections; revocation is handled out-of-band via the account's revocations list rather than via expiry. The default `ttlSeconds: 3600` is suitable only for short-lived containers (jobs, init containers, batch tasks) whose lifetime is shorter than the TTL.
+  - **Permission changes still need a re-apply + container restart** even with `ttlSeconds: 0` — the cred is static once minted. If you need fast permission propagation (no restarts), see the niche signer-with-authenticator-callback recipe in [Connecting your app to NATS](/nats/app-integration#advanced-fast-permission-propagation-via-authenticator-callback).
 
 ## `services[].containerConfig.healthcheck`
 


### PR DESCRIPTION
## Summary

The dynamicEnv `nats-creds` mints a JWT once at apply time with the role's `ttlSeconds` (default `3600`s) and **never refreshes**. When the JWT expires, NATS closes the connection and rejects every reconnect attempt — the existing session does **not** get a grace period, contrary to what the prior doc claimed. Any long-running service using the default-TTL `nats-creds` is on a 1-hour timer.

Hit in the wild on a slackbot stack in a worktree dev env earlier today:
- 13:00 UTC — containers boot, NATS-connect with fresh creds.
- 14:00 UTC — JWTs expire.
- 14:06 UTC — NATS server starts returning `authentication error` on every reconnect; client logs show `nats: authentication expired on connection`.
- 14:48 UTC — `slack-gateway` fails an `ensure_worker` request to the pool manager (`request: nats: connection closed`); manager never spawned anything.

**The fix is to set `ttlSeconds: 0` on the role** to mint a non-expiring user JWT — the canonical NATS pattern for service-owned connections. Revocation is via the account's revocations list rather than expiry. **No app-side code changes needed**, just a redeploy. Mini-infra already supports this end-to-end (see `nats-key-manager.ts:143` — `if (ttlSeconds > 0)` only sets `exp` when positive).

This PR makes that the documented recommendation and corrects the prior incorrect "fix is the signer pattern" framing.

## What changed

- **[`docs/user/stack-definition-reference.md`](docs/user/stack-definition-reference.md)** — dynamicEnv table now lists `nats-url` and `nats-creds` (which were missing entirely). Runtime notes lead with the `ttlSeconds: 0` recipe; signer pattern reduced to a "if you need fast permission propagation" link.
- **[`client/src/user-docs/nats/nats-app-integration.md`](client/src/user-docs/nats/nats-app-integration.md)**:
  - **Step 1 role-fields table**: documents `ttlSeconds: 0` as the recommended setting for long-running services.
  - **Step 2** (`nats-creds`): explicit ⚠ block with the `ttlSeconds: 0` fix in three lines of YAML.
  - **Step 4** reframed from "use a signer for long-running connections" → **"mint ephemeral per-tenant creds with a signer"**. That is what the signer pattern is actually for (e.g. an agent gateway minting per-user worker creds — the slackbot worker-pool pattern). The callout up top steers the reader away from this section unless they have that specific use case.
  - **Authenticator-callback recipe (TS + Go)** preserved but moved to a clearly-labelled **"Advanced: fast permission propagation via authenticator callback"** subsection with a "skip this unless..." callout. Still useful for the niche where you want permission changes to propagate without container restarts.
  - **"What to watch out for"** bullet updated: fix is `ttlSeconds: 0`, not signers.
  - **"Putting it all together"** example sets `ttlSeconds: 0` to demonstrate the recommended default.

## Why this revision

The first push of this PR pushed the signer + authenticator-callback pattern as the canonical fix. That's not what the vendor recommends:

| Pattern | NATS canonical use |
|---|---|
| `.creds` with `exp = 0` (`ttlSeconds: 0`) | **Service-owned long-running connections.** Revoke via account's revocations map when needed. |
| Scoped signing keys + in-process minting | **Per-user / per-tenant ephemeral creds** — the slackbot's worker-pool pattern (manager mints per-channel worker creds). |
| Authenticator callback with short JWTs | **Niche.** Useful when you want fast permission propagation without restarts. Adds operational complexity. |

I had the second and third rows swapped in the earlier draft. The current docs put each pattern at its right level: `ttlSeconds: 0` is the headline for service connections, signers are for ephemeral per-tenant creds, callbacks are advanced.

## Why no platform code changes

The platform's behaviour is correct — `ttlSeconds: 0` already works end-to-end. Nothing to fix in the orchestrator or schema. Just docs that point at the right recipe.

A separate small follow-up worth considering: a `POST /api/nats/credentials/:userPub/revoke` endpoint that pushes onto the account's `revocations` map. The revocation pattern is what makes `ttlSeconds: 0` safe, and there's no UI for it today. Out of scope for this PR.

## Test plan

- [x] `pnpm --filter mini-infra-client build` ✓ (user-docs are bundled at client build time)
- [ ] Eyeball-render the rendered docs in the running dev env once merged: `/help/nats/app-integration` — Step 2 warning should lead with `ttlSeconds: 0`, Step 4 should be framed as "ephemeral per-tenant creds".
- [ ] Slackbot fix: set `ttlSeconds: 0` on each `nats.roles[]` entry in the slackbot stack template, redeploy. That's a slackbot-side PR, not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)