### PR TITLE
docs(planning): reframe service-addons-plan around AddonDefinition + egress-firewall section

### DIFF
--- a/docs/planning/not-shipped/service-addons-plan.md
+++ b/docs/planning/not-shipped/service-addons-plan.md
@@ -1,7 +1,7 @@
 # Service Addons — Tailscale and Caddy ingress addons
 
 **Status:** planned, not implemented. Phased rollout — each phase is a separate Linear issue.
-**Builds on:** the existing `Pool` service type and stack-template plumbing ([`PoolConfig`](../../../lib/types/stacks.ts), [`pool-spawner.ts`](../../../server/src/services/stacks/pool-spawner.ts), [`pool-instance-reaper.ts`](../../../server/src/services/stacks/pool-instance-reaper.ts)), the connected-services pattern ([Docker / Azure / Cloudflare / GitHub](../../../server/src/services/connected-services/)), and Vault credential storage.
+**Builds on:** the existing `Pool` service type and stack-template plumbing ([`PoolConfig`](../../../lib/types/stacks.ts), [`pool-spawner.ts`](../../../server/src/services/stacks/pool-spawner.ts), [`pool-instance-reaper.ts`](../../../server/src/services/stacks/pool-instance-reaper.ts)), the connected-services pattern ([Docker / Azure / Cloudflare / GitHub](../../../server/src/services/connected-services/)), the `StackServiceDefinition` schema ([`lib/types/stacks.ts`](../../../lib/types/stacks.ts)), and Vault credential storage.
 **Excludes:** outbound credential proxying — that work lives in the separate [auth-proxy-sidecar-plan.md](auth-proxy-sidecar-plan.md). The `caddy-auth` addon in this plan is an *inbound* user-auth gate and is intentionally named to avoid collision.
 
 ---
@@ -12,11 +12,13 @@ Three feature requests for stack-deployed services share the same structural sha
 
 User-friendliness was a stated design pressure. The cost of "add an addon" must be one line of YAML on the service definition; the cost of "connect to the resulting service from a developer laptop" must be effectively zero-config — Tailscale handles identity, MagicDNS handles hostnames, and the Mini Infra UI surfaces the address.
 
+A second design pressure: addon containers are still containers. They need logs, exec, drift detection, restart policies, healthchecks, labels, deployment events, RBAC, and every other piece of plumbing we already provide for stack services. Re-implementing that surface for "addon containers" would duplicate a large slice of `server/src/services/stacks/`. Instead, addons declare their sidecars *as* `StackServiceDefinition`s and ride the existing reconciler.
+
 ## 2. Goals
 
-1. **A declarative `addons:` block** on `StackServiceDefinition` accepting a map of addon-id → addon-config. `addons: { tailscale-ssh: {} }` is the minimum-viable form.
-2. **Self-contained addon directories** under `server/src/services/stack-addons/<id>/` containing a manifest (with config schema, applicability, connected-service prerequisites), a compose-fragment template, and a small TypeScript module for apply-time provisioning. Adding an addon is dropping a directory.
-3. **Pool-aware lifecycle.** Addons declared on a `Pool`-type service evaluate per pool instance at spawn time, so each pool worker gets its own sidecar identity and per-instance hostname.
+1. **A declarative `addons:` block** on `StackServiceDefinition` accepting a map of addon-id → addon-config. `addons: { tailscale-ssh: {} }` is the minimum-viable form. The user's authored stack carries only this terse block — the addon-derived sidecars never appear in the user's stack definition on disk or in the DB.
+2. **`AddonDefinition` wraps a `StackServiceDefinition`.** Each addon directory under `server/src/services/stack-addons/<id>/` exports a definition whose sidecar is described as a full `StackServiceDefinition`, so addon containers inherit logs / exec / drift detection / labels / events / RBAC for free. Adding an addon is dropping a directory.
+3. **Pool-aware lifecycle.** Addons declared on a `Pool`-type service materialise per pool instance at spawn time, so each pool worker gets its own sidecar identity and per-instance hostname.
 4. **Tailscale becomes a Connected Service** alongside Docker / Azure / Cloudflare / GitHub, with credential storage in Vault, connectivity probing, and an admin UI that emits a copy-paste ACL bootstrap snippet.
 5. **Three v1 addons.** `tailscale-ssh` (operator SSH via tailnet identity), `tailscale-web` (HTTPS exposure on the tailnet with auto-provisioned TLS), and `caddy-auth` (inbound OIDC gate via Caddy).
 6. **Friendly end-user surfaces.** The stack detail page exposes a "Connect" panel listing every addon-attached endpoint with one-click `ssh`/HTTPS, including per-pool-instance entries when expanded.
@@ -33,20 +35,28 @@ User-friendliness was a stated design pressure. The cost of "add an addon" must 
 
 ## 4. The addon framework
 
-A new `addons` block on `StackServiceDefinition` carries a map of addon-id → addon-config. The runtime resolves entries through an addon registry, validates each config blob against the addon's manifest schema, runs apply-time provisioning, renders compose fragments, and merges them into the rendered stack before reconciliation.
+### 4.1 Authored vs rendered stack definition
 
-### 4.1 Concepts
+The framework's central trick: the user's authored stack is never modified by addons. Addons take effect during a *render* pass that runs before the reconciler.
 
