### PR TITLE
skills(linear): retrospective comment, read-only plan doc, combined Plan: anchor

### DIFF
--- a/.claude/skills/execute-next-task/SKILL.md
+++ b/.claude/skills/execute-next-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: execute-next-task
-description: Execution agent. Picks the next unblocked Todo issue from the user's Linear team (Altitude Devops), reads the ticket (which was pre-populated by `plan-to-linear` with Goal/Deliverables/Done-when, per-component CLAUDE.md and ARCHITECTURE.md pointers, and phase-specific smoke tests), runs `pnpm install`, kicks off `pnpm worktree-env start` in the background to warm the dev env, then executes the work end-to-end — code changes, build/lint/unit tests, live smoke against the dev env, PR with `Closes ALT-NN`, and Linear state transitions. **Does not produce an ExitPlanMode plan** — the planning was already done when the ticket was created. Use this skill whenever the user says "execute next task", "what's next in linear", "do the next phase", "pick up the next todo", "work on the next thing", "what should I do next", or any equivalent request to advance through a Linear-tracked migration. Do NOT trigger for one-off non-Linear tasks or for "what should I work on?" without an obvious Linear context.
+description: Execution agent. Picks the next unblocked Todo issue from the user's Linear team (Altitude Devops), reads the ticket (which was pre-populated by `plan-to-linear` with Goal/Deliverables/Done-when, per-component CLAUDE.md and ARCHITECTURE.md pointers, and phase-specific smoke tests), runs `pnpm install`, kicks off `pnpm worktree-env start` in the background to warm the dev env, then executes the work end-to-end — code changes, build/lint/unit tests, live smoke against the dev env, PR with `Closes ALT-NN`, and Linear state transitions ending in In Review with a structured handoff comment (Known issues / Work deferred / Blockers / Deviations from the plan). **Does not produce an ExitPlanMode plan** — planning happened when the ticket was created. **Does not edit the plan doc** — drift goes only in the handoff comment for a re-integration agent to fold back later. Use this skill whenever the user says "execute next task", "what's next in linear", "do the next phase", "pick up the next todo", "work on the next thing", "what should I do next", or any equivalent request to advance through a Linear-tracked migration. Do NOT trigger for one-off non-Linear tasks or for "what should I work on?" without an obvious Linear context.
 ---
 
 # Execute Next Task
@@ -64,8 +64,15 @@ The Linear ticket is your contract. Read it end to end and treat it as authorita
    - **Relevant docs** — the per-component CLAUDE.md / ARCHITECTURE.md pointers, plus any topic-specific architecture docs.
    - **Smoke tests** — what to run at the end to validate.
    - **Conventions** — commit/PR format, area tag, deferrals.
-2. **Fetch the parent project** (`get_project`) and confirm the `Plan:` line resolves to the same plan doc the ticket cites. If they disagree, **stop** — that's a corruption signal.
-3. **Read the plan doc's matching `### Phase N` section** anyway. The ticket has the same content but the plan doc is the source of truth — if they've drifted, side with the doc and surface the drift in your final commit.
+2. **Fetch the parent project** (`get_project`) and find the **`Plan:` line** in its description. The skill accepts three forms:
+   - `Plan: [docs/planning/.../<slug>-plan.md](https://github.com/.../blob/main/...)` — combined (preferred; what `plan-to-linear` writes today)
+   - `Plan: docs/planning/.../<slug>-plan.md` — bare path (legacy fallback)
+   - `**Plan doc:** [docs/planning/.../<slug>-plan.md](https://...)` — also accepted as a legacy fallback for projects authored before the convention firmed up
+
+   Extract the **relative path** in all cases. If the project description has none of these, **stop** with a clear "no `Plan:` line in project description" message.
+
+   Confirm the path resolves to the same plan doc the ticket cites in its **Source** section. If they disagree, **stop** — that's a corruption signal.
+3. **Read the plan doc's matching `### Phase N` section.** The ticket has the same content but the plan doc is the source of truth — if they've drifted, side with the doc and capture the drift in your handoff comment (Phase 10).
 4. **Read every doc the ticket lists under "Relevant docs."** Don't skim — these were chosen because they're the conventions you must follow. The ticket points at them so you don't have to guess what's relevant.
 5. **Read prior art** — `git log --oneline -20 main` plus any commits matching the project's area tag from the ticket. Shipped phases tell you the commit subject style and the rough size of a phase PR.
 
