### PR TITLE
docs(planning): per-phase Reversibility, UI changes, Verify-in-prod fields

### DIFF
--- a/.claude/skills/plan-to-linear/SKILL.md
+++ b/.claude/skills/plan-to-linear/SKILL.md
@@ -14,21 +14,30 @@ Reference examples in this repo:
 - `docs/planning/not-shipped/observability-otel-tracing-plan.md` — has `ALT-_TBD_` placeholders waiting for this skill.
 - `docs/planning/shipped/nats-app-roles-plan.md` — same shape, already shipped.
 
-The conventions you depend on (also documented in `execute-next-task/SKILL.md`):
+The conventions you depend on (full spec in [`docs/planning/PLANNING.md`](../../../docs/planning/PLANNING.md); also referenced from `execute-next-task/SKILL.md`):
 
 - **H1** (`# <feature title>`) is the Linear project name.
 - **§1 Background** — first paragraph is the project description body.
-- **A "Phased rollout" section** (usually §6) with `### Phase N — <title>` subsections. Each phase has **Goal**, **Deliverables**, and **Done when** lines (sometimes with extra subsections like "Migration shape").
-- **A Linear-tracking section** (usually §8) with a placeholder list:
+- **§2 Goals** and **§3 Non-goals** — required scoping sections.
+- **A "Phased rollout" section** (usually §6) with `### Phase N — <title>` subsections. Each phase has **six required parts**:
+  - **Goal** — one-sentence outcome.
+  - **Deliverables** — bullet list.
+  - **Reversibility** — `safe` / `feature-flagged` / `forward-only` / `destructive`, plus rationale.
+  - **UI changes** — bullet list (each item tagged `[design needed]` or `[no design]`) or the literal `none`.
+  - **Done when** — testable acceptance criterion.
+  - **Verify in prod** — production signal, or `n/a — internal only`.
+  Phases may have extra subsections like "Migration shape" or "Subjects" — keep them.
+- **A Linear-tracking section** (usually §8) with a placeholder list and optional `[blocks-by: …]` brackets:
   ```
   - ALT-_TBD_ — Phase 1: <title>
-  - ALT-_TBD_ — Phase 2: <title>
+  - ALT-_TBD_ — Phase 2: <title>  [blocks-by: 1]
+  - ALT-_TBD_ — Phase 3: <title>  [blocks-by: 1, 2]
   ```
-  This list is the contract — the skill writes back into it.
-- **Phase ordering** — the plan text says "phases land in order" or "Phase 1 blocks all later phases" or similar. Translate that to `blocked-by` relationships.
+  This list is the contract — the skill writes back into it. Brackets are preserved through seeding.
+- **Phase ordering** — preferred form is `[blocks-by: N, M]` brackets in §8 (above). Fallback is prose hints in the §6 preamble or §8 intro line ("phases land in order", "Phase 1 blocks all later phases", "Phase N also blocks on Phase M"). Brackets win if both are present. If neither is present, default to **strictly sequential** (each phase blocks-by the previous).
 - **Optional / deferred phases** — marked in the heading or first line ("optional", "deferred", "(optional, deferred)"). They go into Linear as `Backlog`, not `Todo`.
 
-If the doc doesn't follow this shape, **stop and report**. Don't guess.
+If the doc doesn't follow this shape, **stop and report**. Don't guess. Older plans (pre-Reversibility / UI changes / Verify-in-prod) may be missing those fields — surface that to the user and ask whether to backfill before seeding rather than silently dropping the new sections from the issue body.
 
 The team is hardcoded as **Altitude Devops**.
 
@@ -61,12 +70,17 @@ Read the doc end-to-end and extract:
    - **Optional flag** — true if the heading or first line contains "optional", "deferred", or both. (Plan §6 in the OTel doc has "Phase 6 — App-level metrics (optional, deferred)" as a deliberate example.)
    - The **Goal** line.
    - The **Deliverables** list (bullet points; can be nested).
+   - The **Reversibility** line (classifier + rationale).
+   - The **UI changes** block — bullet list with `[design needed]` / `[no design]` tags, or the literal `none`. Surface a count of `[design needed]` items per phase in the Phase 6 confirmation prompt so the user can spot phases that should be deferred pending design.
    - The **Done when** line.
+   - The **Verify in prod** line (production signal or `n/a — internal only`).
    - Any other phase-specific subsections (e.g. "Migration shape", "Subjects", "Subjects:") — keep verbatim.
    - File paths mentioned in any of the above (anything matching `[\w-]+/[\w/.-]+\.\w+` or markdown links to repo paths). Used in Phase 3.
+
+   If a phase is missing any of the six required parts, **stop and report which phase / which field**. Do not silently fill in defaults — the convention is the convention. (Older pre-spec plans that genuinely have no UI/Reversibility/Verify lines are the one exception: ask the user whether to seed anyway with empty placeholders, or pause to backfill the plan first.)
 4. **Plan-doc-level architecture references** — any links to `docs/architecture/*.md` anywhere in the doc. Surface them to every phase as background.
 5. **Linear-tracking section** — confirm a placeholder list exists with the same number of phases as you found. If the count doesn't match, **stop and report** — the doc and §8 are out of sync.
