### PR TITLE
docs(planning): conform OTel tracing plan to PLANNING.md format and seed Linear

### DIFF
--- a/docs/planning/not-shipped/observability-otel-tracing-plan.md
+++ b/docs/planning/not-shipped/observability-otel-tracing-plan.md
@@ -223,7 +223,17 @@ Done when: opening Grafana, picking a time window, and looking at the service-gr
 
 ### Phase 6 — App-level metrics (optional, deferred)
 
-**Goal:** add custom Prometheus metrics for things the spans summarise but are easier to consume as a counter / histogram (`mini_infra_nats_publish_total`, `mini_infra_stack_apply_duration_seconds`, etc.). Out of scope for this plan; pre-listed here only so it doesn't get folded back into Phase 5 by accident.
+**Goal:** custom Prometheus metrics expose the most-queried application signals as first-class counters and histograms, complementing (not replacing) the span-derived `traces_spanmetrics_*` from Phase 5.
+
+Deliverables:
+- `prom-client` registered in the server with a small set of counters / histograms — at minimum `mini_infra_nats_publish_total{subject}`, `mini_infra_nats_request_duration_seconds{subject}`, and `mini_infra_stack_apply_duration_seconds{outcome}`. Cardinality budget agreed up front.
+- A `/metrics` endpoint scraped by the existing Prometheus instance via a new entry in `prometheus.yml` (or via the OTel Collector's Prometheus receiver if cleaner).
+- A Grafana dashboard panel set committed in `server/templates/monitoring/grafana/dashboards/` showing the new metrics alongside the Phase 5 RED panels.
+- Equivalent metrics for the Go sidecars where the publish-rate / decision-rate signal is load-bearing (`egress-fw-agent` decisions, `egress-gateway` proxy outcomes).
+
+Done when: opening the new dashboard shows live counters for NATS publishes per subject and stack-apply durations broken down by outcome, with cardinality verified against the agreed budget.
+
+Out of scope for the current plan; pre-listed here only so it doesn't get folded back into Phase 5 by accident.
 
 ## 7. Risks & open questions
 
@@ -238,11 +248,11 @@ Done when: opening Grafana, picking a time window, and looking at the service-gr
 
 ## 8. Linear tracking
 
-Phase issues will be created under a new "OTel Tracing" project on the Altitude Devops team and linked here once filed. Phase 1 blocks every later phase; Phase 4 also blocks on Phase 2 (Go side context propagation must exist before sidecar local spans are useful).
+Tracked under the [OpenTelemetry Tracing — Adding Tempo to the Monitoring Stack](https://linear.app/altitude-devops/project/opentelemetry-tracing-adding-tempo-to-the-monitoring-stack-01c8e578f25d) project on the Altitude Devops team. Phase 1 blocks every later phase; Phase 4 also blocks on Phase 2 (Go side context propagation must exist before sidecar local spans are useful).
 
-- ALT-_TBD_ — Phase 1: Tempo + OTel Collector + Grafana in monitoring stack
-- ALT-_TBD_ — Phase 2: `NatsBus` context propagation (TS + Go)
-- ALT-_TBD_ — Phase 3: Server auto-instrumentation (Express, Prisma, Socket.IO, outbound HTTP, Pino)
-- ALT-_TBD_ — Phase 4: Sidecar instrumentation (`agent-sidecar`, `update-sidecar`, `egress-fw-agent`, `egress-gateway`)
-- ALT-_TBD_ — Phase 5: Service map, Grafana dashboards, trace ↔ logs ↔ metrics correlation
-- ALT-_TBD_ — Phase 6 (deferred): App-level Prometheus metrics
+- [ALT-44](https://linear.app/altitude-devops/issue/ALT-44) — Phase 1: Tempo + Collector + Grafana in the monitoring stack
+- [ALT-45](https://linear.app/altitude-devops/issue/ALT-45) — Phase 2: `NatsBus` context propagation (TS + Go)
+- [ALT-46](https://linear.app/altitude-devops/issue/ALT-46) — Phase 3: Auto-instrumentation across the server
+- [ALT-47](https://linear.app/altitude-devops/issue/ALT-47) — Phase 4: Sidecars
+- [ALT-48](https://linear.app/altitude-devops/issue/ALT-48) — Phase 5: Service map, dashboards, and correlation polish
+- [ALT-49](https://linear.app/altitude-devops/issue/ALT-49) — Phase 6: App-level metrics (optional, deferred)


### PR DESCRIPTION
## Summary

- Bring Phase 6 of the OpenTelemetry tracing plan into the required PLANNING.md shape (added missing `Deliverables:` and `Done when:`, fixed the §8 line title so it matches the heading).
- Replace the `ALT-_TBD_` placeholders in §8 with real Linear issue links (ALT-44..ALT-49) and rewrite the intro to point at the seeded project. Issues created via the `plan-to-linear` skill, blocking edges set inline.

The first change is a doc-only conformance fix; the second is the standard `plan-to-linear` write-back. Reviewers don't need the live dev env for either.

## Linear

Seeded project: [OpenTelemetry Tracing — Adding Tempo to the Monitoring Stack](https://linear.app/altitude-devops/project/opentelemetry-tracing-adding-tempo-to-the-monitoring-stack-01c8e578f25d)

| Issue | State | Blocked by |
|---|---|---|
| [ALT-44](https://linear.app/altitude-devops/issue/ALT-44) — Phase 1: Tempo + Collector + Grafana in the monitoring stack | Todo | — |
| [ALT-45](https://linear.app/altitude-devops/issue/ALT-45) — Phase 2: NatsBus context propagation (TS + Go) | Todo | ALT-44 |
| [ALT-46](https://linear.app/altitude-devops/issue/ALT-46) — Phase 3: Auto-instrumentation across the server | Todo | ALT-44 |
| [ALT-47](https://linear.app/altitude-devops/issue/ALT-47) — Phase 4: Sidecars | Todo | ALT-44, ALT-45 |
| [ALT-48](https://linear.app/altitude-devops/issue/ALT-48) — Phase 5: Service map, dashboards, and correlation polish | Todo | ALT-44 |
| [ALT-49](https://linear.app/altitude-devops/issue/ALT-49) — Phase 6: App-level metrics (optional, deferred) | Backlog | ALT-48 |

Phase 1 blocks every later phase; Phase 4 also blocks on Phase 2 (Go-side context propagation must exist before sidecar local spans are useful). The doc's §6 preamble and §8 disagreed on whether Phases 3 and 5 also block on Phase 2 — went with the more permissive §8 reading; flagged in the retrospective comment on ALT-44.

## Test plan

- [ ] Render the diff in a Markdown previewer; confirm Phase 6 now has all three required parts and §8 links resolve.
- [ ] Open each ALT-NN; confirm Source link, Goal/Deliverables/Done when, doc pointers, and blocked-by graph match the plan doc.
- [ ] Read the retrospective comment on ALT-44 — flags two `plan-to-linear` skill improvements (mechanical phase-shape validation, surfacing §6/§8 ordering disagreement) and two PLANNING.md convention clarifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)