-- **Service Addon.** A named capability that wraps a service with one or more sidecars and contributes provisioning steps. Identified by a stable string (`tailscale-ssh`).
-- **Addon manifest.** Declares the addon's identity, description, configuration schema, applicability (which `serviceType`s it supports), connected-service prerequisites, and merge strategy.
-- **Addon kind.** An optional grouping label. When two addons of the same kind are declared on the same service, the runtime merges them into a single sidecar rather than spawning two. `tailscale-ssh` and `tailscale-web` share `kind: tailscale`.
-- **Compose fragment.** A Mustache-templated docker-compose snippet rendered per service-addon application.
-- **Provision hook.** Async function called before compose rendering. Receives the service definition and addon config; returns a `ProvisionedValues` map (sidecar env, target-service env, generated files, template variables) merged into the template context. This is where Tailscale authkeys are minted, Caddyfiles rendered, and per-instance secrets generated.
+- **Authored stack definition** — what the user wrote and what's persisted in the DB. Each `StackServiceDefinition` may carry an `addons:` block; that block is the only addon-related data on disk.
+- **Rendered stack definition** — produced at apply (or at pool-instance spawn) by expanding the authored definition. The renderer materialises each addon's `serviceDefinition` template, splices the sidecars into the services list, and applies any target-side rewrites declared by the addon's `targetIntegration`. The reconciler consumes the rendered form and otherwise runs unchanged.
+
+Because the rendered form is itself a `StackDefinition`, addon sidecars *are* `StackServiceDefinition`s by the time anything downstream sees them. Container labels, log streams, drift detection, restart policy, deployment events, the containers page, RBAC — all of it works without parallel implementation. This mirrors how a `Pool` service materialises into N per-instance containers at spawn time: the authored entity is one, the runtime entities are many, and the runtime entities flow through the same plumbing as everything else.
+
+### 4.2 Concepts
+
+- **Service Addon.** A named capability that wraps a target service with a sidecar (and possibly target-side modifications). Identified by a stable string (`tailscale-ssh`).
+- **`AddonDefinition`.** What an addon directory exports. Combines the manifest, the templated `StackServiceDefinition` for the sidecar, the `targetIntegration` describing how the sidecar binds to its target, and the `provision()` hook that mints credentials and computes per-application values.
+- **Addon manifest.** Declares the addon's identity, description, configuration schema, applicability (which `serviceType`s it supports), and connected-service prerequisites.
+- **Addon kind.** An optional grouping label. When two addons of the same kind are declared on the same service, the runtime merges them into a single sidecar rather than spawning two. `tailscale-ssh` and `tailscale-web` share `kind: tailscale`. Merging is implemented by an `AddonMergeStrategy` registered for the kind.
+- **Target integration.** A small enum + bag of values declaring how the sidecar attaches to its target service: peer-on-network, join-target-netns, or own-target-netns; plus optional env / mounts / port-reclaim flags. Most addons don't modify their target.
+- **Provision hook.** Async function called before service-definition materialisation. Receives the addon config and full provision context; returns `ProvisionedValues` (env for sidecar, env for target, generated files, template variables) consumed by the materialisation step. This is where Tailscale authkeys are minted, Caddyfiles rendered, and per-instance secrets generated.
 - **Service-addon application.** The runtime pairing of (one service, one addon, one config blob). Computed once at apply for static services; once per instance at spawn for pool services.
 
-### 4.2 Addon contract
+### 4.3 Addon contract
 
-The contract that addon authors implement and the runtime consumes:
+The contract addon authors implement and the runtime consumes:
 
 ```ts
 export interface AddonManifest {
@@ -56,14 +66,29 @@ export interface AddonManifest {
   configSchema: z.ZodTypeAny;
   appliesTo: StackServiceType[];                       // ["Stateful", "StatelessWeb", "Pool"]
   requiresConnectedService?: ConnectedServiceType;
-  sidecarMergeStrategy?: "shared-tailscale" | "standalone";
 }
+
+export type TargetIntegration = {
+  /**
+   * - "peer-on-target-network": sidecar joins the same Docker network as the target;
+   *   reaches the target by service name. Target unchanged. Default for non-intercepting addons.
+   * - "join-target-netns": sidecar uses `network_mode: service:<target>`. Target unchanged
+   *   in shape; sidecar reaches target on 127.0.0.1. For outbound interceptors and observers.
+   * - "own-target-netns": target's `network_mode` rewritten to `service:<sidecar>`; target's
+   *   published ports stripped (when reclaimTargetPorts is set) and inherited by the sidecar.
+   *   For unbypassable ingress gates.
+   */
+  network: "peer-on-target-network" | "join-target-netns" | "own-target-netns";
+  envForTarget?: Record<string, string>;
+  mountsForTarget?: StackServiceMount[];
+  reclaimTargetPorts?: boolean;                        // valid only with "own-target-netns"
+};
 
 export interface ProvisionContext {
   stack: { id: string; name: string };
   service: { name: string; type: StackServiceType };
   environment: { id: string; name: string; networkType: "Local" | "Internet" };
-  addonConfig: unknown;                                // already validated
+  addonConfig: unknown;                                // already validated against configSchema
   instance?: { instanceId: string };                   // present iff Pool spawn
   vault: VaultClient;
   connectedServices: ConnectedServiceLookup;
@@ -71,34 +96,59 @@ export interface ProvisionContext {
 
 export interface ProvisionedValues {
   envForSidecar?: Record<string, string>;
-  envForTargetService?: Record<string, string>;
+  envForTarget?: Record<string, string>;               // merged into TargetIntegration.envForTarget
   files?: Array<{ path: string; contents: string; mode?: number }>;
-  templateVars: Record<string, unknown>;               // available as {{provisioned.*}} in compose fragment
+  templateVars: Record<string, unknown>;               // available to buildServiceDefinition
 }
 
-export interface AddonModule {
+export interface AddonDefinition {
   manifest: AddonManifest;
+  targetIntegration: TargetIntegration;
   provision(ctx: ProvisionContext): Promise<ProvisionedValues>;
+  buildServiceDefinition(
+    ctx: ProvisionContext,
+    provisioned: ProvisionedValues,
+  ): StackServiceDefinition;                           // the sidecar, fully formed
+  cleanup?(ctx: ProvisionContext, provisioned: ProvisionedValues): Promise<void>;
   status?(ctx: StatusContext): Promise<AddonStatus>;
-  cleanup?(ctx: ProvisionContext): Promise<void>;
+}
+
+export interface AddonMergeStrategy {
+  kind: string;
+  targetIntegration: TargetIntegration;                // single integration for the merged group
+  provision(
+    ctx: ProvisionContext,
+    members: Array<{ addonId: string; config: unknown }>,
+  ): Promise<ProvisionedValues>;
+  buildServiceDefinition(
+    ctx: ProvisionContext,
+    provisioned: ProvisionedValues,
+    members: Array<{ addonId: string; config: unknown }>,
+  ): StackServiceDefinition;
 }
 ```
 