-6. **Ordering hints** — scan for phrases like "phases land in order", "Phase 1 blocks all later phases", "Phase N also blocks on Phase M". Use these to build the `blocked-by` graph in Phase 5. If no hints exist, default to **strictly sequential** (each phase blocked by the previous).
+6. **Ordering** — preferred is `[blocks-by: N, M]` brackets on each §8 line; parse them first. If no brackets are present anywhere in §8, fall back to prose hints elsewhere in the doc ("phases land in order", "Phase 1 blocks all later phases", "Phase N also blocks on Phase M"). If neither brackets nor prose are present, default to **strictly sequential** (each phase blocked by the previous). If both brackets and prose are present, brackets win — log it and continue.
 
 ---
 
@@ -213,8 +227,17 @@ For each phase, in order, create a Linear issue:
 ## Deliverables
 <copied verbatim — preserve list nesting and inline links>
 
+## Reversibility
+<copied verbatim — classifier + rationale>
+
+## UI changes
+<copied verbatim — bullet list with [design needed] / [no design] tags, or `none`>
+
 ## Done when
 <copied verbatim>
+
+## Verify in prod
+<copied verbatim — production signal or `n/a — internal only`>
 
 <copy any other phase-specific subsections like "Migration shape", "Subjects", verbatim>
 
@@ -280,7 +303,13 @@ Capture each issue's ID (`ALT-NN`) and URL.
 
 ## Phase 9 — Set blocking relationships
 
-For each phase in order from 2 onward, add a `blocked-by` relationship to the previous phase using the Linear API. If the plan-doc text specified extra blockers (e.g. "Phase 5 also blocks on Phase 4"), add those too.
+Use the dependency graph you parsed in Phase 2:
+
+- If §8 has `[blocks-by: N, M]` brackets, that's the source of truth — add a `blocked-by` edge to each listed phase.
+- Else if prose hints exist, apply them ("Phase 1 blocks all later phases", "Phase N also blocks on Phase M").
+- Else default to **strictly sequential** — each phase from 2 onward is `blocked-by` the previous.
+
+Add the edges in order via the Linear API.
 
 Optional/deferred phases still get blocked-by relationships — being in `Backlog` doesn't mean unblocked. The blocker just means "even when promoted to Todo, wait for the predecessor".
 

