### PR TITLE
docs+skills: internal-messaging arch, OTel tracing plan, Linear workflow skills

### DIFF
--- a/.claude/skills/execute-next-task/SKILL.md
+++ b/.claude/skills/execute-next-task/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: execute-next-task
+description: Picks the next unblocked Todo issue from the user's Linear team (Altitude Devops), reads the parent project's linked markdown plan doc, plans the work, and on user approval executes it end-to-end — worktree check, code changes, verification, PR with `Closes ALT-NN`, and Linear state transitions. Use this skill whenever the user says "execute next task", "what's next in linear", "do the next phase", "pick up the next todo", "work on the next thing", "what should I do next", or any equivalent request to advance through a Linear-tracked migration. Do NOT trigger for one-off non-Linear tasks or for "what should I work on?" without an obvious Linear context.
+---
+
+# Execute Next Task
+
+You're picking up the next chunk of an in-flight Linear-tracked feature in Mini Infra. The features are codified as markdown plan docs under `docs/planning/` with phased rollouts; each phase is a Linear issue. Your job is to find the next phase ready to work on, plan it concretely against the plan doc, and on user approval execute it end-to-end through to a PR in review.
+
+## Conventions you rely on
+
+These conventions are maintained by the user. If they're violated for the picked task, **stop and report — never guess**.
+
+- **One Linear project per feature**, named after the feature.
+- **Project description starts with a `Plan:` line** linking to a relative path, e.g. `Plan: docs/planning/not-shipped/internal-nats-messaging-plan.md`. That path is your map.
+- **Issue title format**: `Phase N: <short title>`, where `Phase N — <title>` is also a `### Phase N — <title>` heading in the plan doc.
+- **Plan doc lives** in `docs/planning/not-shipped/<slug>-plan.md` while any phase is unshipped. After all phases ship it moves to `docs/planning/shipped/`.
+- **Phases land in order** via `blocked-by` relationships. Phase 2 is blocked by Phase 1, etc. The skill respects that.
+- **Commit / PR title format**: `feat(<area>): <description> (Phase N, ALT-NN) (#PR)` — match the most recent shipped phase in the same project.
+- **PR body must include** `Closes <ALT-NN>` so merging closes the Linear issue automatically.
+
+Reference examples in this repo: `docs/planning/not-shipped/internal-nats-messaging-plan.md`, `docs/planning/not-shipped/observability-otel-tracing-plan.md`, `docs/planning/shipped/nats-app-roles-plan.md`.
+
+The team is hardcoded as **Altitude Devops**. (A future improvement is to read this from `.claude/linear-team.json`; not built yet.)
+
+---
+
+## Phase 1 — Load the Linear MCP tools
+
+The Linear MCP tools are deferred at session start. Load the toolkit in one bulk call before doing anything else:
+
+```
+ToolSearch(query: "linear", max_results: 30)
+```
+
+You should see tools like `mcp__cd9fab4e-...__list_issues`, `__get_issue`, `__get_project`, `__list_comments`, `__save_comment`, `__save_issue`, `__list_issue_statuses`. If any of these are missing, stop and tell the user — don't fall back to anything else.
+
+---
+
+## Phase 2 — Find the next unblocked task
+
+The picking rule is **deliberately simple** — there is no priority sort, no cycle filter, no last-updated heuristic. Just: state = `Todo`, no unfinished `blocked-by`. The user maintains ordering through Linear's blocking relationships.
+
+1. **List Todos** in the Altitude Devops team. Use the `list_issues` tool with `state` = `Todo` (or whatever the team's "Todo" status maps to — fetch the team's issue statuses first if you're unsure).
+2. **For each candidate, check blockers.** Use `get_issue` to read its `relations` / blockers. A candidate survives if every `blocked-by` issue it has is in state `Done` or `Cancelled`. An issue with no blockers automatically survives.
+3. **Decide:**
+   - **0 unblocked candidates** → tell the user "Nothing to do — every Todo is blocked or no Todos exist." Stop.
+   - **1 unblocked candidate** → use it. State the pick: id, title, project name.
+   - **>1 unblocked candidates** → list them with `id | title | project` and ask the user to pick one. Don't infer — ask.
+
+Don't move to Phase 3 until you have exactly one issue in hand.
+
+---
+
+## Phase 3 — Resolve the plan doc and the matching phase section
+
+Once you have the issue:
+
+1. **Fetch the parent project** (`get_project`). Read its description.
+2. **Find the `Plan:` line.** It should be one of the first lines and look like `Plan: docs/planning/not-shipped/<slug>-plan.md`. If absent, **stop** and tell the user the project description is missing the convention.
+3. **Read the plan doc.** Confirm it exists at the cited path.
+4. **Locate the matching phase section.** From the issue title `Phase N: <short title>`, find the `### Phase N — <something>` heading in the plan doc. The titles don't have to match exactly word-for-word — the phase number is the key. If no `### Phase N` heading exists, **stop** and tell the user the plan doc is out of sync.
+5. **Read the matching section in full** — Goal, Deliverables, Done when. These three are your contract.
+6. **Read prior art** — `git log --oneline -20 main` plus any commits whose message contains the project's earlier phases (e.g. `Phase 1, ALT-26`). The shipped phases tell you the commit format, the area-tag style, and the rough size of a phase PR for this project.
+
+If anything in this phase fails, stop and report — never guess your way through.
+
+---
+
+## Phase 4 — Plan and seek approval
+
+Produce a concrete implementation plan keyed to the phase's **Deliverables** and **Done when** lines from the plan doc.
+
+The plan must include:
+
+- A list of files you intend to create or modify.
+- The verification commands you'll run at the end (build / lint / test / browser test as relevant).
+- Any deviation from the plan doc you're proposing, **with reasoning**. (Plans drift; honesty about that is what keeps the doc useful.)
+- An explicit note about anything the plan section says to defer — those stay deferred.
+
+Surface the plan via `ExitPlanMode` and wait for user approval. Do not start writing code before approval.
+
+---
+
+## Phase 5 — Pre-flight checks
+
+Before executing:
+
+```bash
+git status
+git rev-parse --abbrev-ref HEAD
+```
+
+Required state:
+
+- **A clean working tree** — no uncommitted changes.
+- **A feature branch** — not `main` (or whatever the repo's default branch is, check `git remote show origin`).
+- **You're in a worktree path** — `pwd` should match the worktree root the user is operating in.
+
+If any of these fail, **stop with a clear message**. Do not auto-stash, auto-create a branch, or run `pnpm worktree-env start`. The repo's worktree workflow is a separate concern (root `CLAUDE.md`); duplicating it here causes pain.
+
+---
+
+## Phase 6 — Mark the issue In Progress
+
+```
+save_issue(id: <issue-id>, state: "In Progress")
+save_comment(issue_id: <issue-id>, body: "Started by Claude.\n- Worktree: <path>\n- Branch: <branch>")
+```
+
+Fetch the team's issue statuses first if you don't already know the canonical name (`In Progress` vs `In progress` etc. — use whatever the team has).
+
+---
+
+## Phase 7 — Execute
+
+Implement per the approved plan, following the repo's coding conventions:
+
+- Root `CLAUDE.md` — package manager (pnpm), worktree workflow, build invariants, the "always run from project root" rule.
+- `server/CLAUDE.md` — `DockerService.getInstance()`, `ConfigurationServiceFactory`, never raw `dockerode`, all mutations carry `userId`, `Channel.*` / `ServerEvent.*` constants for Socket.IO.
+- `client/CLAUDE.md` — TanStack Query owns server state, no polling when socket is connected, task tracker pattern.
+
+Rules of taste:
+
+- Edit existing files in preference to creating new ones.
+- Don't add features, refactor surrounding code, or introduce abstractions beyond what the phase requires.
+- Don't add error handling for scenarios that can't happen.
+- Default to no comments. Only add a comment when the *why* is non-obvious.
+
+Refer back to the plan doc's "Deliverables" list as you go — those are the things that have to be true at the end. If the work is bigger than the phase scoped, **stop and ask** — never silently expand scope or split phases on the fly.
+
+---
+
+## Phase 8 — Verify
+
+At minimum, run the verification commands you listed in Phase 4. Typical:
+
+```bash
+pnpm build:lib                              # if lib/ changed (always required if so)
+pnpm --filter mini-infra-server build       # if server/ changed
+pnpm --filter mini-infra-server test        # if server/ changed
+pnpm --filter mini-infra-server lint        # if server/ changed
+pnpm --filter mini-infra-client build       # if client/ changed
+pnpm --filter mini-infra-client test        # if client/ tests changed
+```
+
+For the Go components (`egress-gateway/`, `egress-fw-agent/`, `egress-shared/`):
+
+```bash
+go build ./...
+go test ./...
+```
+
+For UI changes the user expects browser testing. **Do not re-implement what `test-dev` does** — invoke that skill, or tell the user it's the next step. Same for `diagnose-dev` if a runtime check is needed.
+
+If something fails, fix it before continuing. Don't paper over with `--no-verify`, `--skip-tests`, or weakened assertions.
+
+---
+
+## Phase 9 — Update the plan doc if reality drifted
+
+If your implementation diverged meaningfully from the plan doc — extra deliverable shipped, planned deliverable deferred, an unforeseen risk discovered — edit the plan doc in the same PR to reflect what actually happened. The plan doc is the lasting artefact; the issue closes when the PR merges.
+
+If you didn't drift, leave the doc alone.
+
+---
+
+## Phase 10 — Commit and open the PR
+
+Match the most recent shipped phase's commit format from the same project. Typical:
+
+```
+feat(<area>): <short description> (Phase N, ALT-NN)
+```
+
+The area tag (`nats`, `egress`, `monitoring`, `docs`, etc.) follows what previous phases used in the same project.
+
+Commit body:
+
+```
+<one or two paragraphs explaining what changed and why,
+ in the same voice as recent commits on main>
+
+Co-Authored-By: <as configured>
+```
+
+Push the branch, then `gh pr create`. PR title matches the commit title. PR body must:
+
+- Have a Summary section (1–3 bullets) describing the change.
+- Have a Test plan section (markdown checklist).
+- **Include `Closes ALT-NN` on its own line** so merging the PR auto-closes the Linear issue.
+- Match the format used in recent PRs on this repo (look at `gh pr list --limit 5` for tone).
+
+---
+
+## Phase 11 — Mark the issue In Review
+
+```
+save_issue(id: <issue-id>, state: "In Review")
+save_comment(issue_id: <issue-id>, body: "PR opened: <PR_URL>")
+```
+
+Then report the PR URL to the user wrapped in a `<pr-created>` tag on its own line so any UI integrations can render a card.
+
+---
+
+## Hard rules
+
+These are non-negotiable. If you find yourself wanting to break one, stop and ask the user instead.
+
+- **Never merge PRs** — even if checks pass and the PR looks great. Merging is a human decision.
+- **Never create new Linear issues** or split phases on the fly. If scope is too big for one phase, stop and report — splitting is a planning decision, not an execution decision.
+- **Never override plan-doc conventions.** If the plan section says "Defer X to follow-up", that X is deferred. Don't quietly include it because it seemed easy.
+- **Never run `pnpm worktree-env start` yourself.** Worktree lifecycle is the user's responsibility; this skill assumes the worktree is already up.
+- **Never skip pre-flight checks** by running on `main` or with a dirty tree. Stop and ask.
+- **Never use `--no-verify` or skip hooks.** If a hook fails, investigate.
+- **Never guess at conventions.** If the project description has no `Plan:` line, or the plan doc has no matching `### Phase N` heading, **stop and report**. The conventions exist so the skill can rely on them; bypassing them silently breaks the next run.
+
+---
+
+## Example end-to-end (abbreviated)
+
+> User: "execute next task"
+>
+> *Skill loads Linear MCP, lists Todos in Altitude Devops. Three Todos: ALT-29, ALT-31, ALT-34. ALT-29 is blocked by ALT-28 (Done). ALT-31 is blocked by ALT-30 (Todo). ALT-34 has no blockers. Two unblocked candidates: ALT-29, ALT-34.*
+>
+> Skill: "Two unblocked Todos:
+> - `ALT-29 | Phase 4: pg-az-backup progress + result events | Internal NATS Messaging`
+> - `ALT-34 | Phase 1: Tempo + OTel Collector + Grafana | OTel Tracing`
+>
+> Which one?"
+>
+> User: "ALT-29"
+>
+> *Skill fetches ALT-29 + parent project. Project description: `Plan: docs/planning/not-shipped/internal-nats-messaging-plan.md`. Skill reads §6 Phase 4 — Goal, Deliverables, Done when. Reads `git log` for `Phase 1`/`Phase 2`/`Phase 3` shipped commits to learn the area tag (`nats`) and PR title shape.*
+>
+> *Skill produces a plan keyed to the deliverables, surfaces via ExitPlanMode. User approves.*
+>
+> *Skill runs pre-flight, marks ALT-29 In Progress, comments. Implements per the plan. Runs verification. Drift check on plan doc — none. Commits with `feat(nats): pg-az-backup progress + result events (Phase 4, ALT-29)`. Opens PR with `Closes ALT-29`. Marks ALT-29 In Review, comments PR URL. Reports.*

--- a/.claude/skills/execute-next-task/SKILL.md
+++ b/.claude/skills/execute-next-task/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: execute-next-task
-description: Picks the next unblocked Todo issue from the user's Linear team (Altitude Devops), reads the parent project's linked markdown plan doc, plans the work, and on user approval executes it end-to-end — worktree check, code changes, verification, PR with `Closes ALT-NN`, and Linear state transitions. Use this skill whenever the user says "execute next task", "what's next in linear", "do the next phase", "pick up the next todo", "work on the next thing", "what should I do next", or any equivalent request to advance through a Linear-tracked migration. Do NOT trigger for one-off non-Linear tasks or for "what should I work on?" without an obvious Linear context.
+description: Execution agent. Picks the next unblocked Todo issue from the user's Linear team (Altitude Devops), reads the ticket (which was pre-populated by `plan-to-linear` with Goal/Deliverables/Done-when, per-component CLAUDE.md and ARCHITECTURE.md pointers, and phase-specific smoke tests), runs `pnpm install`, kicks off `pnpm worktree-env start` in the background to warm the dev env, then executes the work end-to-end — code changes, build/lint/unit tests, live smoke against the dev env, PR with `Closes ALT-NN`, and Linear state transitions. **Does not produce an ExitPlanMode plan** — the planning was already done when the ticket was created. Use this skill whenever the user says "execute next task", "what's next in linear", "do the next phase", "pick up the next todo", "work on the next thing", "what should I do next", or any equivalent request to advance through a Linear-tracked migration. Do NOT trigger for one-off non-Linear tasks or for "what should I work on?" without an obvious Linear context.
 ---
 
 # Execute Next Task
 
-You're picking up the next chunk of an in-flight Linear-tracked feature in Mini Infra. The features are codified as markdown plan docs under `docs/planning/` with phased rollouts; each phase is a Linear issue. Your job is to find the next phase ready to work on, plan it concretely against the plan doc, and on user approval execute it end-to-end through to a PR in review.
+You're an **execution agent**. The planning has already happened — when the Linear ticket was created (by the `plan-to-linear` skill, from a phased markdown plan doc) it was populated with everything you need: Goal, Deliverables, Done when, the relevant per-component CLAUDE.md / ARCHITECTURE.md pointers, prior-art commit hints, and the conventions to follow. Your job is to read the ticket and the linked docs, set up the environment, do the work, and ship a PR. **Do not re-plan, do not stop for approval, do not produce an ExitPlanMode block.** State briefly what you're about to do (one or two sentences) before changing files so the user can interrupt if needed, then execute.
+
+If you read the ticket and find it underspecified or contradictory, that's the only case where you stop and ask — but the populated ticket should rarely have that problem. Treat it as authoritative.
 
 ## Conventions you rely on
 
@@ -52,52 +54,68 @@ Don't move to Phase 3 until you have exactly one issue in hand.
 
 ---
 
-## Phase 3 — Resolve the plan doc and the matching phase section
+## Phase 3 — Read the ticket and linked docs
 
-Once you have the issue:
+The Linear ticket is your contract. Read it end to end and treat it as authoritative.
 
-1. **Fetch the parent project** (`get_project`). Read its description.
-2. **Find the `Plan:` line.** It should be one of the first lines and look like `Plan: docs/planning/not-shipped/<slug>-plan.md`. If absent, **stop** and tell the user the project description is missing the convention.
-3. **Read the plan doc.** Confirm it exists at the cited path.
-4. **Locate the matching phase section.** From the issue title `Phase N: <short title>`, find the `### Phase N — <something>` heading in the plan doc. The titles don't have to match exactly word-for-word — the phase number is the key. If no `### Phase N` heading exists, **stop** and tell the user the plan doc is out of sync.
-5. **Read the matching section in full** — Goal, Deliverables, Done when. These three are your contract.
-6. **Read prior art** — `git log --oneline -20 main` plus any commits whose message contains the project's earlier phases (e.g. `Phase 1, ALT-26`). The shipped phases tell you the commit format, the area-tag style, and the rough size of a phase PR for this project.
+1. **Fetch the issue body.** Look for the standard sections written by `plan-to-linear`:
+   - **Source** — the plan-doc path and phase anchor.
+   - **Goal**, **Deliverables**, **Done when** — the work to do.
+   - **Relevant docs** — the per-component CLAUDE.md / ARCHITECTURE.md pointers, plus any topic-specific architecture docs.
+   - **Smoke tests** — what to run at the end to validate.
+   - **Conventions** — commit/PR format, area tag, deferrals.
+2. **Fetch the parent project** (`get_project`) and confirm the `Plan:` line resolves to the same plan doc the ticket cites. If they disagree, **stop** — that's a corruption signal.
+3. **Read the plan doc's matching `### Phase N` section** anyway. The ticket has the same content but the plan doc is the source of truth — if they've drifted, side with the doc and surface the drift in your final commit.
+4. **Read every doc the ticket lists under "Relevant docs."** Don't skim — these were chosen because they're the conventions you must follow. The ticket points at them so you don't have to guess what's relevant.
+5. **Read prior art** — `git log --oneline -20 main` plus any commits matching the project's area tag from the ticket. Shipped phases tell you the commit subject style and the rough size of a phase PR.
 
-If anything in this phase fails, stop and report — never guess your way through.
-
----
-
-## Phase 4 — Plan and seek approval
-
-Produce a concrete implementation plan keyed to the phase's **Deliverables** and **Done when** lines from the plan doc.
-
-The plan must include:
-
-- A list of files you intend to create or modify.
-- The verification commands you'll run at the end (build / lint / test / browser test as relevant).
-- Any deviation from the plan doc you're proposing, **with reasoning**. (Plans drift; honesty about that is what keeps the doc useful.)
-- An explicit note about anything the plan section says to defer — those stay deferred.
-
-Surface the plan via `ExitPlanMode` and wait for user approval. Do not start writing code before approval.
+If the ticket is missing the Goal / Deliverables / Done when sections, or the project description has no `Plan:` line, **stop and report** — the ticket wasn't populated correctly. Don't paper over it.
 
 ---
 
-## Phase 5 — Pre-flight checks
-
-Before executing:
+## Phase 4 — Pre-flight checks
 
 ```bash
 git status
 git rev-parse --abbrev-ref HEAD
+pwd
 ```
 
 Required state:
 
-- **A clean working tree** — no uncommitted changes.
-- **A feature branch** — not `main` (or whatever the repo's default branch is, check `git remote show origin`).
-- **You're in a worktree path** — `pwd` should match the worktree root the user is operating in.
+- **Clean working tree** — no uncommitted changes.
+- **A feature branch** — not `main`.
+- **You're in a worktree path** under `.claude/worktrees/` (or wherever the repo's worktrees live for this user). `pwd` should not be the main checkout.
 
-If any of these fail, **stop with a clear message**. Do not auto-stash, auto-create a branch, or run `pnpm worktree-env start`. The repo's worktree workflow is a separate concern (root `CLAUDE.md`); duplicating it here causes pain.
+If any of these fail, **stop with a clear message**. Do not auto-stash, auto-create a branch, or auto-checkout. Worktree lifecycle is the user's responsibility — see root `CLAUDE.md` `pnpm worktree-env` workflow.
+
+---
+
+## Phase 5 — Set up the environment (in parallel with starting work)
+
+This phase runs **before** marking In Progress so the env is warming while you read more code and start writing.
+
+### 5.1 Install dependencies
+
+Fresh worktrees do not share `node_modules` with the main checkout (per root `CLAUDE.md`). Always run:
+
+```bash
+pnpm install
+```
+
+This is fast (a no-op if already installed) and required before any other `pnpm` command including `pnpm worktree-env`. Run it synchronously — you need it to finish before anything else.
+
+### 5.2 Spin up the dev environment in the background
+
+`pnpm worktree-env start` takes a few minutes the first time. Kick it off in the background **now** so it's ready when smoke tests need it later. Use the `Bash` tool's `run_in_background: true` and capture the shell id:
+
+```bash
+pnpm worktree-env start
+```
+
+Don't wait for it. Move on to the work; you'll check the status before running smoke tests in Phase 8. If `environment-details.xml` already exists at the worktree root and the env is up, the command is idempotent — still safe.
+
+If the phase is **docs-only** (e.g. only touches `docs/`, README, or a SKILL.md), skip 5.2 — no smoke tests will need a running env.
 
 ---
 
@@ -105,7 +123,7 @@ If any of these fail, **stop with a clear message**. Do not auto-stash, auto-cre
 
 ```
 save_issue(id: <issue-id>, state: "In Progress")
-save_comment(issue_id: <issue-id>, body: "Started by Claude.\n- Worktree: <path>\n- Branch: <branch>")
+save_comment(issue_id: <issue-id>, body: "Started by Claude.\n- Worktree: <path>\n- Branch: <branch>\n- Env startup: backgrounded")
 ```
 
 Fetch the team's issue statuses first if you don't already know the canonical name (`In Progress` vs `In progress` etc. — use whatever the team has).
@@ -114,11 +132,14 @@ Fetch the team's issue statuses first if you don't already know the canonical na
 
 ## Phase 7 — Execute
 
-Implement per the approved plan, following the repo's coding conventions:
+Before writing any file, **state in one or two sentences** what you're about to do — file pointers and the rough order. This is for visibility, not approval; don't wait for a response. If the user wants to redirect they'll interrupt.
 
-- Root `CLAUDE.md` — package manager (pnpm), worktree workflow, build invariants, the "always run from project root" rule.
+Then implement, following the conventions from the docs the ticket pointed at. Common ones:
+
+- Root `CLAUDE.md` — package manager (pnpm), worktree workflow, "always run from project root", build invariants.
 - `server/CLAUDE.md` — `DockerService.getInstance()`, `ConfigurationServiceFactory`, never raw `dockerode`, all mutations carry `userId`, `Channel.*` / `ServerEvent.*` constants for Socket.IO.
 - `client/CLAUDE.md` — TanStack Query owns server state, no polling when socket is connected, task tracker pattern.
+- The component-specific CLAUDE.md / ARCHITECTURE.md files the ticket listed.
 
 Rules of taste:
 
@@ -127,13 +148,15 @@ Rules of taste:
 - Don't add error handling for scenarios that can't happen.
 - Default to no comments. Only add a comment when the *why* is non-obvious.
 
-Refer back to the plan doc's "Deliverables" list as you go — those are the things that have to be true at the end. If the work is bigger than the phase scoped, **stop and ask** — never silently expand scope or split phases on the fly.
+Refer back to the ticket's **Deliverables** list as you go — those are the things that have to be true at the end. If the work is bigger than the phase scoped, **stop and ask** — never silently expand scope or split phases on the fly.
 
 ---
 
-## Phase 8 — Verify
+## Phase 8 — Verify with smoke tests
 
-At minimum, run the verification commands you listed in Phase 4. Typical:
+The ticket's **Smoke tests** section tells you specifically what to run for this phase. Use it as the spec; the layered checklist below is the default if the ticket says "standard smoke" or doesn't specify.
+
+### 8.1 Build / lint / unit tests (always)
 
 ```bash
 pnpm build:lib                              # if lib/ changed (always required if so)
@@ -144,16 +167,33 @@ pnpm --filter mini-infra-client build       # if client/ changed
 pnpm --filter mini-infra-client test        # if client/ tests changed
 ```
 
-For the Go components (`egress-gateway/`, `egress-fw-agent/`, `egress-shared/`):
+For Go components (`egress-gateway/`, `egress-fw-agent/`, `egress-shared/`):
 
 ```bash
 go build ./...
 go test ./...
 ```
 
-For UI changes the user expects browser testing. **Do not re-implement what `test-dev` does** — invoke that skill, or tell the user it's the next step. Same for `diagnose-dev` if a runtime check is needed.
+For sidecars that use npm rather than pnpm (`update-sidecar/`, `agent-sidecar/`):
 
-If something fails, fix it before continuing. Don't paper over with `--no-verify`, `--skip-tests`, or weakened assertions.
+```bash
+cd update-sidecar && npm install && npm run build && npm test && cd ..
+```
+
+### 8.2 Live smoke against the dev env
+
+Once 8.1 passes, **wait for the backgrounded `pnpm worktree-env start` to finish** (or confirm `environment-details.xml` is current and the env is healthy). Then run the phase-specific smoke from the ticket:
+
+- **UI changes** → invoke the `test-dev` skill on the affected user flow. Don't re-implement what `test-dev` does.
+- **Server route changes** → hit the affected endpoint(s) via `curl` against the URL in `environment-details.xml`, or `diagnose-dev` if a runtime check is needed.
+- **Stack template changes** (`server/templates/`) → confirm the affected stack reconciles cleanly: check `docker ps`, look for the new containers, tail logs briefly.
+- **Go sidecar changes** → confirm the container builds, starts, and the affected egress page in dev shows it healthy.
+- **NATS-subject changes** → publish a test message via the bus and verify the consumer side picks it up. The smoke ping (`mini-infra.system.ping`) is a good baseline that the bus is alive.
+- **Docs-only changes** → skip live smoke; build + lint is enough.
+
+### 8.3 Report
+
+If everything passes, move on. If anything fails, **fix it before continuing** — don't paper over with `--no-verify`, `--skip-tests`, or weakened assertions. If a fix isn't obvious, stop and surface the failure with full output.
 
 ---
 
@@ -193,14 +233,36 @@ Push the branch, then `gh pr create`. PR title matches the commit title. PR body
 
 ---
 
-## Phase 11 — Mark the issue In Review
+## Phase 11 — Mark the issue In Review and leave a structured handoff comment
+
+Move the issue to `In Review` (canonical state name from Phase 1's status fetch) and post a single structured comment summarising the run. The comment is the handoff to the human reviewer — it captures everything the PR diff doesn't show.
 
 ```
 save_issue(id: <issue-id>, state: "In Review")
-save_comment(issue_id: <issue-id>, body: "PR opened: <PR_URL>")
+save_comment(issue_id: <issue-id>, body: <handoff comment, see template below>)
+```
+
+Use this template verbatim. Omit any section that genuinely has nothing to report — don't pad with "N/A" or "none". If every section is empty, the comment is just the PR link.
+
+```markdown
+**PR:** <PR_URL>
+
+## Known issues
+<failing tests you couldn't fix in scope, brittleness you noticed but didn't address, anything the reviewer should be aware of when looking at the diff. One bullet each.>
+
+## Work deferred
+<deliverables from the phase that were scoped down, or follow-ups identified along the way that should become their own issues. Reference the plan-doc line that says they can be deferred if applicable.>
+
+## Blockers
+<things that stopped you finishing some part of the work — missing credentials, an upstream bug in another component, a dependency on infrastructure that isn't there. Empty if nothing blocked you.>
+
+## Deviations from the plan
+<places where what you shipped diverges from the plan doc's Deliverables or Done-when. For each: what the plan said, what you shipped, why. If you also edited the plan doc to reflect this in Phase 9, note that.>
 ```
 
 Then report the PR URL to the user wrapped in a `<pr-created>` tag on its own line so any UI integrations can render a card.
+
+The point of this comment is that the next person (human or agent) opens the Linear issue and sees the full state of what shipped without having to read the diff or guess. If it's empty across the board, that's a great sign — but don't fabricate content to fill it.
 
 ---
 
@@ -208,13 +270,14 @@ Then report the PR URL to the user wrapped in a `<pr-created>` tag on its own li
 
 These are non-negotiable. If you find yourself wanting to break one, stop and ask the user instead.
 
+- **Never produce an ExitPlanMode block.** This is an execution agent. Planning happened in `plan-to-linear` when the ticket was created.
 - **Never merge PRs** — even if checks pass and the PR looks great. Merging is a human decision.
 - **Never create new Linear issues** or split phases on the fly. If scope is too big for one phase, stop and report — splitting is a planning decision, not an execution decision.
 - **Never override plan-doc conventions.** If the plan section says "Defer X to follow-up", that X is deferred. Don't quietly include it because it seemed easy.
-- **Never run `pnpm worktree-env start` yourself.** Worktree lifecycle is the user's responsibility; this skill assumes the worktree is already up.
+- **Never `git checkout main`, `git stash`, or create a new branch.** Worktree lifecycle is the user's responsibility — this skill assumes the worktree is already up. (`pnpm install` and the backgrounded `pnpm worktree-env start` are the *only* environment setup the skill performs, and only inside the existing worktree.)
 - **Never skip pre-flight checks** by running on `main` or with a dirty tree. Stop and ask.
 - **Never use `--no-verify` or skip hooks.** If a hook fails, investigate.
-- **Never guess at conventions.** If the project description has no `Plan:` line, or the plan doc has no matching `### Phase N` heading, **stop and report**. The conventions exist so the skill can rely on them; bypassing them silently breaks the next run.
+- **Never guess at conventions.** If the project description has no `Plan:` line, or the ticket has no Goal/Deliverables/Done-when sections, **stop and report**. The conventions exist so the skill can rely on them; bypassing them silently breaks the next run.
 
 ---
 
@@ -232,8 +295,12 @@ These are non-negotiable. If you find yourself wanting to break one, stop and as
 >
 > User: "ALT-29"
 >
-> *Skill fetches ALT-29 + parent project. Project description: `Plan: docs/planning/not-shipped/internal-nats-messaging-plan.md`. Skill reads §6 Phase 4 — Goal, Deliverables, Done when. Reads `git log` for `Phase 1`/`Phase 2`/`Phase 3` shipped commits to learn the area tag (`nats`) and PR title shape.*
+> *Skill fetches ALT-29 + parent project. Project description: `Plan: docs/planning/not-shipped/internal-nats-messaging-plan.md`. Skill reads the ticket body (Goal, Deliverables, Done when, Relevant docs, Smoke tests). Reads each linked CLAUDE.md / ARCHITECTURE.md. Reads `git log` for `Phase 1`/`Phase 2`/`Phase 3` shipped commits to learn the area tag (`nats`) and PR title shape.*
 >
-> *Skill produces a plan keyed to the deliverables, surfaces via ExitPlanMode. User approves.*
+> *Skill runs pre-flight (clean tree, feature branch, in worktree). Runs `pnpm install` synchronously, then kicks off `pnpm worktree-env start` in the background. Marks ALT-29 In Progress, comments worktree path + branch.*
 >
-> *Skill runs pre-flight, marks ALT-29 In Progress, comments. Implements per the plan. Runs verification. Drift check on plan doc — none. Commits with `feat(nats): pg-az-backup progress + result events (Phase 4, ALT-29)`. Opens PR with `Closes ALT-29`. Marks ALT-29 In Review, comments PR URL. Reports.*
+> Skill: "Implementing Phase 4 — adding `mini-infra.backup.run` request handler and JetStream `BackupHistory` stream. Touching `server/src/services/backup/backup-executor.ts` first, then `server/src/services/nats/payload-schemas.ts`, then the boot sequence."
+>
+> *Implements. Runs build/lint/unit tests. Backgrounded env is up by now — runs the ticket's smoke test (publish a test backup-run request, confirm the consumer side fires). Drift check on plan doc — none.*
+>
+> *Commits with `feat(nats): pg-az-backup progress + result events (Phase 4, ALT-29)`. Opens PR with `Closes ALT-29` in the body. Marks ALT-29 In Review. Posts the handoff comment: PR URL, plus a Deviations section noting that the optional retry-on-transient-failure deliverable was deferred to a follow-up issue per the plan doc's wording. Reports the PR URL.*

--- a/.claude/skills/plan-to-linear/SKILL.md
+++ b/.claude/skills/plan-to-linear/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan-to-linear
-description: Reads a phased markdown planning document under `docs/planning/` and populates Linear with a matching project plus one issue per phase. Each issue carries the phase's Goal / Deliverables / Done when, the relevant per-component CLAUDE.md and ARCHITECTURE.md pointers (server vs client vs lib vs go sidecars), prior-art commit references, and the conventions an executor needs — enough context that the `execute-next-task` skill can pick up the issue and start work without re-planning the high-level scope. Also rewrites the plan doc's Linear-tracking section to replace `ALT-_TBD_` placeholders with the real issue IDs. Use this skill whenever the user says "populate linear from plan", "create the linear tickets", "plan to linear", "scaffold linear from this plan", "turn this plan into linear issues", or any equivalent request to seed Linear from an existing markdown plan. Do NOT trigger for one-off issue creation, for plans that aren't phased, or when the user asks to *modify* an existing project's issues.
+description: Reads a phased markdown planning document under `docs/planning/` and populates Linear with a matching project plus one issue per phase. Each issue carries the phase's Goal / Deliverables / Done when, the relevant per-component CLAUDE.md and ARCHITECTURE.md pointers (server vs client vs lib vs go sidecars), a Workflow section (worktree pre-flight, `pnpm install`, background `pnpm worktree-env start`), phase-specific smoke-test recipes derived from which directories the phase touches, prior-art commit references, and the commit/PR conventions — enough context that the `execute-next-task` skill can execute the issue without re-planning the high-level scope. Also rewrites the plan doc's Linear-tracking section to replace `ALT-_TBD_` placeholders with the real issue IDs. Use this skill whenever the user says "populate linear from plan", "create the linear tickets", "plan to linear", "scaffold linear from this plan", "turn this plan into linear issues", or any equivalent request to seed Linear from an existing markdown plan. Do NOT trigger for one-off issue creation, for plans that aren't phased, or when the user asks to *modify* an existing project's issues.
 ---
 
 # Plan to Linear
@@ -70,9 +70,11 @@ Read the doc end-to-end and extract:
 
 ---
 
-## Phase 3 — Map touched components to per-component docs
+## Phase 3 — Map touched components to docs and smoke tests
 
-For each phase, look at the file paths you extracted. Group them by top-level directory and attach the relevant CLAUDE.md / ARCHITECTURE.md pointers. The map for this repo:
+For each phase, look at the file paths you extracted. Group them by top-level directory. Two outputs come from this step: which **doc pointers** to attach to the ticket, and which **smoke-test recipes** to recommend at the end of execution.
+
+### 3.1 Doc pointers per component
 
 | Top-level dir matched | Docs to attach (relative to repo root) |
 |---|---|
@@ -94,7 +96,26 @@ Verify each attached file actually exists with `Read` or `ls` before including i
 
 **Also include** any `docs/architecture/*.md` from the plan-doc-level references collected in Phase 2.
 
-This step is the difference between Reading 1 and Reading 2 of the populator design: the executor doesn't get a pre-baked plan, it gets pointers to exactly the right convention files for the components it'll touch.
+This is the difference between Reading 1 and Reading 2 of the populator design: the executor doesn't get a pre-baked plan, it gets pointers to exactly the right convention files for the components it'll touch.
+
+### 3.2 Smoke-test recipes per component
+
+Map the same touched paths to the live-smoke recipe the executor should run after build/lint/unit tests pass. These go into the ticket's "Smoke tests" section. Pick whichever apply — multiple components → multiple recipes.
+
+| Touched path pattern | Smoke recipe to recommend |
+|---|---|
+| `client/src/`, `client/public/` | Invoke the `test-dev` skill walking the affected user flow in the dev environment. Don't re-implement what `test-dev` does. |
+| `server/src/routes/` | Hit the affected endpoint(s) with `curl` against the URL in `environment-details.xml`. Use the admin API key from `//admin/apiKey` in the same file. |
+| `server/src/services/` (no route change) | If the service runs at boot or on a schedule, watch the server logs for the relevant subcomponent (`grep '"subcomponent":"<name>"' logs/app.*.log`). If it's invoked from a route that already exists, hit that route. |
+| `server/templates/` | Confirm the affected stack reconciles cleanly: `docker ps` shows the new containers, no errors in the relevant container's logs (`docker logs <container>`). |
+| `egress-gateway/`, `egress-fw-agent/`, `egress-shared/` | Confirm the binary builds, the container starts, and the egress page in dev shows the agent/gateway healthy. |
+| Server NATS subjects (`server/src/services/nats/`, `lib/types/nats-subjects.ts`) | Publish a test message via `NatsBus` (or the smoke ping `mini-infra.system.ping`) and verify the consumer side fires. Reference `docs/architecture/internal-messaging.md` for the subject inventory. |
+| `update-sidecar/`, `agent-sidecar/` | Run the sidecar's npm tests (`cd <dir> && npm test`). Live smoke is component-specific; if the phase exercises a runtime path, drive it from the server side. |
+| `pg-az-backup/` | Trigger a backup from the dev UI (or via the API) and confirm the run completes; check Azure Blob if the env has Azure configured, otherwise just confirm the runner exited cleanly. |
+| `lib/types/` only | No live smoke needed; build pass = types compile. |
+| `docs/`, README, SKILL.md, root configs only | No live smoke; build/lint is enough. The phase is docs-only — also tell the executor to skip the backgrounded `pnpm worktree-env start`. |
+
+If the phase touches several components, list one recipe per. If none of these match (rare — usually means a totally new component), write `<no recipe — confirm with user before merging>` and the executor will surface it.
 
 ---
 
@@ -194,7 +215,7 @@ For each phase, in order, create a Linear issue:
 
 ---
 
-## Relevant docs (read before planning)
+## Relevant docs (read before writing code)
 
 **Repo-wide:**
 - [CLAUDE.md](CLAUDE.md) — pnpm, worktree workflow, build invariants
@@ -208,11 +229,37 @@ For each phase, in order, create a Linear issue:
 
 ---
 
+## Workflow
+
+This is an execution-agent ticket — no separate planning phase. Read the docs above, then:
+
+1. **Pre-flight.** Confirm clean working tree, on a feature branch, in a worktree path.
+2. **`pnpm install`.** Fresh worktrees do not share `node_modules` with the main checkout (per root `CLAUDE.md`). Run synchronously; required before any other `pnpm` command including `pnpm worktree-env`.
+3. **Spin up the dev env in the background.** Kick off `pnpm worktree-env start` with `run_in_background: true` so it warms while you work. Idempotent — safe if the env is already up.
+   - <if the phase is docs-only, replace this whole bullet with: "Skip — phase is docs-only, no live smoke needed.">
+4. **Read the dev env URL and admin creds from `environment-details.xml`** at the worktree root once the background command has finished, before running smoke tests.
+
+## Smoke tests (run after build/lint/unit tests pass)
+
+<bullets generated from Phase 3.2's smoke-recipe map for this phase's touched components.
+ Examples by component:>
+
+- **Server route changes** → `curl -H "x-api-key: <admin>" $MINI_INFRA_URL/api/<route>` and verify response shape.
+- **UI changes** → invoke the `test-dev` skill on the affected page; walk the golden path.
+- **Stack template changes** → `docker ps` shows the new containers, `docker logs <container>` clean.
+- **NATS subject changes** → publish via `NatsBus`, confirm consumer fires; baseline with `mini-infra.system.ping`.
+- ...
+
+If none of the recipes match, the populator emits `<no recipe — confirm with user before merging>` here and the executor will surface that.
+
+---
+
 ## Conventions
 
 - Commit format: `<area>(<scope>): <subject> (Phase N, ALT-NN)` — area tag for this project: `<detected from Phase 4>`
-- PR body must include `Closes ALT-NN` so merging closes this issue.
-- Anything the plan section says to **defer** stays deferred — don't expand scope.
+- PR body must include `Closes ALT-NN` so merging the PR auto-closes this issue.
+- Anything the plan section says to **defer** stays deferred — don't expand scope on the fly.
+- When done, the executor leaves a structured handoff comment on this issue covering Known issues / Work deferred / Blockers / Deviations from the plan.
 
 ## Prior art
 

--- a/.claude/skills/plan-to-linear/SKILL.md
+++ b/.claude/skills/plan-to-linear/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: plan-to-linear
+description: Reads a phased markdown planning document under `docs/planning/` and populates Linear with a matching project plus one issue per phase. Each issue carries the phase's Goal / Deliverables / Done when, the relevant per-component CLAUDE.md and ARCHITECTURE.md pointers (server vs client vs lib vs go sidecars), prior-art commit references, and the conventions an executor needs — enough context that the `execute-next-task` skill can pick up the issue and start work without re-planning the high-level scope. Also rewrites the plan doc's Linear-tracking section to replace `ALT-_TBD_` placeholders with the real issue IDs. Use this skill whenever the user says "populate linear from plan", "create the linear tickets", "plan to linear", "scaffold linear from this plan", "turn this plan into linear issues", or any equivalent request to seed Linear from an existing markdown plan. Do NOT trigger for one-off issue creation, for plans that aren't phased, or when the user asks to *modify* an existing project's issues.
+---
+
+# Plan to Linear
+
+You're seeding Linear with a project and per-phase issues from an existing markdown planning document. The output is a populated Linear project that the companion skill `execute-next-task` can pick up phase by phase, with each ticket carrying enough context that the executor can plan against current code state without re-doing the high-level scoping.
+
+## What the plan doc looks like
+
+Reference examples in this repo:
+- `docs/planning/not-shipped/internal-nats-messaging-plan.md` — fully populated.
+- `docs/planning/not-shipped/observability-otel-tracing-plan.md` — has `ALT-_TBD_` placeholders waiting for this skill.
+- `docs/planning/shipped/nats-app-roles-plan.md` — same shape, already shipped.
+
+The conventions you depend on (also documented in `execute-next-task/SKILL.md`):
+
+- **H1** (`# <feature title>`) is the Linear project name.
+- **§1 Background** — first paragraph is the project description body.
+- **A "Phased rollout" section** (usually §6) with `### Phase N — <title>` subsections. Each phase has **Goal**, **Deliverables**, and **Done when** lines (sometimes with extra subsections like "Migration shape").
+- **A Linear-tracking section** (usually §8) with a placeholder list:
+  ```
+  - ALT-_TBD_ — Phase 1: <title>
+  - ALT-_TBD_ — Phase 2: <title>
+  ```
+  This list is the contract — the skill writes back into it.
+- **Phase ordering** — the plan text says "phases land in order" or "Phase 1 blocks all later phases" or similar. Translate that to `blocked-by` relationships.
+- **Optional / deferred phases** — marked in the heading or first line ("optional", "deferred", "(optional, deferred)"). They go into Linear as `Backlog`, not `Todo`.
+
+If the doc doesn't follow this shape, **stop and report**. Don't guess.
+
+The team is hardcoded as **Altitude Devops**.
+
+---
+
+## Phase 1 — Load the Linear MCP tools
+
+Linear MCP tools are deferred. Load them in bulk before doing anything else:
+
+```
+ToolSearch(query: "linear", max_results: 30)
+```
+
+You need at minimum: `list_issues`, `get_issue`, `list_projects`, `get_project`, `save_project`, `save_issue`, `save_comment`, `list_issue_statuses`. If any are missing, stop and tell the user.
+
+Also fetch the team's issue statuses once (`list_issue_statuses` for Altitude Devops) — you'll need the canonical names for `Todo` and `Backlog`. Different teams capitalise / name them differently.
+
+---
+
+## Phase 2 — Locate and parse the plan doc
+
+The user usually points at a path; if not, list `docs/planning/not-shipped/*.md` and ask.
+
+Read the doc end-to-end and extract:
+
+1. **Project name** — the H1, stripped of trailing punctuation.
+2. **Project description body** — §1 Background, first paragraph.
+3. **Phases** — every `### Phase N — <title>` subsection. For each, extract:
+   - The phase number `N` and the title (everything after the em-dash).
+   - **Optional flag** — true if the heading or first line contains "optional", "deferred", or both. (Plan §6 in the OTel doc has "Phase 6 — App-level metrics (optional, deferred)" as a deliberate example.)
+   - The **Goal** line.
+   - The **Deliverables** list (bullet points; can be nested).
+   - The **Done when** line.
+   - Any other phase-specific subsections (e.g. "Migration shape", "Subjects", "Subjects:") — keep verbatim.
+   - File paths mentioned in any of the above (anything matching `[\w-]+/[\w/.-]+\.\w+` or markdown links to repo paths). Used in Phase 3.
+4. **Plan-doc-level architecture references** — any links to `docs/architecture/*.md` anywhere in the doc. Surface them to every phase as background.
+5. **Linear-tracking section** — confirm a placeholder list exists with the same number of phases as you found. If the count doesn't match, **stop and report** — the doc and §8 are out of sync.
+6. **Ordering hints** — scan for phrases like "phases land in order", "Phase 1 blocks all later phases", "Phase N also blocks on Phase M". Use these to build the `blocked-by` graph in Phase 5. If no hints exist, default to **strictly sequential** (each phase blocked by the previous).
+
+---
+
+## Phase 3 — Map touched components to per-component docs
+
+For each phase, look at the file paths you extracted. Group them by top-level directory and attach the relevant CLAUDE.md / ARCHITECTURE.md pointers. The map for this repo:
+
+| Top-level dir matched | Docs to attach (relative to repo root) |
+|---|---|
+| `server/` | `server/CLAUDE.md`, `server/ARCHITECTURE.md` |
+| `client/` | `client/CLAUDE.md`, `client/ARCHITECTURE.md` |
+| `lib/` | `lib/CLAUDE.md` |
+| `acme/` | `acme/CLAUDE.md` |
+| `egress-gateway/` | `egress-gateway/CLAUDE.md` |
+| `egress-fw-agent/` | `egress-fw-agent/CLAUDE.md` |
+| `egress-shared/` | `egress-shared/CLAUDE.md` |
+| `update-sidecar/` | `update-sidecar/CLAUDE.md` |
+| `agent-sidecar/` | `agent-sidecar/CLAUDE.md` |
+| `pg-az-backup/` | `pg-az-backup/CLAUDE.md` |
+| `deployment/`, `scripts/`, `docs/`, root configs only | (no extra; root docs cover it) |
+
+Verify each attached file actually exists with `Read` or `ls` before including it — the map above is correct as of writing but a future component might not have its own doc yet. Drop any that 404.
+
+**Always include** the root `CLAUDE.md` and `ARCHITECTURE.md` — every phase touches the wider codebase.
+
+**Also include** any `docs/architecture/*.md` from the plan-doc-level references collected in Phase 2.
+
+This step is the difference between Reading 1 and Reading 2 of the populator design: the executor doesn't get a pre-baked plan, it gets pointers to exactly the right convention files for the components it'll touch.
+
+---
+
+## Phase 4 — Detect commit-area conventions
+
+Run `git log --oneline -30 main` and look for commit subjects matching the plan's slug or topic. Past PRs in the same project follow a pattern like:
+
+```
+feat(nats): NatsBus foundation for app-to-app messaging (Phase 1, ALT-26) (#335)
+feat(nats): egress-fw-agent onto NATS (Phase 2, ALT-27) (#338)
+docs(nats): tidy two leftover nits in app-integration guide (#339)
+```
+
+Extract the **area tag** (`nats`, `egress`, `monitoring`, etc.) — this becomes a hint in each issue's "Conventions" section so the executor uses the same tag. If the project is brand new and has no shipped commits yet, infer from the most-touched top-level directory or note "no prior commits — choose an area tag at execution time".
+
+---
+
+## Phase 5 — Pre-flight checks
+
+Before writing anything to Linear:
+
+1. **Project must not already exist.** Use `list_projects` (filtered to Altitude Devops) and check for a name match. If a project with the same name exists, **stop**. Don't merge into an existing project — that's a manual decision.
+2. **§8 must have placeholders.** The plan doc's Linear-tracking section must contain `ALT-_TBD_` (or `ALT-TBD`, or similar) entries to fill in. If the entries are already real ALT-NN values, **stop** — the doc looks already populated.
+3. **Repo working tree may be clean or dirty** — this skill writes both Linear *and* a small edit to the plan doc. The plan-doc edit will be staged but not committed. The user commits or amends as they choose.
+
+---
+
+## Phase 6 — Confirm the plan with the user
+
+Show a summary and wait for explicit "go":
+
+```
+Project to create: <name>
+Description: <one-line snippet>
+
+Phases (will create N issues):
+  Phase 1: <title>           [Todo]      blocked-by: —
+  Phase 2: <title>           [Todo]      blocked-by: Phase 1
+  Phase 3: <title>           [Todo]      blocked-by: Phase 2
+  ...
+  Phase 6: <title>           [Backlog]   blocked-by: Phase 5    (optional)
+
+Each issue will reference:
+  - <plan-doc-path>#phase-<N>
+  - root CLAUDE.md, ARCHITECTURE.md
+  - <per-component docs detected>
+  - prior-art commit area: <tag>
+
+Plan doc edit: replace ALT-_TBD_ in §<8> with real issue IDs.
+
+Proceed?
+```
+
+Don't proceed without an explicit yes. Never guess "looks good, going" — the side effects (creating Linear issues) aren't easily reversible.
+
+---
+
+## Phase 7 — Create the project
+
+Create the Linear project with the name from H1 and a description that **starts** with the `Plan:` line — this is the anchor `execute-next-task` looks for:
+
+```
+Plan: <relative-path-to-plan-doc.md>
+
+<§1 Background paragraph 1, copied verbatim>
+```
+
+The relative path is from the repo root, e.g. `docs/planning/not-shipped/observability-otel-tracing-plan.md`. Don't use `./`-prefixed paths or absolute paths.
+
+Capture the project's URL and ID from the response — you'll need them for Phase 9.
+
+---
+
+## Phase 8 — Create one issue per phase
+
+For each phase, in order, create a Linear issue:
+
+**Title:** `Phase N: <title>` — exactly matching the `### Phase N — <title>` heading minus the em-dash. (`execute-next-task` matches by phase number, but exact title parity is good practice.)
+
+**State:** `Todo` for non-optional phases, `Backlog` for optional/deferred ones. Use the canonical state names you fetched in Phase 1.
+
+**Description body:**
+
+```markdown
+**Source:** [<plan-doc-path> §<phase-anchor>](<plan-doc-path>#phase-N)
+
+## Goal
+<copied verbatim from the phase section>
+
+## Deliverables
+<copied verbatim — preserve list nesting and inline links>
+
+## Done when
+<copied verbatim>
+
+<copy any other phase-specific subsections like "Migration shape", "Subjects", verbatim>
+
+---
+
+## Relevant docs (read before planning)
+
+**Repo-wide:**
+- [CLAUDE.md](CLAUDE.md) — pnpm, worktree workflow, build invariants
+- [ARCHITECTURE.md](ARCHITECTURE.md) — system bird's-eye view, invariants
+
+**Component-specific (this phase touches):**
+- <attached per-component CLAUDE.md / ARCHITECTURE.md links from Phase 3>
+
+**Topic-specific:**
+- <any docs/architecture/*.md links picked up at the plan-doc level>
+
+---
+
+## Conventions
+
+- Commit format: `<area>(<scope>): <subject> (Phase N, ALT-NN)` — area tag for this project: `<detected from Phase 4>`
+- PR body must include `Closes ALT-NN` so merging closes this issue.
+- Anything the plan section says to **defer** stays deferred — don't expand scope.
+
+## Prior art
+
+<list of relevant shipped commits from `git log` matching the project's area tag,
+ most recent first, max 5>
+
+(no prior commits yet — first phase of this feature)   <-- only if applicable
+```
+
+Capture each issue's ID (`ALT-NN`) and URL.
+
+---
+
+## Phase 9 — Set blocking relationships
+
+For each phase in order from 2 onward, add a `blocked-by` relationship to the previous phase using the Linear API. If the plan-doc text specified extra blockers (e.g. "Phase 5 also blocks on Phase 4"), add those too.
+
+Optional/deferred phases still get blocked-by relationships — being in `Backlog` doesn't mean unblocked. The blocker just means "even when promoted to Todo, wait for the predecessor".
+
+---
+
+## Phase 10 — Rewrite the plan doc's §8
+
+Edit the plan doc to replace each `ALT-_TBD_` placeholder with the matching real issue ID, in order. Also update the §8 intro line to point at the new project URL if it has a project URL slot. Example diff:
+
+```diff
+-Phase issues will be created under a new "OTel Tracing" project on the Altitude Devops team and linked here once filed.
++Tracked under the [OTel Tracing](https://linear.app/altitude-devops/project/...) project on the Altitude Devops team.
+
+-- ALT-_TBD_ — Phase 1: Tempo + OTel Collector + Grafana in monitoring stack
+-- ALT-_TBD_ — Phase 2: `NatsBus` context propagation (TS + Go)
++- [ALT-41](https://linear.app/altitude-devops/issue/ALT-41) — Phase 1: Tempo + OTel Collector + Grafana in monitoring stack
++- [ALT-42](https://linear.app/altitude-devops/issue/ALT-42) — Phase 2: `NatsBus` context propagation (TS + Go)
+```
+
+Match the link format used in the existing plan docs (look at the NATS migration plan §8 — `[ALT-26](https://linear.app/altitude-devops/issue/ALT-26)`).
+
+Do **not** commit. Leave the diff staged so the user can review and commit it themselves with the rest of any related work.
+
+---
+
+## Phase 11 — Report
+
+Print a summary:
+
+```
+✓ Created project: <name> — <project URL>
+✓ Created N issues:
+   - <ALT-NN> Phase 1: <title>           [Todo]
+   - <ALT-NN> Phase 2: <title>           [Todo]
+   - ...
+   - <ALT-NN> Phase M: <title>           [Backlog]
+✓ Set blocked-by relationships per plan ordering.
+✓ Updated <plan-doc-path> §<8> with real issue IDs (uncommitted).
+
+Next step: review the plan-doc diff, commit it, then run `execute-next-task` when you're ready to start Phase 1.
+```
+
+---
+
+## Hard rules
+
+- **Never merge into an existing project.** If a project with the same name already exists, stop. Same-named projects are almost certainly the same feature — manual reconciliation only.
+- **Never write a pre-baked implementation plan into the issue description.** Issue descriptions carry *context* — Goal, Deliverables, Done when, doc pointers — not file-by-file change lists. Implementation plans live in the executor's ExitPlanMode at execution time, against current code.
+- **Never invent docs.** If `egress-shared/CLAUDE.md` doesn't exist, don't link it. Verify each attached doc.
+- **Never guess at convention.** If §8 has no placeholder list, the H1 is missing, or no `### Phase N` headings parse — stop and report. The conventions exist for a reason.
+- **Never commit the plan-doc edit.** Leave it staged. The user owns the commit.
+- **Never transition issues from their initial state.** `execute-next-task` does that. The populator only creates.
+- **Never skip optional phases.** They go in as `Backlog` so the project is complete and the §8 list reconciles 1:1.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -170,6 +170,10 @@ These show up in nearly every feature. Skim them before making changes that touc
 
 Channels and event names are constants in [lib/types/socket-events.ts](lib/types/socket-events.ts). Use `Channel.*` and `ServerEvent.*` — never raw strings. The server emits via `emitToChannel()`; the client subscribes per-room via `useSocketChannel()` and listens via `useSocketEvent()`. Long-running operations follow a **started → step → completed** triplet; see the patterns sections of [server/ARCHITECTURE.md](server/ARCHITECTURE.md) and [client/ARCHITECTURE.md](client/ARCHITECTURE.md).
 
+### NATS is the system-internal bus
+
+Server↔sidecar control-plane traffic (egress firewall agent, egress gateway, future backup and self-update progress) goes over NATS through the singleton `NatsBus` ([server/src/services/nats/nats-bus.ts](server/src/services/nats/nats-bus.ts)). Subjects live under `mini-infra.>`, with constants in [lib/types/nats-subjects.ts](lib/types/nats-subjects.ts) (and a Go mirror in [egress-shared/natsbus/subjects.go](egress-shared/natsbus/subjects.go), kept in lockstep by a CI drift check). Payloads are Zod-validated on both ends. The client never subscribes to NATS — when a NATS event matters to the UI, the server bridges it to Socket.IO. See [docs/architecture/internal-messaging.md](docs/architecture/internal-messaging.md) for the full namespace, per-pair flows, and how to add a new channel.
+
 ### Task tracker for long-running ops
 
 Operations like certificate issuance, stack apply, container connect, and HAProxy migrations report progress through a single registry-driven UI. Server emits `*_STARTED`, `*_STEP`, `*_COMPLETED`. The client maps task types to that triplet in [client/src/lib/task-type-registry.ts](client/src/lib/task-type-registry.ts), and components register tasks with `trackTask()` so progress is visible from anywhere in the app.

--- a/docs/architecture/internal-messaging.md
+++ b/docs/architecture/internal-messaging.md
@@ -1,0 +1,347 @@
+# Internal Messaging — How Mini Infra Components Talk to Each Other
+
+This document is the bird's-eye view of how the moving parts inside a Mini Infra installation communicate. It's the companion to [ARCHITECTURE.md](../../ARCHITECTURE.md) for the cross-process messaging story.
+
+It is hand-maintained. When a transport changes — a sidecar moves onto NATS, a new subject lands, a stream gets a different retention policy — update it.
+
+The migration that produced today's shape is tracked in [docs/planning/not-shipped/internal-nats-messaging-plan.md](../planning/not-shipped/internal-nats-messaging-plan.md). Phases 1–3 have shipped; Phases 4 and 5 are reserved but not implemented. Each phase section below labels what's live and what's stub.
+
+## 1. Scope and non-scope
+
+**In scope:** every system-internal channel between the server and a sidecar or supporting container — egress firewall agent, egress gateway, backups, self-update — plus the smoke-test loopback that proves the bus is alive.
+
+**Out of scope:**
+
+- **Server ↔ client.** Real-time pushes to the browser stay on Socket.IO. Constants live in [lib/types/socket-events.ts](../../lib/types/socket-events.ts). The browser **never** subscribes to NATS directly.
+- **Server ↔ Docker daemon.** The server still owns `/var/run/docker.sock` via [server/src/services/docker.ts](../../server/src/services/docker.ts). Sidecars do not dial Docker over NATS — the invariant in [ARCHITECTURE.md](../../ARCHITECTURE.md#external-boundaries) holds.
+- **`auth-proxy`.** Synchronous credential brokering on the request path stays HTTP. NATS req/reply would add latency and a second moving part for no benefit.
+- **`agent-sidecar`.** A separate solution is in flight there.
+- **Application traffic.** Apps deployed by users get their own subject namespace (`app.<stack.id>.>` by default) via the App Roles work. That's a tenant-facing surface, not part of the system control plane this document covers.
+
+## 2. The two real-time fabrics
+
+Two transports, two responsibilities, no overlap.
+
+```
+┌──────────┐         Socket.IO          ┌──────────────┐         NATS         ┌────────────────────┐
+│  browser │ ◀───── (events, pushes) ── │ Mini Infra   │ ◀── (req/reply,  ──▶ │ sidecars + helper  │
+│ (client) │                            │ server       │     events,          │ containers         │
+└──────────┘                            │ (Express +   │     heartbeats)      │ (egress-fw-agent,  │
+                                        │  Socket.IO)  │                      │  egress-gateway,   │
+                                        └──────────────┘                      │  pg-az-backup*,    │
+                                                                              │  update-sidecar*)  │
+                                                                              └────────────────────┘
+                                                * = reserved, not yet on NATS
+```
+
+| Fabric | Direction | Use for | Don't use for |
+|---|---|---|---|
+| Socket.IO | Server → client (mostly) | UI updates, `*_STARTED → *_STEP → *_COMPLETED` triplets, the events page, task tracker progress | System-internal pushes that don't need to reach a browser |
+| NATS | Server ↔ sidecars / helper containers | Commands (req/reply), fan-out events, heartbeats, durable replay (JetStream), latest-state caches (KV) | Anything the browser needs to see directly |
+
+The bridge between them is the server. When a NATS event matters to the UI — a backup completed, a firewall rule applied, a gateway decision — the server consumes the NATS message, persists what it needs to (audit log, DB row), and emits a Socket.IO event on the relevant channel. The client subscribes per-room via `useSocketChannel()` and never knows NATS exists.
+
+## 3. The shared `NatsBus`
+
+All publish/subscribe goes through one chokepoint per process. This is the same shape as `DockerService.getInstance()` for the Docker daemon — one connection, one set of guarantees, one place to change the rules.
+
+### 3.1 TypeScript bus
+
+[server/src/services/nats/nats-bus.ts](../../server/src/services/nats/nats-bus.ts)
+
+```ts
+class NatsBus {
+  static getInstance(opts?): NatsBus
+  start(): void                     // fire-and-forget; reconnect loop runs in background
+  ready(opts?): Promise<void>        // block until connected
+  shutdown(): Promise<void>          // drain in-flight handlers, then close
+  getHealth(): BusHealth             // { state, lastConnectedAtMs, lastErrorMessage, url }
+  invalidateCreds(): void            // force reconnect after Vault rotation
+
+  publish<T>(subject, payload, opts?): Promise<void>
+  request<Req, Res>(subject, payload, opts?): Promise<Res>
+  subscribe<T>(subject, handler, opts?): () => void
+  respond<Req, Res>(subject, handler, opts?): () => void
+
+  jetstream: {
+    ensureStream(spec): Promise<void>
+    ensureConsumer(spec): Promise<void>
+    publish<T>(subject, payload, opts?): Promise<PubAck>
+    consume<T>(spec, handler, opts?): () => void
+    ensureKv(spec): Promise<void>
+    kv(bucket): BusKv
+  }
+}
+```
+
+Hard rules — these are what keep messages from getting mixed up:
+
+1. **Singleton.** One connection per process. `NatsBus.getInstance()`. No raw `nats.connect()` anywhere else in `server/src`.
+2. **Subject constants only.** Every subject string lives in [lib/types/nats-subjects.ts](../../lib/types/nats-subjects.ts). No raw subject strings in service code. Mirrors the `Channel.*` / `ServerEvent.*` rule for Socket.IO.
+3. **Typed payloads, validated both ways.** Each subject has a Zod schema in [server/src/services/nats/payload-schemas.ts](../../server/src/services/nats/payload-schemas.ts). The bus validates on **publish and on receive**. Schema mismatch throws — a malformed message never makes it to a handler. Pass `unchecked: true` only for opaque payloads (e.g. NFLOG blobs streaming through a wildcard).
+4. **Durable subscriptions.** `subscribe()` and `jetstream.consume()` register the handler in memory; on every reconnect the bus re-attaches them automatically. Callers register once at boot and forget about NATS bounces.
+5. **Graceful shutdown.** Every handler Promise is tracked. `shutdown()` waits for in-flight handlers to settle before draining the connection — important for stateful consumers (the egress decisions ingester acks JetStream messages only after the DB write commits).
+6. **Logger discipline.** Every publish/subscribe gets `getLogger("integrations", "nats-bus")` context plus the subject and (for req/reply) the inbox correlation id. NDJSON log lines join cleanly with HTTP `requestId` and operation `operationId`.
+
+### 3.2 Go bus
+
+[egress-shared/natsbus/](../../egress-shared/natsbus/)
+
+The two Go sidecars (`egress-fw-agent`, `egress-gateway`) import the same shape from [egress-shared/natsbus/bus.go](../../egress-shared/natsbus/bus.go): `Connect(ctx, opts)`, `Publish`, `Request`, `Subscribe`, `Respond`, `GetKv`, `Close`. JetStream consume is via the native SDK; the bus wrapper handles connection, creds parsing, and reconnect.
+
+Subject constants in [egress-shared/natsbus/subjects.go](../../egress-shared/natsbus/subjects.go) mirror the TS file. They have to stay in lockstep — see §3.4.
+
+### 3.3 What the bus is not
+
+A generic message-broker abstraction. There is no pluggable transport, no retry/DLQ framework, no schema registry, no in-process bus. NATS handles those concerns natively (JetStream for durability, ack/redeliver for retries, work-queue retention for at-least-once delivery). The bus is a thin adapter, not a framework.
+
+### 3.4 Drift control
+
+A CI workflow ([.github/workflows/nats-constants.yml](../../.github/workflows/nats-constants.yml)) runs [scripts/check-nats-subject-drift.mjs](../../scripts/check-nats-subject-drift.mjs) on every PR that touches the constants files or the script itself. It parses both files and fails the build if the subject sets diverge. A code generator is overkill at this scale.
+
+## 4. Subject namespace
+
+All system-internal subjects live under one prefix: **`mini-infra.>`**. Anything else is application traffic.
+
+### 4.1 Shape
+
+```
+mini-infra.<subsystem>.<aggregate>.<verb-or-event>[.<id>]
+```
+
+| Token | Meaning | Examples |
+|---|---|---|
+| `mini-infra` | Always. The system namespace. | — |
+| `<subsystem>` | The owning area, matches the directory layout where possible. | `system`, `egress`, `backup`, `update` |
+| `<aggregate>` | A noun — the thing the subsystem acts on. Optional when the subsystem has only one. | `fw`, `gw`, `cert` |
+| `<verb-or-event>` | The discriminator. Verbs and events follow different rules — see §4.2. | `apply`, `applied`, `health`, `events` |
+| `<id>` | Optional opaque correlator (env id, run id) when fan-out targets need it. | `01HXYZ…` |
+
+Tokens are kebab-case, all lowercase, no underscores. No wildcards in published subjects — wildcards are subscription-side only.
+
+### 4.2 Three idioms, three rules
+
+The shape of a subject tells you what it is at a glance.
+
+- **Commands** — imperative verb, request/reply.
+  Subject ends with the verb: `mini-infra.egress.fw.rules.apply`. Always invoked via `bus.request(...)`. Body is a typed command payload; reply is a typed result. The bus auto-handles `_INBOX.>` plumbing.
+- **Events** — past-participle verb, fan-out publish.
+  Subject ends with what already happened: `mini-infra.egress.fw.rules.applied`. Published once, may be consumed by zero or more subscribers, JetStream-durable when replay matters. Past tense is a hard rule — if a subscriber sees an event subject they know it's a historical fact.
+- **Heartbeats** — the noun, no verb.
+  Subject ends with the aggregate alone: `mini-infra.egress.fw.health`. Periodic publish of current state. Stored in a JetStream KV bucket so subscribers can latch the most recent value across server restarts.
+
+### 4.3 Live subject inventory
+
+Everything the codebase actually publishes or subscribes to today:
+
+| Subject | Kind | Shipped in | Storage |
+|---|---|---|---|
+| `mini-infra.system.ping` | cmd (req/reply) | Phase 1 | core (smoke loopback) |
+| `mini-infra.egress.fw.rules.apply` | cmd | Phase 2 | core req/reply |
+| `mini-infra.egress.fw.rules.applied` | event | Phase 2 | JetStream `EgressFwEvents` |
+| `mini-infra.egress.fw.events` | event (NFLOG) | Phase 2 | JetStream `EgressFwEvents` |
+| `mini-infra.egress.fw.health` | heartbeat | Phase 2 | KV `egress-fw-health` |
+| `mini-infra.egress.gw.rules.apply.<envId>` | cmd | Phase 3 | core req/reply |
+| `mini-infra.egress.gw.rules.applied.<envId>` | event | Phase 3 | core |
+| `mini-infra.egress.gw.container-map.apply.<envId>` | cmd | Phase 3 | core req/reply |
+| `mini-infra.egress.gw.container-map.applied.<envId>` | event | Phase 3 | core |
+| `mini-infra.egress.gw.decisions` | event (proxy decisions) | Phase 3 | JetStream `EgressGwDecisions` (work-queue) |
+| `mini-infra.egress.gw.health` | heartbeat | Phase 3 | KV `egress-gw-health` (per-env key) |
+
+Reserved (constants and Go mirrors exist; no producers/consumers yet — see §7):
+
+| Subject | Phase |
+|---|---|
+| `mini-infra.backup.run`, `.progress.<runId>`, `.completed`, `.failed` | Phase 4 |
+| `mini-infra.update.run`, `.progress.<runId>`, `.completed`, `.failed`, `.health-check-passed` | Phase 5 |
+
+### 4.4 JetStream streams, consumers, KV buckets
+
+All ensured idempotently at server boot by [server/src/services/nats/system-nats-bootstrap.ts](../../server/src/services/nats/system-nats-bootstrap.ts) and [server/src/services/nats/nats-system-bootstrap.ts](../../server/src/services/nats/nats-system-bootstrap.ts).
+
+| Resource | Subjects / keys | Retention | Limits |
+|---|---|---|---|
+| Stream `EgressFwEvents` | `mini-infra.egress.fw.rules.applied`, `.events` | Limits | 1 GiB / 30 d |
+| Stream `EgressGwDecisions` | `mini-infra.egress.gw.decisions` | Work-queue | 1 GiB / 30 d |
+| Consumer `EgressFwEvents-server` | on `EgressFwEvents` | durable, explicit ack, 30 s ack-wait | maxDeliver 5 |
+| Consumer `EgressGwDecisions-server` | on `EgressGwDecisions` | durable, explicit ack | server batch-flushes then acks |
+| KV `egress-fw-health` | key `current` | 30 s TTL, 1 revision | 5 s heartbeat → freshness ≤ 10 s = healthy |
+| KV `egress-gw-health` | key `<envId>` | 10 min TTL, 1 revision | per-env latest heartbeat |
+
+Names are PascalCase and don't carry the `mini-infra.` prefix — streams/buckets live in their own NATS namespace, so the prefix would be visual noise.
+
+## 5. Per-pair flows
+
+This section walks through every system pair that's currently on the bus. Future phases (backups, self-update) get their sections here when they land.
+
+### 5.1 Server ↔ `egress-fw-agent` — Phase 2 (shipped)
+
+**What was bespoke before:** a Unix socket at `/var/run/mini-infra/fw.sock`, plus a 30 s HTTP health poll, plus a Docker stdout tail for NFLOG events. Three transports per peer, each with its own framing.
+
+**What's on NATS now:**
+
+```
+                         mini-infra.egress.fw.rules.apply       (cmd, req/reply)
+                              │
+   ┌─────────────────┐        ▼            ┌──────────────────┐
+   │                 │ ──────────────────▶ │                  │
+   │ Mini Infra      │                     │ egress-fw-agent  │
+   │ server          │ ◀────────────────── │ (Go sidecar)     │
+   │                 │   _INBOX.<auto>     │                  │
+   └─────────────────┘   (typed reply)     └──────────────────┘
+        ▲   ▲   ▲                                  │   │   │
+        │   │   │                                  │   │   │
+        │   │   │  mini-infra.egress.fw.rules.applied   │   │
+        │   │   └──────────────────────────────────────┘   │
+        │   │       (event, JetStream EgressFwEvents)       │
+        │   │                                                │
+        │   │  mini-infra.egress.fw.events                   │
+        │   └────────────────────────────────────────────────┘
+        │       (NFLOG stream, JetStream EgressFwEvents)
+        │
+        │  mini-infra.egress.fw.health
+        └─── (5 s heartbeat, KV egress-fw-health)
+```
+
+**Server side:**
+
+- [server/src/services/egress/fw-agent-transport.ts](../../server/src/services/egress/fw-agent-transport.ts) — `NatsTransport.envUpsert/envRemove/ipsetAdd/Del/Sync` all call `bus.request(EgressFwSubject.rulesApply, …)` with a discriminated-union `op` field (5 s timeout). Reply Zod-validated by the bus.
+- [server/src/services/egress/fw-agent-sidecar.ts](../../server/src/services/egress/fw-agent-sidecar.ts) — health watcher polls the `egress-fw-health` KV bucket every 2 s. Healthy = freshness ≤ 10 s and `ok: true`. The 30 s HTTP poll is gone.
+- [server/src/services/egress/egress-log-ingester.ts](../../server/src/services/egress/egress-log-ingester.ts) — durable JetStream consumer `EgressFwEvents-server` ingests both NFLOG events and `rules.applied` confirmations. Manual ack — the bus acks only after the row hits Postgres.
+
+**Agent side ([egress-fw-agent/](../../egress-fw-agent/)):** subscribes to `rules.apply`, publishes `rules.applied` and `events`, publishes a heartbeat to KV every 5 s. The Unix-socket HTTP server is gone.
+
+**Template ([server/templates/egress-fw-agent/template.json](../../server/templates/egress-fw-agent/template.json)):** declares `nats.roles[]` so the apply pipeline mints a credential profile with publish `[rules.applied, events]`, subscribe `[rules.apply]`, and KV access to `egress-fw-health`. `inboxAuto: "reply"` lets the agent reply to requests without an explicit inbox subscription. `NATS_URL` and `NATS_CREDS` are injected via `dynamicEnv`. The Unix-socket bind mount is gone from `volumes[]`.
+
+**Rollback path:** `MINI_INFRA_FW_AGENT_TRANSPORT=unix` re-enables the legacy Unix-socket transport for one release. Both code paths compile. The flag is marked for removal in a follow-up cleanup issue.
+
+### 5.2 Server ↔ `egress-gateway` — Phase 3 (shipped)
+
+**What was bespoke before:** an HTTP admin port at `:8054` for rule and container-map applies, plus a Docker stdout tail for proxy decisions. The log-tail dropped in-flight lines whenever the gateway container restarted.
+
+**What's on NATS now:** same shape as the fw-agent, with one twist — the gateway is per-environment, so commands and applied-events are addressed by appending the environment id:
+
+```
+                  mini-infra.egress.gw.rules.apply.<envId>             (per-env cmd)
+                  mini-infra.egress.gw.container-map.apply.<envId>     (per-env cmd)
+                              │
+                              ▼
+   ┌─────────────────┐                  ┌──────────────────────────┐
+   │ Mini Infra      │ ───────────────▶ │ egress-gateway (envA)    │
+   │ server          │ ◀───────────────                              │
+   └─────────────────┘                  └──────────────────────────┘
+        ▲                                  │
+        │  mini-infra.egress.gw.decisions  │  (every proxy decision)
+        └─── (shared JetStream EgressGwDecisions, work-queue)
+        ▲
+        │  mini-infra.egress.gw.health
+        └─── (heartbeat, KV egress-gw-health, key=envId)
+```
+
+The decisions stream is **shared across all environments** — a single JetStream stream with a server-side durable consumer batches decisions into `EgressEvent` rows in Postgres. Work-queue retention means each decision is delivered once and then dropped from the stream, so a slow gateway can't fill the disk.
+
+**Server side:**
+
+- [server/src/services/egress/egress-gateway-transport.ts](../../server/src/services/egress/egress-gateway-transport.ts) — `pushRulesViaNats(envId, request)` and `pushContainerMapViaNats(envId, request)` build the per-env subject and call `bus.request(...)`. `readGatewayHealth(envId)` reads the latest heartbeat from KV. A malformed heartbeat returns `null` so the UI shows "unknown" rather than throwing.
+- [server/src/services/egress/egress-log-ingester.ts](../../server/src/services/egress/egress-log-ingester.ts) — same file as the fw-agent ingester, with a second durable consumer for `EgressGwDecisions`. 60 s in-memory dedup window + batched DB writes (100 rows or 1 s); ack only after `prisma.egressEvent.createMany()` succeeds.
+
+**Gateway side ([egress-gateway/](../../egress-gateway/)):** the per-env credential grants `rules.apply.>` and `container-map.apply.>`, so each gateway picks up only its own env's variant — no broadcast-and-filter at the consumer. The `:8054` admin HTTP listener is gone.
+
+**Template ([server/templates/egress-gateway/template.json](../../server/templates/egress-gateway/template.json)):** declares `nats.roles[]` for the gateway role; `:8054` is no longer exposed.
+
+### 5.3 Server loopback — Phase 1 (shipped)
+
+`mini-infra.system.ping` is the smoke test. The server registers a responder at boot ([server/src/services/nats/nats-bus-ping.ts](../../server/src/services/nats/nats-bus-ping.ts)); `pingSelf(timeoutMs)` sends a request, verifies the nonce round-trip, and returns latency. Proves the connection, the credentials, the JSON codec, the Zod validation, and req/reply plumbing are all working. Exposed via [server/src/routes/nats.ts](../../server/src/routes/nats.ts) for ops triage.
+
+## 6. Bootstrap and credentials
+
+Cold-boot ordering matters: the server publishes to a NATS server (`vault-nats` stack) that the server itself manages.
+
+```
+1. Postgres up         ─▶  Prisma client ready
+2. Vault services init ─▶  Read NATS server URL + bus creds from Vault KV
+3. NATS control plane  ─▶  applyConfig(): refresh operator/account JWTs, render nats.conf,
+                            rotate the server-bus creds blob in Vault KV
+4. NatsBus.start()     ─▶  Fire-and-forget. Reconnect loop runs in background;
+                            non-blocking on a fresh worktree where vault-nats
+                            isn't up yet.
+5. registerPingResponder() — durable subscription, attaches when the bus
+                            first reaches "connected".
+6. NatsBus.ready({ 3 s })  — best-effort; on success we run system-resource
+                            bootstrap (ensureStream, ensureConsumer, ensureKv).
+                            On failure we log and continue — bootstrap retries
+                            on next process boot.
+7. Bootstrap fw-agent stack (idempotent); the apply pipeline mints the
+   `agent` role credential profile and the agent picks up `NATS_URL` +
+   `NATS_CREDS` via `dynamicEnv`.
+```
+
+[server/src/server.ts](../../server/src/server.ts) is the source of truth.
+
+**Credentials.**
+
+- The server's own bus creds live at `shared/nats-server-bus-creds` in Vault KV. `applyConfig()` rotates them on every run; `NatsBus.invalidateCreds()` triggers a reconnect when they change. The bus reads the latest blob on every connect attempt.
+- Agent creds are minted per stack apply by the App Roles pipeline. Each role becomes a `NatsCredentialProfile`; the credential is delivered to the container via the existing `nats-creds` `dynamicEnv` plumbing — same code path as user apps. The fw-agent and egress-gateway templates are just stacks with `nats.roles[]` declared; nothing about the apply pipeline knows they're built-in.
+
+**Reconnect.** Full-jitter exponential backoff between 1 s and 30 s. Retries forever. Durable subscriptions and JetStream consumer registrations are re-attached automatically on every reconnect. A NATS bounce is invisible to subscribers beyond the gap in delivery.
+
+## 7. Observability — how NATS traffic reaches the UI
+
+The browser doesn't subscribe to NATS. Instead, NATS messages that the UI cares about turn into Socket.IO events through the server.
+
+For a long-running operation (today: certificate issuance, stack apply, container connect; future: backups, self-update via Phase 4–5):
+
+```
+NATS event                Server consumer                    Socket.IO emission
+────────────────────      ─────────────────────────────      ──────────────────────────────
+mini-infra.backup.run     bus.subscribe → starts run         CHANNEL.BACKUP, BACKUP_STARTED
+mini-infra.backup.        durable consumer →                 BACKUP_STEP (per progress event)
+   progress.<runId>        emit per step
+mini-infra.backup.        durable consumer → DB row +        BACKUP_COMPLETED
+   completed                audit event
+```
+
+The server is the bridge. The client sees the same `*_STARTED → *_STEP → *_COMPLETED` triplet it always has. The task tracker in [client/src/components/task-tracker/](../../client/src/components/task-tracker/) doesn't change.
+
+**Logging.** Every bus operation logs to `getLogger("integrations", "nats-bus")` with the subject and inbox correlation id. NDJSON lines join cleanly with HTTP `requestId` and operation `operationId` — one grep on `operationId` shows the full HTTP-to-NATS-to-DB-to-Socket.IO trace.
+
+**Health.** `bus.getHealth()` returns `{ state, lastConnectedAtMs, lastErrorMessage, url }`. The fw-agent and gateway health watchers expose KV-backed peer health to the UI. ConnectivityScheduler integration (so "NATS bus" shows up alongside "Docker", "Vault", etc. in the connected-services list) is a deferred follow-up.
+
+**Metrics.** Publish/subscribe counters and request-latency histograms aren't wired up to a metrics surface yet — log lines carry the same data on a per-call basis until a real consumer lands.
+
+## 8. Adding a new system-internal channel
+
+When a new sidecar or helper container needs to talk to the server, follow the existing pattern instead of inventing a fourth transport.
+
+1. **Pick a subject space** under `mini-infra.<subsystem>.<aggregate>.>` and add the constants to both [lib/types/nats-subjects.ts](../../lib/types/nats-subjects.ts) (TypeScript) and [egress-shared/natsbus/subjects.go](../../egress-shared/natsbus/subjects.go) (Go, only if a Go peer is involved). The CI drift check will fail the PR if they diverge.
+2. **Define payload schemas** in [server/src/services/nats/payload-schemas.ts](../../server/src/services/nats/payload-schemas.ts). Register them against the concrete subjects so the bus validates on both ends.
+3. **Decide the idiom** — command (req/reply), event (fan-out, JetStream-durable when replay matters), or heartbeat (KV-backed latest-state). Don't mix idioms on one subject.
+4. **For events worth replaying**, declare a JetStream stream + durable consumer in `system-nats-bootstrap.ts`. Pick `Limits` retention for history streams, `WorkQueue` for at-least-once delivery to a single server-side consumer.
+5. **Declare a NATS role on the template** with the minimum publish/subscribe lists. Add `inboxAuto: "reply"` if the role responds to commands. `NATS_URL` and `NATS_CREDS` are delivered through the existing `dynamicEnv` plumbing — you don't need a custom mechanism.
+6. **Server consumer**: `bus.subscribe(...)` or `bus.jetstream.consume(...)` once at boot. Subscriptions are durable across reconnects.
+7. **Bridge to Socket.IO** if the UI needs to react. Wrap the emission in try/catch — emission failures must never break the NATS handler. Use `Channel.*` and `ServerEvent.*` constants from [lib/types/socket-events.ts](../../lib/types/socket-events.ts).
+
+## 9. Future surfaces (Phase 4 and 5)
+
+Subjects, schemas (currently `z.unknown()`), and Go constants are reserved. No producers or consumers exist yet. Sections will be filled in here when each phase lands.
+
+### Phase 4 — `pg-az-backup` (planned)
+
+- `mini-infra.backup.run` (cmd, req/reply, fired by the scheduler)
+- `mini-infra.backup.progress.<runId>` (event stream, plain pub/sub — short-lived, no replay)
+- `mini-infra.backup.completed` / `mini-infra.backup.failed` (events, JetStream `BackupHistory`)
+
+The exit-code path will stay as a fallback so a hard crash mid-run still surfaces as a `failed` event published by the server's container watcher.
+
+### Phase 5 — `update-sidecar` (planned, optional)
+
+- `mini-infra.update.run`, `.progress.<runId>`, `.completed`, `.failed`, `.health-check-passed`
+
+Same shape as Phase 4. Smaller payoff (the sidecar runs to completion in seconds and the existing `docker events` probe works) — landing it just gives us the same `*_STARTED → *_STEP → *_COMPLETED` pattern and lets us delete the bespoke watcher in [server/src/services/self-update.ts](../../server/src/services/self-update.ts).
+
+## 10. Where to next
+
+- [docs/planning/not-shipped/internal-nats-messaging-plan.md](../planning/not-shipped/internal-nats-messaging-plan.md) — the full migration plan (rationale, phase-by-phase deliverables, risks).
+- [docs/planning/shipped/nats-app-roles-plan.md](../planning/shipped/nats-app-roles-plan.md) — App Roles, signers, prefix allowlist, cross-stack imports/exports. The substrate this messaging story builds on.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — the system-wide bird's-eye view.
+- [server/ARCHITECTURE.md](../../server/ARCHITECTURE.md) — server subsystems and patterns (DockerService, ConfigurationService, etc.).

--- a/docs/planning/not-shipped/internal-nats-messaging-plan.md
+++ b/docs/planning/not-shipped/internal-nats-messaging-plan.md
@@ -237,7 +237,7 @@ Defer until Phase 4 has settled — same pattern, same subscribers; no surprise.
 
 ## 8. Linear tracking
 
-Phase issues in Linear (Altitude Devops team) — each links back to this doc. Phase 1 blocks all later phases; Phase 5 also blocks on Phase 4.
+Tracked under the [Internal NATS Messaging Migration](https://linear.app/altitude-devops/project/internal-nats-messaging-migration-e76f6def15e8/overview) project on the Altitude Devops team. Phase issues each link back to this doc. Phase 1 blocks all later phases; Phase 5 also blocks on Phase 4.
 
 - [ALT-26](https://linear.app/altitude-devops/issue/ALT-26) — Phase 1: Foundation (`NatsBus`, subject constants, prefix allowlist)
 - [ALT-27](https://linear.app/altitude-devops/issue/ALT-27) — Phase 2: `egress-fw-agent` onto NATS

--- a/docs/planning/not-shipped/observability-otel-tracing-plan.md
+++ b/docs/planning/not-shipped/observability-otel-tracing-plan.md
@@ -1,0 +1,248 @@
+# OpenTelemetry Tracing — Adding Tempo to the Monitoring Stack
+
+**Status:** planned, not implemented. Phased rollout — each phase is a separate Linear issue.
+**Builds on:** the existing `monitoring` stack (Prometheus + Loki + Alloy + Telegraf, see [server/templates/monitoring/template.json](../../../server/templates/monitoring/template.json)) and the `NatsBus` chokepoint shipped through Phase 3 of the [internal-nats-messaging-plan](./internal-nats-messaging-plan.md).
+**Pairs with:** [docs/architecture/internal-messaging.md](../../architecture/internal-messaging.md) — once tracing lands, that doc gets the trace-context propagation rules added to §3 and a worked end-to-end example in §5.
+
+---
+
+## 1. Background
+
+We can already see what individual components are doing in isolation: Prometheus shows container-level metrics, Loki has every container's stdout, Pino NDJSON files carry `requestId` and `operationId` correlators inside the server. What we **can't** do today is follow a single request across components — for example, a UI click that triggers a stack apply that pushes firewall rules to `egress-fw-agent` over NATS that updates iptables and emits a heartbeat. That request touches Express, Prisma, Docker, NATS, JetStream, KV, Postgres, and a Go sidecar; we have eight separate logs and no spine that joins them.
+
+The standard answer is **distributed tracing**: every component instrumented with OpenTelemetry, every cross-process boundary propagating a W3C `traceparent`, every span shipped to a single backend that knows how to render the call graph and the service map. We already have Prometheus and Loki for metrics and logs; this plan adds the third signal, **traces**, to the same monitoring stack.
+
+The lucky structural fact: thanks to Phases 1–3 of the NATS messaging migration, **every system-internal cross-component message already goes through one chokepoint per language** — `NatsBus` in TypeScript, `egress-shared/natsbus` in Go. Instrument those once and every NATS hop is in traces for free. Without that chokepoint this plan would be much larger.
+
+## 2. Goals
+
+1. **One trace backend, in the existing monitoring stack.** Add **Grafana Tempo** as a fifth service in the `monitoring` template. Same operator surface, same lifecycle, same volumes pattern as Loki/Prometheus.
+2. **One ingestion path.** An **OpenTelemetry Collector** alongside Tempo. All instrumented processes export OTLP to the collector; the collector decides where signals go. Application code never talks to a backend directly.
+3. **Trace context across NATS, transparently.** Inject/extract W3C `traceparent` headers at the bus chokepoint — `NatsBus.publish/request/subscribe/respond` and the JetStream wrappers, plus the Go counterpart. Application code stays unaware.
+4. **Logs ↔ traces ↔ metrics correlation in Grafana.** Add Grafana to the monitoring stack (it isn't there today) so a Pino log line's `trace_id` field links to the Tempo trace, and the trace's spans link to Loki logs and Prometheus metrics on the same time window.
+5. **Service map for free.** Enable Tempo's `metrics-generator` so service-graph metrics flow into Prometheus and the call graph renders as a Grafana Node Graph panel. This is the literal "see all interactions between components" view.
+6. **No app-level metrics in this plan.** Prometheus already scrapes container-level data through Telegraf; that's enough for now. Custom request-rate / NATS-publish-rate metrics are a separate follow-up.
+
+## 3. Non-goals
+
+- **Replacing Loki or Prometheus.** Both stay. This plan adds Tempo, not a replacement.
+- **Migrating away from Pino.** Pino stays. We add `@opentelemetry/instrumentation-pino` (or a small mixin) so `trace_id` / `span_id` ride on every log line. The existing `component`, `subcomponent`, `requestId`, `operationId` fields are unchanged.
+- **Replacing the `*_STARTED → *_STEP → *_COMPLETED` Socket.IO triplet.** Tracing is for engineers; the triplet is for end users. They serve different audiences and stay parallel.
+- **Tracing `pg-az-backup`.** It's a one-shot Bash + Node script behind a Docker exec; the cost of context propagation through the shell boundary outweighs the benefit. Skip.
+- **App-level metrics (`prom-client`, `http_requests_total`, etc.).** Out of scope; covered as an optional Phase 6.
+
+## 4. Architecture
+
+### 4.1 Where Tempo lives
+
+```
+                      Mini Infra monitoring stack (existing)
+       ┌─────────────────────────────────────────────────────────────┐
+       │                                                             │
+       │  telegraf  ─▶  prometheus  ◀── alloy (log shipper)          │
+       │                                  │                          │
+       │                                  ▼                          │
+       │                                loki                         │
+       │                                                             │
+       │  ┌───────── new ──────────┐                                 │
+       │  │                        │                                 │
+       │  │  otel-collector  ─▶  tempo                               │
+       │  │       ▲                │                                 │
+       │  │       │                ▼                                 │
+       │  │   (OTLP gRPC      tempo_data volume                      │
+       │  │    :4317,                                                │
+       │  │    HTTP :4318)                                           │
+       │  └────────────────────────┘                                 │
+       │                                                             │
+       │  grafana ◀──── all four backends as data sources            │
+       │                                                             │
+       └─────────────────────────────────────────────────────────────┘
+                            ▲
+                            │  OTLP from instrumented apps
+        ┌───────────────────┴────────────────────┐
+        │   server, agent-sidecar, update-       │
+        │   sidecar (Node), egress-gateway,      │
+        │   egress-fw-agent (Go)                 │
+        └────────────────────────────────────────┘
+```
+
+Tempo and the OTel Collector join the existing `monitoring_network` bridge. The collector exposes OTLP on `:4317` (gRPC) and `:4318` (HTTP); applications dial it as `monitoring-otel-collector:4317` from inside Docker. Tempo writes to a new `tempo_data` named volume, mirroring how Loki uses `loki_data`.
+
+### 4.2 Why a collector, not direct OTLP to Tempo
+
+Three reasons that justify the extra container:
+
+- **One pipeline, two backends.** The collector fans out to Tempo (traces) **and** to Prometheus (service-graph metrics derived from spans, see §4.4). One config, no per-app branching.
+- **Sampling & redaction at the boundary.** Tail-based sampling, attribute scrubbing, and rate limiting live in the collector — applications stay simple. The fw-agent's NFLOG events especially benefit: we'll drop spans for high-cardinality decisions and keep only the aggregates.
+- **Backend-agnostic apps.** If we ever add a second trace backend (or move to a hosted one), only the collector config changes. The instrumentation isn't aware of Tempo.
+
+### 4.3 Adding Grafana
+
+Grafana is not in the monitoring stack today — the server's `/api/monitoring/*` routes proxy Prometheus and Loki directly. That works for two signals; for traces it doesn't:
+
+- The server would need to re-implement Tempo's TraceQL search, the trace waterfall, and the service-graph node panel from scratch.
+- Cross-signal correlation (click `trace_id` in a log → jump to trace → jump to a span's logs) is what Grafana is for. Building it in our own UI is months of work for parity, not differentiation.
+
+So this plan **adds Grafana** as a sixth service in the monitoring template. The existing `/api/monitoring/*` proxy routes stay (the in-app help, agent-sidecar, and embedded panels keep working); Grafana opens in a new tab for tracing-heavy workflows. We can fold the proxy routes into Grafana iframes later if we want to unify, but that's a separate UX decision.
+
+Alternative considered and rejected: **keep Grafana out and proxy Tempo through the existing routes**. We don't get the service-map view for free, and TraceQL via REST is a meaningful UI surface to recreate. The added container is cheaper than the recreated UI.
+
+### 4.4 Service map for free — Tempo metrics-generator
+
+Tempo's [metrics-generator](https://grafana.com/docs/tempo/latest/metrics-generator/) processes incoming spans and emits two Prometheus metrics:
+
+- `traces_spanmetrics_*` — request rate, error rate, latency per service.
+- `traces_service_graph_request_total{client, server}` — the edge metric for the service graph.
+
+Pointed at the existing Prometheus, the result is a Grafana Node Graph panel that shows every component as a node and every call as an edge with rate/error/latency overlays. Built-in dashboards exist; we provision them via Grafana's file-based provisioning so the template is self-contained.
+
+## 5. The shared instrumentation chokepoints
+
+Same DRY rule as `NatsBus` and `DockerService`: instrument the chokepoint once, never instrument call sites.
+
+### 5.1 Server (Node) — `server/src/lib/otel.ts` (new)
+
+A single module imported **first** in `server/src/server.ts` (before anything else, including the logger factory) that:
+
+1. Initialises `@opentelemetry/sdk-node` with the OTLP exporter pointing at `OTEL_EXPORTER_OTLP_ENDPOINT` (env var, injected by template `dynamicEnv`).
+2. Registers auto-instrumentations: `http`, `express`, `pg` (Prisma), `socket.io`, `undici` (used by node-fetch / our HTTP clients).
+3. Registers the W3C `TraceContext` propagator. This is the default; we name it explicitly so the rule is greppable.
+4. Wires `@opentelemetry/instrumentation-pino` so every Pino log line carries `trace_id` and `span_id` automatically. Existing `requestId` / `operationId` fields stay untouched.
+
+No code in route handlers or services changes. `getLogger("integrations", "nats-bus")` keeps working; its lines just get richer.
+
+### 5.2 NatsBus — TypeScript
+
+The bus's publish/request/subscribe paths today encode JSON with no NATS headers ([nats-bus.ts](../../../server/src/services/nats/nats-bus.ts)). Phase 2 of this plan adds:
+
+```ts
+import { propagation, context, trace } from "@opentelemetry/api";
+
+publish<T>(subject, payload, opts) {
+  const headers = createHeaders();
+  propagation.inject(context.active(), headers, headersSetter);
+  // span: kind=PRODUCER, name=`nats publish ${subject}`, attrs={messaging.system, messaging.destination}
+  this.nc.publish(subject, ENCODER.encode(JSON.stringify(payload)), { headers });
+}
+
+subscribe<T>(subject, handler) {
+  // in the consume loop:
+  const ctx = propagation.extract(context.active(), msg.headers, headersGetter);
+  // span: kind=CONSUMER, name=`nats subscribe ${msg.subject}`, parent=ctx
+  context.with(trace.setSpan(ctx, span), () => handler(...));
+}
+```
+
+Same pattern for `request` (PRODUCER + CONSUMER pair, the reply gets its own span via the `_INBOX.>` subscription), `respond`, `jetstream.publish`, and `jetstream.consume`. Headers are NATS-native (since 2.2); they're not used today, so adding them is a strict superset — no consumer breaks.
+
+### 5.3 NatsBus — Go
+
+Mirror in [egress-shared/natsbus/bus.go](../../../egress-shared/natsbus/bus.go). Same publish/request/subscribe/respond methods, same propagator (`go.opentelemetry.io/otel/propagation`), same NATS-headers-as-carrier shape. The Go SDK's `nats.Msg.Header` is a `nats.Header` (alias for `textproto.MIMEHeader`); it satisfies the OTel `TextMapCarrier` interface with a one-line adapter. Constants for header field names live in [egress-shared/natsbus/](../../../egress-shared/natsbus/) so TS and Go agree without the CI drift check needing a second pass — they only have to agree on `traceparent` and `tracestate`, which are W3C standards.
+
+### 5.4 DockerService and Express handlers
+
+`DockerService.getInstance()` is the other chokepoint that's worth a span manually — Docker calls dominate request latency for some routes (container list, container inspect). Wrap each public method with a span at the singleton boundary. `@opentelemetry/instrumentation-express` covers HTTP handler spans automatically; we don't add per-route instrumentation.
+
+### 5.5 What stays uninstrumented
+
+- **Pino-internal:** the logger doesn't get its own spans — log lines carry the active span's IDs, that's enough.
+- **Synchronous helpers:** utility functions, parsers, schema validators. Spans here would be noise.
+- **Inside JetStream consumer batch loops:** one span per message, not one per batch iteration.
+
+## 6. Phased rollout
+
+Each phase is a separate Linear issue. Phases land in order; Phase 1 unblocks every later one. Phases 3–5 are independent of each other after Phase 2.
+
+### Phase 1 — Tempo + Collector + Grafana in the monitoring stack
+
+**Goal:** the trace backend is up; a single hand-rolled span makes it through end-to-end.
+
+Deliverables:
+- `tempo`, `otel-collector`, and `grafana` services added to [server/templates/monitoring/template.json](../../../server/templates/monitoring/template.json).
+- `tempo.yaml`, `otel-collector.yaml`, and `grafana/{datasources,dashboards}/` config files alongside the existing `prometheus.yml` / `loki.yaml` / `alloy.alloy` in `server/templates/monitoring/`.
+- `tempo_data` named volume; Grafana volume for provisioning + (optional) persisted user settings.
+- Grafana provisioning: Prometheus, Loki, and Tempo as data sources; one starter dashboard with a Node Graph panel pointed at the service-graph metrics.
+- A new `dynamicEnv` kind `otel-otlp-endpoint` (mirroring `nats-url`) that injects `OTEL_EXPORTER_OTLP_ENDPOINT=http://monitoring-otel-collector:4317` into any service that opts in via `services[].dynamicEnv`. Rendered through the same pipeline as `NATS_URL`.
+- A trivial smoke trace: server emits a span on boot (`server.boot`) before the OTel SDK is even instrumented further, just to prove OTLP → collector → Tempo → Grafana works.
+
+Done when: a fresh worktree boots, Grafana opens at the worktree-allocated port, the `server.boot` span is searchable in Tempo, and the Prometheus/Loki/Tempo data sources all show "OK".
+
+### Phase 2 — `NatsBus` context propagation (TS + Go)
+
+**Goal:** every NATS hop is a span. A trace started by an HTTP request arrives at `egress-fw-agent` and continues into Go.
+
+Deliverables:
+- TS `NatsBus` injects/extracts W3C trace headers in `publish`, `request`, `subscribe`, `respond`, `jetstream.publish`, `jetstream.consume`.
+- Span kinds: `PRODUCER` on publish/request, `CONSUMER` on subscribe/respond/consume. Span names follow OTel messaging conventions: `nats {publish|receive|process} {subject}`.
+- Standard messaging attributes: `messaging.system="nats"`, `messaging.destination=<subject>`, `messaging.operation=<op>`, plus our existing `applyId` / `inboxId` correlation fields as span attributes.
+- Go counterpart in `egress-shared/natsbus/` — same shape, same span names, so Tempo treats TS and Go halves of a flow as one trace.
+- The smoke ping (`mini-infra.system.ping`) gains an end-to-end test: client request triggers `pingSelf()`, the resulting trace shows two spans (the client request and the loopback responder) joined by parent/child.
+
+Done when: a `POST /api/egress-firewall/...` route in the server triggers an `envUpsert` over NATS, and Tempo shows a single trace with: HTTP server span → NatsBus PRODUCER span → fw-agent CONSUMER span → fw-agent's local work spans → reply CONSUMER span — all stitched together.
+
+### Phase 3 — Auto-instrumentation across the server
+
+**Goal:** the boring pile of obvious things — Express, Prisma, Socket.IO, outbound HTTP — become spans without per-call-site work.
+
+Deliverables:
+- `@opentelemetry/sdk-node` registered as the first import in [server/src/server.ts](../../../server/src/server.ts), gated behind `OTEL_EXPORTER_OTLP_ENDPOINT` so an unset env var disables tracing entirely (zero overhead in tests).
+- Auto-instrumentations for `http`, `express`, `pg`, `socket.io`, `undici`. Each has a small allow-list of attributes to keep cardinality sane.
+- `@opentelemetry/instrumentation-pino` so Pino lines carry `trace_id` / `span_id`. `getLogger()`'s contract doesn't change.
+- Manual spans wrapped around `DockerService.getInstance()` public methods — Docker calls dominate latency on some routes and `dockerode` has no first-party instrumentation.
+- Sampling: head-based, parent-respecting, default 100% in dev (we want every trace), to be tuned in prod.
+
+Done when: opening a stack-detail page in the UI produces one trace per request, every database query is a child span, every outbound HTTP call (Cloudflare, Azure, Vault) is a span, and every server log line for that request carries the same `trace_id`.
+
+### Phase 4 — Sidecars
+
+**Goal:** instrument the components that aren't the main server. Phase 2 gave us NATS-side traces from Go sidecars; this phase fills in the local work inside each.
+
+Deliverables:
+- `agent-sidecar/` — Node OTel SDK boot in [agent-sidecar/src/index.ts](../../../agent-sidecar/src/index.ts), Express auto-instrumentation, Pino instrumentation. The agent's tool calls become child spans of the user request's trace.
+- `update-sidecar/` — minimal: a single `update.run` span around `main()` in [update-sidecar/src/index.ts](../../../update-sidecar/src/index.ts). Limited value (one-shot, runs in seconds) but lets us see the self-update window inside a trace alongside the rest of the system. Optional; defer to a follow-up if Phase 5 of the NATS migration hasn't landed yet, since the cleaner integration is "self-update progress over NATS, traced end-to-end".
+- `egress-fw-agent/` — Go OTel SDK boot in [egress-fw-agent/cmd/main.go](../../../egress-fw-agent/cmd/main.go). NATS context propagation already in from Phase 2; this phase adds local spans for nftables apply, NFLOG batch flush, and the heartbeat publisher.
+- `egress-gateway/` — same shape in [egress-gateway/cmd/main.go](../../../egress-gateway/cmd/main.go). Local spans for the proxy decision path; NFLOG-equivalent decisions are already a JetStream stream, so the existing PRODUCER span from Phase 2 covers the egress hop.
+
+Done when: a UI action that fans out to the gateway shows a trace with spans inside the Go process, not just at the NATS boundary.
+
+### Phase 5 — Service map, dashboards, and correlation polish
+
+**Goal:** turn the raw spans into the "see all interactions between components" view the planning conversation started with.
+
+Deliverables:
+- Tempo `metrics-generator` enabled in `tempo.yaml`, emitting `traces_service_graph_*` and `traces_spanmetrics_*` to Prometheus.
+- A Grafana dashboard committed in `server/templates/monitoring/grafana/dashboards/` with:
+  - A Node Graph panel rendering the service map (filterable by environment and time window).
+  - A trace search panel (TraceQL).
+  - Per-service latency / error / request-rate panels (RED method) sourced from `traces_spanmetrics_*`.
+- Trace ↔ logs correlation: data-source-level config so clicking a span jumps to the matching Loki query (`{component=~"...", trace_id="<id>"}`).
+- Trace ↔ metrics correlation: exemplars from Prometheus dashboards link back to traces.
+- A short [docs/architecture/internal-messaging.md §7](../../architecture/internal-messaging.md#7-observability--how-nats-traffic-reaches-the-ui) update — the Observability section grows a "tracing" subsection that points readers at Grafana.
+
+Done when: opening Grafana, picking a time window, and looking at the service-graph panel shows every Mini Infra component with edges representing real cross-component traffic. Clicking an edge drills into traces for that interaction.
+
+### Phase 6 — App-level metrics (optional, deferred)
+
+**Goal:** add custom Prometheus metrics for things the spans summarise but are easier to consume as a counter / histogram (`mini_infra_nats_publish_total`, `mini_infra_stack_apply_duration_seconds`, etc.). Out of scope for this plan; pre-listed here only so it doesn't get folded back into Phase 5 by accident.
+
+## 7. Risks & open questions
+
+- **OTel SDK boot ordering.** The Node SDK must initialise *before* anything that monkey-patches `http`, `express`, etc. Today [server/src/server.ts](../../../server/src/server.ts) imports `getLogger` and a few services at the top of the file; Phase 1 must move OTel setup to position 1, ahead of every other import. A small ESM-side-effect file (`server/src/lib/otel.ts`) imported first solves it cleanly.
+- **Pino log volume in Loki when traces are also live.** Loki ingests every container's stdout via Alloy already; adding `trace_id` to every line doesn't increase line count, but makes correlation queries practical. No change in cost expected, but worth re-checking after Phase 3.
+- **NATS header behaviour change.** Today messages have no `Headers`; Phase 2 starts setting `traceparent` on every publish. Subscribers that read `msg.headers === undefined` and branch on it would break — a grep over both TS and Go confirms no such code today, but Phase 2's PR description should call this out.
+- **JetStream historical replay.** When the bus reconnects and JetStream replays old messages, those messages won't have headers. Extraction must tolerate missing headers (start a root span, log a debug line). The plan: never assume `traceparent` is present.
+- **Tempo storage budget.** Default Tempo config writes blocks to a local volume. With 100% sampling in dev that's fine; for prod we'll need to revisit (sampler tuning + retention policy on the metrics-generator output). Defer to Phase 5.
+- **`pg-az-backup` left out.** Sometimes a backup is the slow piece on the timeline; we won't see it in traces. Document in the plan; reconsider if it becomes load-bearing after Phase 4 of the NATS migration moves backup status onto the bus (then a backup is just another NATS-traced operation).
+- **Grafana auth.** Built-in stacks shipped today don't have user auth. We should not expose Grafana to the public network without putting it behind the existing auth-proxy or basic-auth-on-HAProxy. Phase 1 ships it on the worktree-local port only; production exposure is a separate decision.
+- **Cross-process clock skew.** Spans crossing into Go containers running on a separate `egress-fw-agent` Linux namespace can render with negative durations if the host clocks drift. NTP is on by default; flag if we ever see weird waterfalls.
+
+## 8. Linear tracking
+
+Phase issues will be created under a new "OTel Tracing" project on the Altitude Devops team and linked here once filed. Phase 1 blocks every later phase; Phase 4 also blocks on Phase 2 (Go side context propagation must exist before sidecar local spans are useful).
+
+- ALT-_TBD_ — Phase 1: Tempo + OTel Collector + Grafana in monitoring stack
+- ALT-_TBD_ — Phase 2: `NatsBus` context propagation (TS + Go)
+- ALT-_TBD_ — Phase 3: Server auto-instrumentation (Express, Prisma, Socket.IO, outbound HTTP, Pino)
+- ALT-_TBD_ — Phase 4: Sidecar instrumentation (`agent-sidecar`, `update-sidecar`, `egress-fw-agent`, `egress-gateway`)
+- ALT-_TBD_ — Phase 5: Service map, Grafana dashboards, trace ↔ logs ↔ metrics correlation
+- ALT-_TBD_ — Phase 6 (deferred): App-level Prometheus metrics


### PR DESCRIPTION
## Summary

Three independent docs/tooling additions, bundled together because they came out of the same conversation. None of them ship code — all docs and skills.

- **`docs/architecture/internal-messaging.md`** — bird's-eye view of how server↔sidecar comms are organised after Phases 1–3 of the [Internal NATS Messaging Migration](https://linear.app/altitude-devops/project/internal-nats-messaging-migration-e76f6def15e8/overview). Covers the two real-time fabrics (Socket.IO vs NATS), the `NatsBus` contract (TS + Go), the `mini-infra.>` namespace and current subject inventory, per-pair flows for the egress fw-agent and gateway, bootstrap and credential ordering, observability, and a recipe for adding a new system-internal channel. Cross-linked from `ARCHITECTURE.md` "Cross-cutting concerns".
- **`docs/planning/not-shipped/observability-otel-tracing-plan.md`** — phased plan to add Grafana Tempo to the existing monitoring stack and instrument every server/sidecar component with OpenTelemetry tracing. Six phases (Tempo + collector + Grafana, NatsBus context propagation, server auto-instrumentation, sidecars, service map / dashboards, optional app-level metrics). `ALT-_TBD_` placeholders ready to be populated by `plan-to-linear`.
- **`.claude/skills/execute-next-task/SKILL.md`** — picks the next unblocked Todo from the Altitude Devops team in Linear, reads the parent project's linked plan doc, plans against the phase's deliverables, executes through to a PR, and transitions Linear states.
- **`.claude/skills/plan-to-linear/SKILL.md`** — companion: seeds Linear from a phased markdown plan doc. Each issue carries the phase's Goal/Deliverables/Done-when verbatim, plus per-component `CLAUDE.md` and `ARCHITECTURE.md` pointers based on which top-level dirs the phase touches. Rewrites §8 of the plan doc to replace `ALT-_TBD_` with real issue IDs.

Phase 4 and 5 sections in the internal-messaging doc are intentional stubs to fill in as those phases land. The OTel plan is unscaffolded in Linear (placeholders); `plan-to-linear` will populate it on first use.

## Test plan

- [ ] Skim `docs/architecture/internal-messaging.md` end-to-end and confirm the live subject inventory, JetStream/KV table, and per-pair flow diagrams match the actual code.
- [ ] Confirm the `ARCHITECTURE.md` cross-cutting paragraph reads naturally next to the Socket.IO entry.
- [ ] Confirm the Linear project link in §8 of the NATS plan doc resolves correctly.
- [ ] Skim the OTel tracing plan; sanity-check the §6 phasing and the §7 risks list before scaffolding it into Linear.
- [ ] Read both skill SKILL.md files; confirm the conventions they expect (`Plan:` line, `### Phase N` headings, `ALT-_TBD_` placeholders, `Closes ALT-NN` in PR body) match how we want to operate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)