-### 4.3 Pipeline
+`buildServiceDefinition` returns a `StackServiceDefinition` rather than a compose YAML fragment. Provision values flow in through `ProvisionedValues.envForSidecar` and `templateVars`; the function chooses how to use them — usually by interpolating into env values, command args, mount sources, or labels on the returned definition. Choosing function-form over a Mustache-templated YAML keeps the sidecar's shape exactly the type the rest of the codebase already understands, avoids string-template type-safety holes, and lets the addon author use the same helpers (volume name builders, label helpers, healthcheck builders) the rest of the stacks code uses.
 
-For each `(service, addon)` pair:
+### 4.4 Render pipeline
+
+For each `(service, addon)` pair on the authored stack:
 
 1. **Validate.** Manifest's `configSchema` parses the user-supplied addon config. Failures surface in stack validation alongside other definition errors.
-2. **Check applicability.** Reject if `serviceType` not in `appliesTo` or `requiresConnectedService` not configured.
-3. **Resolve merge groups.** Group by `kind`. Manifest-defined merge functions combine configs (for `tailscale`: `{ ssh: bool, serve: ServeConfig | null }`).
-4. **Provision.** Call each addon's (or merged group's) `provision()`.
-5. **Render compose fragment.** Mustache-render with `{ service, stack, env, addon, provisioned, instance? }`.
-6. **Merge.** Sidecar appended to `services:`; target service's `network_mode` rewritten to `service:<sidecar>`; original `ports:` claims removed (sidecar owns ingress); `envForTargetService` merged into target env.
-7. **Apply.** Reconciler proceeds with the augmented compose.
+2. **Check applicability.** Reject if `serviceType` not in `appliesTo` or if `requiresConnectedService` is not configured.
+3. **Resolve merge groups.** Group by `kind`. For each group with more than one member, look up the registered `AddonMergeStrategy` for the kind; for solo members the addon's own `provision` / `buildServiceDefinition` run directly.
+4. **Provision.** Call `provision()` (or the merge strategy's `provision()` for a group). Side effects (authkey minting, Vault writes, tailnet device pre-registration) happen here.
+5. **Materialise sidecar.** Call `buildServiceDefinition()` to produce the addon's `StackServiceDefinition`. Append it to the rendered stack's services list with a `synthetic: true` flag and back-reference to its target service.
+6. **Apply target integration.** Walk the `targetIntegration` for the application:
+   - `peer-on-target-network`: ensure the sidecar service definition declares the target's network; no rewrite to the target.
+   - `join-target-netns`: set the sidecar's `network_mode` to `service:<target>`. Inject `envForTarget` and `mountsForTarget` (from both the integration spec and provisioned values) into the target service definition.
+   - `own-target-netns`: set the target's `network_mode` to `service:<sidecar>`. If `reclaimTargetPorts`, move the target's `ports:` claims onto the sidecar and bind the target to localhost. Inject env / mounts as above.
+7. **Run cross-addon rewrites.** A small post-merge step lets specific addon combinations rewire each other — concretely, when `caddy-auth` and `tailscale-web` both apply to the same target, the runtime rewrites Tailscale's `serve.json` to forward to Caddy's port instead of the app's. This is the only target-aware composition that escapes the one-addon-at-a-time loop above.
+8. **Reconcile.** The rendered stack definition flows into the existing reconciler unchanged.
 
-For pool services the same pipeline runs at instance spawn rather than at apply, with `instance.instanceId` populated. Each instance gets its own sidecar container, its own provisioned credentials, and the per-instance hostname described below. Addon containers carry the same `mini-infra.stack-id` / `mini-infra.service` labels as the pool instance plus `mini-infra.addon: <kind>`. The pool reaper invokes `cleanup()` hooks when an instance is reaped.
+For pool services the same pipeline runs at instance spawn rather than at apply, with `instance.instanceId` populated. Each instance gets its own sidecar `StackServiceDefinition`, its own provisioned credentials, and the per-instance hostname described below. Addon sidecars carry the same `mini-infra.stack-id` / `mini-infra.service` labels as the pool instance plus `mini-infra.addon: <kind-or-id>` and `mini-infra.synthetic: true`. The pool reaper invokes `cleanup()` hooks when an instance is reaped.
 
-### 4.4 Hostname convention
+### 4.5 Hostname convention
 
 | Service shape | Hostname (TS_HOSTNAME / sidecar identity) |
 |---|---|
@@ -108,18 +158,63 @@ For pool services the same pipeline runs at instance spawn rather than at apply,
 
 Sanitised to `[a-z0-9-]`, lowercased, max 63 chars (DNS label limit). For Tailscale-attached services this becomes the device name in the tailnet admin console, the MagicDNS short name, and the FQDN root for HTTPS exposure.
 
-### 4.5 Permissions and events
+### 4.6 Permissions and events
 
 Addons read from the same RBAC surface as their target features — `stacks:write` to add or remove an addon, `connected-services:write` to configure prerequisites. No new top-level permission domain. Two new addon-lifecycle Socket.IO events on the `stacks` channel surface provisioning progress and failures; a separate `tailscale` channel exposes device online/offline transitions polled from the Tailscale API.
 
+### 4.7 Interaction with the egress firewall
+
+The egress firewall ([egress-gateway/CLAUDE.md](../../../egress-gateway/CLAUDE.md), [egress-fw-agent/CLAUDE.md](../../../egress-fw-agent/CLAUDE.md)) and the addon framework compose without any new primitive, because the firewall enforces at the network/host layer (env-scoped Docker bridge + nftables + L7 forward proxy at the bridge `.2`) and addon sidecars are real `StackServiceDefinition`s that join the same network as their target. Three properties make this fall out for free:
+
+1. **Network membership is the only thing that matters for enforcement.** When the env's `egressFirewallEnabled` flag is on, every container on the env's egress network has its outbound L3/L4 dropped by the host fw-agent except via the gateway, and the gateway applies the L7 hostname allowlist. Addon sidecars join the target service's network during render — for firewalled envs that *is* the egress network — so they're automatically in scope. No per-addon firewall plumbing is needed for any of the three `targetIntegration` modes.
+2. **`requiredEgress` declarations flow through `containerConfig` automatically.** The egress-policy reconciler ([egress-policy-lifecycle.ts](../../../server/src/services/egress/egress-policy-lifecycle.ts)) reads `requiredEgress: string[]` off each service's `containerConfig` and seeds template-sourced rules. Because `AddonDefinition.buildServiceDefinition()` returns a full `StackServiceDefinition` whose `containerConfig` is just a `StackContainerConfig`, the addon declares its sidecar's required outbound destinations there — Tailscale's coordination plane (`*.tailscale.com`, `controlplane.tailscale.com`, DERP relays), Caddy's IdP endpoints (discovery / token / JWKS), the outbound auth proxy's upstream host list — and the existing reconciler picks them up alongside user-authored services' patterns. No new framework primitive, no parallel firewall code path.
+3. **Fixed vs config-derived `requiredEgress`.** Tailscale and Caddy have fixed control-plane dependencies — encode them as constants the addon's `buildServiceDefinition()` writes into `containerConfig.requiredEgress`. The outbound auth proxy is config-derived: `provision()` computes the upstream host list from the addon config and threads it through `templateVars` so `buildServiceDefinition()` can emit the right `requiredEgress`.
+
+#### Worked example: agent that needs both the firewall and extra auth headers
+
+A target agent service in a firewalled env, with the (separate-plan) outbound auth proxy attached:
+
+```
+agent container (target)
+  └─ HTTP_PROXY=http://127.0.0.1:8080  ← injected by auth-proxy addon via envForTarget
+       │
+       ▼
+   auth-proxy-sidecar      (join-target-netns: shares agent's netns; on env egress network)
+       │ adds Authorization / API-Key headers from Vault
+       ▼
+   env egress network bridge gateway (.1)
+       │ nftables on host: only the gateway container's IP may egress this subnet
+       ▼
+   egress-gateway container (.2)
+       │ Smokescreen L7 allowlist on Host header
+       ▼
+   external destination
+```
+
+Behaviours worth pinning:
+
+- **The agent doesn't know the firewall exists.** It talks to `HTTP_PROXY` on localhost; the chain after that is invisible to its code.
+- **The L7 gateway sees the proxy's outbound, not the agent's.** Since the auth proxy preserves the `Host:` header (it's adding auth, not rewriting destination), the hostname allowlist behaves identically to a no-proxy setup. If a future auth-proxy ever rewrites destinations, its `requiredEgress` must list the *actual* upstream hostnames, not the apparent ones — flagged in the auth-proxy plan, not here.
+- **No double-proxy loop.** The auth proxy doesn't know the egress gateway exists. Its outbound socket connects directly to the destination IP; bridge routing + nftables transparently force that flow through the gateway. Two separate proxies, neither configured against the other.
+- **Each container's `requiredEgress` unions independently.** With `caddy-auth` + `own-target-netns` + `reclaimTargetPorts`, target and sidecar are still distinct service rows — their required-egress sets union at policy reconcile time. Same for the agent + auth-proxy case: agent declares its real upstreams, auth-proxy adds whatever it needs (e.g., a credential-fetch endpoint), policy picks up both.
+- **Cross-addon ordering is irrelevant for egress.** Inbound chains like `tailscale-web → caddy-auth → app` only affect the inbound path. Each container's outbound is independently firewalled by being on the egress network; nothing about the inbound chain changes that.
+
+#### Implications for Phase 1
+
+The framework deliverables don't grow — `containerConfig.requiredEgress` already exists on `StackContainerConfig` and the reconciler already reads it. What's required instead is documentation and a sanity check: Phase 1's `tailscale-ssh` addon must encode the right Tailscale control-plane hostnames in its `buildServiceDefinition()` output, and Phase 1's done-when criteria should include "addon attached to a service in a firewalled env still functions, with the addon-declared hostnames showing up as template-sourced rules in the env's egress policy." Phase 3's `caddy-auth` adds the IdP-resolved hostnames; Phase 4 verifies pool-instance addon services emit per-instance `requiredEgress` correctly. Phases 2 and 5 don't touch this surface.
+
 ## 5. The three v1 addons
+
+Each addon below describes its `targetIntegration` shape, the `StackServiceDefinition` its `buildServiceDefinition()` produces (in shorthand), and the inputs flowing in from `provision()`.
 
 ### 5.1 `tailscale-ssh`
 
 - **Kind:** `tailscale`. Merges with `tailscale-web` when both are present on the same service.
 - **Requires:** Tailscale connected service.
 - **Config:** optional `extraTags` (array of `tag:*` strings).
-- **Provision:** mint a one-time, ephemeral, preauthorized authkey scoped to `tag:mini-infra-managed,tag:stack-<id>,tag:env-<env>,tag:service-<name>` plus `extraTags`. Inject `TS_AUTHKEY` and `TS_HOSTNAME` into the sidecar; pass `--ssh` in `TS_EXTRA_ARGS`.
+- **Target integration:** `network: "peer-on-target-network"`. The sidecar joins the same Docker network as the target so it can reach `<target>:<port>` by name. The target service is unmodified — no `network_mode` rewrite, no port reclamation.
+- **Provision:** mint a one-time, ephemeral, preauthorized authkey scoped to `tag:mini-infra-managed,tag:stack-<id>,tag:env-<env>,tag:service-<name>` plus `extraTags`. Returns `envForSidecar: { TS_AUTHKEY, TS_HOSTNAME }` and `templateVars: { tsExtraArgs: "--ssh" }`.
+- **Sidecar `StackServiceDefinition`:** Tailscale image, the provisioned env, a per-application state volume, no published ports, the standard mini-infra labels, `restart: unless-stopped`, and `containerConfig.requiredEgress` listing the Tailscale control-plane hostnames (`controlplane.tailscale.com`, `*.tailscale.com`, `*.tailscale.io`, DERP relay hostnames) so the egress-policy reconciler pre-allows them in firewalled envs (§4.7).
 - **End-user surface:** `ssh root@<service>-<env>` from any tailnet-joined laptop. Authentication is the tailnet identity provider via the ACL `ssh` stanza configured during connected-service setup. Default ACL is `action: check` with a 12-hour `checkPeriod` — one IdP re-auth per workday.
 
 ### 5.2 `tailscale-web`
@@ -127,18 +222,26 @@ Addons read from the same RBAC surface as their target features — `stacks:writ
 - **Kind:** `tailscale`.
 - **Requires:** Tailscale connected service.
 - **Config:** required `port` (local container port to expose); optional `path` (URL prefix, defaults to `/`).
-- **Provision:** mint authkey (same shape as `tailscale-ssh`); resolve the tailnet domain from the connected service; render a `serve.json` that terminates HTTPS on `${TS_CERT_DOMAIN}:443` and proxies to `127.0.0.1:<port>`; mount it at `TS_SERVE_CONFIG`.
+- **Target integration:** `network: "peer-on-target-network"`. Same as `tailscale-ssh` — the sidecar reaches the app by service-name DNS over the shared Docker network. No target rewrite.
+- **Provision:** mint authkey (same shape as `tailscale-ssh`); resolve the tailnet domain from the connected service; render a `serve.json` that terminates HTTPS on `${TS_CERT_DOMAIN}:443` and proxies to the target service's `port`. Returns the file under `files: [{ path: "/etc/tailscale/serve.json", … }]` and the env (`TS_AUTHKEY`, `TS_HOSTNAME`, `TS_SERVE_CONFIG=/etc/tailscale/serve.json`).
+- **Sidecar `StackServiceDefinition`:** as for `tailscale-ssh` (including the same `requiredEgress` for the Tailscale control plane), plus a config-file mount populated from the provisioned `files`.
 - **End-user surface:** `https://<service>-<env>.<tailnet>.ts.net` opens directly with auto-provisioned Let's Encrypt certs. No tunnel, no DNS configuration, no port-forwarding.
-- **Merge with `tailscale-ssh`:** the runtime emits one sidecar with both `--ssh` and `TS_SERVE_CONFIG` set, sharing one authkey, one hostname, one tailnet device, one state volume.
+- **Merge with `tailscale-ssh`:** the registered `kind: tailscale` merge strategy emits one sidecar definition with both `--ssh` and `TS_SERVE_CONFIG` set, sharing one authkey, one hostname, one tailnet device, one state volume, one published serve.json.
 
 ### 5.3 `caddy-auth`
 
-- **Kind:** none — runs as a standalone sidecar in the same netns as the target service (and as `tailscale-web`'s sidecar when present).
+- **Kind:** none — runs as a standalone sidecar.
 - **Requires:** OIDC provider config in Vault at `secret/connected-services/oidc/<provider>` (v1); the deferred `OidcProvider` model in v2.
 - **Config:** required `provider` (symbolic IdP id) and `upstreamPort`; optional `allowedGroups[]` and `publicPaths[]` (paths that bypass the auth gate).
-- **Provision:** read OIDC client config from Vault; render a Caddyfile pinning `caddy-security` to the provider, gating the route on `allowedGroups`, exempting `publicPaths`, and reverse-proxying authenticated traffic to `127.0.0.1:<upstreamPort>`.
-- **Composition with Tailscale.** When `tailscale-web` is also present, the runtime rewrites `serve.json` to proxy to Caddy's port instead of the app's, producing the chain `tailscale-web → caddy-auth → app` inside one shared netns.
+- **Target integration:** `network: "own-target-netns"`, `reclaimTargetPorts: true`. Caddy is unbypassable only if it owns ingress, so the runtime rewrites the target's `network_mode` to `service:<caddy-sidecar>`, moves the target's published ports onto the sidecar, and binds the target to `127.0.0.1`. No env injection into the target.
+- **Provision:** read OIDC client config from Vault; render a Caddyfile pinning `caddy-security` to the provider, gating the route on `allowedGroups`, exempting `publicPaths`, and reverse-proxying authenticated traffic to `127.0.0.1:<upstreamPort>`. Resolve the IdP's discovery / token / JWKS hostnames from the provider config and surface them via `templateVars` for `buildServiceDefinition` to use as `requiredEgress`. Returns the Caddyfile under `files`.
+- **Sidecar `StackServiceDefinition`:** the `mini-infra/caddy-auth` image, no published ports of its own (the target's reclaimed ports flow in via `targetIntegration`), a config-file mount for the Caddyfile, `containerConfig.requiredEgress` populated with the IdP hostnames resolved during provision (§4.7), the standard mini-infra labels.
+- **Composition with Tailscale.** When `tailscale-web` is also present on the same service, the cross-addon rewrite step (§4.4 step 7) rewrites Tailscale's `serve.json` to proxy to Caddy's port instead of the app's, producing the chain `tailscale-web → caddy-auth → app` in the rendered definition. The Tailscale sidecar still uses `peer-on-target-network`; the Caddy sidecar still uses `own-target-netns`. The two integrations don't conflict because Tailscale never asks for the target's netns.
 - **Image source.** A new `caddy-auth-sidecar/` directory mirroring `update-sidecar/` and `agent-sidecar/`, building `mini-infra/caddy-auth:<tag>` with the `caddy-security` plugin pinned.
+
+### 5.4 Forward look: outbound auth proxy
+
+Out of scope for this plan, but worth confirming the framework fits the next addon-shaped feature without further extension. The agent auth proxy ([auth-proxy-sidecar-plan.md](auth-proxy-sidecar-plan.md)) intercepts *outbound* HTTP from a target so it can inject upstream credentials. It maps to `network: "join-target-netns"` plus `envForTarget: { HTTP_PROXY, HTTPS_PROXY, NODE_EXTRA_CA_CERTS }` plus `mountsForTarget` for a CA bundle. Its `requiredEgress` is config-derived — `provision()` reads the user's upstream-host list from the addon config and the resulting `containerConfig.requiredEgress` rides into the egress-policy reconcile alongside the agent's own declarations (§4.7). No new framework primitive is required.
 
 ## 6. Phased rollout
 
@@ -149,25 +252,26 @@ Phases land in order — each phase blocks all subsequent phases. Phases 1-3 bui
 **Goal:** the framework exists end-to-end, and the simplest addon ships against static services.
 
 Deliverables:
-- The addon registry, manifest schema, runtime pipeline, and Mustache rendering helper as the foundation in `server/src/services/stack-addons/`.
+- The addon registry and `AddonDefinition` / `AddonMergeStrategy` types in `server/src/services/stack-addons/`.
+- The render pipeline: the existing stack-render step gains an addon-expansion phase that runs validation → applicability check → merge-group resolution → provision → `buildServiceDefinition` → target-integration application. The reconciler is unchanged; it consumes the rendered (expanded) stack definition.
 - An `addons` field on `stackServiceDefinitionSchema` with per-addon `superRefine` validation against the registered manifests.
-- The compose-builder gains a `mergeAddons` step that splices addon contributions into the rendered stack.
+- Synthetic-service flagging: rendered addon services carry `synthetic: true` and a back-reference to the target service so the UI can label them as derived rather than user-authored.
 - A new `tailscale` connected-service type with OAuth client_id/secret in Vault, tailnet domain auto-discovery, default tags, and a click-to-copy ACL bootstrap snippet on the settings page.
 - Tailscale connectivity prober wired into the existing `ConnectedServiceProber` and surfaced on the connected-services page.
 - Authkey minter using OAuth `client_credentials` against the Tailscale API; access tokens cached with pre-expiry refresh.
-- The `tailscale-ssh` addon directory with manifest, compose fragment, and provision module.
+- The `tailscale-ssh` addon directory with manifest, `targetIntegration` (`peer-on-target-network`), `provision`, and `buildServiceDefinition`. The materialized sidecar's `containerConfig.requiredEgress` lists the Tailscale control-plane hostnames (§4.7) so attaching the addon in a firewalled env works without manual policy edits.
 - Two new Socket.IO events on the `stacks` channel: `STACK_ADDON_PROVISIONED` and `STACK_ADDON_FAILED`.
 - Admin documentation page walking through OAuth client creation, scopes, tagging, and pasting the ACL snippet.
 
-Done when: a stack template with `addons: { tailscale-ssh: {} }` on a `Stateful` or `StatelessWeb` service applies cleanly, the Tailscale sidecar joins the tailnet under `tag:mini-infra-managed`, and an operator can `ssh root@<service>-<env>` from a tailnet-joined laptop with the IdP-driven `check` flow.
+Done when: a stack template with `addons: { tailscale-ssh: {} }` on a `Stateful` or `StatelessWeb` service applies cleanly, the Tailscale sidecar appears as a synthetic service in the rendered stack, joins the tailnet under `tag:mini-infra-managed`, shows up on the containers page with logs/exec/labels working, and an operator can `ssh root@<service>-<env>` from a tailnet-joined laptop with the IdP-driven `check` flow. *Firewall sanity check:* the same template applied in an env with `egressFirewallEnabled: true` still works end-to-end, and the Tailscale control-plane hostnames appear as template-sourced rules on the env's egress policy without operator intervention.
 
 ### Phase 2 — `tailscale-web` and tailscale addon merging
 
 **Goal:** services expose HTTPS on the tailnet with auto-provisioned TLS; both Tailscale addons can run together as one sidecar.
 
 Deliverables:
-- The `tailscale-web` addon directory with manifest, compose fragment, and provision module that renders `serve.json` from the addon's port/path config.
-- Merge logic in the addon runtime for shared-`kind` addons: when `tailscale-ssh` and `tailscale-web` both target the same service, one sidecar carries both `--ssh` and `TS_SERVE_CONFIG`, sharing one authkey and one state volume.
+- The `tailscale-web` addon directory with manifest, `targetIntegration` (`peer-on-target-network`), `provision` (renders `serve.json` from port/path config), and `buildServiceDefinition`.
+- `AddonMergeStrategy` registered for `kind: tailscale`: when `tailscale-ssh` and `tailscale-web` both target the same service, one sidecar definition carries both `--ssh` and `TS_SERVE_CONFIG`, sharing one authkey, one hostname, and one state volume.
 - The "Connect" panel on the stack detail page lists every addon-attached endpoint with one-click `ssh root@…` and `https://…` actions.
 - A Tailscale device-status poller that emits `TAILSCALE_DEVICE_ONLINE` / `OFFLINE` on a new `tailscale` Socket.IO channel; the Connect panel reflects live status badges.
 
@@ -179,25 +283,26 @@ Done when: a service with both Tailscale addons enabled is reachable as `ssh roo
 
 Deliverables:
 - A new standalone package `caddy-auth-sidecar/` mirroring the `update-sidecar` / `agent-sidecar` shape, building a `mini-infra/caddy-auth` image with the `caddy-security` plugin pinned.
-- The `caddy-auth` addon directory with manifest, compose fragment, Caddyfile template, and provision module that resolves OIDC client config from Vault.
+- The `caddy-auth` addon directory with manifest, `targetIntegration` (`own-target-netns` + `reclaimTargetPorts: true`), `provision` (reads OIDC config from Vault, renders Caddyfile, resolves the IdP's discovery / token / JWKS hostnames), and `buildServiceDefinition` (writes the resolved IdP hostnames into `containerConfig.requiredEgress` per §4.7 so the addon works in firewalled envs without manual policy edits).
 - Vault path convention `secret/connected-services/oidc/<provider>` documented for v1 manual editing.
-- Composition logic: when `caddy-auth` and `tailscale-web` both target the same service, the runtime rewrites the Tailscale `serve.json` to forward to Caddy's port instead of the app's.
+- Cross-addon rewrite: when `caddy-auth` and `tailscale-web` both apply, the post-merge step rewrites Tailscale's `serve.json` to forward to Caddy's port instead of the app's. This is the one place the framework reasons about pairs of addons; nothing else needs to.
 - Operator documentation page covering the Vault path layout and a worked example for one IdP (Entra ID).
 
-Done when: a service with `caddy-auth` plus `tailscale-web` enabled redirects unauthenticated browsers to the IdP, accepts authenticated users whose group membership matches `allowedGroups`, returns 403 for users who don't match, and forwards authenticated traffic transparently to the app.
+Done when: a service with `caddy-auth` plus `tailscale-web` enabled redirects unauthenticated browsers to the IdP, accepts authenticated users whose group membership matches `allowedGroups`, returns 403 for users who don't match, and forwards authenticated traffic transparently to the app. The rendered stack definition shows three services — app, caddy-auth, tailscale — with the right `network_mode` rewrites and reclaimed ports.
 
 ### Phase 4 — Pool integration
 
 **Goal:** addons declared on a `Pool` service materialise per instance at spawn time.
 
 Deliverables:
-- The pool spawner invokes the addon pipeline with `instance: { instanceId }` populated, producing per-instance provisioned credentials and template variables.
-- Per-instance sidecar containers created during pool spawn with the per-instance hostname convention; the pool instance container's `network_mode` set to the sidecar.
+- The pool spawner invokes the render pipeline with `instance: { instanceId }` populated, producing per-instance provisioned credentials and a per-instance `StackServiceDefinition` for each addon application.
+- Per-instance sidecar containers created during pool spawn with the per-instance hostname convention; the pool instance container's `network_mode` (or the sidecar's, depending on `targetIntegration`) wired up accordingly.
 - The pool reaper extension cleans up addon containers when instances are reaped and invokes addon `cleanup()` hooks.
-- Container labelling: addon sidecars carry the same `mini-infra.stack-id` / `mini-infra.service` / `mini-infra.pool-instance-id` labels as the pool instance, plus `mini-infra.addon: <kind>`.
+- Container labelling: addon sidecars carry the same `mini-infra.stack-id` / `mini-infra.service` / `mini-infra.pool-instance-id` labels as the pool instance, plus `mini-infra.addon: <kind-or-id>` and `mini-infra.synthetic: true`.
 - Connect panel pool-row expansion: clicking a pool service row reveals running instances with per-instance `ssh`/HTTPS rows.
+- Egress-policy correctness for pools: per-instance addon sidecars emit `containerConfig.requiredEgress` that flows into the env's policy reconcile the same way static addon services do (§4.7) — verify this works when the pool service is in a firewalled env.
 
-Done when: a pool service with `addons: { tailscale-ssh: {} }` spawns instances that each register as their own tailnet device with a unique per-instance hostname, an operator can SSH into a specific instance by name, and idle reaping removes both the worker container and the sidecar from Docker (and the device from the tailnet via ephemeral cleanup).
+Done when: a pool service with `addons: { tailscale-ssh: {} }` spawns instances that each register as their own tailnet device with a unique per-instance hostname, an operator can SSH into a specific instance by name, and idle reaping removes both the worker container and the sidecar from Docker (and the device from the tailnet via ephemeral cleanup). In a firewalled env, the Tailscale control-plane hostnames appear as template-sourced rules and per-instance sidecars reach the tailnet without manual policy edits.
 
 ### Phase 5 — UI polish and status surfacing
 
@@ -207,7 +312,7 @@ Deliverables:
 - Connect-panel improvements: per-pool-instance rows update live via the `tailscale` channel; copy-to-clipboard for `ssh` commands and URLs.
 - An addon-status rollup on the stack detail header summarising addon health (provisioned / failed / pending) at a glance.
 - A "Test connection" button per Tailscale-attached service that calls the Tailscale API to confirm the device is online and reports response time.
-- Filter chip on the containers page using the `mini-infra.addon` label so operators can isolate addon sidecars.
+- Filter chip on the containers page using the `mini-infra.addon` and `mini-infra.synthetic` labels so operators can isolate (or hide) addon sidecars.
 
 Done when: the stack detail page surfaces the right URL for every addon-attached service (including pool instances), live online/offline transitions reflect within ~5s, and an operator can audit addon health for an entire stack from one screen.
 
@@ -217,7 +322,7 @@ Done when: the stack detail page surfaces the right URL for every addon-attached
 
 Deliverables:
 - A new `OidcProvider` model with admin UI for adding, editing, and testing IdPs.
-- The `caddy-auth` addon's provision module switches from direct Vault path lookup to `OidcProvider` resolution.
+- The `caddy-auth` addon's `provision` switches from direct Vault path lookup to `OidcProvider` resolution.
 - A "test sign-in" affordance per provider that exercises the OAuth flow end-to-end and reports success or failure.
 
 Done when: an admin can add a new IdP through the UI, attach it to a service via `addons: { caddy-auth: { provider: <id> } }`, and verify the round trip from the connected-services page without editing Vault directly.
@@ -230,7 +335,8 @@ Done when: an admin can add a new IdP through the UI, attach it to a service via
 - **Pool instance Tailscale state volume.** Per-instance state volumes are cheap, but pool instances are short-lived and authkeys are minted per-spawn. With ephemeral nodes auto-cleaning, the volume is effectively write-only. Phase 4 should validate that skipping the volume on pool instances doesn't introduce a re-registration race, and pick the cleaner of the two paths.
 - **Pool instance hostname collisions across stacks.** `worker-prod-u12345` in stack A and `worker-prod-u12345` in stack B produce duplicate device names in the tailnet. Per-stack tags prevent ACL crossover but the device list stays ambiguous. Phase 4 may need to prefix pool hostnames with the stack name and accept longer hostnames.
 - **Funnel-shaped follow-up.** Once Tailscale-only HTTPS is shipped, the smallest extension to reach the public internet is enabling Tailscale Funnel. It overlaps the Cloudflare tunnel feature, so a deliberate "when do you pick which?" call is needed before any Phase 6+ extension touches Funnel.
-- **Addon config drift.** A definition-hash that includes the addon config block makes any addon edit a re-apply. Confirm during Phase 1 that the existing definition-hash logic naturally extends to the new field rather than oscillating on per-apply provisioned values.
+- **Definition-hash determinism.** The rendered stack definition includes addon-derived services and target-integration rewrites. Provision values like authkeys are minted fresh on each render, which would oscillate the hash and force needless re-applies. Phase 1 must ensure the hash is computed from the *authored* definition (plus addon-config), not the rendered form, or that mint-once values are cached and reused across renders. Confirm during Phase 1 that the existing definition-hash logic naturally extends to the new field rather than drifting.
+- **Synthetic-service surface in the UI.** Addon-derived services appearing in the same lists as user-authored ones is the whole point, but they need clear visual distinction (a "from addon" badge) and edit affordances should be disabled. Phase 1 should land at least the badge; Phase 5 polishes.
 
 ## 8. Linear tracking
 


### PR DESCRIPTION
## Summary

- Reworks [docs/planning/not-shipped/service-addons-plan.md](docs/planning/not-shipped/service-addons-plan.md) §4 around an `AddonDefinition` that wraps a templated `StackServiceDefinition`, so addon sidecars are real services in the rendered stack and inherit the existing logs / exec / drift / labels / deployment-events / RBAC plumbing instead of growing a parallel container surface. The user's authored stack stays untouched on disk and in the DB.
- Replaces the previous compose-fragment contract with `AddonDefinition` + `AddonMergeStrategy` + a typed `buildServiceDefinition()`. Adds a `TargetIntegration` knob with three explicit modes — `peer-on-target-network`, `join-target-netns`, `own-target-netns` (+ `envForTarget` / `mountsForTarget` / `reclaimTargetPorts`) — so each addon declares exactly how its sidecar binds to the target.
- Adds **§4.7 Interaction with the egress firewall**: addon sidecars participate in the per-env egress firewall ([egress-gateway](egress-gateway/CLAUDE.md), [egress-fw-agent](egress-fw-agent/CLAUDE.md)) automatically because enforcement is at the network/host layer and the existing egress-policy reconciler ([egress-policy-lifecycle.ts](server/src/services/egress/egress-policy-lifecycle.ts)) picks up `containerConfig.requiredEgress` from the materialized `StackServiceDefinition` — no new framework primitive needed. Includes the worked agent + firewall + outbound auth-proxy chain.

## Why

A parallel \"addon container\" concept would have duplicated a large slice of the stacks subsystem (logs, drift detection, RBAC, container events, egress policy). This framing keeps the terse `addons:` authoring surface while reusing the existing reconciler end-to-end. It also means the egress firewall and the inbound/outbound auth gateways compose without coordination — each addon declares its own `requiredEgress` and the existing reconciler unions them into the env's policy.

## Per-addon shapes pinned in the rewrite

- `tailscale-ssh` / `tailscale-web`: `peer-on-target-network`, target untouched. `requiredEgress` lists Tailscale control-plane hostnames so firewalled envs work without manual policy edits.
- `caddy-auth`: `own-target-netns` + `reclaimTargetPorts: true` for unbypassable ingress; `requiredEgress` populated from IdP discovery.
- Forward look at the [auth-proxy-sidecar plan](docs/planning/not-shipped/auth-proxy-sidecar-plan.md): fits as `join-target-netns` + `envForTarget` (HTTP_PROXY injection), with config-derived `requiredEgress`. No framework extension required.

## Phase impact

Phase 1 / 3 / 4 done-when criteria gained a firewalled-env sanity check; Phase 1's deliverables explicitly call out `requiredEgress` for the Tailscale control plane. Phases 2 and 5 are unchanged.

## Test plan

- [ ] Skim [§4.1 / §4.3 / §4.4](docs/planning/not-shipped/service-addons-plan.md) and confirm the authored-vs-rendered model + `AddonDefinition` contract reads cleanly.
- [ ] Read [§4.7](docs/planning/not-shipped/service-addons-plan.md) and verify the egress-firewall worked example matches the actual enforcement model (env-scoped bridge + nftables + Smokescreen).
- [ ] Confirm the per-addon `targetIntegration` shapes in [§5.1 / §5.2 / §5.3 / §5.4](docs/planning/not-shipped/service-addons-plan.md) are right for the intended UX.
- [ ] (Followup, not in this PR) Decide whether the linked [Linear ALT-38..ALT-43](https://linear.app/altitude-devops/project/service-addons-tailscale-and-caddy-ingress-addons-a171d68a60ae) issue descriptions need re-syncing to match the new framing before execution begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)