--- a/docs/planning/BACKFILL.md
+++ b/docs/planning/BACKFILL.md
@@ -1,0 +1,76 @@
+# Plan-doc spec backfill — todo
+
+The [`PLANNING.md`](PLANNING.md) spec was extended (2026-05-02) to require three new per-phase fields:
+
+- **Reversibility** — `safe` / `feature-flagged` / `forward-only` / `destructive` + one-line rationale.
+- **UI changes** — bullet list with `[design needed]` / `[no design]` tags, or the literal `none`.
+- **Verify in prod** — production signal, or `n/a — internal only`.
+
+All in-flight plans pre-date the spec change. Pick one off the list below and backfill — every phase needs all three fields.
+
+The structural value of doing this isn't just "make the spec happy." It surfaces:
+- **Designer dependencies** — `grep -r "\[design needed\]" docs/planning/` becomes the live designer-todo list across all in-flight plans.
+- **Rollback gaps** — Reversibility forces a per-phase answer to "what if this breaks in prod?" Several plans implicitly assume `safe` and would be `forward-only` on inspection.
+- **Outcome vs deliverable confusion** — Verify-in-prod separates "the code does the right thing in CI" from "the goal materialised after rollout."
+
+---
+
+## Status
+
+- [x] **[service-addons-plan](not-shipped/service-addons-plan.md)** (6 phases) — done.
+
+## Priority 1 — UI is bunched late; designer can't see the work without reading the whole plan
+
+These plans split UI from backend in ways that hide design dependencies. Backfilling forces the per-phase UI line, which exposes the back-loading. Worth a 5-minute think *before* backfilling about whether to shift UI work earlier in the phasing — if not, the backfilled lines will read "Phases 1-3: `none`. Phase 4: 12 items `[design needed]`" and the designer becomes the critical path.
+
+- [ ] **[auth-proxy-sidecar-plan](not-shipped/auth-proxy-sidecar-plan.md)** (4 PRs) — PRs 1–3 are backend; PR 4 ships the entire admin UI.
+- [ ] **[dns-providers-plan](not-shipped/dns-providers-plan.md)** (5 phases) — Phases 1–2 build the framework with no affordances; Phase 4 lands the `/dns-providers` page. Phase 3 also sneaks in Socket.IO events without a UI call-out.
+
+## Priority 2 — UI is buried in deliverables, code blocks, or background prose
+
+Real UI work is mentioned but in places a designer scanning for the UI block would miss.
+
+- [ ] **[native-heap-profiling](not-shipped/native-heap-profiling.md)** (1 phase) — "two buttons on the diagnostics page" is buried in a code block.
+- [ ] **[observability-otel-tracing-plan](not-shipped/observability-otel-tracing-plan.md)** (6 phases) — Phase 6's "new Grafana dashboard panel set" is mentioned but not framed as user-facing work. Phases 1, 5 already clear.
+- [ ] **[unified-backups-plan](not-shipped/unified-backups-plan.md)** (5 phases) — Phase 1 ships two distinct UIs (bootstrap surface + admin Backups page) but only one is in the deliverable bullets.
+
+## Priority 3 — UI articulation is fine; just rote backfill of Reversibility + Verify-in-prod
+
+UI lines will mostly be `none` or copy-from-existing. The rate-limiter is writing the Reversibility classifier and Verify-in-prod signal honestly.
+
+- [ ] **[internal-nats-messaging-plan](not-shipped/internal-nats-messaging-plan.md)** (5 phases) — UI is clear (events page, health UI). Reversibility for Phases 2-5 is `feature-flagged` per the existing prose ("old transport stays compiled for one release behind a feature flag for rollback").
+- [ ] **[vault-oidc-plan](not-shipped/vault-oidc-plan.md)** (3 stages) — Stage 1 UI is clear; Stages 2–3 backend-only (`UI changes: none`).
+- [ ] **[job-pool-service-type-plan](not-shipped/job-pool-service-type-plan.md)** (5 phases) — UI is clear (events page, Run-now affordance reuse).
+- [ ] **[worktree-egress-subnet-allocation](not-shipped/worktree-egress-subnet-allocation.md)** — entirely infra; UI is `none` for every phase. Shortest backfill in the list.
+
+---
+
+## Per-phase template to paste
+
+Insert between **Deliverables** and **Done when** in each phase:
+
+```
+Reversibility: <safe | feature-flagged | forward-only | destructive> — <one-line rationale>
+
+UI changes:
+- <user-visible change — page/screen + what changes + what user sees> [design needed]
+- <user-visible change> [no design]
+- (or the literal word `none` if this phase ships nothing user-visible)
+```
+
+Then after **Done when**:
+
+```
+Verify in prod: <production signal that confirms the Goal materialised> (or `n/a — internal only`)
+```
+
+See [service-addons-plan](not-shipped/service-addons-plan.md) Phase 1 for a worked example.
+
+---
+
+## Notes
+
+- **Already-seeded plans:** every plan in the list except `native-heap-profiling` is already seeded to Linear. The new sections won't auto-propagate to existing Linear issues. Decide per-plan whether to manually update the issue body, or accept the doc as source-of-truth and let the Linear ticket stay as a frozen snapshot.
+- **The `plan-to-linear` skill has been updated** to extract and propagate the new fields, so any *new* plan seeded after the spec change will carry them into Linear automatically.
+- **Strict-sequential plans don't need `[blocks-by]` brackets** in §8 — the omitted-bracket form means strict sequential. Most plans here are strict sequential and §8 needs no change.
+- **Delete this file** once the list is empty.

--- a/docs/planning/PLANNING.md
+++ b/docs/planning/PLANNING.md
@@ -47,6 +47,28 @@ The H1 (stripped of trailing punctuation) becomes the Linear **project name**. D
 
 The **first paragraph of §1** is copied verbatim into the Linear project description. Make it self-contained — no "see above" references — and fit the gist of the project in 3-6 sentences.
 
+### §2 Goals
+
+```markdown
+## 2. Goals
+
+1. <numbered point — what success looks like, stated as an outcome>
+2. ...
+```
+
+3-6 numbered points. Each point states an *outcome*, not a deliverable. Goals scope what the **project** is for; per-phase Done-when scopes what each **phase** ships. The two should reinforce each other — if a Goal isn't testable from at least one phase's Done-when or Verify-in-prod line, either the Goal is too vague or the plan is missing a phase.
+
+### §3 Non-goals
+
+```markdown
+## 3. Non-goals
+
+- **<thing>.** <one-line rationale for why it's out of scope>
+- ...
+```
+
+The single most important section for preventing scope creep. Anything you've considered and decided not to do belongs here, with a one-line *why*. Without the rationale, future readers (and the executor) will re-litigate the decision. If you find yourself writing more than ~6 non-goals, the project is probably too broad — consider splitting.
+
 ### Phased rollout section (typically §6)
 
 ```markdown
@@ -62,19 +84,31 @@ Deliverables:
 - <bullet>
 - <bullet>
 
+Reversibility: <safe | feature-flagged | forward-only | destructive> — <one-line rationale>
+
+UI changes:
+- <user-visible change — page/screen + what changes + what the user sees> [design needed]
+- <user-visible change> [no design]
+- (or the literal word `none` if this phase ships nothing user-visible)
+
 Done when: <one sentence acceptance criterion>
+
+Verify in prod: <production signal that confirms the Goal materialised> (or `n/a — internal only`)
 
 ### Phase 2 — <title>
 …
 ```
 
