### PR TITLE
docs(skills): expand execute-next-task with standalone tickets, eager In Progress, and Sonnet code-review phase

### DIFF
--- a/.claude/skills/execute-next-task/SKILL.md
+++ b/.claude/skills/execute-next-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: execute-next-task
-description: Execution agent. Assumes you start at the main checkout root on `main` with a clean tree. Picks the next unblocked Todo issue from the user's Linear team (Altitude Devops), reads the ticket (which was pre-populated by `plan-to-linear` with Goal/Deliverables/Done-when, per-component CLAUDE.md and ARCHITECTURE.md pointers, and phase-specific smoke tests), runs `git pull --ff-only origin main`, creates a fresh worktree at `.claude/worktrees/alt-NN` on branch `claude/alt-NN`, runs `pnpm install`, kicks off `pnpm worktree-env start --description "..."` in the background to warm the dev env, then executes the work end-to-end inside the new worktree — code changes, build/lint/unit tests, live smoke against the dev env, PR with `Closes ALT-NN`, and Linear state transitions ending in In Review with a structured handoff comment (Known issues / Work deferred / Blockers / Deviations from the plan). On the success path it then spawns a Sonnet subagent that runs the `session-retrospective` skill (passing the parent session ID and the Linear issue ID), which creates a new "retro"-tagged Linear issue in the Backlog referencing the original, and **cleans up the worktree** (`pnpm worktree-env delete <slug>` + `git worktree remove`) so the VM/distro slot is freed; on any failure the worktree is left alive for investigation. **Does not produce an ExitPlanMode plan** — planning happened when the ticket was created. **Does not edit the plan doc** — drift goes only in the handoff comment for a re-integration agent to fold back later. Use this skill whenever the user says "execute next task", "what's next in linear", "do the next phase", "pick up the next todo", "work on the next thing", "what should I do next", or any equivalent request to advance through a Linear-tracked migration. Do NOT trigger for one-off non-Linear tasks or for "what should I work on?" without an obvious Linear context.
+description: Execution agent. Assumes you start at the main checkout root on `main` with a clean tree. Accepts an **optional issue ID** as an argument (e.g. `/execute-next-task ALT-32`) — when supplied, the skill jumps straight to that issue and skips the picking flow; when omitted, it picks the next unblocked Todo issue from the user's Linear team (Altitude Devops). Handles two ticket flavours uniformly — phased plan-doc tickets (populated by `plan-to-linear` from a markdown plan in `docs/planning/`) and standalone tickets (populated by `task-to-linear`, or filed by hand) that may have no plan-doc entry. The ticket body — Goal / Deliverables / Done-when / Relevant docs / Smoke tests — is the contract; the plan doc, when one exists, is supplemental context. Marks the issue **In Progress as soon as it's picked** (so the Linear board reflects who's working on it before any setup runs), then runs `git pull --ff-only origin main`, creates a fresh worktree at `.claude/worktrees/alt-NN` on branch `claude/alt-NN`, runs `pnpm install`, kicks off `pnpm worktree-env start --description "..."` in the background to warm the dev env, then executes the work end-to-end inside the new worktree — code changes, build/lint/unit tests, live smoke against the dev env, PR with `Closes ALT-NN`, and a final transition to In Review with a structured handoff comment (Known issues / Work deferred / Blockers / Deviations). On the success path it then spawns a Sonnet subagent that runs the `session-retrospective` skill (passing the parent session ID and the Linear issue ID), which creates a new "retro"-tagged Linear issue in the Backlog referencing the original, and **cleans up the worktree** (`pnpm worktree-env delete <slug>` + `git worktree remove`) so the VM/distro slot is freed; on any failure the worktree is left alive for investigation. **Does not produce an ExitPlanMode plan** — planning happened when the ticket was created. **Does not edit the plan doc** — drift goes only in the handoff comment for a re-integration agent to fold back later. Use this skill whenever the user says "execute next task", "what's next in linear", "do the next phase", "pick up the next todo", "work on the next thing", "what should I do next", "execute ALT-NN", "work on ALT-NN", or any equivalent request to advance through Linear-tracked work. Do NOT trigger for non-Linear tasks or for "what should I work on?" without an obvious Linear context.
 ---
 
 # Execute Next Task
@@ -13,15 +13,31 @@ If you read the ticket and find it underspecified or contradictory, that's the o
 
 These conventions are maintained by the user. If they're violated for the picked task, **stop and report — never guess**.
 
-- **One Linear project per feature**, named after the feature.
-- **Project description starts with a `Plan:` line** linking to a relative path, e.g. `Plan: docs/planning/not-shipped/internal-nats-messaging-plan.md`. That path is your map.
-- **Issue title format**: `Phase N: <short title>`, where `Phase N — <title>` is also a `### Phase N — <title>` heading in the plan doc.
-- **Plan doc lives** in `docs/planning/not-shipped/<slug>-plan.md` while any phase is unshipped. After all phases ship it moves to `docs/planning/shipped/`.
-- **Phases land in order** via `blocked-by` relationships. Phase 2 is blocked by Phase 1, etc. The skill respects that.
-- **Commit / PR title format**: `feat(<area>): <description> (Phase N, ALT-NN) (#PR)` — match the most recent shipped phase in the same project.
-- **PR body must include** `Closes <ALT-NN>` so merging closes the Linear issue automatically.
+There are two ticket flavours, and both are handled by the same flow. The shape of each is:
 
-Reference examples in this repo: `docs/planning/not-shipped/internal-nats-messaging-plan.md`, `docs/planning/not-shipped/observability-otel-tracing-plan.md`, `docs/planning/shipped/nats-app-roles-plan.md`.
+**Phased plan-doc tickets** (created by `plan-to-linear` from a markdown plan):
+
+- One Linear project per feature, named after the feature.
+- Project description starts with a `Plan:` line linking to a relative path, e.g. `Plan: docs/planning/not-shipped/internal-nats-messaging-plan.md`. That path is the map.
+- Issue title format: `Phase N: <short title>`, where `Phase N — <title>` is also a `### Phase N — <title>` heading in the plan doc.
+- Plan doc lives in `docs/planning/not-shipped/<slug>-plan.md` while any phase is unshipped. After all phases ship it moves to `docs/planning/shipped/`.
+- Phases land in order via `blocked-by` relationships. Phase 2 is blocked by Phase 1, etc. The skill respects that.
+
+**Standalone tickets** (created by `task-to-linear`, or filed by hand):
+
+- Live under the persistent `Maintenance` project (or any project without a strict per-feature plan doc).
+- Project description may have a `Plan:` line pointing to a shared evergreen doc (e.g. `docs/planning/maintenance.md`), or no `Plan:` line at all.
+- Issue title may follow `Phase N: <short title>` (the `task-to-linear` convention) but isn't required to.
+- The matching `### Phase N` section in the plan doc is **best-effort** — the doc may have no entry at all (legitimate when the ticket was filed directly in Linear, or when the doc has been pruned). The ticket body remains the contract either way.
+- No `blocked-by` chain — these are independent.
+
+What's true for **both** flavours, and is non-negotiable:
+
+- The ticket body carries **Goal / Deliverables / Done when / Relevant docs / Smoke tests** sections. That's the contract you execute against.
+- Commit / PR title format: `feat(<area>): <description> (Phase N, ALT-NN) (#PR)` — match the most recent shipped commit in the same project (or, for one-offs, the most recent commit touching the same component).
+- PR body must include `Closes <ALT-NN>` so merging closes the Linear issue automatically.
+
+Reference examples in this repo: `docs/planning/not-shipped/internal-nats-messaging-plan.md`, `docs/planning/not-shipped/observability-otel-tracing-plan.md`, `docs/planning/shipped/nats-app-roles-plan.md`, and the standalone `docs/planning/maintenance.md`.
 
 The team is hardcoded as **Altitude Devops**. (A future improvement is to read this from `.claude/linear-team.json`; not built yet.)
 
@@ -39,9 +55,30 @@ You should see tools like `mcp__cd9fab4e-...__list_issues`, `__get_issue`, `__ge
 
 ---
 
-## Phase 2 — Find the next unblocked task
+## Phase 2 — Find the next unblocked task and claim it
 
-The picking rule is **deliberately simple** — there is no priority sort, no cycle filter, no last-updated heuristic. Just: state = `Todo`, no unfinished `blocked-by`. The user maintains ordering through Linear's blocking relationships.
+The skill has two entry modes:
+
+- **Auto-pick mode** (no argument supplied) — list Todos, filter by blocker state, pick the single unblocked candidate or ask the user to disambiguate.
+- **Explicit-ID mode** (an `ALT-NN` was passed as the argument, e.g. `/execute-next-task ALT-32`) — jump straight to that issue, skipping the listing/filtering. The user has already chosen.
+
+### 2.0 Branch on the argument
+
+Look at the arguments the user passed to the skill. If the args contain a Linear issue identifier matching `ALT-\d+` (case-insensitive, may appear with surrounding text — e.g. `ALT-32`, `alt-32`, `pick up ALT-32`), treat that as the explicit pick and **skip the listing logic entirely**. Otherwise fall through to the auto-pick path.
+
+#### Explicit-ID path
+
+1. Fetch the issue with `get_issue(id: <ALT-NN>)`. If it doesn't exist (404), stop and tell the user.
+2. **Soft validations.** These produce warnings, not stops — when the user names an explicit ID, they're overriding the heuristics on purpose:
+   - If the issue is **not in `Todo` state** (e.g. `Backlog`, `In Progress`, `Done`), surface that to the user and ask "still proceed?" — useful for resuming a session that was interrupted, but not silently auto-resuming work the user might not realise was already shipped.
+   - If the issue has **incomplete `blocked-by` relations**, list them and ask "still proceed?". Don't auto-skip — sometimes the dependency was already done in a way Linear didn't capture.
+3. Once you have user confirmation (or the soft validations all passed), proceed to Phase 2.1.
+
+State the pick the same way as the auto-pick path: id, title, project name.
+
+#### Auto-pick path
+
+The picking rule is **deliberately simple** — there is no priority sort, no cycle filter, no last-updated heuristic. Just: state = `Todo`, no unfinished `blocked-by`. The user maintains ordering through Linear's blocking relationships (where they exist; standalone tickets in the Maintenance project have none).
 
 1. **List Todos** in the Altitude Devops team. Use the `list_issues` tool with `state` = `Todo` (or whatever the team's "Todo" status maps to — fetch the team's issue statuses first if you're unsure).
 2. **For each candidate, check blockers.** Use `get_issue` to read its `relations` / blockers. A candidate survives if every `blocked-by` issue it has is in state `Done` or `Cancelled`. An issue with no blockers automatically survives.
@@ -50,33 +87,52 @@ The picking rule is **deliberately simple** — there is no priority sort, no cy
    - **1 unblocked candidate** → use it. State the pick: id, title, project name.
    - **>1 unblocked candidates** → list them with `id | title | project` and ask the user to pick one. Don't infer — ask.
 
-Don't move to Phase 3 until you have exactly one issue in hand.
+### 2.1 Mark it In Progress immediately
+
+Once you have a single issue in hand — **before** reading the ticket body, before pre-flight, before anything else — flip its state and post a brief "claimed" comment. This signals on the Linear board that the work is now owned, prevents a parallel session or human reviewer from picking up the same ticket, and gives the user a timestamp for when the agent started.
+
+```
+save_issue(id: <issue-id>, state: "In Progress")
+save_comment(issue_id: <issue-id>, body: "Claimed by Claude. Reading ticket and preparing the worktree — full setup details will follow once the worktree is up.")
+```
+
+Use the canonical "In Progress" name for this team (fetch via `list_issue_statuses` if you didn't already in Phase 1). The state transition is idempotent — re-running the skill on the same issue is harmless.
+
+If, in any later phase, the skill stops with a hard-fail (malformed ticket, dirty tree, worktree collision, etc.), **leave the issue In Progress** and surface the failure to the user. Don't auto-roll-back to Todo — the user decides whether to retry, hand off, or revert state manually.
+
+Don't move to Phase 3 until the issue is In Progress with the claim comment posted.
 
 ---
 
 ## Phase 3 — Read the ticket and linked docs
 
-The Linear ticket is your contract. Read it end to end and treat it as authoritative.
+The Linear ticket body is your contract. Read it end to end and treat it as authoritative. The plan doc, when one exists and matches, is supplemental context — useful for understanding how the phase fits into a larger arc — but the ticket is what you execute against.
 
-1. **Fetch the issue body.** Look for the standard sections written by `plan-to-linear`:
-   - **Source** — the plan-doc path and phase anchor.
-   - **Goal**, **Deliverables**, **Done when** — the work to do.
+1. **Fetch the issue body.** Look for the standard sections written by `plan-to-linear` / `task-to-linear`:
+   - **Source** — the plan-doc path and phase anchor (may be absent on hand-filed tickets).
+   - **Goal**, **Deliverables**, **Done when** — the work to do. **Required.**
    - **Relevant docs** — the per-component CLAUDE.md / ARCHITECTURE.md pointers, plus any topic-specific architecture docs.
    - **Smoke tests** — what to run at the end to validate.
    - **Conventions** — commit/PR format, area tag, deferrals.
-2. **Fetch the parent project** (`get_project`) and find the **`Plan:` line** in its description. The skill accepts three forms:
-   - `Plan: [docs/planning/.../<slug>-plan.md](https://github.com/.../blob/main/...)` — combined (preferred; what `plan-to-linear` writes today)
-   - `Plan: docs/planning/.../<slug>-plan.md` — bare path (legacy fallback)
-   - `**Plan doc:** [docs/planning/.../<slug>-plan.md](https://...)` — also accepted as a legacy fallback for projects authored before the convention firmed up
 
-   Extract the **relative path** in all cases. If the project description has none of these, **stop** with a clear "no `Plan:` line in project description" message.
+   If **Goal / Deliverables / Done when** are missing, **stop and report** — the ticket wasn't populated correctly. Don't paper over it. The other sections are nice-to-have; their absence is a soft signal, not a stop condition.
 
-   Confirm the path resolves to the same plan doc the ticket cites in its **Source** section. If they disagree, **stop** — that's a corruption signal.
-3. **Read the plan doc's matching `### Phase N` section.** The ticket has the same content but the plan doc is the source of truth — if they've drifted, side with the doc and capture the drift in your handoff comment (Phase 11).
+2. **Try to fetch the parent project's `Plan:` line.** Use `get_project` to read the project description. The skill accepts three forms:
+   - `Plan: [docs/planning/.../<slug>.md](https://github.com/.../blob/main/...)` — combined (preferred; what `plan-to-linear` and `task-to-linear` write today)
+   - `Plan: docs/planning/.../<slug>.md` — bare path (legacy fallback)
+   - `**Plan doc:** [docs/planning/.../<slug>.md](https://...)` — also accepted as a legacy fallback for projects authored before the convention firmed up
+
+   Extract the **relative path** if any form matches. **No `Plan:` line is fine** — that's a legitimate state for projects whose tickets are self-contained (e.g. the `Maintenance` project). Don't stop; just note "no plan doc" in your internal scratchpad and skip step 3.
+
+   If a `Plan:` line is present but its path conflicts with the ticket's **Source** section (the ticket cites a different doc), **stop** — that's a corruption signal worth surfacing.
+
+3. **If a plan doc was located, read its matching `### Phase N` section** — best-effort. Three sub-cases:
+   - **Section present and consistent with the ticket** → use it as supplemental context. If the ticket and the doc have drifted, side with the **ticket body** (it's the executable contract) and capture the drift in your handoff comment (Phase 12) so a re-integration agent can fold it back later.
+   - **Section missing entirely** → not fatal. The plan doc may have been pruned, or the ticket was filed directly in Linear and the doc never recorded it. Note it in your scratchpad and proceed with the ticket body alone.
+   - **Plan doc itself missing on disk** → same as above. Proceed.
+
 4. **Read every doc the ticket lists under "Relevant docs."** Don't skim — these were chosen because they're the conventions you must follow. The ticket points at them so you don't have to guess what's relevant.
-5. **Read prior art** — `git log --oneline -20 main` plus any commits matching the project's area tag from the ticket. Shipped phases tell you the commit subject style and the rough size of a phase PR.
-
-If the ticket is missing the Goal / Deliverables / Done when sections, or the project description has no `Plan:` line, **stop and report** — the ticket wasn't populated correctly. Don't paper over it.
+5. **Read prior art** — `git log --oneline -20 main` plus any commits matching the project's area tag from the ticket. Shipped commits tell you the commit subject style and the rough size of a phase/task PR.
 
 ---
 
@@ -157,14 +213,15 @@ If the phase is **docs-only** (e.g. only touches `docs/`, a README, or a SKILL.m
 
 ---
 
-## Phase 7 — Mark the issue In Progress
+## Phase 7 — Post the worktree details to Linear
+
+The state transition already happened in Phase 2.1 (right after the pick) — at this point the issue is In Progress and there's a "claimed" comment. Now that the worktree exists, the env-startup is backgrounded, and `pnpm install` has finished, post a follow-up comment with the concrete details so anyone reading the ticket knows where the work is happening:
 
 ```
-save_issue(id: <issue-id>, state: "In Progress")
-save_comment(issue_id: <issue-id>, body: "Started by Claude.\n- Worktree: <path>\n- Branch: <branch>\n- Env startup: backgrounded")
+save_comment(issue_id: <issue-id>, body: "Worktree ready.\n- Worktree: <path>\n- Branch: <branch>\n- Env startup: backgrounded (`pnpm worktree-env start`)")
 ```
 
-Fetch the team's issue statuses first if you don't already know the canonical name (`In Progress` vs `In progress` etc. — use whatever the team has).
+If the phase is **docs-only** and Phase 6.2 was skipped, drop the env-startup line.
 
 ---
 
@@ -235,17 +292,19 @@ If everything passes, move on. If anything fails, **fix it before continuing** �
 
 ---
 
-## Phase 10 — Commit and open the PR
+## Phase 10 — Commit, push, and run a code review
 
-Match the most recent shipped phase's commit format from the same project. Typical:
+Smoke tests passed. Before opening the PR, the diff goes through a Sonnet-backed review pass so obvious issues get caught locally instead of becoming review noise on GitHub. The phase commits the implementation, pushes the branch (so the work is safely on the remote regardless of what happens next), runs the review subagent, then applies fixes for any medium / high / critical findings that hold up under scrutiny.
+
+### 10.1 Commit the implementation
+
+Match the most recent shipped commit format from the same project (or, for one-offs, the most recent commit touching the same component). Typical:
 
 ```
 feat(<area>): <short description> (Phase N, ALT-NN)
 ```
 
-The area tag (`nats`, `egress`, `monitoring`, `docs`, etc.) follows what previous phases used in the same project.
-
-Commit body:
+The area tag (`nats`, `egress`, `monitoring`, `docs`, etc.) follows what previous commits used. Commit body:
 
 ```
 <one or two paragraphs explaining what changed and why,
@@ -254,7 +313,122 @@ Commit body:
 Co-Authored-By: <as configured>
 ```
 
-Push the branch, then `gh pr create`. PR title matches the commit title. PR body must:
+Stage and commit. Don't push yet — keep all of 10.1's commits local until 10.2 so a single push lands them together.
+
+### 10.2 Push the branch
+
+```bash
+git push -u origin claude/<slug>
+```
+
+`-u` sets upstream so subsequent `git push` calls are bare. The work is now safe on the remote — even if the review phase explodes, nothing is lost.
+
+### 10.3 Spawn a Sonnet subagent to review the diff
+
+Use the `Agent` tool with `subagent_type: general-purpose` and `model: sonnet`. Sonnet is the right tier for review — fast, cheap, and the diff fits comfortably in its window.
+
+Prompt the subagent (substitute the branch name and the picked Linear issue ID):
+
+```
+Review the changes on branch `claude/<slug>` for issue <ALT-NN>.
+
+Compute the diff vs main with:
+  git fetch origin main
+  git diff origin/main...HEAD
+
+Read the relevant project conventions before reviewing:
+  - root CLAUDE.md (pnpm, worktree workflow, build invariants)
+  - server/CLAUDE.md if any server/ files changed (DockerService, ConfigurationServiceFactory, Channel.*/ServerEvent.*, userId on mutations, never raw dockerode)
+  - client/CLAUDE.md if any client/ files changed (TanStack Query patterns, no polling when socket connected, task tracker)
+  - any per-component CLAUDE.md / ARCHITECTURE.md that the touched dirs map to
+  - the Linear issue body for <ALT-NN> (Goal / Deliverables / Done when) so you can judge whether the diff actually does what was asked
+
+Look for:
+  - bugs (logic errors, off-by-one, null-deref, race conditions)
+  - security issues (injection, secrets, auth bypass, OWASP-top-10 patterns)
+  - convention violations (raw SDK calls bypassing service wrappers, raw dockerode, raw socket strings, missing userId on mutations, missing Plan: line patterns the codebase relies on)
+  - dead code / unused imports / leftover debug logging
+  - missing tests where the convention says they're required
+  - drift from the ticket's Deliverables (something asked for that didn't land, something landed that wasn't asked for)
+
+DO NOT flag:
+  - style nits the linter would catch
+  - opinions about "could be cleaner" without a concrete bug or convention violation
+  - missing comments or docstrings (the codebase defaults to no comments unless WHY is non-obvious)
+  - hypothetical future-extensibility concerns
+
+Return findings as a JSON array. One object per finding:
+  {
+    "severity": "critical" | "high" | "medium" | "low",
+    "file": "<path relative to repo root>",
+    "line": <line number on the new side, or null if file-level>,
+    "title": "<short imperative phrase>",
+    "detail": "<1-3 sentences: what's wrong, why it matters>",
+    "suggested_fix": "<concrete change — file/line + before/after, or null if non-obvious>"
+  }
+
+If you find nothing actionable, return an empty array `[]`. Do NOT pad with low-severity nits to look thorough. Empty is a great result.
+
+Return ONLY the JSON array. No preamble, no summary, no markdown fences.
+```
+
+### 10.4 Triage and apply fixes
+
+Parse the subagent's JSON. Filter to `severity in ["critical", "high", "medium"]`. Drop `low` — they're not worth a follow-up commit unless they coincidentally fall out of a higher-severity fix.
+
+For each remaining finding, **sanity-check before applying**. The subagent is right most of the time but occasionally:
+
+- Misreads a convention (e.g. flags `dockerode.getContainer()` when the wrapper *is* the surrounding code).
+- Misses context that's a few files away (e.g. flags a missing null-check that's enforced upstream).
+- Suggests a "fix" that's worse than the code it's fixing.
+
+Read the cited file, decide whether the finding is real:
+
+- **Holds up** → apply the suggested fix (or a better one). Add to a fixups list.
+- **Doesn't apply** → skip. Note it in the handoff comment (Phase 12) under "Review findings consciously dismissed" so the human reviewer knows the agent considered it.
+
+If every finding gets dismissed as not-applicable, that's fine — the code is fine. Move to 10.5 with no fixups.
+
+### 10.5 Commit and push the fixups (only if you applied any)
+
+If 10.4 produced changes, commit them as a separate commit so the diff history shows the implementation and the review-driven cleanup separately. Use a body that lists what was addressed:
+
+```
+review: address sonnet review findings (Phase N, ALT-NN)
+
+- <one bullet per applied finding>
+- <...>
+
+Co-Authored-By: <as configured>
+```
+
+Then push:
+
+```bash
+git push
+```
+
+If 10.4 produced no changes, this sub-phase is a no-op — proceed to Phase 11.
+
+---
+
+## Phase 11 — Open the PR
+
+The branch is committed, pushed, and (where applicable) cleaned up by review. Now create the PR:
+
+```bash
+gh pr create --title "<commit subject from Phase 10.1>" --body @- <<'EOF'
+## Summary
+- <1-3 bullets describing the change>
+
+## Test plan
+- [<checklist item>]
+
+Closes ALT-NN
+EOF
+```
+
+PR title matches the implementation commit's subject (not the `review:` follow-up). PR body must:
 
 - Have a Summary section (1–3 bullets) describing the change.
 - Have a Test plan section (markdown checklist).
@@ -263,16 +437,16 @@ Push the branch, then `gh pr create`. PR title matches the commit title. PR body
 
 ---
 
-## Phase 11 — Mark the issue In Review and leave a structured handoff comment
+## Phase 12 — Mark the issue In Review and leave a structured handoff comment
 
-Move the issue to `In Review` (canonical state name from Phase 1's status fetch) and post a single structured comment summarising the run. The comment is the handoff to the human reviewer — and to the future re-integration agent that will fold drift back into the plan doc — so it captures everything the PR diff doesn't show. **The plan doc itself is read-only for this skill** (see hard rules); drift goes here.
+Move the issue to `In Review` (canonical state name from Phase 1's status fetch) and post a single structured comment summarising the run. The comment is the handoff to the human reviewer — and, when a plan doc was loaded, to the future re-integration agent that will fold drift back into it — so it captures everything the PR diff doesn't show. **The plan doc itself is read-only for this skill** (see hard rules); drift goes here.
 
 ```
 save_issue(id: <issue-id>, state: "In Review")
 save_comment(issue_id: <issue-id>, body: <handoff comment, see template below>)
 ```
 
-Use this template verbatim. Omit any section that genuinely has nothing to report — don't pad with "N/A" or "none". If every section is empty, the comment is just the PR link.
+Use this template. Omit any section that genuinely has nothing to report — don't pad with "N/A" or "none". If every section is empty, the comment is just the PR link.
 
 ```markdown
 **PR:** <PR_URL>
@@ -281,14 +455,19 @@ Use this template verbatim. Omit any section that genuinely has nothing to repor
 <failing tests you couldn't fix in scope, brittleness you noticed but didn't address, anything the reviewer should be aware of when looking at the diff. One bullet each.>
 
 ## Work deferred
-<deliverables from the phase that were scoped down, or follow-ups identified along the way that should become their own issues. Reference the plan-doc line that says they can be deferred if applicable.>
+<deliverables from the ticket that were scoped down, or follow-ups identified along the way that should become their own issues. Reference the ticket / plan-doc line that says they can be deferred if applicable.>
 
 ## Blockers
 <things that stopped you finishing some part of the work — missing credentials, an upstream bug in another component, a dependency on infrastructure that isn't there. Empty if nothing blocked you.>
 
-## Deviations from the plan
-<places where what you shipped diverges from the plan doc's Deliverables or Done-when. For each: what the plan said, what you shipped, why. The plan doc itself stays untouched — a re-integration agent will fold these notes back into the doc later.>
+## Deviations from the spec
+<places where what you shipped diverges from the ticket's Deliverables or Done-when (and, if a plan doc was loaded in Phase 3, from its `### Phase N` section). For each: what the spec said, what you shipped, why. When a plan doc is in play, this section is also the input a re-integration agent uses to fold the drift back into the doc — keep it precise. **Omit this section entirely** when there's no spec drift to report.>
+
+## Review findings consciously dismissed
+<medium / high / critical findings the Phase 10 review subagent surfaced but you decided not to apply. For each: what the subagent said, why you concluded it didn't apply (e.g. it misread the surrounding context, the convention is actually being followed a few files away, the suggested fix was worse than the original). One bullet each. **Omit this section entirely** when the review returned no findings, or when every finding was applied.>
 ```
+
+If Phase 3 found no plan doc (standalone ticket), the handoff still uses this template — the "Deviations from the spec" wording covers both cases. There's just no re-integration agent involvement to plan for; the comment is purely for the human reviewer.
 
 Then report the PR URL to the user wrapped in a `<pr-created>` tag on its own line so any UI integrations can render a card.
 
@@ -296,13 +475,13 @@ The point of this comment is that the next person (human or agent) opens the Lin
 
 ---
 
-## Phase 12 — Post a session retrospective to Linear (success path only)
+## Phase 13 — Post a session retrospective to Linear (success path only)
 
 After the handoff comment is posted but before worktree cleanup, kick off a session retrospective. The `session-retrospective` skill creates a **new** "retro"-tagged Linear issue in the Backlog, linked back to the issue you just shipped — so retros accumulate as their own searchable list with their own lifecycle, separate from the contract-style handoff comment on the original ticket. Future runs of this skill (and the user, scanning retros over time) can mine that trail for lessons.
 
-If anything earlier in the run failed and the skill stopped, this phase doesn't fire — there's no successful run to retrospect on, and the human will be debugging the failure directly. Only the success path reaches Phase 12.
+If anything earlier in the run failed and the skill stopped, this phase doesn't fire — there's no successful run to retrospect on, and the human will be debugging the failure directly. Only the success path reaches Phase 13.
 
-### 12.1 Capture the parent session ID
+### 13.1 Capture the parent session ID
 
 The retrospective skill takes the session ID as an explicit parameter rather than reading `$CLAUDE_SESSION_ID`, because it's invoked from a subagent and a subagent's `$CLAUDE_SESSION_ID` points at its own (effectively empty) session, not the parent's. Capture your own session ID here so you can pass it through:
 
@@ -310,9 +489,9 @@ The retrospective skill takes the session ID as an explicit parameter rather tha
 echo "$CLAUDE_SESSION_ID"
 ```
 
-Hold onto the value alongside the picked Linear issue ID (`ALT-NN` from Phase 2). These two are the parameters Phase 12.2 passes to the subagent.
+Hold onto the value alongside the picked Linear issue ID (`ALT-NN` from Phase 2). These two are the parameters Phase 13.2 passes to the subagent.
 
-### 12.2 Spawn a Sonnet subagent that invokes the skill
+### 13.2 Spawn a Sonnet subagent that invokes the skill
 
 Use the `Agent` tool with `subagent_type: general-purpose` and `model: sonnet`. Sonnet is the right tier — by this point the parent context is huge (full task history, code reads, tool results), and Opus on top of that just to summarize JSONL is wasteful. Sonnet handles the analysis comfortably, and the heavy lifting (JSONL reads, MCP calls) stays scoped to the subagent so it doesn't bloat the parent thread. Only the new retro issue's URL flows back across the subagent boundary.
 
@@ -321,7 +500,7 @@ Prompt the subagent (substitute the captured session ID and the Linear issue ID)
 ```
 Invoke the session-retrospective skill with these parameters:
 
-  --session-id <PARENT_SESSION_ID>     (the parent's session ID captured in Phase 12.1)
+  --session-id <PARENT_SESSION_ID>     (the parent's session ID captured in Phase 13.1)
   --linear-issue <ALT-NN>              (the Linear issue this run was working on)
 
 The skill will:
@@ -336,19 +515,19 @@ Return ONLY the new retro issue's URL. Do NOT return the markdown body.
 
 The skill itself owns the Linear posting (team / state / label resolution, `save_issue`) — the parent doesn't need to do anything else with the result.
 
-### 12.3 Relay the retro issue URL in the run report
+### 13.3 Relay the retro issue URL in the run report
 
-When the subagent returns the URL, append it to your final run report so the user can navigate to it directly. The structured handoff comment (Phase 11) and the retro issue (Phase 12) are deliberately separate Linear records — the handoff is the contract for the human reviewer of the PR; the retro is meta-feedback about the run itself, with a different audience and shelf-life.
+When the subagent returns the URL, append it to your final run report so the user can navigate to it directly. The structured handoff comment (Phase 12) and the retro issue (Phase 13) are deliberately separate Linear records — the handoff is the contract for the human reviewer of the PR; the retro is meta-feedback about the run itself, with a different audience and shelf-life.
 
-### 12.4 Failure handling
+### 13.4 Failure handling
 
-The retrospective is a feedback loop, not a gate. If the subagent fails — script can't find the session, the `retro` label doesn't exist in Linear, the subagent returns garbage instead of a URL, the Linear MCP errors — **don't block cleanup**. Note the failure in the run report and continue to Phase 13. A broken or hollow retro issue is worse than no retro issue.
+The retrospective is a feedback loop, not a gate. If the subagent fails — script can't find the session, the `retro` label doesn't exist in Linear, the subagent returns garbage instead of a URL, the Linear MCP errors — **don't block cleanup**. Note the failure in the run report and continue to Phase 14. A broken or hollow retro issue is worse than no retro issue.
 
 ---
 
-## Phase 13 — Clean up the worktree (success path only)
+## Phase 14 — Clean up the worktree (success path only)
 
-**Only run this if every previous phase succeeded** — build/lint/unit passed, smoke passed, the PR is open, the issue is In Review, the handoff comment posted. If anything failed or stopped earlier, **skip this phase entirely** and leave the worktree alive so the user can investigate. The retrospective phase (12) is best-effort and doesn't gate this — a failed retrospective still counts as a successful run.
+**Only run this if every previous phase succeeded** — build/lint/unit passed, smoke passed, review fixups applied (if any), the PR is open, the issue is In Review, the handoff comment posted. If anything failed or stopped earlier, **skip this phase entirely** and leave the worktree alive so the user can investigate. The retrospective phase (13) is best-effort and doesn't gate this — a failed retrospective still counts as a successful run.
 
 The worktree's purpose is to host the build + smoke for this phase. Once the PR is open and in review, the work that needs the dev env is over — review happens in GitHub on the diff, not in the worktree. So we tear it down to free the VM/distro slot and keep `pnpm worktree-env list` tidy.
 
@@ -376,7 +555,7 @@ Append a final line to the run report:
 ✓ Cleaned up worktree .claude/worktrees/<slug> and the dev-env VM.
 ```
 
-**Macos users** who run the bulk `pnpm worktree-env cleanup` command (or installed the hourly launchd agent) can rely on that to clean merged-PR worktrees on a schedule and skip Phase 13 by interrupting the skill before it runs. For Windows / WSL2 users without an equivalent agent, this phase is the cleanup mechanism.
+**Macos users** who run the bulk `pnpm worktree-env cleanup` command (or installed the hourly launchd agent) can rely on that to clean merged-PR worktrees on a schedule and skip Phase 14 by interrupting the skill before it runs. For Windows / WSL2 users without an equivalent agent, this phase is the cleanup mechanism.
 
 ---
 
@@ -384,16 +563,18 @@ Append a final line to the run report:
 
 These are non-negotiable. If you find yourself wanting to break one, stop and ask the user instead.
 
-- **Never produce an ExitPlanMode block.** This is an execution agent. Planning happened in `plan-to-linear` when the ticket was created.
-- **Never run Phase 13 (cleanup) on a failure path.** If smoke failed, the PR didn't open, the In Review transition didn't go through, or you stopped to ask the user mid-phase — leave the worktree alive. The user needs it to investigate. Cleanup is the *reward* for a fully successful run. (Phase 12, the retrospective, also only runs on the success path, but a failure inside Phase 12 itself does not block Phase 13 — the retrospective is best-effort.)
-- **Never edit the plan doc.** The plan doc under `docs/planning/` is read-only for this skill. If your implementation drifts from the plan, capture the drift in the handoff comment (Phase 11 — Deviations from the plan section). A separate re-integration agent will fold those notes back into the plan doc; don't pre-empt that.
+- **Never produce an ExitPlanMode block.** This is an execution agent. Planning happened when the ticket was created (in `plan-to-linear` for phased tickets, in `task-to-linear` for standalone ones, or by the user filing it directly).
+- **Never run Phase 14 (cleanup) on a failure path.** If smoke failed, the review subagent errored fatally, the PR didn't open, the In Review transition didn't go through, or you stopped to ask the user mid-phase — leave the worktree alive. The user needs it to investigate. Cleanup is the *reward* for a fully successful run. (Phase 13, the retrospective, also only runs on the success path, but a failure inside Phase 13 itself does not block Phase 14 — the retrospective is best-effort.)
+- **Never edit the plan doc.** When a plan doc was loaded in Phase 3, the doc under `docs/planning/` is read-only for this skill. If your implementation drifts from the spec, capture the drift in the handoff comment (Phase 12 — Deviations from the spec section). A separate re-integration agent will fold those notes back into the plan doc; don't pre-empt that. (When no plan doc was loaded, this rule is vacuous — there's nothing to edit.)
+- **Never blindly apply review subagent findings.** Phase 10.4 requires a sanity check on every medium/high/critical finding before fixing. The subagent is a second pair of eyes, not an oracle — if a finding misreads context, dismiss it (and note it in the handoff comment). Equally, never *skip* a finding because the fix is inconvenient — the dismissal must be justifiable.
+- **Never auto-roll-back the In Progress transition.** Phase 2.1 marks the issue In Progress before any other work begins. If the run later hard-fails, leave it In Progress and report — don't quietly flip it back to Todo. The user decides whether to retry, hand off, or revert state.
 - **Never merge PRs** — even if checks pass and the PR looks great. Merging is a human decision.
 - **Never create new Linear issues** or split phases on the fly. If scope is too big for one phase, stop and report — splitting is a planning decision, not an execution decision.
-- **Never override plan-doc conventions.** If the plan section says "Defer X to follow-up", that X is deferred. Don't quietly include it because it seemed easy.
+- **Never override the ticket's Deferrals.** If the ticket (or its plan-doc section, when one exists) says "Defer X to follow-up", that X is deferred. Don't quietly include it because it seemed easy.
 - **Never `git checkout main`, `git stash`, or create a new branch.** Worktree lifecycle is the user's responsibility — this skill assumes the worktree is already up. (`pnpm install` and the backgrounded `pnpm worktree-env start` are the *only* environment setup the skill performs, and only inside the existing worktree.)
 - **Never skip pre-flight checks** by running on `main` or with a dirty tree. Stop and ask.
 - **Never use `--no-verify` or skip hooks.** If a hook fails, investigate.
-- **Never guess at conventions.** If the project description has no `Plan:` line, or the ticket has no Goal/Deliverables/Done-when sections, **stop and report**. The conventions exist so the skill can rely on them; bypassing them silently breaks the next run.
+- **Never guess at the contract.** If the ticket has no Goal/Deliverables/Done-when sections, **stop and report** — the ticket wasn't populated correctly. (A missing `Plan:` line on the project, or a missing `### Phase N` section in the plan doc, is *not* a stop condition under the looser flow — see Phase 3 for the rules.)
 
 ---
 
@@ -411,16 +592,22 @@ These are non-negotiable. If you find yourself wanting to break one, stop and as
 >
 > User: "ALT-29"
 >
-> *Skill fetches ALT-29 + parent project. Project description: `Plan: [docs/planning/not-shipped/internal-nats-messaging-plan.md](https://github.com/...)`. Skill reads the ticket body (Goal, Deliverables, Done when, Relevant docs, Smoke tests). Reads each linked CLAUDE.md / ARCHITECTURE.md. Reads `git log` for `Phase 1`/`Phase 2`/`Phase 3` shipped commits to learn the area tag (`nats`) and PR title shape.*
+> *Skill immediately marks ALT-29 In Progress and posts a "Claimed by Claude. Reading ticket and preparing the worktree…" comment (Phase 2.1) so the Linear board reflects the claim before any setup runs.*
 >
-> *Pre-flight: pwd is the repo root, branch is main, tree clean. Runs `git pull --ff-only origin main`. Creates worktree: `git worktree add .claude/worktrees/alt-29 -b claude/alt-29`, then `cd` into it. Runs `pnpm install` synchronously, then kicks off `pnpm worktree-env start --description "Phase 4 — pg-az-backup progress + result events"` in the background. Marks ALT-29 In Progress, comments worktree path + branch.*
+> *Skill fetches ALT-29 + parent project. Project description: `Plan: [docs/planning/not-shipped/internal-nats-messaging-plan.md](https://github.com/...)`. Skill reads the ticket body (Goal, Deliverables, Done when, Relevant docs, Smoke tests). The plan-doc resolves and its `### Phase 4` section matches the ticket — read as supplemental context. Reads each linked CLAUDE.md / ARCHITECTURE.md. Reads `git log` for `Phase 1`/`Phase 2`/`Phase 3` shipped commits to learn the area tag (`nats`) and PR title shape.*
+>
+> *Pre-flight: pwd is the repo root, branch is main, tree clean. Runs `git pull --ff-only origin main`. Creates worktree: `git worktree add .claude/worktrees/alt-29 -b claude/alt-29`, then `cd` into it. Runs `pnpm install` synchronously, then kicks off `pnpm worktree-env start --description "Phase 4 — pg-az-backup progress + result events"` in the background. Posts the worktree-details follow-up comment on ALT-29.*
 >
 > Skill: "Implementing Phase 4 — adding `mini-infra.backup.run` request handler and JetStream `BackupHistory` stream. Touching `server/src/services/backup/backup-executor.ts` first, then `server/src/services/nats/payload-schemas.ts`, then the boot sequence."
 >
 > *Implements. Runs build/lint/unit tests. Backgrounded env is up by now — runs the ticket's smoke test (publish a test backup-run request, confirm the consumer side fires).*
 >
-> *Commits with `feat(nats): pg-az-backup progress + result events (Phase 4, ALT-29)`. Opens PR with `Closes ALT-29` in the body. Marks ALT-29 In Review. Posts the handoff comment: PR URL, plus a Deviations section noting that the optional retry-on-transient-failure deliverable was deferred to a follow-up issue per the plan doc's wording — the plan doc itself is left untouched, the re-integration agent will fold this back later. Reports the PR URL.*
+> *Phase 10: commits with `feat(nats): pg-az-backup progress + result events (Phase 4, ALT-29)`, pushes the branch with `-u`. Spawns a Sonnet review subagent prompted to diff `claude/alt-29` against main. Subagent returns two findings: one `medium` (a missing try/catch around a socket emit, which is real) and one `high` (a "raw dockerode call bypassing DockerService" — but on inspection that's actually inside a test helper that intentionally pokes the daemon, so it's dismissed). Skill applies the medium fix, commits as `review: address sonnet review findings (Phase 4, ALT-29)`, and pushes again.*
 >
-> *Phase 12: captures `$CLAUDE_SESSION_ID` (the parent session), spawns a `general-purpose` subagent on Sonnet, and tells it to invoke the `session-retrospective` skill with `--session-id <parent-id> --linear-issue ALT-29`. The skill loads the Linear MCP, runs `scripts/get-session.sh` against the parent JSONL, generates retrospective markdown, resolves the Altitude Devops team / Backlog state / `retro` label, and creates a new issue `ALT-42 — Retro: ALT-29 — Phase 4: pg-az-backup progress + result events` with the markdown body and a Source link back to ALT-29. Subagent returns the URL of ALT-42; skill appends it to the run report.*
+> *Phase 11: opens PR with the implementation commit's title and `Closes ALT-29` in the body.*
 >
-> *Phase 13: every prior phase succeeded, so the skill `cd`s back to the repo root, runs `pnpm worktree-env delete alt-29 --force`, then `git worktree remove .claude/worktrees/alt-29`. Reports cleanup done. The `claude/alt-29` branch stays on the remote (the PR points at it).*
+> *Phase 12: marks ALT-29 In Review. Posts the handoff comment: PR URL, plus a Deviations section noting that the optional retry-on-transient-failure deliverable was deferred to a follow-up issue per the plan doc's wording, plus a "Review findings consciously dismissed" section explaining the test-helper carve-out. The plan doc itself is left untouched; the re-integration agent will fold the Deviations back later. Reports the PR URL.*
+>
+> *Phase 13: captures `$CLAUDE_SESSION_ID` (the parent session), spawns a `general-purpose` subagent on Sonnet, and tells it to invoke the `session-retrospective` skill with `--session-id <parent-id> --linear-issue ALT-29`. The skill loads the Linear MCP, runs `scripts/get-session.sh` against the parent JSONL, generates retrospective markdown, resolves the Altitude Devops team / Backlog state / `retro` label, and creates a new issue `ALT-42 — Retro: ALT-29 — Phase 4: pg-az-backup progress + result events` with the markdown body and a Source link back to ALT-29. Subagent returns the URL of ALT-42; skill appends it to the run report.*
+>
+> *Phase 14: every prior phase succeeded, so the skill `cd`s back to the repo root, runs `pnpm worktree-env delete alt-29 --force`, then `git worktree remove .claude/worktrees/alt-29`. Reports cleanup done. The `claude/alt-29` branch stays on the remote (the PR points at it).*

--- a/.claude/skills/task-to-linear/SKILL.md
+++ b/.claude/skills/task-to-linear/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: task-to-linear
-description: Turns a one-line job description into a single Linear ticket in the shape `execute-next-task` expects, without writing a full phased plan doc. The skill files the issue under a persistent **Maintenance** project (auto-created on first run) and appends a `### Phase N — <title>` entry to `docs/planning/maintenance.md` so the project still satisfies the "Plan: <doc>" convention every Linear project on Altitude Devops needs. Asks at most three clarifying questions before creating the ticket — one always about how to smoke-test the change (UI via `test-dev`, `curl` against a route, unit-only, or none), and up to two more only when the request is genuinely ambiguous (vague success criteria, unclear component scope, conflicting acceptance hints). Auto-detects which CLAUDE.md / ARCHITECTURE.md pointers apply from any file paths in the description and from the components named, picks an area tag for the eventual commit by reading recent `git log` on main, and sets the issue to Todo so `execute-next-task` picks it up naturally with no other changes. Use this skill whenever the user says "create a linear task for X", "make me a ticket to Y", "file a maintenance task to Z", "spin up a linear issue for ...", "task: ...", "queue up a linear todo for ...", or any equivalent ask to scaffold a single one-off Linear issue without a multi-phase plan. Make sure to use it even when the user doesn't say the word "Linear" but clearly wants a tracked task that Claude can later pick up — e.g. "remember to fix the X bug later", "let's queue a ticket to clean up Y", "log a follow-up to revisit Z". Do NOT trigger when the user wants Claude to do the work right now (use the work-doing skills instead), when they're describing a multi-phase plan (use `plan-to-linear`), or when they're asking about an *existing* ticket (use the Linear MCP directly).
+description: Turns a one-line job description into a single Linear ticket in the shape `execute-next-task` expects. The skill files the issue under a persistent **Maintenance** project (auto-created on first run). Linear is the single source of truth for maintenance tickets — `docs/planning/maintenance.md` is a static stub describing the project, never per-task entries. Asks at most three clarifying questions before creating the ticket — one always about how to smoke-test the change (UI via `test-dev`, `curl` against a route, unit-only, or none), and up to two more only when the request is genuinely ambiguous (vague success criteria, unclear component scope, conflicting acceptance hints). Auto-detects which CLAUDE.md / ARCHITECTURE.md pointers apply from any file paths in the description and from the components named, picks an area tag for the eventual commit by reading recent `git log` on main, and sets the issue to Todo so `execute-next-task` picks it up naturally with no other changes. Use this skill whenever the user says "create a linear task for X", "make me a ticket to Y", "file a maintenance task to Z", "spin up a linear issue for ...", "task: ...", "queue up a linear todo for ...", or any equivalent ask to scaffold a single one-off Linear issue without a multi-phase plan. Make sure to use it even when the user doesn't say the word "Linear" but clearly wants a tracked task that Claude can later pick up — e.g. "remember to fix the X bug later", "let's queue a ticket to clean up Y", "log a follow-up to revisit Z". Do NOT trigger when the user wants Claude to do the work right now (use the work-doing skills instead), when they're describing a multi-phase plan (use `plan-to-linear`), or when they're asking about an *existing* ticket (use the Linear MCP directly).
 ---
 
 # Task to Linear
 
-You're filing a single one-off ticket against the persistent **Maintenance** project on the Altitude Devops Linear team, in the exact shape that `execute-next-task` expects to consume. No plan doc per ticket — every one-off lives in one shared, evergreen plan doc at `docs/planning/maintenance.md`. New entries append a `### Phase N — <title>` section. The "Phase" wording is a contract with `execute-next-task`, not a semantic claim that one-offs are sequenced — they're independent and never block each other.
+You're filing a single one-off ticket against the persistent **Maintenance** project on the Altitude Devops Linear team, in the exact shape that `execute-next-task` expects to consume. Linear is the single source of truth — there is no per-task entry in any plan doc. The "Phase" wording in the issue title is a contract with `execute-next-task` (it matches by `Phase N` prefix), not a semantic claim that one-offs are sequenced — they're independent and never block each other.
 
 ## Why this skill exists
 
@@ -15,15 +15,13 @@ The big phased-plan flow (`plan-to-linear` → `execute-next-task`) is great for
 
 - **Team**: Altitude Devops (hardcoded, same as the other Linear skills).
 - **Project**: `Maintenance` — single, persistent, auto-created on first run.
-- **Project description**: starts with `Plan: [docs/planning/maintenance.md](<github-blob-url>)` so `execute-next-task`'s anchor check passes.
-- **Plan doc**: `docs/planning/maintenance.md` — top-level under `docs/planning/`, **not** under `not-shipped/` or `shipped/`. It never "ships"; it's an evergreen running list. Auto-scaffolded on first run with §1 Background + an empty Phases section.
-- **Phase numbering**: monotonic, scoped to the maintenance project. Read the existing plan doc to find the highest `Phase N`, increment by one.
+- **Project description**: starts with `Plan: [docs/planning/maintenance.md](<github-blob-url>)`. The doc is a static stub describing the project — `execute-next-task` reads it as supplemental context but tolerates missing per-phase entries (it does, since the loosened flow). Don't edit it from this skill.
+- **Phase numbering**: monotonic, scoped to the maintenance project. Read it from Linear (issue titles in the Maintenance project), incrementing the highest existing `Phase N`. The plan doc is *not* consulted for numbering.
 - **Issue title**: `Phase N: <title>` — same pattern `plan-to-linear` writes, so `execute-next-task` matches by phase number.
 - **Issue state**: `Todo` (default — don't gate behind Backlog).
 - **Blocked-by**: never set. One-offs are independent.
-- **Plan-doc edit**: staged with `git add`, **not** committed. The user owns the commit.
 
-If any of these conventions ever stops being true (Maintenance project deleted, plan doc moved, Altitude Devops renamed), **stop and ask** — don't paper over silently.
+If any of these conventions ever stops being true (Maintenance project deleted, plan-doc stub overwritten with phase entries, Altitude Devops renamed), **stop and ask** — don't paper over silently.
 
 ---
 
@@ -41,47 +39,13 @@ Fetch the team's issue statuses once (`list_issue_statuses` for Altitude Devops)
 
 ---
 
-## Phase 2 — Ensure the Maintenance project + plan doc exist
+## Phase 2 — Ensure the Maintenance project exists
 
-This phase is **idempotent** — on every run, after the first, it's a fast no-op.
-
-### 2.1 Plan doc
-
-Check whether `docs/planning/maintenance.md` exists.
-
-**If it doesn't**, scaffold it. Use this template verbatim — the H1, the §1 Background line, and the §6 Phased rollout heading mirror the conventions `plan-to-linear` writes for phased plans, so any future Linear-side tooling can read either doc the same way.
-
-```markdown
-# Maintenance
-
-## 1. Background
-
-Catch-all evergreen plan doc for one-off maintenance and follow-up tasks
-filed via the `task-to-linear` skill. Each task is a `### Phase N` entry
-below. Tasks are independent — they do not block each other and they do
-not have to land in numerical order. The "Phase" wording is preserved so
-`execute-next-task` matches by phase number; nothing more is implied.
-
-This doc is never archived to `docs/planning/shipped/`. Tasks shipped
-long ago stay here as historical record (or are pruned manually when the
-list gets unwieldy — that's a human decision).
-
-## 6. Phased rollout
-
-<!-- task-to-linear appends new phases below this comment -->
-
-## 8. Linear tracking
-
-Tracked under the **Maintenance** project on the Altitude Devops team.
-Issue IDs are recorded inline against each phase above when the skill
-appends them.
-```
-
-### 2.2 Linear project
+This phase is **idempotent** — on every run, after the first, it's a fast no-op. The skill no longer touches `docs/planning/maintenance.md`; the doc is a static stub describing the project, maintained by humans separately.
 
 `list_projects` (filtered to Altitude Devops) and look for one named exactly `Maintenance`.
 
-**If it doesn't exist**, create it via `save_project`. Description must start with the `Plan:` line so `execute-next-task` can find the anchor:
+**If it doesn't exist**, create it via `save_project`. Description must start with the `Plan:` line:
 
 ```
 Plan: [docs/planning/maintenance.md](<github-blob-url>)
@@ -96,6 +60,8 @@ Build the GitHub URL from `git remote get-url origin` + `/blob/main/docs/plannin
 Capture the project's ID and URL — you'll need both later.
 
 **If it does exist**, fetch its description and verify the `Plan:` line still points at `docs/planning/maintenance.md`. If it's been edited to point somewhere else, **stop and ask** — that's a corruption signal worth surfacing rather than fixing silently.
+
+**Don't scaffold or modify the plan doc.** If `docs/planning/maintenance.md` is missing on disk, that's a separate problem for a human to handle (it's expected to exist as a stub) — the skill doesn't auto-create it.
 
 ---
 
@@ -214,9 +180,11 @@ If no recent commits matched the touched components, write `<choose at execution
 
 ## Phase 6 — Determine the next phase number
 
-Read `docs/planning/maintenance.md`. Find the highest existing `### Phase N — <title>` heading. Next task is `Phase N+1`. If the file was just scaffolded in Phase 2.1, next task is `Phase 1`.
+Linear is the source of truth. `list_issues` filtered to the Maintenance project (include all states — `Todo`, `In Progress`, `In Review`, `Done`, `Cancelled` — since closed tickets still occupy phase numbers). Find the highest `Phase N` in the titles, increment by one.
 
-Cross-check against Linear: `list_issues` filtered to the Maintenance project, look for the highest `Phase N` in the titles. If Linear and the doc disagree, **stop and ask** — that's a sign someone created an issue manually or the doc has been pruned, and the right resolution is human.
+If no maintenance tickets exist yet, next is `Phase 1`.
+
+The plan doc is *not* consulted here — it's a static stub and contains no per-phase entries.
 
 ---
 
@@ -235,9 +203,6 @@ About to file:
   Components: <list of detected dirs>
   Docs:       <list of CLAUDE.md / ARCHITECTURE.md links to attach>
 
-Plan-doc edit (staged, not committed):
-  + ### Phase <N> — <title>  in docs/planning/maintenance.md
-
 Proceed?
 ```
 
@@ -245,52 +210,28 @@ Don't proceed without an explicit yes. "lgtm", "go", "yes", "ship it" all count.
 
 ---
 
-## Phase 8 — Append the new phase to the plan doc
-
-Edit `docs/planning/maintenance.md`. Append a section under `## 6. Phased rollout` (after any existing phases, before any other top-level heading). Keep it tight — this is a maintenance doc, not a design doc.
-
-```markdown
-### Phase <N> — <title>
-
-**Linear:** [ALT-_TBD_](https://linear.app/altitude-devops/team/altitude-devops) *(filled in after the issue is created)*
-
-**Goal.** <one sentence — copied from Phase 3 / clarified in Phase 4>
-
-**Deliverables.**
-- <bullet>
-- <bullet>
-
-**Done when.** <one sentence — testable end state>
-
-**Smoke.** <one line — paraphrase of the recipe written into the ticket>
-```
-
-`git add docs/planning/maintenance.md` so the change is staged. **Do not commit** — the user owns the commit.
-
----
-
-## Phase 9 — Create the Linear issue
+## Phase 8 — Create the Linear issue
 
 Issue title: `Phase <N>: <title>`.
 
 State: `Todo` (canonical name from Phase 1).
 
-Description body — same shape `plan-to-linear` writes, so `execute-next-task` reads it without special-casing:
+Description body — same shape `plan-to-linear` writes, so `execute-next-task` reads it without special-casing. The `Source` line points at the maintenance plan doc (the project stub) — `execute-next-task` will tolerate the lack of a per-phase anchor under the loosened flow.
 
 ```markdown
-**Source:** [docs/planning/maintenance.md §phase-<N>](docs/planning/maintenance.md#phase-<N>--<slug-of-title>)
+**Source:** [docs/planning/maintenance.md](docs/planning/maintenance.md) — Maintenance project (one-off ticket, no per-phase doc entry)
 
 ## Goal
 
-<copied from Phase 8 verbatim>
+<from Phase 3, clarified in Phase 4>
 
 ## Deliverables
 
-<copied from Phase 8 verbatim — preserve list nesting>
+<from Phase 3, clarified in Phase 4 — preserve list nesting>
 
 ## Done when
 
-<copied from Phase 8 verbatim>
+<from Phase 3, clarified in Phase 4>
 
 ---
 
@@ -342,34 +283,21 @@ Capture the issue's `ALT-NN` ID and URL.
 
 ---
 
-## Phase 10 — Backfill the issue ID into the plan doc
-
-Edit `docs/planning/maintenance.md` once more — replace the `ALT-_TBD_` placeholder you just appended with the real issue ID:
-
-```diff
--**Linear:** [ALT-_TBD_](https://linear.app/altitude-devops/team/altitude-devops) *(filled in after the issue is created)*
-+**Linear:** [ALT-NN](https://linear.app/altitude-devops/issue/ALT-NN)
-```
-
-`git add` again so the staged diff is now complete. **Still don't commit.**
-
----
-
-## Phase 11 — Report
+## Phase 9 — Report
 
 Print a tight summary:
 
 ```
 ✓ Created Phase <N>: <title>
    <ALT-NN> — <issue URL>
-✓ Appended to docs/planning/maintenance.md (staged, uncommitted)
 ✓ Smoke approach: <UI / curl / unit-only / docs-only / custom>
 
 Next steps:
-  - review the staged plan-doc diff (`git diff --cached docs/planning/maintenance.md`)
-  - commit it with the rest of any related work
-  - run `execute-next-task` when you're ready to pick this up
+  - run `execute-next-task ALT-NN` when you're ready to pick this up,
+    or `execute-next-task` to take whatever's next in the queue
 ```
+
+The skill makes no working-tree changes — `docs/planning/maintenance.md` is a stub maintained by humans, not by this skill. There's nothing to stage or commit.
 
 ---
 
@@ -378,9 +306,9 @@ Next steps:
 These are non-negotiable. If you find yourself wanting to break one, stop and ask the user instead.
 
 - **Never ask more than three clarifying questions in Phase 4.** One smoke-test slot + at most two ambiguity probes. If you find yourself wanting a fourth, the request is too big for a one-off — suggest the user run `plan-to-linear` against a quick markdown plan instead.
-- **Never commit the plan-doc edit.** Stage with `git add`; the user owns the commit. Same convention as `plan-to-linear`.
+- **Never edit `docs/planning/maintenance.md`.** It's a static stub describing the Maintenance project. Per-task data lives in Linear only.
 - **Never set `blocked-by` relationships** between maintenance tickets. They're independent. If a one-off genuinely blocks another one-off, both should probably live in a small phased plan, not in maintenance.
-- **Never silently fix a corrupted Maintenance project.** If the project's `Plan:` line points somewhere other than `docs/planning/maintenance.md`, stop. Same for plan-doc/Linear phase-number drift.
+- **Never silently fix a corrupted Maintenance project.** If the project's `Plan:` line points somewhere other than `docs/planning/maintenance.md`, stop. (Phase numbering drift between Linear and the doc is no longer a concern — the doc is a stub and isn't consulted for numbering.)
 - **Never write a multi-phase ticket.** This skill creates exactly one Linear issue per run. If the user describes work that's clearly multiple phases, suggest `plan-to-linear`.
 - **Never invent docs.** Each `Relevant docs` link must `Read`-resolve. If `egress-shared/CLAUDE.md` doesn't exist, drop it from the attach list.
 - **Never transition the issue out of `Todo`.** That's `execute-next-task`'s job. The skill only creates.
@@ -392,7 +320,7 @@ These are non-negotiable. If you find yourself wanting to break one, stop and as
 
 > User: "task: the cert renewer doesn't retry transient cloudflare 429s. file a maintenance ticket to add a small backoff."
 >
-> *Skill loads Linear MCP. Maintenance project exists already; plan doc exists, highest existing phase is `Phase 12`. Skill parses the request: title "Add retry-with-backoff to cert renewer on Cloudflare 429"; component scope clearly `acme/` and probably `server/src/services/certificates/`; smoke-test approach not stated; goal/done-when implicit but extractable. Area tag from `git log`: `acme` is most recent for `acme/` changes.*
+> *Skill loads Linear MCP. Maintenance project exists already; the highest existing `Phase N` in the project's Linear titles is `Phase 12`. Skill parses the request: title "Add retry-with-backoff to cert renewer on Cloudflare 429"; component scope clearly `acme/` and probably `server/src/services/certificates/`; smoke-test approach not stated; goal/done-when implicit but extractable. Area tag from `git log`: `acme` is most recent for `acme/` changes.*
 >
 > Skill: "Quick check before I file —
 >
@@ -419,21 +347,16 @@ These are non-negotiable. If you find yourself wanting to break one, stop and as
 >   Components: acme/, server/src/services/certificates/
 >   Docs:       CLAUDE.md, ARCHITECTURE.md, server/CLAUDE.md, server/ARCHITECTURE.md, acme/CLAUDE.md
 >
-> Plan-doc edit (staged, not committed):
->   + ### Phase 13 — Add retry-with-backoff to cert renewer on Cloudflare 429
->
 > Proceed?"
 >
 > User: "go"
 >
-> *Skill appends to `docs/planning/maintenance.md`, creates the Linear issue, captures `ALT-47`, backfills the issue ID into the plan doc, stages both edits.*
+> *Skill creates the Linear issue and captures `ALT-47`. No plan-doc edits — the doc is a stub.*
 >
 > Skill: "✓ Created Phase 13: Add retry-with-backoff to cert renewer on Cloudflare 429
 >    ALT-47 — https://linear.app/altitude-devops/issue/ALT-47
-> ✓ Appended to docs/planning/maintenance.md (staged, uncommitted)
 > ✓ Smoke approach: Unit / build / lint only
 >
 > Next steps:
->   - review `git diff --cached docs/planning/maintenance.md`
->   - commit it
->   - run `execute-next-task` when you're ready to pick this up"
+>   - run `execute-next-task ALT-47` when you're ready to pick this up,
+>     or `execute-next-task` to take whatever's next in the queue"

--- a/docs/planning/maintenance.md
+++ b/docs/planning/maintenance.md
@@ -1,40 +1,15 @@
 # Maintenance
 
-## 1. Background
+Catch-all project for one-off maintenance and follow-up work in Mini Infra.
 
-Catch-all evergreen plan doc for one-off maintenance and follow-up tasks
-filed via the `task-to-linear` skill. Each task is a `### Phase N` entry
-below. Tasks are independent — they do not block each other and they do
-not have to land in numerical order. The "Phase" wording is preserved so
-`execute-next-task` matches by phase number; nothing more is implied.
+Tickets are tracked in Linear under the **Maintenance** project on the Altitude
+Devops team. Each ticket is independent — they do not block each other and do
+not have to ship in any particular order.
 
-This doc is never archived to `docs/planning/shipped/`. Tasks shipped
-long ago stay here as historical record (or are pruned manually when the
-list gets unwieldy — that's a human decision).
+This doc is intentionally a stub. The ticket body in Linear (Goal /
+Deliverables / Done when / Relevant docs / Smoke tests) is the contract for
+each task — there is no per-task design here.
 
-## 6. Phased rollout
-
-<!-- task-to-linear appends new phases below this comment -->
-
-### Phase 1 — Upgrade @anthropic-ai/claude-agent-sdk in server and agent-sidecar
-
-**Linear:** [ALT-31](https://linear.app/altitude-devops/issue/ALT-31)
-
-**Goal.** Bump `@anthropic-ai/claude-agent-sdk` to the latest stable release across every package that depends on it, aligning both consumers on the same version.
-
-**Deliverables.**
-- Bump `@anthropic-ai/claude-agent-sdk` in `server/package.json` (currently `^0.2.123`).
-- Bump `@anthropic-ai/claude-agent-sdk` in `agent-sidecar/package.json` (currently `^0.2.107`).
-- Consider bumping the related `@mrgeoffrich/claude-agent-sdk-tap` (`^0.1.8`) in `agent-sidecar/` if a compatible newer version exists.
-- Update `pnpm-lock.yaml` and `agent-sidecar/package-lock.json` accordingly.
-- Resolve any TypeScript / API breakage from the version jump.
-
-**Done when.** Both packages build, lint, and pass their unit test suites against the upgraded SDK with no regressions; both consumers are on the same SDK minor/patch.
-
-**Smoke.** Unit / build / lint only — `pnpm --filter mini-infra-server build|test|lint` from root, plus `cd agent-sidecar && npm install && npm run build && npm test`.
-
-## 8. Linear tracking
-
-Tracked under the **Maintenance** project on the Altitude Devops team.
-Issue IDs are recorded inline against each phase above when the skill
-appends them.
+Use the `task-to-linear` skill to file new maintenance tickets, and
+`execute-next-task` (with no argument, or with an explicit `ALT-NN`) to pick
+one up and ship it.


### PR DESCRIPTION
## Summary

- Loosen `execute-next-task` so it handles both phased plan-doc tickets and standalone (e.g. Maintenance) tickets uniformly. The ticket body is the contract; a missing project `Plan:` line or missing `### Phase N` section in the plan doc is no longer fatal.
- Mark the picked issue **In Progress immediately** (new Phase 2.1) with a "claimed" comment, before any setup runs — so the Linear board reflects ownership while the worktree is still warming.
- Accept an optional `ALT-NN` argument (e.g. `/execute-next-task ALT-32`) to skip the picking flow and jump straight to a specific ticket. Auto-pick path is unchanged when no arg is supplied.
- New **Phase 10 — Commit, push, and run a code review**: commits the implementation, pushes the branch, spawns a Sonnet review subagent against the diff vs main, triages findings (sanity-checks every medium/high/critical against context before applying), and lands fixups as a separate review commit. Phases downstream shift: open-PR is now Phase 11, handoff Phase 12, retrospective Phase 13, cleanup Phase 14. Hard rules, sub-phase numbering, cross-references, and the example end-to-end all updated.
- Reduce [docs/planning/maintenance.md](docs/planning/maintenance.md) to a stub. Per-phase entries no longer live in the doc — Linear is the system of record for maintenance work. (`task-to-linear` still appends phase entries today; that's flagged as a follow-up.)

## Why

The skill previously hard-failed on tickets without a phased plan doc (e.g. anything in the Maintenance project, or any orphaned `### Phase N` section like ALT-32 has today). It also waited until after worktree setup to mark the issue In Progress, which left the Linear board ambiguous during the slow part of a run. And it had no defensive review pass before opening the PR — review noise had to play out on GitHub instead of being caught and fixed locally.

## Test plan

- [ ] Pick up a standalone Maintenance ticket via `/execute-next-task ALT-NN` and confirm: (1) issue flips to In Progress before pre-flight runs, (2) the skill doesn't stop on the missing `### Phase N` section, (3) the new Phase 10 review subagent fires and any applied fixups land as a separate `review:` commit, (4) PR opens cleanly in Phase 11.
- [ ] Pick up a phased plan-doc ticket (e.g. an upcoming `internal-nats-messaging-plan.md` phase) and confirm: existing flow still works end-to-end, with the plan-doc section read as supplemental context and Deviations captured in the Phase 12 handoff.
- [ ] Run `/execute-next-task` with no argument and confirm the auto-pick path still ranks Todos by no-blockers and asks for disambiguation when there are multiple unblocked candidates.

## Follow-ups

- Update `task-to-linear` to skip the plan-doc append for the Maintenance project, since [docs/planning/maintenance.md](docs/planning/maintenance.md) is now a stub. (Currently the skill would re-grow phase entries on the next maintenance ticket.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)