### PR TITLE
fix(worktree): detect stopped Colima VMs in colimaExists

### DIFF
--- a/deployment/development/lib/colima.ts
+++ b/deployment/development/lib/colima.ts
@@ -7,8 +7,31 @@ export function isColimaRunning(profile: string): boolean {
 }
 
 export function colimaExists(profile: string): boolean {
-  const res = spawnSync('colima', ['status', profile], { encoding: 'utf8' });
-  return res.status === 0;
+  // `colima status <profile>` exits non-zero for *stopped* VMs as well as
+  // missing ones, so it can't distinguish "doesn't exist" from "not running".
+  // `colima list --json` enumerates every instance regardless of state.
+  const res = spawnSync('colima', ['list', '--json'], { encoding: 'utf8' });
+  if (res.status !== 0) return false;
+  const stdout = res.stdout || '';
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const obj = JSON.parse(trimmed) as { name?: string };
+      if (obj?.name === profile) return true;
+    } catch {
+      // Some colima versions wrap the output in a JSON array; fall through.
+    }
+  }
+  try {
+    const arr = JSON.parse(stdout) as Array<{ name?: string }>;
+    if (Array.isArray(arr)) {
+      return arr.some((entry) => entry?.name === profile);
+    }
+  } catch {
+    // No JSON to parse — treat as not found.
+  }
+  return false;
 }
 
 export interface ColimaStartOpts {


### PR DESCRIPTION
## Summary
- `colima status <profile>` exits non-zero for **stopped** VMs as well as missing ones, so `colimaExists()` returned `false` for any stopped profile.
- That meant `worktree-env delete` and `worktree-env cleanup` would remove the registry entry but silently skip the actual `colima delete --data --force`, leaving the stopped VM (and its container data) on disk forever.
- Hit this in practice today cleaning up 8 worktrees — only the 2 *running* VMs were torn down by the helper; the other 6 stopped VMs had to be deleted manually.
- Fix: use `colima list --json`, which enumerates every instance regardless of state, and check for the profile name. Handles both the NDJSON-per-line format (current colima) and the array fallback for older versions.

## Test plan
- [x] Verified `colima list --json` outputs `{"name":"...","status":"..."}` per line for both running and stopped VMs.
- [x] Spun up a `colima start test-fix-validation` VM, ran the new `colimaExists('test-fix-validation')` → `true`.
- [x] `colima stop test-fix-validation`, ran again → still `true` (this is the bug).
- [x] `colimaExists('definitely-does-not-exist')` → `false`.
- [x] `colima delete test-fix-validation --data --force`, ran again → `false`.
- [x] `pnpm worktree-env list` still loads cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)