-Three required parts per phase:
+Six required parts per phase:
 
 | Part | Shape | Notes |
 |---|---|---|
 | **Goal** | one-sentence headline | Becomes the issue's Goal section. State the *outcome*, not the steps. |
 | **Deliverables** | bullet list | Concrete artifacts the phase ships. May nest. May include inline links to files/PRs. **Not** a file-by-file change plan — see "What not to write" below. |
-| **Done when** | one sentence | The acceptance criterion. Should be testable. |
+| **Reversibility** | one of `safe` / `feature-flagged` / `forward-only` / `destructive`, plus one-line rationale | What happens if this phase ships and breaks. `safe` = revert the PR cleanly. `feature-flagged` = flip a flag, no rollback PR needed. `forward-only` = a forward-fix is required (data migration, contract change, irreversible state). `destructive` = data loss or external state change that cannot be undone. The executor uses this to decide whether to gate the rollout, add a flag, or require ops sign-off before merging. |
+| **UI changes** | bullet list, or the literal word `none` | Every user-visible change this phase ships. Write in user terms ("operators see a new column on the certificates page"), not implementation terms ("add `<CertStatusBadge>` to the cert table"). For each item, tag `[design needed]` if it needs a designer to mock first, or `[no design]` if it can ship as-is (copy tweaks, new technical fields with obvious layouts). Saying `none` is fine — but say it; don't omit the line. **Why this exists:** UI changes are extracted from plans before implementation so the designer can be looped in early. A missing line is indistinguishable from "no UI changes" and leads to mid-PR surprises and rework. Grep `[design needed]` across `docs/planning/` for an instant designer-todo list. |
+| **Done when** | one sentence | The acceptance criterion. Should be testable in CI or the dev env. |
+| **Verify in prod** | one bullet, or `n/a — internal only` | The production signal that confirms the *outcome* (Goal), not just the *deliverables*. A counter that should appear, an error rate that should drop, a dashboard panel to watch, a graph that should change shape, an alert to wire up. Different from Done-when: Done-when is "the code does the right thing in CI"; Verify-in-prod is "we can tell the goal materialised after rollout." Use `n/a — internal only` for refactors and other phases with no user-visible production signal — but write it explicitly so reviewers know you considered it. |
 
 Optional per-phase subsections (used when they help):
 
@@ -89,11 +123,11 @@ Heading convention: `### Phase N — <title>` with an em-dash (`—`), not a hyp
 ```markdown
 ## 8. Linear tracking
 
-<one-line pointer to where these issues will live, plus any blocking-relationship hints>
+<one-line pointer to where these issues will live>
 
 - ALT-_TBD_ — Phase 1: <title>
-- ALT-_TBD_ — Phase 2: <title>
-- ALT-_TBD_ — Phase 3: <title>
+- ALT-_TBD_ — Phase 2: <title>  [blocks-by: 1]
+- ALT-_TBD_ — Phase 3: <title>  [blocks-by: 1, 2]
 ```
 
 Required:
@@ -101,17 +135,18 @@ Required:
 - One line per phase, in order, count must equal the number of `### Phase N` headings.
 - Placeholder is exactly `ALT-_TBD_` (with underscores). `plan-to-linear` rewrites these to real Linear-linked references after seeding.
 - Phase title after the colon should match the heading title (minus the em-dash).
+- **`[blocks-by: N, M]` brackets** encode the dependency graph (see "Phase ordering" below). Omit the brackets entirely on every line to fall back to strict-sequential default. Brackets are preserved through seeding so the graph stays readable from the doc.
 
 After seeding, this section is rewritten in place to:
 
 ```markdown
-Tracked under the [<Project Name>](<linear project URL>) project on the Altitude Devops team. Phase 1 blocks all later phases.
+Tracked under the [<Project Name>](<linear project URL>) project on the Altitude Devops team.
 
 - [ALT-NN](https://linear.app/altitude-devops/issue/ALT-NN) — Phase 1: <title>
-- [ALT-NN](https://linear.app/altitude-devops/issue/ALT-NN) — Phase 2: <title>
+- [ALT-NN](https://linear.app/altitude-devops/issue/ALT-NN) — Phase 2: <title>  [blocks-by: 1]
 ```
 
-Don't pre-write that shape — leave the placeholders, let `plan-to-linear` write them.
+`[blocks-by: …]` brackets are preserved verbatim through seeding so the dependency graph remains readable in the doc without opening Linear. Don't pre-write the linked shape — leave the placeholders, let `plan-to-linear` write them.
 
 ---
 
@@ -122,24 +157,33 @@ These don't affect Linear seeding but are common and worth knowing.
 | Section | Purpose |
 |---|---|
 | `**Status:** …`, `**Builds on:** …`, `**Excludes:** …` lines under the H1 | Quick orientation for readers. The "Builds on" line is especially useful — link prior PRs or shipped plans. |
