### PR TITLE
docs(nats): tidy two leftover nits in app-integration guide

### DIFF
--- a/client/src/user-docs/nats/nats-app-integration.md
+++ b/client/src/user-docs/nats/nats-app-integration.md
@@ -111,9 +111,7 @@ for await (const msg of sub) {
 }
 ```
 
-> **Wait — don't I need to publish to `app.<stack-id>.jobs.completed`?** Yes, on the wire. But the credential JWT pins your client into the prefixed namespace, so your code uses the unprefixed name and the server rewrites/enforces. In practice you publish and subscribe by the relative subject everywhere.
-
-Actually that's a half-truth: NATS does **not** rewrite subjects. Your code must use the *full* subject including the prefix. Read [the prefix gotcha](#the-prefix-gotcha) below before you ship.
+> **The example above is incomplete — your client code must use the *absolute* subject (prefix-included), not the relative one from the role declaration.** NATS does not rewrite subjects on the server; the role's prefix-relative form is just how mini-infra renders the permission allowlist. Read [the prefix gotcha](#the-prefix-gotcha) below for the corrected pattern before you ship.
 
 ### Go (`nats.go`)
 
@@ -161,7 +159,7 @@ A **signer** is a scoped NKey on your stack's NATS account. Your service holds t
 ```json
 {
   "nats": {
-    "roles": [{ "name": "gateway", "publish": ["agent.>"], "subscribe": ["agent.>"] }],
+    "roles": [{ "name": "gateway", "publish": ["agent.>"], "subscribe": ["agent.>"], "ttlSeconds": 0 }],
     "signers": [
       { "name": "worker-minter", "subjectScope": "agent.worker" }
     ]


### PR DESCRIPTION
Two small touch-ups to the NATS app-integration guide spotted while reviewing #337 on main:

## 1. Step 3's wrong-then-retracted blockquote

Before:
\`\`\`
> **Wait — don't I need to publish to \`app.<stack-id>.jobs.completed\`?** Yes, on the wire. But
> the credential JWT pins your client into the prefixed namespace, so your code uses the
> unprefixed name and the server rewrites/enforces. In practice you publish and subscribe by
> the relative subject everywhere.

Actually that's a half-truth: NATS does **not** rewrite subjects. Your code must use the *full*
subject including the prefix. Read [the prefix gotcha](#the-prefix-gotcha) below before you ship.
\`\`\`

The blockquote claims something incorrect, then the next paragraph immediately retracts it. Replaced with a single accurate callout that points the reader to the prefix-gotcha section for the corrected pattern.

## 2. Step 4's gateway role missing \`ttlSeconds: 0\`

The example role at the top of Step 4:

\`\`\`json
{ \"name\": \"gateway\", \"publish\": [\"agent.>\"], \"subscribe\": [\"agent.>\"] }
\`\`\`

…was missing \`ttlSeconds: 0\`, even though it's the kind of long-running gateway service the doc now recommends \`ttlSeconds: 0\` for. The \"Putting it all together\" example at the bottom of the page sets it correctly; this one in Step 4 missed the same touch-up. Added it for consistency.

## Test plan

- [x] \`pnpm --filter mini-infra-client build\` ✓
- [ ] Render check on \`/help/nats/app-integration\` once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)