### PR TITLE
skills(execute-next-task): per-run retrospective via session-retrospective skill

### DIFF
--- a/.claude/skills/execute-next-task/SKILL.md
+++ b/.claude/skills/execute-next-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: execute-next-task
-description: Execution agent. Assumes you start at the main checkout root on `main` with a clean tree. Picks the next unblocked Todo issue from the user's Linear team (Altitude Devops), reads the ticket (which was pre-populated by `plan-to-linear` with Goal/Deliverables/Done-when, per-component CLAUDE.md and ARCHITECTURE.md pointers, and phase-specific smoke tests), runs `git pull --ff-only origin main`, creates a fresh worktree at `.claude/worktrees/alt-NN` on branch `claude/alt-NN`, runs `pnpm install`, kicks off `pnpm worktree-env start --description "..."` in the background to warm the dev env, then executes the work end-to-end inside the new worktree — code changes, build/lint/unit tests, live smoke against the dev env, PR with `Closes ALT-NN`, and Linear state transitions ending in In Review with a structured handoff comment (Known issues / Work deferred / Blockers / Deviations from the plan). On the success path it then **cleans up the worktree** (`pnpm worktree-env delete <slug>` + `git worktree remove`) so the VM/distro slot is freed; on any failure the worktree is left alive for investigation. **Does not produce an ExitPlanMode plan** — planning happened when the ticket was created. **Does not edit the plan doc** — drift goes only in the handoff comment for a re-integration agent to fold back later. Use this skill whenever the user says "execute next task", "what's next in linear", "do the next phase", "pick up the next todo", "work on the next thing", "what should I do next", or any equivalent request to advance through a Linear-tracked migration. Do NOT trigger for one-off non-Linear tasks or for "what should I work on?" without an obvious Linear context.
+description: Execution agent. Assumes you start at the main checkout root on `main` with a clean tree. Picks the next unblocked Todo issue from the user's Linear team (Altitude Devops), reads the ticket (which was pre-populated by `plan-to-linear` with Goal/Deliverables/Done-when, per-component CLAUDE.md and ARCHITECTURE.md pointers, and phase-specific smoke tests), runs `git pull --ff-only origin main`, creates a fresh worktree at `.claude/worktrees/alt-NN` on branch `claude/alt-NN`, runs `pnpm install`, kicks off `pnpm worktree-env start --description "..."` in the background to warm the dev env, then executes the work end-to-end inside the new worktree — code changes, build/lint/unit tests, live smoke against the dev env, PR with `Closes ALT-NN`, and Linear state transitions ending in In Review with a structured handoff comment (Known issues / Work deferred / Blockers / Deviations from the plan). On the success path it then spawns a Sonnet subagent that runs the `session-retrospective` skill (passing the parent session ID and the Linear issue ID), which creates a new "retro"-tagged Linear issue in the Backlog referencing the original, and **cleans up the worktree** (`pnpm worktree-env delete <slug>` + `git worktree remove`) so the VM/distro slot is freed; on any failure the worktree is left alive for investigation. **Does not produce an ExitPlanMode plan** — planning happened when the ticket was created. **Does not edit the plan doc** — drift goes only in the handoff comment for a re-integration agent to fold back later. Use this skill whenever the user says "execute next task", "what's next in linear", "do the next phase", "pick up the next todo", "work on the next thing", "what should I do next", or any equivalent request to advance through a Linear-tracked migration. Do NOT trigger for one-off non-Linear tasks or for "what should I work on?" without an obvious Linear context.
 ---
 
 # Execute Next Task
@@ -296,9 +296,59 @@ The point of this comment is that the next person (human or agent) opens the Lin
 
 ---
 
-## Phase 12 — Clean up the worktree (success path only)
+## Phase 12 — Post a session retrospective to Linear (success path only)
 