-| `## 2. Goals` | What success looks like. 3-6 numbered points. |
-| `## 3. Non-goals` | Things the plan deliberately doesn't cover, with one-line rationale each. The most important section for preventing scope creep. |
-| `## <N>. <Architecture / concept section>` | Type definitions, subject naming conventions, or other shared concepts referenced across multiple phases. Lives between Goals and Phased rollout. |
+| `## <N>. <Architecture / concept section>` | Type definitions, subject naming conventions, or other shared concepts referenced across multiple phases. Lives between Non-goals and Phased rollout. Worth writing whenever ≥2 phases share a contract or convention — without it the same decision gets baked into each phase implicitly and drifts. |
 | `## 7. Risks & open questions` | Bullets that survived planning unresolved. Honest ambiguity > false confidence. |
 
 ---
 
 ## Phase ordering
 
-`plan-to-linear` builds Linear `blocked-by` relationships from prose hints in the plan doc. Default is **strictly sequential** (each phase blocks the next) if no hints exist.
+`plan-to-linear` builds Linear `blocked-by` relationships from the §8 list. Two ways to express ordering, in order of preference:
 
-Patterns that get parsed:
+**Preferred — explicit `[blocks-by: N, M]` brackets in §8.** Mechanical, unambiguous, survives copy-paste and review:
+
+```markdown
+- ALT-_TBD_ — Phase 1: foundation
+- ALT-_TBD_ — Phase 2: migration A   [blocks-by: 1]
+- ALT-_TBD_ — Phase 3: migration B   [blocks-by: 1]
+- ALT-_TBD_ — Phase 4: cleanup       [blocks-by: 2, 3]
+```
+
+Phases 2 and 3 fan out from Phase 1 in parallel; Phase 4 waits for both. Omit the brackets entirely on every line to fall back to **strict sequential** (each phase blocks-by the previous).
+
+**Fallback — prose hints.** Still parsed for back-compat with older plans:
 
 - "Phases land in order" → strictly sequential.
 - "Phase 1 blocks all later phases" → fan-out from Phase 1.
 - "Phase N also blocks on Phase M" → extra `blocked-by` edge.
 
-Put one explicit ordering sentence in the §6 preamble or §8 intro line. Don't make the skill guess.
+Brackets win if both forms are present. Don't mix them in the same plan.
 
 ### Optional / deferred phases
 
@@ -177,19 +221,23 @@ What's good to write:
 ## Workflow
 
 1. Author the plan in `docs/planning/not-shipped/<slug>.md` with `ALT-_TBD_` placeholders in §8.
-2. Run `plan-to-linear` (or ask Claude to). It creates the Linear project, files one issue per phase, sets blocked-by edges, and rewrites §8 with the real IDs. The plan-doc edit is staged but not committed — review the diff before committing.
-3. Use `execute-next-task` to pick up phases one at a time. Each phase ships as its own PR with `Closes ALT-NN`.
-4. When the project is fully shipped, move the plan to `docs/planning/shipped/`.
+2. **If any phase has `[design needed]` UI changes**, brief the designer with those phases extracted before seeding to Linear. Either delay seeding the design-blocked phases until designs land, or seed them as `(deferred)` so they go into Linear `Backlog` rather than `Todo`. Grep across all in-flight plans for outstanding designer work with `grep -r "\[design needed\]" docs/planning/`.
+3. Run `plan-to-linear` (or ask Claude to). It creates the Linear project, files one issue per phase, sets blocked-by edges, and rewrites §8 with the real IDs. The plan-doc edit is staged but not committed — review the diff before committing.
+4. Use `execute-next-task` to pick up phases one at a time. Each phase ships as its own PR with `Closes ALT-NN`.
+5. When the project is fully shipped, move the plan to `docs/planning/shipped/`.
 
 ---
 
 ## Quick checklist before running `plan-to-linear`
 
 - [ ] H1 present, single-line, no trailing punctuation.
-- [ ] §1 Background first paragraph reads standalone.
+- [ ] §1 Background first paragraph reads standalone in 3-6 sentences.
+- [ ] §2 Goals and §3 Non-goals present.
 - [ ] Every phase has a `### Phase N — <title>` heading with an em-dash.
-- [ ] Every phase has Goal, Deliverables, Done when.
-- [ ] §8 has exactly one `ALT-_TBD_ — Phase N: <title>` line per phase.
+- [ ] Every phase has all six required parts: Goal, Deliverables, Reversibility, UI changes, Done when, Verify in prod.
+- [ ] UI changes is either a bullet list (each item tagged `[design needed]` or `[no design]`) or the literal word `none`. Don't omit the line.
+- [ ] Verify in prod is a production signal or the literal `n/a — internal only`.
+- [ ] §8 has exactly one `ALT-_TBD_ — Phase N: <title>[ [blocks-by: …]]` line per phase.
 - [ ] Optional/deferred phases say so in the heading.