@@ -197,15 +204,7 @@ If everything passes, move on. If anything fails, **fix it before continuing** �
 
 ---
 
-## Phase 9 — Update the plan doc if reality drifted
-
-If your implementation diverged meaningfully from the plan doc — extra deliverable shipped, planned deliverable deferred, an unforeseen risk discovered — edit the plan doc in the same PR to reflect what actually happened. The plan doc is the lasting artefact; the issue closes when the PR merges.
-
-If you didn't drift, leave the doc alone.
-
----
-
-## Phase 10 — Commit and open the PR
+## Phase 9 — Commit and open the PR
 
 Match the most recent shipped phase's commit format from the same project. Typical:
 
@@ -233,9 +232,9 @@ Push the branch, then `gh pr create`. PR title matches the commit title. PR body
 
 ---
 
-## Phase 11 — Mark the issue In Review and leave a structured handoff comment
+## Phase 10 — Mark the issue In Review and leave a structured handoff comment
 
-Move the issue to `In Review` (canonical state name from Phase 1's status fetch) and post a single structured comment summarising the run. The comment is the handoff to the human reviewer — it captures everything the PR diff doesn't show.
+Move the issue to `In Review` (canonical state name from Phase 1's status fetch) and post a single structured comment summarising the run. The comment is the handoff to the human reviewer — and to the future re-integration agent that will fold drift back into the plan doc — so it captures everything the PR diff doesn't show. **The plan doc itself is read-only for this skill** (see hard rules); drift goes here.
 
 ```
 save_issue(id: <issue-id>, state: "In Review")
@@ -257,7 +256,7 @@ Use this template verbatim. Omit any section that genuinely has nothing to repor
 <things that stopped you finishing some part of the work — missing credentials, an upstream bug in another component, a dependency on infrastructure that isn't there. Empty if nothing blocked you.>
 
 ## Deviations from the plan
-<places where what you shipped diverges from the plan doc's Deliverables or Done-when. For each: what the plan said, what you shipped, why. If you also edited the plan doc to reflect this in Phase 9, note that.>
+<places where what you shipped diverges from the plan doc's Deliverables or Done-when. For each: what the plan said, what you shipped, why. The plan doc itself stays untouched — a re-integration agent will fold these notes back into the doc later.>
 ```
 
 Then report the PR URL to the user wrapped in a `<pr-created>` tag on its own line so any UI integrations can render a card.
@@ -271,6 +270,7 @@ The point of this comment is that the next person (human or agent) opens the Lin
 These are non-negotiable. If you find yourself wanting to break one, stop and ask the user instead.
 
 - **Never produce an ExitPlanMode block.** This is an execution agent. Planning happened in `plan-to-linear` when the ticket was created.
+- **Never edit the plan doc.** The plan doc under `docs/planning/` is read-only for this skill. If your implementation drifts from the plan, capture the drift in the handoff comment (Phase 10 — Deviations from the plan section). A separate re-integration agent will fold those notes back into the plan doc; don't pre-empt that.
 - **Never merge PRs** — even if checks pass and the PR looks great. Merging is a human decision.
 - **Never create new Linear issues** or split phases on the fly. If scope is too big for one phase, stop and report — splitting is a planning decision, not an execution decision.
 - **Never override plan-doc conventions.** If the plan section says "Defer X to follow-up", that X is deferred. Don't quietly include it because it seemed easy.
@@ -301,6 +301,6 @@ These are non-negotiable. If you find yourself wanting to break one, stop and as
 >
 > Skill: "Implementing Phase 4 — adding `mini-infra.backup.run` request handler and JetStream `BackupHistory` stream. Touching `server/src/services/backup/backup-executor.ts` first, then `server/src/services/nats/payload-schemas.ts`, then the boot sequence."
 >
-> *Implements. Runs build/lint/unit tests. Backgrounded env is up by now — runs the ticket's smoke test (publish a test backup-run request, confirm the consumer side fires). Drift check on plan doc — none.*
+> *Implements. Runs build/lint/unit tests. Backgrounded env is up by now — runs the ticket's smoke test (publish a test backup-run request, confirm the consumer side fires).*
 >
-> *Commits with `feat(nats): pg-az-backup progress + result events (Phase 4, ALT-29)`. Opens PR with `Closes ALT-29` in the body. Marks ALT-29 In Review. Posts the handoff comment: PR URL, plus a Deviations section noting that the optional retry-on-transient-failure deliverable was deferred to a follow-up issue per the plan doc's wording. Reports the PR URL.*
+> *Commits with `feat(nats): pg-az-backup progress + result events (Phase 4, ALT-29)`. Opens PR with `Closes ALT-29` in the body. Marks ALT-29 In Review. Posts the handoff comment: PR URL, plus a Deviations section noting that the optional retry-on-transient-failure deliverable was deferred to a follow-up issue per the plan doc's wording — the plan doc itself is left untouched, the re-integration agent will fold this back later. Reports the PR URL.*

--- a/.claude/skills/plan-to-linear/SKILL.md
+++ b/.claude/skills/plan-to-linear/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan-to-linear
-description: Reads a phased markdown planning document under `docs/planning/` and populates Linear with a matching project plus one issue per phase. Each issue carries the phase's Goal / Deliverables / Done when, the relevant per-component CLAUDE.md and ARCHITECTURE.md pointers (server vs client vs lib vs go sidecars), a Workflow section (worktree pre-flight, `pnpm install`, background `pnpm worktree-env start`), phase-specific smoke-test recipes derived from which directories the phase touches, prior-art commit references, and the commit/PR conventions — enough context that the `execute-next-task` skill can execute the issue without re-planning the high-level scope. Also rewrites the plan doc's Linear-tracking section to replace `ALT-_TBD_` placeholders with the real issue IDs. Use this skill whenever the user says "populate linear from plan", "create the linear tickets", "plan to linear", "scaffold linear from this plan", "turn this plan into linear issues", or any equivalent request to seed Linear from an existing markdown plan. Do NOT trigger for one-off issue creation, for plans that aren't phased, or when the user asks to *modify* an existing project's issues.
+description: Reads a phased markdown planning document under `docs/planning/` and populates Linear with a matching project plus one issue per phase. Each issue carries the phase's Goal / Deliverables / Done when, the relevant per-component CLAUDE.md and ARCHITECTURE.md pointers (server vs client vs lib vs go sidecars), a Workflow section (worktree pre-flight, `pnpm install`, background `pnpm worktree-env start`), phase-specific smoke-test recipes derived from which directories the phase touches, prior-art commit references, and the commit/PR conventions — enough context that the `execute-next-task` skill can execute the issue without re-planning the high-level scope. Rewrites the plan doc's Linear-tracking section to replace `ALT-_TBD_` placeholders with the real issue IDs. Finally posts a session retrospective comment on Phase 1's issue capturing meta-feedback about the run itself (ambiguities resolved, workflow friction, suggestions) — this is the feedback loop that improves the skill and the plan-doc conventions over time. Use this skill whenever the user says "populate linear from plan", "create the linear tickets", "plan to linear", "scaffold linear from this plan", "turn this plan into linear issues", or any equivalent request to seed Linear from an existing markdown plan. Do NOT trigger for one-off issue creation, for plans that aren't phased, or when the user asks to *modify* an existing project's issues.
 ---
 
 # Plan to Linear
@@ -175,17 +175,22 @@ Don't proceed without an explicit yes. Never guess "looks good, going" — the s
 
 ## Phase 7 — Create the project
 
-Create the Linear project with the name from H1 and a description that **starts** with the `Plan:` line — this is the anchor `execute-next-task` looks for:
+Create the Linear project with the name from H1 and a description that **starts** with the `Plan:` line. This serves two purposes in one line: machine-readable anchor for `execute-next-task` and a clickable link for humans browsing the project in Linear's UI.
 
 ```
-Plan: <relative-path-to-plan-doc.md>
+Plan: [<relative-path-to-plan-doc.md>](<full-https-url-to-plan-doc-on-main>)
 
 <§1 Background paragraph 1, copied verbatim>
 ```
 
-The relative path is from the repo root, e.g. `docs/planning/not-shipped/observability-otel-tracing-plan.md`. Don't use `./`-prefixed paths or absolute paths.
+Examples:
+- `Plan: [docs/planning/not-shipped/observability-otel-tracing-plan.md](https://github.com/<owner>/<repo>/blob/main/docs/planning/not-shipped/observability-otel-tracing-plan.md)`
 
-Capture the project's URL and ID from the response — you'll need them for Phase 9.
+Derive the GitHub URL by reading `git remote get-url origin` (e.g. `https://github.com/mrgeoffrich/mini-infra`) and appending `/blob/main/<relative-path>`. Don't use `./`-prefixed paths or absolute filesystem paths.
+
+The bare-path variant (`Plan: docs/planning/...md`) is also accepted by `execute-next-task` as a legacy fallback for projects authored before this convention firmed up — but new projects use the combined format.
+
+Capture the project's URL and ID from the response — you'll need them for Phase 9 and the retrospective in Phase 11.
 
 ---
 
@@ -301,7 +306,51 @@ Do **not** commit. Leave the diff staged so the user can review and commit it th
 
 ---
 
-## Phase 11 — Report
+## Phase 11 — Session retrospective
+
+Leave a single comment on **Phase 1's issue** capturing meta-feedback about the run: ambiguities you had to resolve, friction in the skill or the conventions, and concrete suggestions. This is the feedback loop — read accumulated retrospectives to spot patterns and improve the skill (or the plan-doc convention) over time.
+
+**Crucially this is *meta*** — about how the skill ran, not about the *contents* of the tickets. If you want to flag something about a phase's deliverables, that belongs in the ticket itself or in a code-review pass on the eventual PR.
+
+Use this template. Omit any section that genuinely has nothing to report — don't pad with "N/A" or invent observations. If the entire run was uneventful, the comment is one line: "No notable friction this run."
+
+```markdown
+### Session notes — `plan-to-linear` retrospective
+
+*Meta: about how the skill ran, not the work itself. Drop a code-review pass on the ticket content separately if you want to comment on deliverables.*
+
+**Ambiguities resolved**
+- <plan-doc § / file path>: <what was unclear> → <judgment call I made>
+- ...
+
+**Workflow friction**
+- <observation about the skill, the MCP roundtrips, the plan-doc shape, or the codebase context the skill relied on>
+- ...
+
+**Suggestions** *(tag with `skill:`, `convention:`, or `project:` so they're greppable)*
+- skill: <improvement to the skill prompt or its phases>
+- convention: <improvement to the plan-doc / Linear conventions>
+- project: <improvement to this specific project's setup>
+- ...
+
+**What worked well** *(optional, short bullets)*
+- ...
+```
+
+Examples of *good* meta-feedback (concrete, actionable, about the loop):
+- `convention: Phase 4 had no "Migration shape" subsection — copying it forward to the ticket left a thin Goal/Deliverables-only body. Either the convention should require it for non-trivial phases or the skill should infer it.`
+- `skill: When the plan doc's §8 list and the §6 phase headings disagree on count, the skill stops with "out of sync" but doesn't surface the diff. Print both lists side by side.`
+- `project: No prior commits matching the area tag yet — area-tag detection fell back to "no prior commits" branch. Worked, but a hint in the plan doc would have been faster than scanning git log.`
+
+Examples of *bad* meta-feedback (about the work, not the loop) — don't include these:
+- ❌ `Phase 4 deliverables look thin. Should add a deliverable for log redaction.` — that's a code review, not retrospective.
+- ❌ `The plan is good and the phasing makes sense.` — content compliment, not workflow.
+
+Echo the comment to the user in the chat when reporting (Phase 12) so they don't have to switch contexts to read it.
+
+---
+
+## Phase 12 — Report
 
 Print a summary:
 
@@ -314,6 +363,7 @@ Print a summary:
    - <ALT-NN> Phase M: <title>           [Backlog]
 ✓ Set blocked-by relationships per plan ordering.
 ✓ Updated <plan-doc-path> §<8> with real issue IDs (uncommitted).
+✓ Posted session retrospective to <Phase 1 ALT-NN URL>.
 
 Next step: review the plan-doc diff, commit it, then run `execute-next-task` when you're ready to start Phase 1.
 ```
@@ -323,7 +373,9 @@ Next step: review the plan-doc diff, commit it, then run `execute-next-task` whe
 ## Hard rules
 
 - **Never merge into an existing project.** If a project with the same name already exists, stop. Same-named projects are almost certainly the same feature — manual reconciliation only.
-- **Never write a pre-baked implementation plan into the issue description.** Issue descriptions carry *context* — Goal, Deliverables, Done when, doc pointers — not file-by-file change lists. Implementation plans live in the executor's ExitPlanMode at execution time, against current code.
+- **Never write a pre-baked implementation plan into the issue description.** Issue descriptions carry *context* — Goal, Deliverables, Done when, doc pointers — not file-by-file change lists. The executor produces its concrete implementation against current code at execution time.
+- **Never put work-content critique in the retrospective comment.** Phase 11 is meta-only — about how the skill ran. Comments about whether deliverables are right, whether the plan is good, or whether the phasing makes sense belong in a code-review pass on the eventual PR, not as plan-to-linear retrospective.
+- **Never fabricate retrospective content.** If the run was clean, the comment is "No notable friction this run." Padding with invented friction defeats the feedback loop.
 - **Never invent docs.** If `egress-shared/CLAUDE.md` doesn't exist, don't link it. Verify each attached doc.
 - **Never guess at convention.** If §8 has no placeholder list, the H1 is missing, or no `### Phase N` headings parse — stop and report. The conventions exist for a reason.
 - **Never commit the plan-doc edit.** Leave it staged. The user owns the commit.


### PR DESCRIPTION
## Summary

Three follow-up refinements to the `plan-to-linear` and `execute-next-task` skills introduced in #342, validated by populating ALT-29 / ALT-30 in Linear and updating the Internal NATS Messaging Migration project description to match the convention.

- **`plan-to-linear` — new Phase 11 (Session retrospective).** After populating Linear and updating the plan doc's §8, the skill leaves a single meta-comment on Phase 1's issue capturing ambiguities resolved, workflow friction, and concrete suggestions tagged `skill:` / `convention:` / `project:`. Strict rule: meta only — about how the skill ran, not the work content. If nothing notable happened, the comment is one line: "No notable friction this run." Don't fabricate.
- **`execute-next-task` — plan doc is now read-only.** Removed the Phase 9 step that edited the plan doc when implementation drifted. Drift now goes only into the handoff comment's `Deviations from the plan` section. A separate re-integration agent (not built yet) will read those comments and fold them back into the doc out-of-band. Cleaner separation: execution writes Linear, planning writes the markdown.
- **Combined `Plan: [path](url)` project-description anchor.** `plan-to-linear` now writes the Linear project description with `Plan: [<relative-path>](<https://github.com/...>)` as the first line — machine-parseable for `execute-next-task`, clickable for humans. `execute-next-task`'s parser accepts the combined form, the bare `Plan: <path>`, and the legacy `**Plan doc:**` shape.

Also: stale ExitPlanMode reference removed from `plan-to-linear`'s hard rules; `execute-next-task` worked example updated to stop mentioning a plan-doc drift check.

## Test plan

- [ ] Read both SKILL.md files end-to-end and confirm the renumbering is consistent (plan-to-linear has 12 phases now; execute-next-task has 10).
- [ ] Confirm the retrospective template's "good vs bad meta-feedback" examples make the meta-only constraint clear at a glance.
- [ ] Confirm `execute-next-task`'s Phase 3 parser description is unambiguous about which `Plan:` shapes are accepted.
- [ ] On the next live run of either skill, sanity-check that the new sections fire as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)