-**Only run this if every previous phase succeeded** — build/lint/unit passed, smoke passed, the PR is open, the issue is In Review, the handoff comment posted. If anything failed or stopped earlier, **skip this phase entirely** and leave the worktree alive so the user can investigate.
+After the handoff comment is posted but before worktree cleanup, kick off a session retrospective. The `session-retrospective` skill creates a **new** "retro"-tagged Linear issue in the Backlog, linked back to the issue you just shipped — so retros accumulate as their own searchable list with their own lifecycle, separate from the contract-style handoff comment on the original ticket. Future runs of this skill (and the user, scanning retros over time) can mine that trail for lessons.
+
+If anything earlier in the run failed and the skill stopped, this phase doesn't fire — there's no successful run to retrospect on, and the human will be debugging the failure directly. Only the success path reaches Phase 12.
+
+### 12.1 Capture the parent session ID
+
+The retrospective skill takes the session ID as an explicit parameter rather than reading `$CLAUDE_SESSION_ID`, because it's invoked from a subagent and a subagent's `$CLAUDE_SESSION_ID` points at its own (effectively empty) session, not the parent's. Capture your own session ID here so you can pass it through:
+
+```bash
+echo "$CLAUDE_SESSION_ID"
+```
+
+Hold onto the value alongside the picked Linear issue ID (`ALT-NN` from Phase 2). These two are the parameters Phase 12.2 passes to the subagent.
+
+### 12.2 Spawn a Sonnet subagent that invokes the skill
+
+Use the `Agent` tool with `subagent_type: general-purpose` and `model: sonnet`. Sonnet is the right tier — by this point the parent context is huge (full task history, code reads, tool results), and Opus on top of that just to summarize JSONL is wasteful. Sonnet handles the analysis comfortably, and the heavy lifting (JSONL reads, MCP calls) stays scoped to the subagent so it doesn't bloat the parent thread. Only the new retro issue's URL flows back across the subagent boundary.
+
+Prompt the subagent (substitute the captured session ID and the Linear issue ID):
+
+```
+Invoke the session-retrospective skill with these parameters:
+
+  --session-id <PARENT_SESSION_ID>     (the parent's session ID captured in Phase 12.1)
+  --linear-issue <ALT-NN>              (the Linear issue this run was working on)
+
+The skill will:
+  1. Run scripts/get-session.sh <PARENT_SESSION_ID> to fetch the parent JSONL.
+  2. Analyze it and generate retrospective markdown per the skill's Output Format.
+  3. Create a NEW Linear issue in the Altitude Devops team's Backlog, tagged "retro",
+     titled "Retro: <ALT-NN> — <original-issue-title>", with a Source link back to
+     <ALT-NN> at the top of the description.
+
+Return ONLY the new retro issue's URL. Do NOT return the markdown body.
+```
+
+The skill itself owns the Linear posting (team / state / label resolution, `save_issue`) — the parent doesn't need to do anything else with the result.
+
+### 12.3 Relay the retro issue URL in the run report
+
+When the subagent returns the URL, append it to your final run report so the user can navigate to it directly. The structured handoff comment (Phase 11) and the retro issue (Phase 12) are deliberately separate Linear records — the handoff is the contract for the human reviewer of the PR; the retro is meta-feedback about the run itself, with a different audience and shelf-life.
+
+### 12.4 Failure handling
+
+The retrospective is a feedback loop, not a gate. If the subagent fails — script can't find the session, the `retro` label doesn't exist in Linear, the subagent returns garbage instead of a URL, the Linear MCP errors — **don't block cleanup**. Note the failure in the run report and continue to Phase 13. A broken or hollow retro issue is worse than no retro issue.
+
+---
+
+## Phase 13 — Clean up the worktree (success path only)
+
+**Only run this if every previous phase succeeded** — build/lint/unit passed, smoke passed, the PR is open, the issue is In Review, the handoff comment posted. If anything failed or stopped earlier, **skip this phase entirely** and leave the worktree alive so the user can investigate. The retrospective phase (12) is best-effort and doesn't gate this — a failed retrospective still counts as a successful run.
 
 The worktree's purpose is to host the build + smoke for this phase. Once the PR is open and in review, the work that needs the dev env is over — review happens in GitHub on the diff, not in the worktree. So we tear it down to free the VM/distro slot and keep `pnpm worktree-env list` tidy.
 