-- [ ] Phase ordering is stated in prose somewhere (or you accept strict sequencing).
+- [ ] Phase ordering uses `[blocks-by: …]` brackets, prose hints, or strict-sequential default — pick one, don't mix.
 - [ ] No pre-baked implementation steps in Deliverables.

--- a/docs/planning/not-shipped/service-addons-plan.md
+++ b/docs/planning/not-shipped/service-addons-plan.md
@@ -263,7 +263,18 @@ Deliverables:
 - Two new Socket.IO events on the `stacks` channel: `STACK_ADDON_PROVISIONED` and `STACK_ADDON_FAILED`.
 - Admin documentation page walking through OAuth client creation, scopes, tagging, and pasting the ACL snippet.
 
+Reversibility: feature-flagged — addon expansion runs only when a service declares `addons:`; with the registry empty no behaviour changes. Rollback is reverting the PR or removing the registered `tailscale-ssh` addon. Tailscale connected service is opt-in (admin must add it), so absence of credentials is also a clean no-op state.
+
+UI changes:
+- Connected Services page gains a "Tailscale" entry alongside Docker / Azure / Cloudflare / GitHub: connection status, last-checked timestamp, edit form. [no design] — fits the established connected-service card pattern.
+- Settings: new "Tailscale" admin form for OAuth client_id/secret, default tags, and a click-to-copy ACL-bootstrap snippet box. [design needed] — the snippet preview + tag list + copy block layout is new for our settings forms.
+- Stack detail / Containers page: addon-derived sidecars appear in the existing service/container lists with a "from addon" badge and a back-reference to the target service; edit affordances disabled. [design needed] — badge style and how a synthetic sidecar visually relates to its target row (indented? linked icon?) needs a designer call.
+- Stack apply flow: live progress reflects two new lifecycle events (`STACK_ADDON_PROVISIONED`, `STACK_ADDON_FAILED`) under the existing apply task in the task tracker. [no design] — slots into existing task-tracker step rendering.
+- New admin docs page walking operators through Tailscale OAuth client creation and ACL bootstrap. [no design] — uses the existing user-docs article shell.
+
 Done when: a stack template with `addons: { tailscale-ssh: {} }` on a `Stateful` or `StatelessWeb` service applies cleanly, the Tailscale sidecar appears as a synthetic service in the rendered stack, joins the tailnet under `tag:mini-infra-managed`, shows up on the containers page with logs/exec/labels working, and an operator can `ssh root@<service>-<env>` from a tailnet-joined laptop with the IdP-driven `check` flow. *Firewall sanity check:* the same template applied in an env with `egressFirewallEnabled: true` still works end-to-end, and the Tailscale control-plane hostnames appear as template-sourced rules on the env's egress policy without operator intervention.
+
+Verify in prod: Tailscale entry appears under Connected Services with a green status; the first stack applied with `addons: { tailscale-ssh: {} }` shows the sidecar online in the Tailscale admin console under `tag:mini-infra-managed`; no spike in `STACK_ADDON_FAILED` events for 24 h after rollout.
 
 ### Phase 2 — `tailscale-web` and tailscale addon merging
 
@@ -275,7 +286,16 @@ Deliverables:
 - The "Connect" panel on the stack detail page lists every addon-attached endpoint with one-click `ssh root@…` and `https://…` actions.
 - A Tailscale device-status poller that emits `TAILSCALE_DEVICE_ONLINE` / `OFFLINE` on a new `tailscale` Socket.IO channel; the Connect panel reflects live status badges.
 
+Reversibility: feature-flagged — only services that opt into `tailscale-web` are affected; merging is automatic when both Tailscale addons are present. Rollback is removing the addon from the service definition (next apply unrolls the sidecar config). Tailnet device de-registration happens via ephemeral cleanup so there's no residual state to reap.
+
+UI changes:
+- Stack detail page: new "Connect" panel listing every addon-attached endpoint with one-click `ssh root@…` and `https://…` actions. [design needed] — brand-new panel; placement relative to the services list, empty / failed / loading states all need design.
+- Live status badges on Connect panel rows reflecting `TAILSCALE_DEVICE_ONLINE` / `OFFLINE` events. [design needed] — needs a green / grey / red dot style and the transition timing pattern.
+- New Socket.IO channel `tailscale` surfaced via the existing connection-status indicator (same place users see other channel disconnections). [no design].
+
 Done when: a service with both Tailscale addons enabled is reachable as `ssh root@<host>` and `https://<host>.<tailnet>.ts.net` from any tailnet-joined laptop, exactly one Tailscale device exists in the tailnet for that service, and the Connect panel shows the right URLs and live online/offline state.
+
+Verify in prod: at least one production service is reachable via both `ssh root@<host>` and `https://<host>.<tailnet>.ts.net`; tailnet device count matches the count of `tailscale-*` addon applications recorded in the DB; Connect panel renders within ~1 s and badges flip within ~5 s of a real device transition.
 
 ### Phase 3 — `caddy-auth` v1
 
@@ -288,7 +308,16 @@ Deliverables:
 - Cross-addon rewrite: when `caddy-auth` and `tailscale-web` both apply, the post-merge step rewrites Tailscale's `serve.json` to forward to Caddy's port instead of the app's. This is the one place the framework reasons about pairs of addons; nothing else needs to.
 - Operator documentation page covering the Vault path layout and a worked example for one IdP (Entra ID).
 
+Reversibility: forward-only if the addon is removed mid-flight from a live service — re-applying without `caddy-auth` restores the unprotected app, but in-flight authenticated sessions are dropped (Caddy's session state vanishes with the container). For a true rollback during the rollout window, removing the addon from the registry hides it from new use; existing applications must be unrolled per service.
+
+UI changes:
+- Stack detail page: rendered services list now shows a chain (app + caddy-auth, plus tailscale-web when present) with `network_mode` rewrites and reclaimed ports visible. [design needed] — how to convey "caddy owns the target's netns and reclaimed its ports" without operators having to read YAML.
+- Operator docs page: Vault layout for `secret/connected-services/oidc/<provider>` plus a worked Entra ID example. [no design] — docs article.
+- Auth-gated services display the IdP redirect chain on first request (anonymous → IdP → service). No new UI widget; operators see the existing Caddy 302 in the browser network tab when smoke-testing. [no design].
+
 Done when: a service with `caddy-auth` plus `tailscale-web` enabled redirects unauthenticated browsers to the IdP, accepts authenticated users whose group membership matches `allowedGroups`, returns 403 for users who don't match, and forwards authenticated traffic transparently to the app. The rendered stack definition shows three services — app, caddy-auth, tailscale — with the right `network_mode` rewrites and reclaimed ports.
+
+Verify in prod: at least one service deployed with `caddy-auth` rejects unauthenticated requests with the IdP redirect; an authenticated user in `allowedGroups` reaches the app; a user not in `allowedGroups` gets 403; no spike in IdP-side `failed_auth` events for 24 h after rollout.
 
 ### Phase 4 — Pool integration
 
@@ -302,7 +331,16 @@ Deliverables:
 - Connect panel pool-row expansion: clicking a pool service row reveals running instances with per-instance `ssh`/HTTPS rows.
 - Egress-policy correctness for pools: per-instance addon sidecars emit `containerConfig.requiredEgress` that flows into the env's policy reconcile the same way static addon services do (§4.7) — verify this works when the pool service is in a firewalled env.
 
+Reversibility: safe — pool addon support is additive. Pools without `addons:` declarations are unaffected. If addon provisioning fails for a pool instance, that single instance fails to spawn through the existing pool-spawn error path; remove the addon from the pool service definition to revert.
+
+UI changes:
+- Stack detail Connect panel: pool service rows expand to reveal per-instance rows, each with their own `ssh` / HTTPS row. [design needed] — disclosure pattern for a pool with N instances; how to handle 50-instance pools without flooding the panel.
+- Containers page: per-instance addon sidecars appear with `mini-infra.synthetic` and `mini-infra.pool-instance-id` labels visible. [no design] — fits existing container-row label rendering.
+- Pool detail: per-instance hostname (`{service}-{env}-{instance-id}`) shown alongside the existing instance-id column. [no design].
+
 Done when: a pool service with `addons: { tailscale-ssh: {} }` spawns instances that each register as their own tailnet device with a unique per-instance hostname, an operator can SSH into a specific instance by name, and idle reaping removes both the worker container and the sidecar from Docker (and the device from the tailnet via ephemeral cleanup). In a firewalled env, the Tailscale control-plane hostnames appear as template-sourced rules and per-instance sidecars reach the tailnet without manual policy edits.
+
+Verify in prod: at least one production pool service with `tailscale-ssh` shows N tailnet devices for N instances, names match the `{service-name}-{env-name}-{instance-id}` pattern, idle reaping removes both the worker container and the sidecar within the ephemeral-cleanup window, and pool resize events don't leave orphan devices behind.
 
 ### Phase 5 — UI polish and status surfacing
 
@@ -314,7 +352,17 @@ Deliverables:
 - A "Test connection" button per Tailscale-attached service that calls the Tailscale API to confirm the device is online and reports response time.
 - Filter chip on the containers page using the `mini-infra.addon` and `mini-infra.synthetic` labels so operators can isolate (or hide) addon sidecars.
 
+Reversibility: safe — pure UI; revert the PR.
+
+UI changes:
+- Stack detail header gains an "Addons" rollup pill ("3 healthy / 1 failed / 1 pending") clickable to open the Connect panel scrolled to the failed addon. [design needed] — pill style, colour rules, click target.
+- Connect panel: copy-to-clipboard buttons next to every `ssh` command and HTTPS URL. [no design] — fits the existing copy-icon pattern from the API key page.
+- Per-Tailscale-attached service: a "Test connection" button that calls the Tailscale API and displays response time inline. [no design] — fits the "Test" button pattern from connected services.
+- Containers page: filter chip "Show synthetic addons" using `mini-infra.synthetic` and `mini-infra.addon` labels, defaulted to off. [design needed] — chip placement and the default-off vs default-on call.
+
 Done when: the stack detail page surfaces the right URL for every addon-attached service (including pool instances), live online/offline transitions reflect within ~5s, and an operator can audit addon health for an entire stack from one screen.
+
+Verify in prod: stack detail header surfaces the right addon count and health on a stack with mixed-state addons; live online/offline transitions reflect within ~5 s (measured against a deliberate device-down test); copy-to-clipboard click count rises in the events log (operators using it instead of selecting + copying by hand).
 
 ### Phase 6 — OIDC provider management UI (optional, deferred)
 
@@ -325,7 +373,17 @@ Deliverables:
 - The `caddy-auth` addon's `provision` switches from direct Vault path lookup to `OidcProvider` resolution.
 - A "test sign-in" affordance per provider that exercises the OAuth flow end-to-end and reports success or failure.
 
+Reversibility: forward-only — once `caddy-auth` switches from direct Vault paths to `OidcProvider` resolution, services that authored against the old path break unless migrated. Ship with an "import from Vault" affordance and a documented migration step before flipping the resolution source.
+
+UI changes:
+- New `/connected-services/oidc-providers` admin page: list, add, edit, delete IdPs with provider-specific fields (Entra, Auth0, Google Workspace, generic OIDC). [design needed] — full new page; per-provider form layout; secret-rotation pattern.
+- Per-provider "Test sign-in" button that opens the IdP redirect in a new tab and reports back round-trip success. [design needed] — modal/dialog showing the test result is a new pattern for the connected-services area.
+- `caddy-auth` addon config gains a provider dropdown sourced from the new `OidcProvider` model. [no design] — slots into the existing addon-config form rendering.
+- Connected Services page: new "OIDC Providers" entry alongside Tailscale / Cloudflare / etc. [no design] — fits the established connected-service card pattern.
+
 Done when: an admin can add a new IdP through the UI, attach it to a service via `addons: { caddy-auth: { provider: <id> } }`, and verify the round trip from the connected-services page without editing Vault directly.
+
+Verify in prod: at least one IdP added through the new UI is bound to a `caddy-auth` addon application and produces successful end-to-end sign-in; no operator edits against `secret/connected-services/oidc/<provider>` Vault paths after rollout (per the Vault audit log).
 
 ## 7. Risks & open questions
 


### PR DESCRIPTION
## Summary

- **PLANNING.md spec extension**: per-phase contract grows from 3 → 6 required parts (Goal / Deliverables / **Reversibility** / **UI changes** / Done when / **Verify in prod**); §2 Goals and §3 Non-goals promoted to required; §8 gains explicit `[blocks-by: N, M]` brackets for non-strict-sequential dependency graphs. The new **UI changes** block uses `[design needed]` / `[no design]` tags so designer dependencies can be extracted from plans pre-implementation — `grep -r "\[design needed\]" docs/planning/` becomes the live designer-todo list.
- **`plan-to-linear` skill update**: extracts and propagates the new fields into Linear issue bodies; honors `[blocks-by]` brackets when building the dependency graph (prose hints remain as fallback for older plans).
- **`service-addons-plan` backfilled** as the worked example — all 6 phases now have the new fields, surfacing 8 `[design needed]` UI items across the rollout.
- **`docs/planning/BACKFILL.md`** added as a tracker for the 9 other in-flight plans that pre-date the spec change, grouped by priority (UI bunched late → UI buried → rote backfill).

## Test plan

- [ ] Skim [docs/planning/PLANNING.md](https://github.com/mrgeoffrich/mini-infra/blob/docs/planning-spec-extensions/docs/planning/PLANNING.md) end-to-end — spec change reads as a coherent revision, not patches stacked on patches.
- [ ] Confirm the worked example in [service-addons-plan.md](https://github.com/mrgeoffrich/mini-infra/blob/docs/planning-spec-extensions/docs/planning/not-shipped/service-addons-plan.md) reads as expected — Reversibility classifications honest, UI lines actionable for a designer, Verify-in-prod signals checkable.
- [ ] `grep -rn "\[design needed\]" docs/planning/` returns the expected designer-todo set (8 items, all in service-addons-plan for now).
- [ ] Sanity-check the [plan-to-linear SKILL.md](https://github.com/mrgeoffrich/mini-infra/blob/docs/planning-spec-extensions/.claude/skills/plan-to-linear/SKILL.md) updates — Phase 2 extraction list, Phase 8 issue body template, Phase 9 blocking-relationship rules all match the new spec.
- [ ] Decide whether to manually update existing Linear issues (ALT-38..ALT-43 for service-addons) with the new sections, or accept the doc as source-of-truth and let the Linear ticket stay a frozen snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)