@@ -326,7 +376,7 @@ Append a final line to the run report:
 ✓ Cleaned up worktree .claude/worktrees/<slug> and the dev-env VM.
 ```
 
-**Macos users** who run the bulk `pnpm worktree-env cleanup` command (or installed the hourly launchd agent) can rely on that to clean merged-PR worktrees on a schedule and skip Phase 12 by interrupting the skill before it runs. For Windows / WSL2 users without an equivalent agent, this phase is the cleanup mechanism.
+**Macos users** who run the bulk `pnpm worktree-env cleanup` command (or installed the hourly launchd agent) can rely on that to clean merged-PR worktrees on a schedule and skip Phase 13 by interrupting the skill before it runs. For Windows / WSL2 users without an equivalent agent, this phase is the cleanup mechanism.
 
 ---
 
@@ -335,7 +385,7 @@ Append a final line to the run report:
 These are non-negotiable. If you find yourself wanting to break one, stop and ask the user instead.
 
 - **Never produce an ExitPlanMode block.** This is an execution agent. Planning happened in `plan-to-linear` when the ticket was created.
-- **Never run Phase 12 (cleanup) on a failure path.** If smoke failed, the PR didn't open, the In Review transition didn't go through, or you stopped to ask the user mid-phase — leave the worktree alive. The user needs it to investigate. Cleanup is the *reward* for a fully successful run.
+- **Never run Phase 13 (cleanup) on a failure path.** If smoke failed, the PR didn't open, the In Review transition didn't go through, or you stopped to ask the user mid-phase — leave the worktree alive. The user needs it to investigate. Cleanup is the *reward* for a fully successful run. (Phase 12, the retrospective, also only runs on the success path, but a failure inside Phase 12 itself does not block Phase 13 — the retrospective is best-effort.)
 - **Never edit the plan doc.** The plan doc under `docs/planning/` is read-only for this skill. If your implementation drifts from the plan, capture the drift in the handoff comment (Phase 11 — Deviations from the plan section). A separate re-integration agent will fold those notes back into the plan doc; don't pre-empt that.
 - **Never merge PRs** — even if checks pass and the PR looks great. Merging is a human decision.
 - **Never create new Linear issues** or split phases on the fly. If scope is too big for one phase, stop and report — splitting is a planning decision, not an execution decision.
@@ -371,4 +421,6 @@ These are non-negotiable. If you find yourself wanting to break one, stop and as
 >
 > *Commits with `feat(nats): pg-az-backup progress + result events (Phase 4, ALT-29)`. Opens PR with `Closes ALT-29` in the body. Marks ALT-29 In Review. Posts the handoff comment: PR URL, plus a Deviations section noting that the optional retry-on-transient-failure deliverable was deferred to a follow-up issue per the plan doc's wording — the plan doc itself is left untouched, the re-integration agent will fold this back later. Reports the PR URL.*
 >
-> *Phase 12: every prior phase succeeded, so the skill `cd`s back to the repo root, runs `pnpm worktree-env delete alt-29 --force`, then `git worktree remove .claude/worktrees/alt-29`. Reports cleanup done. The `claude/alt-29` branch stays on the remote (the PR points at it).*
+> *Phase 12: captures `$CLAUDE_SESSION_ID` (the parent session), spawns a `general-purpose` subagent on Sonnet, and tells it to invoke the `session-retrospective` skill with `--session-id <parent-id> --linear-issue ALT-29`. The skill loads the Linear MCP, runs `scripts/get-session.sh` against the parent JSONL, generates retrospective markdown, resolves the Altitude Devops team / Backlog state / `retro` label, and creates a new issue `ALT-42 — Retro: ALT-29 — Phase 4: pg-az-backup progress + result events` with the markdown body and a Source link back to ALT-29. Subagent returns the URL of ALT-42; skill appends it to the run report.*
+>
+> *Phase 13: every prior phase succeeded, so the skill `cd`s back to the repo root, runs `pnpm worktree-env delete alt-29 --force`, then `git worktree remove .claude/worktrees/alt-29`. Reports cleanup done. The `claude/alt-29` branch stays on the remote (the PR points at it).*

--- a/.claude/skills/session-retrospective/SKILL.md
+++ b/.claude/skills/session-retrospective/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: session-retrospective
+description: |
+  Analyze a Claude Code session JSONL and post a retrospective to Linear as a new issue
+  tagged "retro" in the Backlog, referencing the original issue the run was working on.
+  Use when the user (or another skill, e.g. `execute-next-task`) wants to capture lessons
+  learned from a Linear-tracked execution run so a retrospective trail builds up over time.
+  Triggers: "retrospective", "what did we learn", "session summary", "lessons learned", "retro".
+
+  Project-specific fork of github.com/accidentalrebel/claude-skill-session-retrospective —
+  the upstream skill prints markdown to console; this version posts to the Altitude Devops
+  Linear team.
+---
+
+# Session Retrospective
+
+Analyze a Claude Code session JSONL, generate a reflective summary of what happened, and
+post it as a new "retro"-tagged Linear issue in the Backlog, linked back to the original
+issue the run was working on. The point of writing each retro to its own issue (rather than
+a comment on the original) is that retros accumulate in their own searchable list and have
+their own lifecycle — separate from the contract-style handoff comment the executor leaves
+on the original.
+
+## Parameters
+
+The skill is invoked with two **required** parameters, parsed from the args string:
+
+- `--session-id <UUID>` — the Claude Code session ID to retrospect on. Must be passed
+  explicitly because if this skill is invoked from a subagent, `$CLAUDE_SESSION_ID` would
+  point at the subagent's own (effectively empty) session, not the parent's.
+- `--linear-issue <ALT-NN>` — the Linear issue ID the parent run was working on. The retro
+  issue's title and description reference this so the trail is navigable.
+
+If either parameter is missing, **stop and report**. Do not fall back to defaults — silently
+analyzing the wrong session or failing to link back to the source issue both produce a
+worthless retro.
+
+## Workflow
+
+1. **Validate parameters.** Both `--session-id` and `--linear-issue` are required. Stop if
+   either is missing.
+
+2. **Load Linear MCP tools.** They're deferred at session start. One bulk call:
+
+   ```
+   ToolSearch(query: "linear", max_results: 30)
+   ```
+
+   You need at minimum: `list_teams`, `list_issue_statuses`, `list_issue_labels`,
+   `get_issue`, `save_issue`. Stop and report if any are missing.
+
+3. **Retrieve the session JSONL.** Run the helper script with the session ID as a positional
+   arg (do not rely on env):
+
+   ```bash
+   .claude/skills/session-retrospective/scripts/get-session.sh <session-id>
+   ```
+
+   If the script errors (`Session file not found`), stop and surface the error — don't try
+   to continue with empty input.
+
+4. **Parse and analyze the JSONL.** Extract:
+   - `"type":"user"` entries for user messages
+   - `"type":"assistant"` entries for Claude responses and tool uses
+   - `tool_result` blocks with `is_error: true` for rejected/failed actions
+   - User messages immediately following an assistant turn (often corrections)
+
+5. **Resolve Linear references** for posting:
+   - **Team**: `Altitude Devops` (project-specific to this fork). Look it up via
+     `list_teams` to get the team ID.
+   - **Backlog state**: fetch `list_issue_statuses` for the team and pick the entry whose
+     name maps to Backlog (canonical name varies — `Backlog` is the common case).
+   - **`retro` label**: fetch `list_issue_labels` for the team. If the label does not exist,
+     **stop and report** with a clear message (`retro label missing — create it in Linear
+     settings first`). Do not auto-create labels silently; that's a setup decision.
+   - **Original issue**: `get_issue(<linear-issue>)` to grab its title and URL — needed for
+     the retro's title and the Source line.
+
+6. **Generate the retrospective markdown** per the Output Format below.
+
+7. **Create the retro issue** via `save_issue`:
+   - **Title**: `Retro: <ALT-NN> — <original-issue-title>` (truncate the original title to
+     keep the combined length under ~80 chars)
+   - **Team**: Altitude Devops
+   - **State**: Backlog
+   - **Labels**: `["retro"]`
+   - **Description**: a `**Source:** <link-to-original-issue>` line, then a blank line, then
+     the retrospective markdown body
+
+8. **Return only** the new retro issue's ID and URL. Do not echo the markdown body — the
+   caller (typically a subagent in `execute-next-task`) just needs the URL to relay back.
+
+## Output Format
+
+The retrospective markdown that goes into the issue description (after the `**Source:**`
+line):
+
+```markdown
+**Source:** <https://linear.app/.../ALT-NN>
+
+## TL;DR
+
+[2-3 sentence summary of what was accomplished and the key takeaway]
+
+## What We Set Out To Do
+
+[Brief description of the initial goal/problem]
+
+## The Journey
+
+### [Challenge / Phase 1 Title]
+
+[What happened, what was tried, what worked, what didn't]
+
+**Key insight**: [The important lesson from this phase]
+
+### [Challenge / Phase 2 Title]
+
+[Continue for each significant phase...]
+
+## Mistakes Made (And What I Learned)
+
+- **[Mistake 1]**: [What went wrong] → [What the fix/lesson was]
+- **[Mistake 2]**: ...
+
+## Techniques Worth Remembering
+
+- **[Technique 1]**: [When and why to use it]
+- **[Technique 2]**: ...
+
+## Key Takeaways
+
+1. [Most important lesson]
+2. [Second most important lesson]
+3. [Third most important lesson]
+```
+
+## Writing Guidelines
+
+- **Be specific**: include actual error messages, command names, file paths where relevant.
+- **Show the process**: document the messy middle, not just the clean final solution.
+- **Extract transferable lessons**: frame insights so they apply beyond this specific run.
+- **Honest about mistakes**: the most valuable lessons usually come from what went wrong.
+- **Conversational tone**: write as if explaining to a fellow developer over coffee.
+- **Don't pad**: omit a section entirely if there's nothing real to put in it. An honest
+  short retro is more useful than a long one with hollow bullets.
+
+## Script reference
+
+The helper script (`scripts/get-session.sh`) is read-only — it just `cat`s the matching
+session JSONL out of `~/.claude/projects/`. The fallback to `$CLAUDE_SESSION_ID` exists for
+direct human invocation outside the parameterized flow above; in this skill's normal use
+path the session ID is always passed explicitly.

--- a/.claude/skills/session-retrospective/scripts/get-session.sh
+++ b/.claude/skills/session-retrospective/scripts/get-session.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Get current session JSONL content for retrospective analysis
+# Usage: get-session.sh [session-id]
+# If no session-id provided, uses current session from CLAUDE_SESSION_ID env var
+
+set -e
+
+SESSION_ID="${1:-$CLAUDE_SESSION_ID}"
+PROJECTS_DIR="$HOME/.claude/projects"
+
+if [ -z "$SESSION_ID" ]; then
+  echo "Error: No session ID provided and CLAUDE_SESSION_ID not set" >&2
+  exit 1
+fi
+
+# Find the session file (could be in any project subdirectory)
+SESSION_FILE=$(find "$PROJECTS_DIR" -name "${SESSION_ID}.jsonl" -type f 2>/dev/null | head -1)
+
+if [ -z "$SESSION_FILE" ] || [ ! -f "$SESSION_FILE" ]; then
+  echo "Error: Session file not found for ID: $SESSION_ID" >&2
+  exit 1
+fi
+
+# Output session content
+cat "$SESSION_FILE"


### PR DESCRIPTION
## Summary

- Add `session-retrospective` skill (project-specific fork of [accidentalrebel/claude-skill-session-retrospective](https://github.com/accidentalrebel/claude-skill-session-retrospective)). Takes `--session-id` and `--linear-issue` parameters, analyzes the JSONL, and creates a new `retro`-labeled Linear issue in the Backlog with a Source link back to the original.
- Wire Phase 12 of `execute-next-task` to spawn a Sonnet subagent on the success path that invokes the skill with the captured parent session ID and the picked `ALT-NN`. Only the new retro issue URL flows back across the subagent boundary — the parent's accumulated context stays out of Sonnet, and the markdown body never crosses the boundary.
- Best-effort: a Phase 12 failure (missing label, MCP error, bad return) does not gate the Phase 13 worktree cleanup.

Retros accumulate as their own searchable trail rather than being buried as a second comment on the original ticket — different audience, different lifecycle.

## Test plan

- [ ] On the next `execute-next-task` run, verify Phase 12 fires after the handoff comment and creates a new `Retro: ALT-NN — <title>` issue tagged `retro` in the Backlog.
- [ ] Confirm the retro issue body starts with a `**Source:**` line linking back to the original `ALT-NN`.
- [ ] Confirm the parent run report ends with the retro issue URL.
- [ ] Confirm Phase 13 (worktree cleanup) still runs even if Phase 12 hypothetically failed (e.g. by temporarily renaming the `retro` label and re-running).
- [ ] Confirm the `session-retrospective` skill stops with a clear error if called without both `--session-id` and `--linear-issue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)