### PR TITLE
feat(skills): plan-to-linear auto-creates design tickets from [design needed] tags

### DIFF
--- a/.claude/skills/brainstorm-to-plan/SKILL.md
+++ b/.claude/skills/brainstorm-to-plan/SKILL.md
@@ -97,6 +97,7 @@ Watch for these in the input. When the brainstorm is shaped like one of these, t
 | **Docs padded onto a feature phase** | Docs ride with the feature unless the feature has multiple operator-onboarding steps (OAuth client creation, Vault path setup, ACL bootstrap). Then docs are their own slim phase. |
 | **"Foundation" phase with no concrete deliverable** | Reject — there's no such thing as a "foundation" phase. Either it lands a concrete artifact (a type, a registered service, a working endpoint) or it's not a phase. |
 | **Cross-cutting concern (auth, observability, error handling) bolted onto every phase** | Surface as a §`<N>` shared-concept section *and* check whether one early phase should land the convention before any consumer phase. |
+| **Design / mockup work split out as its own phase** | Don't write standalone `Phase N — Design: …` phases. `plan-to-linear` auto-creates a paired `Backlog` design ticket per phase from each `[design needed]` tag in that phase's UI changes block, and wires it up as a `blocked-by` edge on the phase ticket. Keep design items as `[design needed]` tags inline on the impl phase — the skill materialises them. |
 
 ### Optional / deferred phases
 
@@ -137,7 +138,7 @@ For every ✗, emit a concrete reject sentence and a concrete split suggestion. 
 
 **5. Reversibility-classifiable.** Pass: one of `safe` / `feature-flagged` / `forward-only` / `destructive` fits without weasel words ("mostly safe except…"). Reject: "Phase N's reversibility doesn't classify cleanly — its rollback story has '<quote of weasel clause>'. That's a sign it's doing two things; split the destructive part out."
 
-**6. UI-extractable.** Pass: every user-visible change is a bullet tagged `[design needed]` or `[no design]`, or the literal word `none`. Never `TBD`. Reject: "Phase N's UI changes include 'TBD' or untagged items. Either tag each item explicitly (a clean [no design] is fine) or split out the UI-bearing slice as its own phase so the design ask is scoped."
+**6. UI-extractable.** Pass: every user-visible change is a bullet tagged `[design needed]` or `[no design]`, or the literal word `none`. Never `TBD`. Reject: "Phase N's UI changes include 'TBD' or untagged items. Either tag each item explicitly (a clean [no design] is fine) or split out the UI-bearing slice as its own phase so the design ask is scoped." (Note: `[design needed]` tags become paired `Backlog` design tickets at seed time via `plan-to-linear` — don't pre-split design out as its own phase; just tag the items.)
 
 **7. Verify-in-prod-statable.** Pass: a production signal that confirms the *outcome* (the Goal), not just that the artifacts exist. Or `n/a — internal only` and the phase actually is. Reject: "Phase N's Verify-in-prod restates Done-when ('<quote>'). Done-when is 'the code does the right thing in CI'; Verify-in-prod is 'the goal materialised in production'. They should be different signals — what counter / dashboard / log line / user-visible state confirms the *Goal* in prod?"
 

--- a/.claude/skills/plan-to-linear/SKILL.md
+++ b/.claude/skills/plan-to-linear/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan-to-linear
-description: Reads a phased markdown planning document under `docs/planning/` and either seeds Linear with a matching project plus one issue per phase (**create mode** — §8 has `ALT-_TBD_` placeholders) or refreshes an already-seeded project's issue bodies and dependency edges from the plan doc (**update mode** — §8 has real `ALT-NN` IDs). Each issue carries the phase's Goal / Deliverables / Reversibility / UI changes / Done when / Verify in prod, the relevant per-component CLAUDE.md and ARCHITECTURE.md pointers (server vs client vs lib vs go sidecars), a **Source-code touchpoints** section produced by a per-phase codebase exploration (best-guess New / Modify / Read paths) plus a **Shared-library opportunities** sub-section flagging types/constants/helpers that should land in `lib/` or `egress-shared/` rather than be duplicated, a Workflow section (worktree pre-flight, `pnpm install`, background `pnpm worktree-env start`), phase-specific smoke-test recipes derived from which directories the phase touches, prior-art commit references, and the commit/PR conventions — enough context that the `execute-next-task` skill can execute the issue without re-planning the high-level scope or re-exploring from scratch. Update mode preserves issue state, assignee, cycle, estimate, labels, and all prior comments (retros, handoff notes); only the body, title (if changed), and blocked-by edges are refreshed, and orphan issues (phases removed from the plan since seeding) are surfaced for manual handling rather than auto-deleted. In create mode, rewrites the plan doc's §8 to replace `ALT-_TBD_` placeholders with real issue IDs and posts a full session retrospective comment on Phase 1; in update mode, posts a one-line refresh-summary comment instead. Use this skill whenever the user says "populate linear from plan", "create the linear tickets", "plan to linear", "scaffold linear from this plan", "turn this plan into linear issues", "refresh linear from plan", "update linear issues", "re-sync linear from plan", "plan-to-linear refresh", or any equivalent request to seed *or* refresh Linear from a plan markdown. Do NOT trigger for one-off issue creation, for plans that aren't phased, or when the user wants to ad-hoc-edit a single Linear issue (use the Linear UI directly).
+description: Reads a phased markdown planning document under `docs/planning/` and either seeds Linear with a matching project plus one issue per phase (**create mode** — §8 has `ALT-_TBD_` placeholders) or refreshes an already-seeded project's issue bodies and dependency edges from the plan doc (**update mode** — §8 has real `ALT-NN` IDs). Each issue carries the phase's Goal / Deliverables / Reversibility / UI changes / Done when / Verify in prod, the relevant per-component CLAUDE.md and ARCHITECTURE.md pointers (server vs client vs lib vs go sidecars), a **Source-code touchpoints** section produced by a per-phase codebase exploration (best-guess New / Modify / Read paths) plus a **Shared-library opportunities** sub-section flagging types/constants/helpers that should land in `lib/` or `egress-shared/` rather than be duplicated, a Workflow section (worktree pre-flight, `pnpm install`, background `pnpm worktree-env start`), phase-specific smoke-test recipes derived from which directories the phase touches, prior-art commit references, and the commit/PR conventions — enough context that the `execute-next-task` skill can execute the issue without re-planning the high-level scope or re-exploring from scratch. Phases whose UI changes block contains one or more `[design needed]` items also get a **paired design ticket** auto-created in `Backlog` (designer-owned, kept out of the execute-next-task queue) and wired up as a `blocked-by` edge on the impl ticket — plan authors don't write standalone "Design: …" phases. Update mode preserves issue state, assignee, cycle, estimate, labels, and all prior comments (retros, handoff notes); only the body, title (if changed), and blocked-by edges are refreshed, and orphan issues (phases removed from the plan since seeding) are surfaced for manual handling rather than auto-deleted. In create mode, rewrites the plan doc's §8 to replace `ALT-_TBD_` placeholders with real issue IDs and posts a full session retrospective comment on Phase 1; in update mode, posts a one-line refresh-summary comment instead. Use this skill whenever the user says "populate linear from plan", "create the linear tickets", "plan to linear", "scaffold linear from this plan", "turn this plan into linear issues", "refresh linear from plan", "update linear issues", "re-sync linear from plan", "plan-to-linear refresh", or any equivalent request to seed *or* refresh Linear from a plan markdown. Do NOT trigger for one-off issue creation, for plans that aren't phased, or when the user wants to ad-hoc-edit a single Linear issue (use the Linear UI directly).
 ---
 
 # Plan to Linear
@@ -78,7 +78,7 @@ Read the doc end-to-end and extract:
    - The **Goal** line.
    - The **Deliverables** list (bullet points; can be nested).
    - The **Reversibility** line (classifier + rationale).
-   - The **UI changes** block — bullet list with `[design needed]` / `[no design]` tags, or the literal `none`. Surface a count of `[design needed]` items per phase in the Phase 6 confirmation prompt so the user can spot phases that should be deferred pending design.
+   - The **UI changes** block — bullet list with `[design needed]` / `[no design]` tags, or the literal `none`. Capture each `[design needed]` bullet verbatim per phase — these become the body of the paired design ticket created in Phase 8.1. Surface the per-phase count in the Phase 6 confirmation prompt so the user can see how many design tickets will be created (or refreshed in update mode).
    - The **Done when** line.
    - The **Verify in prod** line (production signal or `n/a — internal only`).
    - Any other phase-specific subsections (e.g. "Migration shape", "Subjects", "Subjects:") — keep verbatim.
@@ -288,12 +288,16 @@ Show a summary and wait for explicit "go". The summary differs by mode.
 Project to create: <name>
 Description: <one-line snippet>
 
-Phases (will create N issues):
-  Phase 1: <title>           [Todo]      blocked-by: —             touchpoints: 4N/3M/2R   shared-lib: 2 flagged
-  Phase 2: <title>           [Todo]      blocked-by: Phase 1       touchpoints: 1N/5M/1R   shared-lib: none
-  Phase 3: <title>           [Todo]      blocked-by: Phase 2       touchpoints: <unable to map — phase too vague>  ⚠
+Phases (will create N impl issues + M design tickets):
+  Phase 1: <title>           [Todo]      blocked-by: —             touchpoints: 4N/3M/2R   shared-lib: 2 flagged   design: 0
+  Phase 2: <title>           [Todo]      blocked-by: 1, Design#2   touchpoints: 1N/5M/1R   shared-lib: none        design: 2 [needed] → 1 paired ticket
+  Phase 3: <title>           [Todo]      blocked-by: 2             touchpoints: <unable to map — phase too vague>  ⚠
   ...
-  Phase 6: <title>           [Backlog]   blocked-by: Phase 5       touchpoints: 0N/2M/0R   shared-lib: 1 flagged    (optional)
+  Phase 6: <title>           [Backlog]   blocked-by: 5, Design#6   touchpoints: 0N/2M/0R   shared-lib: 1 flagged    (optional, deferred)   design: 1 [needed] → 1 paired ticket
+
+Design tickets to create (Backlog, designer-owned, not picked by execute-next-task):
+  Design: Phase 2 — <title>     [Backlog]   blocks: Phase 2     items: 2 [design needed]
+  Design: Phase 6 — <title>     [Backlog]   blocks: Phase 6     items: 1 [design needed]
 
 Touchpoint counts are New/Modify/Read paths the per-phase explorer found.
 Phases flagged "unable to map" mean the deliverables are too vague for the explorer
@@ -305,7 +309,7 @@ Shared-library opportunities flagged across all phases: <total>
   - Phase 6: shared egress code → egress-shared/<...>.go
   (full per-phase list rendered into each ticket; review before confirming)
 
-Each issue will reference:
+Each impl issue will reference:
   - <plan-doc-path>#phase-<N>
   - root CLAUDE.md, ARCHITECTURE.md
   - <per-component docs detected>
@@ -313,7 +317,13 @@ Each issue will reference:
   - per-phase Shared-library opportunities (from Phase 3.5 explorer)
   - prior-art commit area: <tag>
 
-Plan doc edit: replace ALT-_TBD_ in §<8> with real issue IDs.
+Each design ticket will reference:
+  - <plan-doc-path>#phase-<N> (same source as the paired impl phase)
+  - The verbatim list of [design needed] UI items
+  - A "Blocks: Phase N — <title>" pointer back to the impl ticket
+
+Plan doc edit: replace ALT-_TBD_ in §<8> with real impl issue IDs.
+Design tickets are NOT listed in §8 — they're auto-generated metadata.
 
 Proceed?
 ```
@@ -325,17 +335,27 @@ Hold on confirmation if any phase is flagged `<unable to map>` — surface that 
 ```
 Project to refresh: <name>  →  <existing project URL>
 
-Existing issues to refresh (M of N matched 1:1 with plan phases):
+Existing impl issues to refresh (M of N matched 1:1 with plan phases):
   ALT-NN  Phase 1: <title>          [In Review]    body: refresh
   ALT-NN  Phase 2: <title>          [In Progress]  body: refresh
   ALT-NN  Phase 3: <title>          [Todo]         body: refresh, title rename: "<old>" → "<new>"
   ...
 
-Phases added since seeding (will create new issues): <count>
+Paired design tickets to refresh: <count>
+  ALT-NN  Design: Phase 2 — <title>     [Backlog]   body: refresh   items now: 2 [design needed]
+  ALT-NN  Design: Phase 6 — <title>     [In Progress] body: unchanged
+
+Design tickets to create (phase newly has [design needed] items): <count>
+  Design: Phase N — <title>             [Backlog]   blocks: Phase N
+
+Design tickets orphaned (phase no longer has [design needed] items; not deleted): <count>
+  ALT-NN  Design: Phase X — <title>     [<state>]   ← reported only; no auto-delete
+
+Phases added since seeding (will create new impl issues): <count>
   Phase N: <title>           [Todo]
   ...
 
-Orphan issues (in Linear but not in plan; will NOT be touched): <count>
+Orphan impl issues (in Linear but not in plan; will NOT be touched): <count>
   ALT-NN  <title>            [<state>]   ← reported only; no auto-delete
 
 What changes per refreshed issue:
@@ -531,6 +551,44 @@ If none of the recipes match, the populator emits `<no recipe — confirm with u
 
 Capture each issue's ID (`ALT-NN`) and URL.
 
+### Create mode — paired design tickets (Phase 8.1)
+
+After the impl ticket is created, scan its UI changes block for items tagged `[design needed]`. **If any exist**, create a paired design ticket:
+
+**Title:** `Design: Phase N: <title>` — same shape as the impl title with a `Design:` prefix, so they sort adjacent in any title-sorted view.
+
+**State:** `Backlog`. Designers own these tickets; `execute-next-task` only picks from `Todo`, so `Backlog` keeps the design ticket out of the execution queue while letting designers transition through their own states normally.
+
+**Description body:**
+
+```markdown
+**Source:** [<plan-doc-path> §<phase-anchor>](<plan-doc-path>#phase-N)
+
+This design ticket was auto-generated by `plan-to-linear` from the
+`[design needed]` items in Phase N's UI changes block. Once Figma frames are
+signed off and linked, mark this issue Done — the impl ticket unblocks
+automatically.
+
+## Design needed
+
+<verbatim copy of every UI-changes bullet tagged `[design needed]`, including the tag itself>
+
+## Done when
+
+Figma link attached to this ticket and signed off by the designer; any new
+design tokens merged into the design system.
+
+## Blocks
+
+- [<impl-ALT-NN>](https://linear.app/altitude-devops/issue/<impl-ALT-NN>) — Phase N: <phase title>
+```
+
+Capture the design ticket's ALT-NN and URL — Phase 9 uses it as a `blocked-by` edge on the impl ticket.
+
+**Skip the scan entirely** when the phase's UI changes block is the literal `none` or contains zero `[design needed]` items.
+
+**Cross-phase design dedupe is out of scope.** If Phases 4 and 12 both reference the same visual treatment (e.g., the addon visual language used on multiple pages), each gets its own design ticket. Designers can mark one Done and immediately Done the duplicate — auto-deduping at seed time would require parsing and comparing the design items across phases, and that's a fragility we don't need.
+
 ### Update mode — refresh existing issue bodies
 
 For each phase, look up the matching Linear issue by its §8 ALT-NN ID (use `get_issue`). Match by ID, **not** by title — titles can change between seed and refresh, and ID is the stable key.
@@ -546,28 +604,48 @@ For phases newly added to the plan since seeding (detected in Phase 5 update-mod
 
 For orphan issues (Phase 5 update-mode pre-flight, step 3 case "Project has more issues than plan"), do nothing — they were already surfaced to the user. Just remember the list for the Phase 12 report.
 
+### Update mode — paired design ticket reconciliation
+
+After refreshing each impl ticket, reconcile its paired design ticket against the current `[design needed]` items in the phase's UI changes block.
+
+1. **Lookup.** Find the existing design ticket by walking the impl ticket's `blocked-by` graph and matching against issues whose title starts with `Design: Phase N` (where `N` matches the impl phase). At most one paired design ticket per phase.
+
+2. **Reconcile against current `[design needed]` items:**
+   | Plan has items? | Design ticket exists? | Action |
+   |---|---|---|
+   | yes | yes | Refresh design body (regenerate `## Design needed` from the current verbatim items; preserve `## Source` and `## Done when`). |
+   | yes | no | Create the design ticket fresh (same template as Phase 8.1 create mode); add the design→impl `blocked-by` edge in Phase 9. |
+   | no | yes | **Leave alone.** Surface as orphan in the Phase 12 report. Designers may still be working on it; auto-delete is never the right call. |
+   | no | no | No-op. |
+
+3. **State preservation** — same rules as impl tickets. Pass only `body` and (if changed) `title` to `save_issue`. State, assignee, comments survive untouched.
+
 Capture, for the Phase 12 report:
 
-- Which issues had body refreshed (all matched issues, by ID).
-- Which issues had a title rename (and old → new).
-- Which issues were newly created (with ALT-NN).
-- The orphan list, unchanged.
+- Which impl issues had body refreshed (all matched issues, by ID).
+- Which impl issues had a title rename (and old → new).
+- Which impl issues were newly created (with ALT-NN).
+- The impl orphan list, unchanged.
+- Design tickets refreshed (count + IDs).
+- Design tickets newly created (count + IDs + which impl phase they pair).
+- Design tickets orphaned (count + IDs; not deleted).
 
 ---
 
 ## Phase 9 — Set blocking relationships
 
-Use the dependency graph you parsed in Phase 2 to compute the **desired** set of `blocked-by` edges:
+Use the dependency graph you parsed in Phase 2, plus the design pairings from Phase 8.1, to compute the **desired** set of `blocked-by` edges for each impl ticket — the union of:
 
-- If §8 has `[blocks-by: N, M]` brackets, that's the source of truth — each phase wants a `blocked-by` edge to each listed phase.
-- Else if prose hints exist, apply them ("Phase 1 blocks all later phases", "Phase N also blocks on Phase M").
-- Else default to **strictly sequential** — each phase from 2 onward is `blocked-by` the previous.
+- **Inter-phase edges from §8.** If §8 has `[blocks-by: N, M]` brackets, that's the source of truth — each phase wants a `blocked-by` edge to each listed phase. Else if prose hints exist, apply them ("Phase 1 blocks all later phases", "Phase N also blocks on Phase M"). Else default to **strictly sequential** — each phase from 2 onward is `blocked-by` the previous.
+- **Design pairing edge from Phase 8.1.** If the phase has a paired design ticket, the impl ticket also gets a `blocked-by` edge to that design ticket's ALT-NN.
 
 Optional/deferred phases still get blocked-by relationships — being in `Backlog` doesn't mean unblocked. The blocker just means "even when promoted to Todo, wait for the predecessor".
 
+Design tickets themselves have **no `blocked-by` edges** — designers can start the moment the ticket is filed.
+
 ### Create mode
 
-Add the desired edges in order via the Linear API. There's nothing to compare against — the issues were just created and have no relationships yet.
+Add the desired edges in order via the Linear API. There's nothing to compare against — the issues were just created and have no relationships yet. The design→impl pairing edges are added alongside the inter-phase edges in the same pass.
 
 ### Update mode
 
@@ -583,6 +661,8 @@ Existing edges may not match the desired graph — §8 brackets may have changed
 4. **Cross-project edges** (issues in this project blocked by issues in *other* projects) are out of scope for this skill — leave them untouched even if §8 makes no mention of them. They were added deliberately; we won't second-guess.
 
 For phases newly created during this update run (Phase 8 update-mode tail), apply their desired edges from scratch (same as create mode for those issues).
+
+For design tickets newly created during the Phase 8 update-mode design reconciliation (a phase newly has `[design needed]` items), add the design→impl `blocked-by` edge from scratch. For impl tickets whose paired design ticket was just created, add the new design→impl edge alongside any other edge changes — the impl ticket's `blocked-by` set is recomputed end-to-end (inter-phase from §8 ∪ design pairing), and the delta logic above handles add/remove/leave-alone uniformly.
 
 ---
 
@@ -742,6 +822,9 @@ Next step: <if §8 changed, "review and commit the plan-doc diff"; if orphans / 
 - **Never invent docs.** If `egress-shared/CLAUDE.md` doesn't exist, don't link it. Verify each attached doc.
 - **Never guess at convention.** If §8 has no placeholder list (create mode) or has mixed placeholders + real IDs (either mode), the H1 is missing, or no `### Phase N` headings parse — stop and report. The conventions exist for a reason.
 - **Never commit the plan-doc edit.** Leave it staged. The user owns the commit.
+- **Design tickets are auto-generated from `[design needed]` tags, not from explicit plan phases.** Plan authors don't write standalone "Phase N — Design: …" phases (the brainstorm-to-plan skill warns against this). Each phase whose UI changes block contains one or more `[design needed]` items gets exactly one paired design ticket; no `[design needed]` items means no design ticket. If the plan doc contains a phase whose title starts with "Design:", treat it as a regular impl phase (the user wrote it deliberately) and skip the design-pairing scan for that phase.
+- **Design tickets are not listed in §8.** They're auto-generated metadata, found via Linear's `blocked-by` graph from the impl ticket. The §8 list keeps its 1:1 phase-to-line invariant; never inject design tickets into §8 (neither as siblings nor as sub-bullets).
+- **Never auto-delete design tickets.** Same surface-don't-delete rule as impl tickets — designers may still be working on them, and history (Figma link comments, sign-off comments) is valuable. Phases that lose all `[design needed]` items produce orphan design tickets that get reported, never deleted.
 - **Never skip optional phases.** They go in as `Backlog` so the project is complete and the §8 list reconciles 1:1.
 
 ### Create mode only

--- a/docs/planning/not-shipped/service-addons-plan.md
+++ b/docs/planning/not-shipped/service-addons-plan.md
@@ -28,10 +28,11 @@ A second design pressure: addon containers are still containers. They need logs,
 - **Multi-tailnet support.** v1 binds Mini Infra to one tailnet via one OAuth client. Operators with multiple tailnets are out of scope.
 - **Auto-managing the tailnet ACL.** v1 emits a copy-paste snippet the operator pastes into their tailnet policy file; we do not call the Tailscale ACL API.
 - **Tailscale Funnel (public exposure).** v1 ships `tailscale-web` in tailnet-only mode. Funnel overlaps the existing Cloudflare tunnel feature; deferred.
-- **Full OIDC provider management.** v1 ships the Caddy sidecar reading provider config from Vault directly. The `OidcProvider` model and admin UI for managing IdPs are deferred (see Phase 6).
+- **Full OIDC provider management.** v1 ships the Caddy sidecar reading provider config from Vault directly. The `OidcProvider` model and admin UI for managing IdPs are deferred (see Phases 13–16).
 - **User-defined addons.** Only addons in the registry are usable; addon authoring is not a user-facing feature.
 - **Cross-stack addon composition.** Addons are scoped to one service in one stack. No "addon X depends on addon Y on a different stack."
 - **Drift detection on tailnet devices.** Ephemeral nodes self-clean; a reconciler that detects "this Tailscale device exists but no longer corresponds to a running container" is deferred.
+- **UI polish / status rollups.** v1 ships the initial pages only — no addon-status header pills, no copy-to-clipboard affordances, no "Test connection" button per addon, no synthetic-addon filter chips. Scoped out during re-phasing in favour of initial page development; revisit after operator feedback.
 
 ## 4. The addon framework
 
@@ -199,9 +200,9 @@ Behaviours worth pinning:
 - **Each container's `requiredEgress` unions independently.** With `caddy-auth` + `own-target-netns` + `reclaimTargetPorts`, target and sidecar are still distinct service rows — their required-egress sets union at policy reconcile time. Same for the agent + auth-proxy case: agent declares its real upstreams, auth-proxy adds whatever it needs (e.g., a credential-fetch endpoint), policy picks up both.
 - **Cross-addon ordering is irrelevant for egress.** Inbound chains like `tailscale-web → caddy-auth → app` only affect the inbound path. Each container's outbound is independently firewalled by being on the egress network; nothing about the inbound chain changes that.
 
-#### Implications for Phase 1
+#### Implications for the framework
 
-The framework deliverables don't grow — `containerConfig.requiredEgress` already exists on `StackContainerConfig` and the reconciler already reads it. What's required instead is documentation and a sanity check: Phase 1's `tailscale-ssh` addon must encode the right Tailscale control-plane hostnames in its `buildServiceDefinition()` output, and Phase 1's done-when criteria should include "addon attached to a service in a firewalled env still functions, with the addon-declared hostnames showing up as template-sourced rules in the env's egress policy." Phase 3's `caddy-auth` adds the IdP-resolved hostnames; Phase 4 verifies pool-instance addon services emit per-instance `requiredEgress` correctly. Phases 2 and 5 don't touch this surface.
+The framework deliverables don't grow — `containerConfig.requiredEgress` already exists on `StackContainerConfig` and the reconciler already reads it. What's required instead is documentation and a sanity check: the `tailscale-ssh` addon (Phase 4) must encode the right Tailscale control-plane hostnames in its `buildServiceDefinition()` output, and Phase 4's smoke tests should include "addon attached to a service in a firewalled env still functions, with the addon-declared hostnames showing up as template-sourced rules in the env's egress policy." Phase 10's `caddy-auth` adds the IdP-resolved hostnames; Phase 12 verifies pool-instance addon services emit per-instance `requiredEgress` correctly.
 
 ## 5. The three v1 addons
 
@@ -245,164 +246,351 @@ Out of scope for this plan, but worth confirming the framework fits the next add
 
 ## 6. Phased rollout
 
-Phases land in order — each phase blocks all subsequent phases. Phases 1-3 build the framework and the three addons against static services; Phase 4 generalises to pools; Phase 5 polishes the operator and end-user surfaces; Phase 6 is deferred follow-up work for OIDC management.
+Phases form a dependency graph (see the `[blocks-by: …]` brackets in §8). Design phases land first as `(deferred)` Backlog issues — designer-owned, picked up by humans rather than the execute-next-task agent — and gate the UI implementation phases that consume them. Phases 1, 3, 4, 5 build the framework, the Tailscale connected service, and the two Tailscale addons against static services. Phase 7 ships the Connect panel and live device-status poller. Phases 8, 10, 11 build the Caddy auth-gate sidecar image, the addon, and its composition with `tailscale-web`. Phase 12 generalises addons to pool services. Phases 13–16 are the deferred OIDC provider management work.
 
-### Phase 1 — Addon framework + Tailscale connected service + `tailscale-ssh`
+### Phase 1 — Addon framework
 
-**Goal:** the framework exists end-to-end, and the simplest addon ships against static services.
+**Goal:** the render pipeline expands `addons:` declarations into rendered `StackServiceDefinition`s, proven by a no-op test addon, with no production addon shipping yet.
 
 Deliverables:
-- The addon registry and `AddonDefinition` / `AddonMergeStrategy` types in `server/src/services/stack-addons/`.
-- The render pipeline: the existing stack-render step gains an addon-expansion phase that runs validation → applicability check → merge-group resolution → provision → `buildServiceDefinition` → target-integration application. The reconciler is unchanged; it consumes the rendered (expanded) stack definition.
-- An `addons` field on `stackServiceDefinitionSchema` with per-addon `superRefine` validation against the registered manifests.
-- Synthetic-service flagging: rendered addon services carry `synthetic: true` and a back-reference to the target service so the UI can label them as derived rather than user-authored.
-- A new `tailscale` connected-service type with OAuth client_id/secret in Vault, tailnet domain auto-discovery, default tags, and a click-to-copy ACL bootstrap snippet on the settings page.
-- Tailscale connectivity prober wired into the existing `ConnectedServiceProber` and surfaced on the connected-services page.
-- Authkey minter using OAuth `client_credentials` against the Tailscale API; access tokens cached with pre-expiry refresh.
-- The `tailscale-ssh` addon directory with manifest, `targetIntegration` (`peer-on-target-network`), `provision`, and `buildServiceDefinition`. The materialized sidecar's `containerConfig.requiredEgress` lists the Tailscale control-plane hostnames (§4.7) so attaching the addon in a firewalled env works without manual policy edits.
-- Two new Socket.IO events on the `stacks` channel: `STACK_ADDON_PROVISIONED` and `STACK_ADDON_FAILED`.
-- Admin documentation page walking through OAuth client creation, scopes, tagging, and pasting the ACL snippet.
+- The `AddonDefinition`, `AddonMergeStrategy`, `AddonManifest`, `TargetIntegration`, `ProvisionContext`, and `ProvisionedValues` types in `lib/` and `server/src/services/stack-addons/`.
+- The addon registry — a single registration entry point under `server/src/services/stack-addons/` listing the active addons by id.
+- The `addons` field on `stackServiceDefinitionSchema` with per-entry `superRefine` validation against the registered manifests.
+- The render pipeline `expandAddons()` step running validation → applicability check → merge-group resolution → `provision` → `buildServiceDefinition` → target-integration application, called by the existing render step before reconcile.
+- Synthetic-service flagging — rendered addon services carry `synthetic: true` and a back-reference to the target service.
+- Two new Socket.IO event names on the `stacks` channel: `STACK_ADDON_PROVISIONED` and `STACK_ADDON_FAILED` (defined in `lib/types/socket-events.ts`; not yet emitted).
+- A no-op test addon registered in test-only code that round-trips the validate → render → reconcile path in unit tests.
+- Definition-hash logic confirmed to compute from the *authored* definition + addon-config, not the rendered form (per §7).
 
-Reversibility: feature-flagged — addon expansion runs only when a service declares `addons:`; with the registry empty no behaviour changes. Rollback is reverting the PR or removing the registered `tailscale-ssh` addon. Tailscale connected service is opt-in (admin must add it), so absence of credentials is also a clean no-op state.
+Reversibility: feature-flagged — addon expansion is a pure function of `addons:` declarations. With the production registry empty, the render pass is a no-op for every existing stack. Rollback is reverting the PR.
+
+UI changes: none
+
+Done when: a unit test registers a no-op test addon, applies a stack template with `addons: { noop: {} }` on a Stateful service, and asserts the rendered stack has the synthetic sidecar appended with `synthetic: true` while the target service remains unchanged; an authored stack with no `addons:` declarations round-trips through the render pipeline byte-identical to its authored form.
+
+Verify in prod: `n/a — internal only`
+
+### Phase 2 — Design: Tailscale settings + addon visual language (deferred)
+
+**Goal:** approved Figma frames covering the Tailscale settings form and the "from addon" badge / synthetic-sidecar visual treatment used in the stack and containers pages.
+
+Deliverables:
+- Figma frames for the Tailscale connected-service settings form: OAuth client_id / client_secret fields, default tags input, ACL bootstrap snippet preview + copy block, tag list display.
+- Figma frames for the "from addon" badge on synthetic services in the stack-detail and containers pages, including the visual relationship between a synthetic sidecar and its target service row.
+- Any new design tokens merged into the design system.
+- Designer sign-off recorded in the Linear ticket.
+
+Reversibility: safe — design only.
+
+UI changes: none — the design *is* the deliverable; pixels land in Phases 3 and 4.
+
+Done when: Figma link is attached to the Linear ticket and signed off by the designer.
+
+Verify in prod: `n/a — internal only`
+
+### Phase 3 — Tailscale connected service
+
+**Goal:** Mini Infra can authenticate to a Tailscale tailnet, mint authkeys, and report connectivity from the admin UI.
+
+Deliverables:
+- A new `tailscale` connected-service type alongside Docker / Azure / Cloudflare / GitHub.
+- OAuth `client_credentials` access-token minter using the configured OAuth client; access tokens cached with pre-expiry refresh.
+- Tailnet domain auto-discovery from the OAuth client.
+- A server-side authkey minter (one-time, ephemeral, preauthorized) callable as a service method.
+- Tailscale connectivity prober wired into the existing `ConnectedServiceProber`.
+- The Tailscale settings form on the connected-services admin page (built against the Phase 2 Figma).
+- The ACL bootstrap snippet box on the same form (built against the Phase 2 Figma).
+- Vault path conventions for the OAuth client_id / client_secret.
+- Admin documentation page walking operators through Tailscale OAuth client creation, scopes, tagging, and pasting the ACL snippet.
+
+Reversibility: feature-flagged — Tailscale becomes opt-in. Without credentials configured, no behaviour changes anywhere in the system. Rollback is reverting the PR or removing the Tailscale connected-service entry.
 
 UI changes:
 - Connected Services page gains a "Tailscale" entry alongside Docker / Azure / Cloudflare / GitHub: connection status, last-checked timestamp, edit form. [no design] — fits the established connected-service card pattern.
-- Settings: new "Tailscale" admin form for OAuth client_id/secret, default tags, and a click-to-copy ACL-bootstrap snippet box. [design needed] — the snippet preview + tag list + copy block layout is new for our settings forms.
-- Stack detail / Containers page: addon-derived sidecars appear in the existing service/container lists with a "from addon" badge and a back-reference to the target service; edit affordances disabled. [design needed] — badge style and how a synthetic sidecar visually relates to its target row (indented? linked icon?) needs a designer call.
-- Stack apply flow: live progress reflects two new lifecycle events (`STACK_ADDON_PROVISIONED`, `STACK_ADDON_FAILED`) under the existing apply task in the task tracker. [no design] — slots into existing task-tracker step rendering.
+- Settings: new "Tailscale" admin form for OAuth client_id / client_secret, default tags, click-to-copy ACL bootstrap snippet block. [no design] — built against Phase 2 Figma.
 - New admin docs page walking operators through Tailscale OAuth client creation and ACL bootstrap. [no design] — uses the existing user-docs article shell.
 
-Done when: a stack template with `addons: { tailscale-ssh: {} }` on a `Stateful` or `StatelessWeb` service applies cleanly, the Tailscale sidecar appears as a synthetic service in the rendered stack, joins the tailnet under `tag:mini-infra-managed`, shows up on the containers page with logs/exec/labels working, and an operator can `ssh root@<service>-<env>` from a tailnet-joined laptop with the IdP-driven `check` flow. *Firewall sanity check:* the same template applied in an env with `egressFirewallEnabled: true` still works end-to-end, and the Tailscale control-plane hostnames appear as template-sourced rules on the env's egress policy without operator intervention.
+Done when: an admin can configure Tailscale credentials via the new form, the connectivity prober shows green, and a server-side `mintAuthkey()` invocation from a test command produces a working tailnet authkey.
 
-Verify in prod: Tailscale entry appears under Connected Services with a green status; the first stack applied with `addons: { tailscale-ssh: {} }` shows the sidecar online in the Tailscale admin console under `tag:mini-infra-managed`; no spike in `STACK_ADDON_FAILED` events for 24 h after rollout.
+Verify in prod: Tailscale entry appears under Connected Services with a green status; no `tailscale.auth_failed` log spike for 24 h after rollout.
 
-### Phase 2 — `tailscale-web` and tailscale addon merging
+### Phase 4 — `tailscale-ssh` addon
 
-**Goal:** services expose HTTPS on the tailnet with auto-provisioned TLS; both Tailscale addons can run together as one sidecar.
+**Goal:** operators can SSH into addon-attached static services using their tailnet identity.
 
 Deliverables:
-- The `tailscale-web` addon directory with manifest, `targetIntegration` (`peer-on-target-network`), `provision` (renders `serve.json` from port/path config), and `buildServiceDefinition`.
-- `AddonMergeStrategy` registered for `kind: tailscale`: when `tailscale-ssh` and `tailscale-web` both target the same service, one sidecar definition carries both `--ssh` and `TS_SERVE_CONFIG`, sharing one authkey, one hostname, and one state volume.
-- The "Connect" panel on the stack detail page lists every addon-attached endpoint with one-click `ssh root@…` and `https://…` actions.
-- A Tailscale device-status poller that emits `TAILSCALE_DEVICE_ONLINE` / `OFFLINE` on a new `tailscale` Socket.IO channel; the Connect panel reflects live status badges.
+- The `tailscale-ssh` addon directory under `server/src/services/stack-addons/tailscale-ssh/` with its `AddonDefinition` (manifest, `targetIntegration: peer-on-target-network`, `provision`, `buildServiceDefinition`).
+- The Tailscale state-volume convention for static services.
+- Default tag scoping `tag:mini-infra-managed,tag:stack-<id>,tag:env-<env>,tag:service-<name>` plus user-supplied `extraTags`.
+- The static-service hostname rule `{service-name}-{env-name}` (sanitised, ≤63 chars).
+- The materialised sidecar's `containerConfig.requiredEgress` lists the Tailscale control-plane hostnames (`controlplane.tailscale.com`, `*.tailscale.com`, `*.tailscale.io`, DERP relays), so the addon works in firewalled envs without manual policy edits (§4.7).
+- The "from addon" badge rendered on synthetic services in the stack-detail and containers pages (built against the Phase 2 Figma).
+- `STACK_ADDON_PROVISIONED` and `STACK_ADDON_FAILED` events emitted by the render pipeline and surfaced under the existing apply task in the task tracker.
 
-Reversibility: feature-flagged — only services that opt into `tailscale-web` are affected; merging is automatic when both Tailscale addons are present. Rollback is removing the addon from the service definition (next apply unrolls the sidecar config). Tailnet device de-registration happens via ephemeral cleanup so there's no residual state to reap.
+Reversibility: feature-flagged — only services that opt in via `addons: { tailscale-ssh: {} }` are affected. Removing the addon from the service definition unrolls the sidecar on next apply. Tailnet device de-registration via ephemeral cleanup leaves no residual state.
 
 UI changes:
-- Stack detail page: new "Connect" panel listing every addon-attached endpoint with one-click `ssh root@…` and `https://…` actions. [design needed] — brand-new panel; placement relative to the services list, empty / failed / loading states all need design.
-- Live status badges on Connect panel rows reflecting `TAILSCALE_DEVICE_ONLINE` / `OFFLINE` events. [design needed] — needs a green / grey / red dot style and the transition timing pattern.
-- New Socket.IO channel `tailscale` surfaced via the existing connection-status indicator (same place users see other channel disconnections). [no design].
+- Stack detail / Containers page: addon-derived sidecars appear in the existing service/container lists with a "from addon" badge and the synthetic-sidecar visual treatment from the Phase 2 design; edit affordances disabled. [no design] — built against Phase 2 Figma.
+- Stack apply flow: live progress reflects `STACK_ADDON_PROVISIONED` / `STACK_ADDON_FAILED` under the existing apply task in the task tracker. [no design] — slots into existing task-tracker step rendering.
 
-Done when: a service with both Tailscale addons enabled is reachable as `ssh root@<host>` and `https://<host>.<tailnet>.ts.net` from any tailnet-joined laptop, exactly one Tailscale device exists in the tailnet for that service, and the Connect panel shows the right URLs and live online/offline state.
+Done when: a stack template with `addons: { tailscale-ssh: {} }` on a Stateful or StatelessWeb service applies cleanly, the synthetic sidecar joins the tailnet under the right tags, shows up on the containers page with the "from addon" badge and working logs/exec, and `ssh root@<service>-<env>` from a tailnet-joined laptop succeeds via the ACL-driven `check` flow — including in an env with `egressFirewallEnabled: true`, where the Tailscale control-plane hostnames must appear as template-sourced rules without manual policy edits.
 
-Verify in prod: at least one production service is reachable via both `ssh root@<host>` and `https://<host>.<tailnet>.ts.net`; tailnet device count matches the count of `tailscale-*` addon applications recorded in the DB; Connect panel renders within ~1 s and badges flip within ~5 s of a real device transition.
+Verify in prod: the first stack applied with `addons: { tailscale-ssh: {} }` shows the sidecar online in the Tailscale admin console under `tag:mini-infra-managed`; no spike in `STACK_ADDON_FAILED` events for 24 h after rollout.
 
-### Phase 3 — `caddy-auth` v1
+### Phase 5 — `tailscale-web` and tailscale addon merging
 
-**Goal:** services can be gated on OIDC sign-in via a Caddy reverse proxy, composing with Tailscale when present.
+**Goal:** services can expose HTTPS on the tailnet with auto-provisioned TLS, and both Tailscale addons run together as a single sidecar when both are declared.
 
 Deliverables:
-- A new standalone package `caddy-auth-sidecar/` mirroring the `update-sidecar` / `agent-sidecar` shape, building a `mini-infra/caddy-auth` image with the `caddy-security` plugin pinned.
-- The `caddy-auth` addon directory with manifest, `targetIntegration` (`own-target-netns` + `reclaimTargetPorts: true`), `provision` (reads OIDC config from Vault, renders Caddyfile, resolves the IdP's discovery / token / JWKS hostnames), and `buildServiceDefinition` (writes the resolved IdP hostnames into `containerConfig.requiredEgress` per §4.7 so the addon works in firewalled envs without manual policy edits).
-- Vault path convention `secret/connected-services/oidc/<provider>` documented for v1 manual editing.
-- Cross-addon rewrite: when `caddy-auth` and `tailscale-web` both apply, the post-merge step rewrites Tailscale's `serve.json` to forward to Caddy's port instead of the app's. This is the one place the framework reasons about pairs of addons; nothing else needs to.
+- The `tailscale-web` addon directory with manifest, `targetIntegration: peer-on-target-network`, `provision` (renders `serve.json` from port/path config and resolves the tailnet domain), and `buildServiceDefinition` (config-file mount for `serve.json`; reuses Tailscale control-plane `requiredEgress` from Phase 4).
+- An `AddonMergeStrategy` registered for `kind: tailscale`: when `tailscale-ssh` and `tailscale-web` both target the same service, one sidecar definition carries both `--ssh` and `TS_SERVE_CONFIG`, sharing one authkey, one hostname, one tailnet device, and one state volume.
+
+Reversibility: feature-flagged — opt-in per service. Removing the addon unrolls on next apply. Merging is automatic when both Tailscale addons are declared on the same service.
+
+UI changes: none — the operator-visible difference (one merged sidecar instead of two) is a side-effect of the rendered definition; the user-friendly Connect-panel surface ships in Phase 7.
+
+Done when: a service with both `tailscale-ssh` and `tailscale-web` declared exposes one merged sidecar in the rendered stack, exactly one Tailscale device exists in the tailnet for that service, and both `ssh root@<host>` and `https://<host>.<tailnet>.ts.net` work end-to-end (verified via the tailnet admin console plus manual `ssh`/`curl` from a tailnet-joined laptop).
+
+Verify in prod: at least one production service is reachable via both `ssh` and `https://…ts.net`; tailnet device count matches the number of `tailscale-*` addon applications recorded in the DB.
+
+### Phase 6 — Design: Connect panel (deferred)
+
+**Goal:** approved Figma frames for the Connect panel on the stack-detail page, including layout, status badge style, and live transition timing.
+
+Deliverables:
+- Figma frames for the Connect panel: placement on the stack-detail page; empty / failed / loading states; per-row layout for `ssh` and `https://…` actions.
+- Live status badge style (green / grey / red dot pattern) and the transition timing pattern.
+- Designer sign-off recorded in the Linear ticket.
+
+Reversibility: safe — design only.
+
+UI changes: none — pixels land in Phase 7.
+
+Done when: Figma link is attached to the Linear ticket and signed off by the designer.
+
+Verify in prod: `n/a — internal only`
+
+### Phase 7 — Connect panel + Tailscale device-status poller
+
+**Goal:** operators see every addon-attached endpoint with one-click `ssh`/HTTPS actions and live online/offline status.
+
+Deliverables:
+- A Tailscale device-status poller as a server-side scheduled task; emits `TAILSCALE_DEVICE_ONLINE` / `TAILSCALE_DEVICE_OFFLINE` events.
+- A new `tailscale` Socket.IO channel for those events, defined in `lib/types/socket-events.ts`.
+- The Connect panel on the stack-detail page (built against the Phase 6 Figma): rows per addon-attached endpoint with `ssh root@…` / `https://…` actions and live status badges.
+- The new `tailscale` channel surfaced via the existing connection-status indicator alongside the other channels.
+
+Reversibility: safe — additive UI plus a new background poller. Disabling the poller stops emitting events and the panel falls back to last-known state. Rollback is reverting the PR.
+
+UI changes:
+- Stack detail page: new Connect panel listing every addon-attached endpoint with one-click `ssh root@…` and `https://…` actions, with live online/offline status badges. [no design] — built against Phase 6 Figma.
+- Existing connection-status indicator surfaces the `tailscale` channel alongside the others. [no design] — fits the established pattern.
+
+Done when: a service with both Tailscale addons enabled has a Connect panel row that renders within ~1 s, and badges flip within ~5 s of a deliberate device-down test in the tailnet admin console.
+
+Verify in prod: at least one production service with `tailscale-web` has the Connect panel rendering correct URLs; live online/offline transitions reflect within ~5 s (measured against a deliberate device-down test).
+
+### Phase 8 — `caddy-auth-sidecar` image package
+
+**Goal:** a `mini-infra/caddy-auth` Docker image with the `caddy-security` plugin pinned, built and tested in CI alongside the other sidecars.
+
+Deliverables:
+- A new top-level `caddy-auth-sidecar/` directory mirroring the `update-sidecar/` and `agent-sidecar/` shape — standalone npm package outside the pnpm workspace.
+- `Dockerfile`, `package.json`, build scripts producing `mini-infra/caddy-auth:<tag>` with the `caddy-security` plugin pinned to a specific version.
+- Unit / smoke tests covering plugin load and a static Caddyfile probe.
+- `pnpm build:caddy-auth-sidecar` script wired into the root build flow alongside `build:sidecar` and `build:agent-sidecar`.
+- CI workflow updates to publish the image on tag.
+
+Reversibility: safe — additive package; if the image doesn't ship correctly, no service references it yet. Rollback is reverting the PR.
+
+UI changes: none
+
+Done when: `cd caddy-auth-sidecar && npm test` passes, `pnpm build:caddy-auth-sidecar` from the project root produces an image, and the image launches with the `caddy-security` plugin loaded against a static Caddyfile.
+
+Verify in prod: image is published to the registry under the expected tag; pulled by zero stacks (no consumer yet).
+
+### Phase 9 — Design: stack-detail synthetic chain + pool-row disclosure (deferred)
+
+**Goal:** approved Figma frames for two related stack-detail surfaces: the rendered services chain (showing `network_mode` rewrites and reclaimed ports) and the pool-row disclosure pattern (per-instance row reveal).
+
+Deliverables:
+- Figma frames showing how the rendered services chain is conveyed on the stack-detail page (app + caddy-auth + tailscale-web), including how `network_mode` rewrites and reclaimed ports are surfaced without operators having to read YAML.
+- Figma frames for the pool-row disclosure pattern — how a pool service row expands to show per-instance rows, including the 50-instance pool case.
+- Designer sign-off recorded in the Linear ticket.
+
+Reversibility: safe — design only.
+
+UI changes: none — pixels land in Phases 10 and 12.
+
+Done when: Figma link is attached to the Linear ticket and signed off by the designer.
+
+Verify in prod: `n/a — internal only`
+
+### Phase 10 — `caddy-auth` addon
+
+**Goal:** services can be gated by OIDC sign-in via a Caddy reverse proxy that owns the target's netns.
+
+Deliverables:
+- The `caddy-auth` addon directory under `server/src/services/stack-addons/caddy-auth/` with manifest, `targetIntegration: own-target-netns + reclaimTargetPorts: true`, `provision` (reads OIDC client config from Vault, renders Caddyfile gating on `allowedGroups` / exempting `publicPaths`, resolves IdP discovery / token / JWKS hostnames), and `buildServiceDefinition` (writes resolved IdP hostnames into `containerConfig.requiredEgress`).
+- The Vault path convention `secret/connected-services/oidc/<provider>` documented for v1 manual editing.
+- The rendered services chain visualisation on the stack-detail page (built against the Phase 9 Figma) — operators see the app + caddy-auth chain with `network_mode` rewrites and reclaimed ports surfaced without reading YAML.
 - Operator documentation page covering the Vault path layout and a worked example for one IdP (Entra ID).
 
-Reversibility: forward-only if the addon is removed mid-flight from a live service — re-applying without `caddy-auth` restores the unprotected app, but in-flight authenticated sessions are dropped (Caddy's session state vanishes with the container). For a true rollback during the rollout window, removing the addon from the registry hides it from new use; existing applications must be unrolled per service.
+Reversibility: forward-only — once a Caddy sidecar holds live sessions, removing the addon mid-flight drops in-flight authenticated sessions (Caddy's session state vanishes with the container). The PR itself is revertible until a service is deployed with the addon; afterwards, removing the addon from a live service is forward-only by nature.
 
 UI changes:
-- Stack detail page: rendered services list now shows a chain (app + caddy-auth, plus tailscale-web when present) with `network_mode` rewrites and reclaimed ports visible. [design needed] — how to convey "caddy owns the target's netns and reclaimed its ports" without operators having to read YAML.
-- Operator docs page: Vault layout for `secret/connected-services/oidc/<provider>` plus a worked Entra ID example. [no design] — docs article.
-- Auth-gated services display the IdP redirect chain on first request (anonymous → IdP → service). No new UI widget; operators see the existing Caddy 302 in the browser network tab when smoke-testing. [no design].
+- Stack detail page: rendered services list shows the chain (app + caddy-auth) with `network_mode` rewrites and reclaimed ports visible. [no design] — built against Phase 9 Figma.
+- Operator docs page: Vault layout for `secret/connected-services/oidc/<provider>` plus a worked Entra ID example. [no design] — uses the existing user-docs article shell.
 
-Done when: a service with `caddy-auth` plus `tailscale-web` enabled redirects unauthenticated browsers to the IdP, accepts authenticated users whose group membership matches `allowedGroups`, returns 403 for users who don't match, and forwards authenticated traffic transparently to the app. The rendered stack definition shows three services — app, caddy-auth, tailscale — with the right `network_mode` rewrites and reclaimed ports.
+Done when: a service with `addons: { caddy-auth: { provider: "entra", upstreamPort: 8080, allowedGroups: [...] } }` redirects unauthenticated browsers to the IdP, accepts authenticated users in `allowedGroups`, returns 403 for users not in `allowedGroups`, and forwards authenticated traffic to the app — verified against a real Entra ID tenant in dev.
 
-Verify in prod: at least one service deployed with `caddy-auth` rejects unauthenticated requests with the IdP redirect; an authenticated user in `allowedGroups` reaches the app; a user not in `allowedGroups` gets 403; no spike in IdP-side `failed_auth` events for 24 h after rollout.
+Verify in prod: at least one production service with `caddy-auth` rejects unauthenticated requests with the IdP redirect; an authenticated user in `allowedGroups` reaches the app; users outside `allowedGroups` get 403.
 
-### Phase 4 — Pool integration
+### Phase 11 — `caddy-auth` ↔ `tailscale-web` cross-addon composition
 
-**Goal:** addons declared on a `Pool` service materialise per instance at spawn time.
+**Goal:** services can layer `tailscale-web` and `caddy-auth` together so the chain `tailscale → caddy → app` works without manual config.
 
 Deliverables:
-- The pool spawner invokes the render pipeline with `instance: { instanceId }` populated, producing per-instance provisioned credentials and a per-instance `StackServiceDefinition` for each addon application.
-- Per-instance sidecar containers created during pool spawn with the per-instance hostname convention; the pool instance container's `network_mode` (or the sidecar's, depending on `targetIntegration`) wired up accordingly.
-- The pool reaper extension cleans up addon containers when instances are reaped and invokes addon `cleanup()` hooks.
-- Container labelling: addon sidecars carry the same `mini-infra.stack-id` / `mini-infra.service` / `mini-infra.pool-instance-id` labels as the pool instance, plus `mini-infra.addon: <kind-or-id>` and `mini-infra.synthetic: true`.
-- Connect panel pool-row expansion: clicking a pool service row reveals running instances with per-instance `ssh`/HTTPS rows.
-- Egress-policy correctness for pools: per-instance addon sidecars emit `containerConfig.requiredEgress` that flows into the env's policy reconcile the same way static addon services do (§4.7) — verify this works when the pool service is in a firewalled env.
+- The cross-addon rewrite step (§4.4 step 7): when `caddy-auth` and `tailscale-web` both apply to the same target, the post-merge step rewrites the Tailscale sidecar's `serve.json` to forward to the Caddy sidecar's port instead of the app's port.
+- A test fixture covering the layering and the rewrite output.
+- Documentation that this is the only target-aware composition the framework reasons about.
 
-Reversibility: safe — pool addon support is additive. Pools without `addons:` declarations are unaffected. If addon provisioning fails for a pool instance, that single instance fails to spawn through the existing pool-spawn error path; remove the addon from the pool service definition to revert.
+Reversibility: feature-flagged — the rewrite only fires when both addons are present on the same service. Either addon shipping alone behaves identically to before this phase.
 
 UI changes:
-- Stack detail Connect panel: pool service rows expand to reveal per-instance rows, each with their own `ssh` / HTTPS row. [design needed] — disclosure pattern for a pool with N instances; how to handle 50-instance pools without flooding the panel.
+- Stack detail page: rendered services list reflects three services in the chain (app + caddy-auth + tailscale-web) with the right rewrites visible. [no design] — uses the chain visualisation already built in Phase 10 against the Phase 9 Figma.
+
+Done when: a service with `addons: { caddy-auth: {…}, tailscale-web: {…} }` produces the chain `tailscale-web → caddy-auth → app` in the rendered definition; a tailnet-joined browser hitting `https://<host>.<tailnet>.ts.net` is redirected to the IdP, authenticates, and reaches the app.
+
+Verify in prod: at least one production service with both addons enabled is reachable via `https://<host>.<tailnet>.ts.net` only after IdP authentication; the rendered stack shows three services with the expected chain.
+
+### Phase 12 — Pool integration
+
+**Goal:** addons declared on a pool service materialise per pool instance at spawn time.
+
+Deliverables:
+- `pool-spawner.ts` invokes the render pipeline with `instance: { instanceId }` populated, producing per-instance provisioned credentials and per-instance `StackServiceDefinition`s for each addon application.
+- Per-instance hostname rule `{service-name}-{env-name}-{instance-id}` (sanitised, ≤63 chars; `instance-id-sha256[:8]` fallback when oversized).
+- Per-instance addon sidecars carry `mini-infra.stack-id`, `mini-infra.service`, `mini-infra.pool-instance-id`, `mini-infra.addon: <kind-or-id>`, and `mini-infra.synthetic: true` labels.
+- `pool-instance-reaper.ts` extension: invokes addon `cleanup()` hooks and removes addon sidecar containers when instances are reaped.
+- Per-instance addon sidecars emit `containerConfig.requiredEgress` flowing into the env's policy reconcile the same way static addon services do (§4.7).
+- The pool-row disclosure on the Connect panel (built against the Phase 9 Figma): pool service rows expand to show per-instance rows with their own `ssh` / HTTPS actions.
+- Per-instance hostname displayed alongside the existing instance-id column on the pool detail page.
+
+Reversibility: safe — pool addon support is additive. Pools without `addons:` declarations are unaffected. Per-instance provisioning failures fail through the existing pool-spawn error path.
+
+UI changes:
+- Stack detail Connect panel: pool service rows expand to per-instance rows, each with their own `ssh` / HTTPS actions. [no design] — built against Phase 9 Figma.
 - Containers page: per-instance addon sidecars appear with `mini-infra.synthetic` and `mini-infra.pool-instance-id` labels visible. [no design] — fits existing container-row label rendering.
 - Pool detail: per-instance hostname (`{service}-{env}-{instance-id}`) shown alongside the existing instance-id column. [no design].
 
-Done when: a pool service with `addons: { tailscale-ssh: {} }` spawns instances that each register as their own tailnet device with a unique per-instance hostname, an operator can SSH into a specific instance by name, and idle reaping removes both the worker container and the sidecar from Docker (and the device from the tailnet via ephemeral cleanup). In a firewalled env, the Tailscale control-plane hostnames appear as template-sourced rules and per-instance sidecars reach the tailnet without manual policy edits.
+Done when: a pool service with `addons: { tailscale-ssh: {} }` spawns N instances, each registers as its own tailnet device with the per-instance hostname pattern, an operator can SSH into a specific instance by name, and idle reaping removes both the worker container and the sidecar (and the device from the tailnet via ephemeral cleanup) — including in a firewalled env where per-instance sidecars must reach the tailnet without manual policy edits.
 
-Verify in prod: at least one production pool service with `tailscale-ssh` shows N tailnet devices for N instances, names match the `{service-name}-{env-name}-{instance-id}` pattern, idle reaping removes both the worker container and the sidecar within the ephemeral-cleanup window, and pool resize events don't leave orphan devices behind.
+Verify in prod: at least one production pool service with `tailscale-ssh` shows N tailnet devices for N instances, names match the `{service-name}-{env-name}-{instance-id}` pattern, and idle reaping removes both worker and sidecar within the ephemeral-cleanup window without orphan devices.
 
-### Phase 5 — UI polish and status surfacing
+### Phase 13 — Design: OIDC provider admin (deferred)
 
-**Goal:** operators have a low-friction view of addon health and addressable endpoints.
-
-Deliverables:
-- Connect-panel improvements: per-pool-instance rows update live via the `tailscale` channel; copy-to-clipboard for `ssh` commands and URLs.
-- An addon-status rollup on the stack detail header summarising addon health (provisioned / failed / pending) at a glance.
-- A "Test connection" button per Tailscale-attached service that calls the Tailscale API to confirm the device is online and reports response time.
-- Filter chip on the containers page using the `mini-infra.addon` and `mini-infra.synthetic` labels so operators can isolate (or hide) addon sidecars.
-
-Reversibility: safe — pure UI; revert the PR.
-
-UI changes:
-- Stack detail header gains an "Addons" rollup pill ("3 healthy / 1 failed / 1 pending") clickable to open the Connect panel scrolled to the failed addon. [design needed] — pill style, colour rules, click target.
-- Connect panel: copy-to-clipboard buttons next to every `ssh` command and HTTPS URL. [no design] — fits the existing copy-icon pattern from the API key page.
-- Per-Tailscale-attached service: a "Test connection" button that calls the Tailscale API and displays response time inline. [no design] — fits the "Test" button pattern from connected services.
-- Containers page: filter chip "Show synthetic addons" using `mini-infra.synthetic` and `mini-infra.addon` labels, defaulted to off. [design needed] — chip placement and the default-off vs default-on call.
-
-Done when: the stack detail page surfaces the right URL for every addon-attached service (including pool instances), live online/offline transitions reflect within ~5s, and an operator can audit addon health for an entire stack from one screen.
-
-Verify in prod: stack detail header surfaces the right addon count and health on a stack with mixed-state addons; live online/offline transitions reflect within ~5 s (measured against a deliberate device-down test); copy-to-clipboard click count rises in the events log (operators using it instead of selecting + copying by hand).
-
-### Phase 6 — OIDC provider management UI (optional, deferred)
-
-**Goal:** managing IdPs becomes a first-class connected-service concern instead of direct Vault editing.
+**Goal:** approved Figma frames for the new OIDC provider admin area: list page, per-provider edit form (Entra / Auth0 / Google Workspace / generic OIDC), test sign-in modal.
 
 Deliverables:
-- A new `OidcProvider` model with admin UI for adding, editing, and testing IdPs.
-- The `caddy-auth` addon's `provision` switches from direct Vault path lookup to `OidcProvider` resolution.
-- A "test sign-in" affordance per provider that exercises the OAuth flow end-to-end and reports success or failure.
+- Figma frames for `/connected-services/oidc-providers`: list, add, edit, delete views, with provider-specific field layouts.
+- Figma frames for the secret-rotation pattern.
+- Figma frames for the per-provider "Test sign-in" modal/dialog showing round-trip success or failure.
+- Designer sign-off recorded in the Linear ticket.
 
-Reversibility: forward-only — once `caddy-auth` switches from direct Vault paths to `OidcProvider` resolution, services that authored against the old path break unless migrated. Ship with an "import from Vault" affordance and a documented migration step before flipping the resolution source.
+Reversibility: safe — design only.
+
+UI changes: none — pixels land in Phases 14 and 16.
+
+Done when: Figma link is attached to the Linear ticket and signed off by the designer.
+
+Verify in prod: `n/a — internal only`
+
+### Phase 14 — `OidcProvider` model + admin UI (deferred)
+
+**Goal:** admins can manage IdPs as a first-class connected service through the Mini Infra UI instead of editing Vault directly.
+
+Deliverables:
+- A new `OidcProvider` Prisma model + migration.
+- CRUD admin UI at `/connected-services/oidc-providers` (built against the Phase 13 Figma): list, add, edit, delete IdPs with provider-specific fields (Entra, Auth0, Google Workspace, generic OIDC).
+- Connected Services page card: new "OIDC Providers" entry alongside Tailscale / Cloudflare / etc.
+- An "import from Vault" affordance that pulls existing `secret/connected-services/oidc/<provider>` entries into the new model.
+
+Reversibility: forward-only — the new model coexists with the old Vault path layout for the duration of this phase. Reverting the PR purges `OidcProvider` rows via the migration's down-step; any provider authored only via the new UI is lost.
 
 UI changes:
-- New `/connected-services/oidc-providers` admin page: list, add, edit, delete IdPs with provider-specific fields (Entra, Auth0, Google Workspace, generic OIDC). [design needed] — full new page; per-provider form layout; secret-rotation pattern.
-- Per-provider "Test sign-in" button that opens the IdP redirect in a new tab and reports back round-trip success. [design needed] — modal/dialog showing the test result is a new pattern for the connected-services area.
-- `caddy-auth` addon config gains a provider dropdown sourced from the new `OidcProvider` model. [no design] — slots into the existing addon-config form rendering.
+- New `/connected-services/oidc-providers` admin page: list, add, edit, delete. [no design] — built against Phase 13 Figma.
 - Connected Services page: new "OIDC Providers" entry alongside Tailscale / Cloudflare / etc. [no design] — fits the established connected-service card pattern.
 
-Done when: an admin can add a new IdP through the UI, attach it to a service via `addons: { caddy-auth: { provider: <id> } }`, and verify the round trip from the connected-services page without editing Vault directly.
+Done when: an admin can add an IdP through the new UI, see it in the list, edit / delete it, and import existing Vault-stored providers via the import affordance.
 
-Verify in prod: at least one IdP added through the new UI is bound to a `caddy-auth` addon application and produces successful end-to-end sign-in; no operator edits against `secret/connected-services/oidc/<provider>` Vault paths after rollout (per the Vault audit log).
+Verify in prod: at least one IdP managed via the new UI; no operator edits against `secret/connected-services/oidc/<provider>` Vault paths after rollout (per the Vault audit log).
+
+### Phase 15 — `caddy-auth` provider-resolution swap (deferred)
+
+**Goal:** the `caddy-auth` addon resolves OIDC providers via the `OidcProvider` model instead of direct Vault path lookup.
+
+Deliverables:
+- `caddy-auth` addon's `provision()` switches from direct Vault path lookup (`secret/connected-services/oidc/<provider>`) to `OidcProvider` model resolution by id.
+- Migration documentation for operators with services authored against the old path.
+- A documented deprecation window for the old Vault path (read-only fallback for one release; removed afterwards).
+- The `caddy-auth` addon-config form's provider field becomes a dropdown sourced from the new `OidcProvider` model.
+
+Reversibility: forward-only — once the swap is live, services that authored against the old Vault path break unless migrated. Ship paired with the import-from-Vault affordance from Phase 14 and the documented deprecation window above.
+
+UI changes:
+- `caddy-auth` addon config form: provider field becomes a dropdown sourced from the new `OidcProvider` model. [no design] — slots into existing addon-config form rendering.
+
+Done when: a service with `addons: { caddy-auth: { provider: "entra-prod" } }` resolves the provider via the `OidcProvider` model and authenticates correctly; the same config that previously used the Vault path migrates seamlessly via the Phase 14 import affordance.
+
+Verify in prod: every production `caddy-auth` application resolves its provider via the model after the deprecation window closes; `caddy-auth.vault_fallback` log emissions hit zero for 24 h.
+
+### Phase 16 — Per-provider Test sign-in flow (deferred)
+
+**Goal:** admins can verify an OIDC provider's round-trip from the connected-services UI without leaving the page.
+
+Deliverables:
+- A "Test sign-in" button per provider on `/connected-services/oidc-providers`: opens the IdP redirect in a new tab, captures the round-trip result, and reports success or failure in a modal/dialog (built against the Phase 13 Figma).
+
+Reversibility: safe — additive UI affordance.
+
+UI changes:
+- Per-provider "Test sign-in" button + modal/dialog showing test result. [no design] — built against Phase 13 Figma.
+
+Done when: an admin can click "Test sign-in" on a provider, complete the IdP flow in the new tab, and see the success / failure outcome reported in the modal.
+
+Verify in prod: at least one production IdP admin uses the Test sign-in button and sees a successful round-trip.
 
 ## 7. Risks & open questions
 
-- **Connected Service config model.** Three Tailscale-specific columns on `ConnectedService` may be the wrong shape if other connected services need similar growth. Worth a 30-minute look at the existing connected-services directory before Phase 1 to decide between a shared-table extension and a per-type satellite table.
+- **Connected Service config model.** Three Tailscale-specific columns on `ConnectedService` may be the wrong shape if other connected services need similar growth. Worth a 30-minute look at the existing connected-services directory before Phase 3 to decide between a shared-table extension and a per-type satellite table.
 - **ACL bootstrap rendering.** JSON is parseable; HuJSON (Tailscale's commenting variant) is friendlier for the operator's eventual hand-editing but introduces a dependency. Default to JSON unless a user objects.
-- **Caddy image provenance.** Building our own `caddy-auth-sidecar` pins the `caddy-security` plugin version and matches the existing sidecar pattern; pulling upstream `caddy:latest` is one less moving part. Mild preference for building, but worth confirming during Phase 3.
-- **Pool instance Tailscale state volume.** Per-instance state volumes are cheap, but pool instances are short-lived and authkeys are minted per-spawn. With ephemeral nodes auto-cleaning, the volume is effectively write-only. Phase 4 should validate that skipping the volume on pool instances doesn't introduce a re-registration race, and pick the cleaner of the two paths.
-- **Pool instance hostname collisions across stacks.** `worker-prod-u12345` in stack A and `worker-prod-u12345` in stack B produce duplicate device names in the tailnet. Per-stack tags prevent ACL crossover but the device list stays ambiguous. Phase 4 may need to prefix pool hostnames with the stack name and accept longer hostnames.
-- **Funnel-shaped follow-up.** Once Tailscale-only HTTPS is shipped, the smallest extension to reach the public internet is enabling Tailscale Funnel. It overlaps the Cloudflare tunnel feature, so a deliberate "when do you pick which?" call is needed before any Phase 6+ extension touches Funnel.
+- **Caddy image provenance.** Building our own `caddy-auth-sidecar` (Phase 8) pins the `caddy-security` plugin version and matches the existing sidecar pattern; pulling upstream `caddy:latest` is one less moving part. Mild preference for building, but worth confirming during Phase 8.
+- **Pool instance Tailscale state volume.** Per-instance state volumes are cheap, but pool instances are short-lived and authkeys are minted per-spawn. With ephemeral nodes auto-cleaning, the volume is effectively write-only. Phase 12 should validate that skipping the volume on pool instances doesn't introduce a re-registration race, and pick the cleaner of the two paths.
+- **Pool instance hostname collisions across stacks.** `worker-prod-u12345` in stack A and `worker-prod-u12345` in stack B produce duplicate device names in the tailnet. Per-stack tags prevent ACL crossover but the device list stays ambiguous. Phase 12 may need to prefix pool hostnames with the stack name and accept longer hostnames.
+- **Funnel-shaped follow-up.** Once Tailscale-only HTTPS is shipped, the smallest extension to reach the public internet is enabling Tailscale Funnel. It overlaps the Cloudflare tunnel feature, so a deliberate "when do you pick which?" call is needed before any post-v1 extension touches Funnel.
 - **Definition-hash determinism.** The rendered stack definition includes addon-derived services and target-integration rewrites. Provision values like authkeys are minted fresh on each render, which would oscillate the hash and force needless re-applies. Phase 1 must ensure the hash is computed from the *authored* definition (plus addon-config), not the rendered form, or that mint-once values are cached and reused across renders. Confirm during Phase 1 that the existing definition-hash logic naturally extends to the new field rather than drifting.
-- **Synthetic-service surface in the UI.** Addon-derived services appearing in the same lists as user-authored ones is the whole point, but they need clear visual distinction (a "from addon" badge) and edit affordances should be disabled. Phase 1 should land at least the badge; Phase 5 polishes.
+- **Synthetic-service surface in the UI.** Addon-derived services appearing in the same lists as user-authored ones is the whole point, but they need clear visual distinction (a "from addon" badge) and edit affordances should be disabled. Phase 4 lands the badge against the Phase 2 design; further polish (status rollup, filter chips, copy-to-clipboard affordances) was scoped out during re-phasing — revisit after operator feedback if friction surfaces.
 
 ## 8. Linear tracking
 
-Tracked under the [Service Addons — Tailscale and Caddy ingress addons](https://linear.app/altitude-devops/project/service-addons-tailscale-and-caddy-ingress-addons-a171d68a60ae) project on the Altitude Devops team. Phases land in order; each phase blocks the next.
+Tracked under the [Service Addons — Tailscale and Caddy ingress addons](https://linear.app/altitude-devops/project/service-addons-tailscale-and-caddy-ingress-addons-a171d68a60ae) project on the Altitude Devops team.
 
-- [ALT-38](https://linear.app/altitude-devops/issue/ALT-38) — Phase 1: Addon framework + Tailscale connected service + `tailscale-ssh`
-- [ALT-39](https://linear.app/altitude-devops/issue/ALT-39) — Phase 2: `tailscale-web` and tailscale addon merging
-- [ALT-40](https://linear.app/altitude-devops/issue/ALT-40) — Phase 3: `caddy-auth` v1
-- [ALT-41](https://linear.app/altitude-devops/issue/ALT-41) — Phase 4: Pool integration
-- [ALT-42](https://linear.app/altitude-devops/issue/ALT-42) — Phase 5: UI polish and status surfacing
-- [ALT-43](https://linear.app/altitude-devops/issue/ALT-43) — Phase 6 (deferred): OIDC provider management UI
+- ALT-_TBD_ — Phase 1: Addon framework
+- ALT-_TBD_ — Phase 2: Design: Tailscale settings + addon visual language
+- ALT-_TBD_ — Phase 3: Tailscale connected service  [blocks-by: 2]
+- [ALT-38](https://linear.app/altitude-devops/issue/ALT-38) — Phase 4: `tailscale-ssh` addon  [blocks-by: 1, 2, 3]
+- [ALT-39](https://linear.app/altitude-devops/issue/ALT-39) — Phase 5: `tailscale-web` and tailscale addon merging  [blocks-by: 4]
+- ALT-_TBD_ — Phase 6: Design: Connect panel  [blocks-by: 2]
+- ALT-_TBD_ — Phase 7: Connect panel + Tailscale device-status poller  [blocks-by: 5, 6]
+- ALT-_TBD_ — Phase 8: `caddy-auth-sidecar` image package
+- ALT-_TBD_ — Phase 9: Design: stack-detail synthetic chain + pool-row disclosure  [blocks-by: 2]
+- [ALT-40](https://linear.app/altitude-devops/issue/ALT-40) — Phase 10: `caddy-auth` addon  [blocks-by: 1, 8, 9]
+- ALT-_TBD_ — Phase 11: `caddy-auth` ↔ `tailscale-web` cross-addon composition  [blocks-by: 5, 10]
+- [ALT-41](https://linear.app/altitude-devops/issue/ALT-41) — Phase 12: Pool integration  [blocks-by: 4, 9]
+- ALT-_TBD_ — Phase 13: Design: OIDC provider admin
+- [ALT-43](https://linear.app/altitude-devops/issue/ALT-43) — Phase 14: `OidcProvider` model + admin UI  [blocks-by: 13]
+- ALT-_TBD_ — Phase 15: `caddy-auth` provider-resolution swap  [blocks-by: 10, 14]
+- ALT-_TBD_ — Phase 16: Per-provider Test sign-in flow  [blocks-by: 13, 14]
+
+*Re-phasing note for `plan-to-linear` update mode: [ALT-42](https://linear.app/altitude-devops/issue/ALT-42) (previously Phase 5: "UI polish and status surfacing") was removed from the plan during re-phasing — polish was scoped out in favour of initial-page-development focus only (see §3 Non-goals, last bullet). Surface for manual cancellation; this skill does not auto-delete.*

--- a/docs/planning/not-shipped/service-addons-plan.md
+++ b/docs/planning/not-shipped/service-addons-plan.md
@@ -507,17 +507,17 @@ Verify in prod: at least one production IdP admin uses the Test sign-in button a
 
 ## 8. Linear tracking
 
-Phase issues will be created under the [Service Addons Framework](https://linear.app/altitude-devops/project/service-addons-framework-a171d68a60ae) project on the Altitude Devops team and linked here once filed.
+Tracked under the [Service Addons Framework](https://linear.app/altitude-devops/project/service-addons-framework-0391849444a5) project on the Altitude Devops team.
 
-- ALT-_TBD_ — Phase 1: Addon framework
-- ALT-_TBD_ — Phase 2: Tailscale connected service  [blocks-by: 1]
-- ALT-_TBD_ — Phase 3: `tailscale-ssh` addon  [blocks-by: 1, 2]
-- ALT-_TBD_ — Phase 4: `tailscale-web` and tailscale addon merging  [blocks-by: 3]
-- ALT-_TBD_ — Phase 5: Connect panel + Tailscale device-status poller  [blocks-by: 4]
-- ALT-_TBD_ — Phase 6: `caddy-auth-sidecar` image package
-- ALT-_TBD_ — Phase 7: `caddy-auth` addon  [blocks-by: 1, 6]
-- ALT-_TBD_ — Phase 8: `caddy-auth` ↔ `tailscale-web` cross-addon composition  [blocks-by: 4, 7]
-- ALT-_TBD_ — Phase 9: Pool integration  [blocks-by: 3]
-- ALT-_TBD_ — Phase 10: `OidcProvider` model + admin UI (deferred)
-- ALT-_TBD_ — Phase 11: `caddy-auth` provider-resolution swap (deferred)  [blocks-by: 7, 10]
-- ALT-_TBD_ — Phase 12: Per-provider Test sign-in flow (deferred)  [blocks-by: 10]
+- [ALT-56](https://linear.app/altitude-devops/issue/ALT-56) — Phase 1: Addon framework
+- [ALT-57](https://linear.app/altitude-devops/issue/ALT-57) — Phase 2: Tailscale connected service  [blocks-by: 1]
+- [ALT-58](https://linear.app/altitude-devops/issue/ALT-58) — Phase 3: `tailscale-ssh` addon  [blocks-by: 1, 2]
+- [ALT-59](https://linear.app/altitude-devops/issue/ALT-59) — Phase 4: `tailscale-web` and tailscale addon merging  [blocks-by: 3]
+- [ALT-60](https://linear.app/altitude-devops/issue/ALT-60) — Phase 5: Connect panel + Tailscale device-status poller  [blocks-by: 4]
+- [ALT-61](https://linear.app/altitude-devops/issue/ALT-61) — Phase 6: `caddy-auth-sidecar` image package
+- [ALT-62](https://linear.app/altitude-devops/issue/ALT-62) — Phase 7: `caddy-auth` addon  [blocks-by: 1, 6]
+- [ALT-63](https://linear.app/altitude-devops/issue/ALT-63) — Phase 8: `caddy-auth` ↔ `tailscale-web` cross-addon composition  [blocks-by: 4, 7]
+- [ALT-64](https://linear.app/altitude-devops/issue/ALT-64) — Phase 9: Pool integration  [blocks-by: 3]
+- [ALT-65](https://linear.app/altitude-devops/issue/ALT-65) — Phase 10: `OidcProvider` model + admin UI (deferred)
+- [ALT-66](https://linear.app/altitude-devops/issue/ALT-66) — Phase 11: `caddy-auth` provider-resolution swap (deferred)  [blocks-by: 7, 10]
+- [ALT-67](https://linear.app/altitude-devops/issue/ALT-67) — Phase 12: Per-provider Test sign-in flow (deferred)  [blocks-by: 10]

--- a/docs/planning/not-shipped/service-addons-plan.md
+++ b/docs/planning/not-shipped/service-addons-plan.md
@@ -1,4 +1,4 @@
-# Service Addons — Tailscale and Caddy ingress addons
+# Service Addons Framework
 
 **Status:** planned, not implemented. Phased rollout — each phase is a separate Linear issue.
 **Builds on:** the existing `Pool` service type and stack-template plumbing ([`PoolConfig`](../../../lib/types/stacks.ts), [`pool-spawner.ts`](../../../server/src/services/stacks/pool-spawner.ts), [`pool-instance-reaper.ts`](../../../server/src/services/stacks/pool-instance-reaper.ts)), the connected-services pattern ([Docker / Azure / Cloudflare / GitHub](../../../server/src/services/connected-services/)), the `StackServiceDefinition` schema ([`lib/types/stacks.ts`](../../../lib/types/stacks.ts)), and Vault credential storage.
@@ -28,11 +28,11 @@ A second design pressure: addon containers are still containers. They need logs,
 - **Multi-tailnet support.** v1 binds Mini Infra to one tailnet via one OAuth client. Operators with multiple tailnets are out of scope.
 - **Auto-managing the tailnet ACL.** v1 emits a copy-paste snippet the operator pastes into their tailnet policy file; we do not call the Tailscale ACL API.
 - **Tailscale Funnel (public exposure).** v1 ships `tailscale-web` in tailnet-only mode. Funnel overlaps the existing Cloudflare tunnel feature; deferred.
-- **Full OIDC provider management.** v1 ships the Caddy sidecar reading provider config from Vault directly. The `OidcProvider` model and admin UI for managing IdPs are deferred (see Phases 13–16).
+- **Full OIDC provider management.** v1 ships the Caddy sidecar reading provider config from Vault directly. The `OidcProvider` model and admin UI for managing IdPs are deferred (see Phases 10–12).
 - **User-defined addons.** Only addons in the registry are usable; addon authoring is not a user-facing feature.
 - **Cross-stack addon composition.** Addons are scoped to one service in one stack. No "addon X depends on addon Y on a different stack."
 - **Drift detection on tailnet devices.** Ephemeral nodes self-clean; a reconciler that detects "this Tailscale device exists but no longer corresponds to a running container" is deferred.
-- **UI polish / status rollups.** v1 ships the initial pages only — no addon-status header pills, no copy-to-clipboard affordances, no "Test connection" button per addon, no synthetic-addon filter chips. Scoped out during re-phasing in favour of initial page development; revisit after operator feedback.
+- **UI polish / status rollups.** v1 ships the initial pages only — no addon-status header pills, no copy-to-clipboard affordances, no "Test connection" button per addon, no synthetic-addon filter chips. Scoped out in favour of initial page development; revisit after operator feedback.
 
 ## 4. The addon framework
 
@@ -202,7 +202,7 @@ Behaviours worth pinning:
 
 #### Implications for the framework
 
-The framework deliverables don't grow — `containerConfig.requiredEgress` already exists on `StackContainerConfig` and the reconciler already reads it. What's required instead is documentation and a sanity check: the `tailscale-ssh` addon (Phase 4) must encode the right Tailscale control-plane hostnames in its `buildServiceDefinition()` output, and Phase 4's smoke tests should include "addon attached to a service in a firewalled env still functions, with the addon-declared hostnames showing up as template-sourced rules in the env's egress policy." Phase 10's `caddy-auth` adds the IdP-resolved hostnames; Phase 12 verifies pool-instance addon services emit per-instance `requiredEgress` correctly.
+The framework deliverables don't grow — `containerConfig.requiredEgress` already exists on `StackContainerConfig` and the reconciler already reads it. What's required instead is documentation and a sanity check: the `tailscale-ssh` addon (Phase 3) must encode the right Tailscale control-plane hostnames in its `buildServiceDefinition()` output, and Phase 3's smoke tests should include "addon attached to a service in a firewalled env still functions, with the addon-declared hostnames showing up as template-sourced rules in the env's egress policy." Phase 7's `caddy-auth` adds the IdP-resolved hostnames; Phase 9 verifies pool-instance addon services emit per-instance `requiredEgress` correctly.
 
 ## 5. The three v1 addons
 
@@ -246,7 +246,9 @@ Out of scope for this plan, but worth confirming the framework fits the next add
 
 ## 6. Phased rollout
 
-Phases form a dependency graph (see the `[blocks-by: …]` brackets in §8). Design phases land first as `(deferred)` Backlog issues — designer-owned, picked up by humans rather than the execute-next-task agent — and gate the UI implementation phases that consume them. Phases 1, 3, 4, 5 build the framework, the Tailscale connected service, and the two Tailscale addons against static services. Phase 7 ships the Connect panel and live device-status poller. Phases 8, 10, 11 build the Caddy auth-gate sidecar image, the addon, and its composition with `tailscale-web`. Phase 12 generalises addons to pool services. Phases 13–16 are the deferred OIDC provider management work.
+Phases form a dependency graph (see the `[blocks-by: …]` brackets in §8). Phases 1–4 build the framework, the Tailscale connected service, and the two Tailscale addons against static services. Phase 5 ships the Connect panel and live device-status poller. Phases 6–8 build the Caddy auth-gate sidecar image, the addon, and its composition with `tailscale-web`. Phase 9 generalises addons to pool services. Phases 10–12 are the deferred OIDC provider management work.
+
+`[design needed]` UI items are picked up by `plan-to-linear` at seed time and materialised as paired `Backlog` design tickets that block their phase — designers own those tickets, kept out of `execute-next-task`'s queue.
 
 ### Phase 1 — Addon framework
 
@@ -270,25 +272,7 @@ Done when: a unit test registers a no-op test addon, applies a stack template wi
 
 Verify in prod: `n/a — internal only`
 
-### Phase 2 — Design: Tailscale settings + addon visual language (deferred)
-
-**Goal:** approved Figma frames covering the Tailscale settings form and the "from addon" badge / synthetic-sidecar visual treatment used in the stack and containers pages.
-
-Deliverables:
-- Figma frames for the Tailscale connected-service settings form: OAuth client_id / client_secret fields, default tags input, ACL bootstrap snippet preview + copy block, tag list display.
-- Figma frames for the "from addon" badge on synthetic services in the stack-detail and containers pages, including the visual relationship between a synthetic sidecar and its target service row.
-- Any new design tokens merged into the design system.
-- Designer sign-off recorded in the Linear ticket.
-
-Reversibility: safe — design only.
-
-UI changes: none — the design *is* the deliverable; pixels land in Phases 3 and 4.
-
-Done when: Figma link is attached to the Linear ticket and signed off by the designer.
-
-Verify in prod: `n/a — internal only`
-
-### Phase 3 — Tailscale connected service
+### Phase 2 — Tailscale connected service
 
 **Goal:** Mini Infra can authenticate to a Tailscale tailnet, mint authkeys, and report connectivity from the admin UI.
 
@@ -298,8 +282,8 @@ Deliverables:
 - Tailnet domain auto-discovery from the OAuth client.
 - A server-side authkey minter (one-time, ephemeral, preauthorized) callable as a service method.
 - Tailscale connectivity prober wired into the existing `ConnectedServiceProber`.
-- The Tailscale settings form on the connected-services admin page (built against the Phase 2 Figma).
-- The ACL bootstrap snippet box on the same form (built against the Phase 2 Figma).
+- The Tailscale settings form on the connected-services admin page.
+- The ACL bootstrap snippet box on the same form.
 - Vault path conventions for the OAuth client_id / client_secret.
 - Admin documentation page walking operators through Tailscale OAuth client creation, scopes, tagging, and pasting the ACL snippet.
 
@@ -307,14 +291,14 @@ Reversibility: feature-flagged — Tailscale becomes opt-in. Without credentials
 
 UI changes:
 - Connected Services page gains a "Tailscale" entry alongside Docker / Azure / Cloudflare / GitHub: connection status, last-checked timestamp, edit form. [no design] — fits the established connected-service card pattern.
-- Settings: new "Tailscale" admin form for OAuth client_id / client_secret, default tags, click-to-copy ACL bootstrap snippet block. [no design] — built against Phase 2 Figma.
+- Settings: new "Tailscale" admin form with OAuth client_id / client_secret, default tags, click-to-copy ACL bootstrap snippet block. [design needed] — the snippet preview + tag list + copy block layout is new for our settings forms.
 - New admin docs page walking operators through Tailscale OAuth client creation and ACL bootstrap. [no design] — uses the existing user-docs article shell.
 
 Done when: an admin can configure Tailscale credentials via the new form, the connectivity prober shows green, and a server-side `mintAuthkey()` invocation from a test command produces a working tailnet authkey.
 
 Verify in prod: Tailscale entry appears under Connected Services with a green status; no `tailscale.auth_failed` log spike for 24 h after rollout.
 
-### Phase 4 — `tailscale-ssh` addon
+### Phase 3 — `tailscale-ssh` addon
 
 **Goal:** operators can SSH into addon-attached static services using their tailnet identity.
 
@@ -324,73 +308,57 @@ Deliverables:
 - Default tag scoping `tag:mini-infra-managed,tag:stack-<id>,tag:env-<env>,tag:service-<name>` plus user-supplied `extraTags`.
 - The static-service hostname rule `{service-name}-{env-name}` (sanitised, ≤63 chars).
 - The materialised sidecar's `containerConfig.requiredEgress` lists the Tailscale control-plane hostnames (`controlplane.tailscale.com`, `*.tailscale.com`, `*.tailscale.io`, DERP relays), so the addon works in firewalled envs without manual policy edits (§4.7).
-- The "from addon" badge rendered on synthetic services in the stack-detail and containers pages (built against the Phase 2 Figma).
+- The "from addon" badge rendered on synthetic services in the stack-detail and containers pages.
 - `STACK_ADDON_PROVISIONED` and `STACK_ADDON_FAILED` events emitted by the render pipeline and surfaced under the existing apply task in the task tracker.
 
 Reversibility: feature-flagged — only services that opt in via `addons: { tailscale-ssh: {} }` are affected. Removing the addon from the service definition unrolls the sidecar on next apply. Tailnet device de-registration via ephemeral cleanup leaves no residual state.
 
 UI changes:
-- Stack detail / Containers page: addon-derived sidecars appear in the existing service/container lists with a "from addon" badge and the synthetic-sidecar visual treatment from the Phase 2 design; edit affordances disabled. [no design] — built against Phase 2 Figma.
+- Stack detail / Containers page: addon-derived sidecars appear in the existing service/container lists with a "from addon" badge and a back-reference to the target service; edit affordances disabled. [design needed] — badge style and how a synthetic sidecar visually relates to its target row (indented? linked icon?) needs a designer call.
 - Stack apply flow: live progress reflects `STACK_ADDON_PROVISIONED` / `STACK_ADDON_FAILED` under the existing apply task in the task tracker. [no design] — slots into existing task-tracker step rendering.
 
 Done when: a stack template with `addons: { tailscale-ssh: {} }` on a Stateful or StatelessWeb service applies cleanly, the synthetic sidecar joins the tailnet under the right tags, shows up on the containers page with the "from addon" badge and working logs/exec, and `ssh root@<service>-<env>` from a tailnet-joined laptop succeeds via the ACL-driven `check` flow — including in an env with `egressFirewallEnabled: true`, where the Tailscale control-plane hostnames must appear as template-sourced rules without manual policy edits.
 
 Verify in prod: the first stack applied with `addons: { tailscale-ssh: {} }` shows the sidecar online in the Tailscale admin console under `tag:mini-infra-managed`; no spike in `STACK_ADDON_FAILED` events for 24 h after rollout.
 
-### Phase 5 — `tailscale-web` and tailscale addon merging
+### Phase 4 — `tailscale-web` and tailscale addon merging
 
 **Goal:** services can expose HTTPS on the tailnet with auto-provisioned TLS, and both Tailscale addons run together as a single sidecar when both are declared.
 
 Deliverables:
-- The `tailscale-web` addon directory with manifest, `targetIntegration: peer-on-target-network`, `provision` (renders `serve.json` from port/path config and resolves the tailnet domain), and `buildServiceDefinition` (config-file mount for `serve.json`; reuses Tailscale control-plane `requiredEgress` from Phase 4).
+- The `tailscale-web` addon directory with manifest, `targetIntegration: peer-on-target-network`, `provision` (renders `serve.json` from port/path config and resolves the tailnet domain), and `buildServiceDefinition` (config-file mount for `serve.json`; reuses Tailscale control-plane `requiredEgress` from Phase 3).
 - An `AddonMergeStrategy` registered for `kind: tailscale`: when `tailscale-ssh` and `tailscale-web` both target the same service, one sidecar definition carries both `--ssh` and `TS_SERVE_CONFIG`, sharing one authkey, one hostname, one tailnet device, and one state volume.
 
 Reversibility: feature-flagged — opt-in per service. Removing the addon unrolls on next apply. Merging is automatic when both Tailscale addons are declared on the same service.
 
-UI changes: none — the operator-visible difference (one merged sidecar instead of two) is a side-effect of the rendered definition; the user-friendly Connect-panel surface ships in Phase 7.
+UI changes: none — the operator-visible difference (one merged sidecar instead of two) is a side-effect of the rendered definition; the user-friendly Connect-panel surface ships in Phase 5.
 
 Done when: a service with both `tailscale-ssh` and `tailscale-web` declared exposes one merged sidecar in the rendered stack, exactly one Tailscale device exists in the tailnet for that service, and both `ssh root@<host>` and `https://<host>.<tailnet>.ts.net` work end-to-end (verified via the tailnet admin console plus manual `ssh`/`curl` from a tailnet-joined laptop).
 
 Verify in prod: at least one production service is reachable via both `ssh` and `https://…ts.net`; tailnet device count matches the number of `tailscale-*` addon applications recorded in the DB.
 
-### Phase 6 — Design: Connect panel (deferred)
-
-**Goal:** approved Figma frames for the Connect panel on the stack-detail page, including layout, status badge style, and live transition timing.
-
-Deliverables:
-- Figma frames for the Connect panel: placement on the stack-detail page; empty / failed / loading states; per-row layout for `ssh` and `https://…` actions.
-- Live status badge style (green / grey / red dot pattern) and the transition timing pattern.
-- Designer sign-off recorded in the Linear ticket.
-
-Reversibility: safe — design only.
-
-UI changes: none — pixels land in Phase 7.
-
-Done when: Figma link is attached to the Linear ticket and signed off by the designer.
-
-Verify in prod: `n/a — internal only`
-
-### Phase 7 — Connect panel + Tailscale device-status poller
+### Phase 5 — Connect panel + Tailscale device-status poller
 
 **Goal:** operators see every addon-attached endpoint with one-click `ssh`/HTTPS actions and live online/offline status.
 
 Deliverables:
 - A Tailscale device-status poller as a server-side scheduled task; emits `TAILSCALE_DEVICE_ONLINE` / `TAILSCALE_DEVICE_OFFLINE` events.
 - A new `tailscale` Socket.IO channel for those events, defined in `lib/types/socket-events.ts`.
-- The Connect panel on the stack-detail page (built against the Phase 6 Figma): rows per addon-attached endpoint with `ssh root@…` / `https://…` actions and live status badges.
+- The Connect panel on the stack-detail page: rows per addon-attached endpoint with `ssh root@…` / `https://…` actions and live status badges.
 - The new `tailscale` channel surfaced via the existing connection-status indicator alongside the other channels.
 
 Reversibility: safe — additive UI plus a new background poller. Disabling the poller stops emitting events and the panel falls back to last-known state. Rollback is reverting the PR.
 
 UI changes:
-- Stack detail page: new Connect panel listing every addon-attached endpoint with one-click `ssh root@…` and `https://…` actions, with live online/offline status badges. [no design] — built against Phase 6 Figma.
+- Stack detail page: new Connect panel listing every addon-attached endpoint with one-click `ssh root@…` and `https://…` actions, with live online/offline status badges. [design needed] — brand-new panel; placement relative to the services list, empty / failed / loading states all need design.
+- Live status badge style (green / grey / red dot) and the transition timing pattern. [design needed].
 - Existing connection-status indicator surfaces the `tailscale` channel alongside the others. [no design] — fits the established pattern.
 
 Done when: a service with both Tailscale addons enabled has a Connect panel row that renders within ~1 s, and badges flip within ~5 s of a deliberate device-down test in the tailnet admin console.
 
 Verify in prod: at least one production service with `tailscale-web` has the Connect panel rendering correct URLs; live online/offline transitions reflect within ~5 s (measured against a deliberate device-down test).
 
-### Phase 8 — `caddy-auth-sidecar` image package
+### Phase 6 — `caddy-auth-sidecar` image package
 
 **Goal:** a `mini-infra/caddy-auth` Docker image with the `caddy-security` plugin pinned, built and tested in CI alongside the other sidecars.
 
@@ -409,44 +377,27 @@ Done when: `cd caddy-auth-sidecar && npm test` passes, `pnpm build:caddy-auth-si
 
 Verify in prod: image is published to the registry under the expected tag; pulled by zero stacks (no consumer yet).
 
-### Phase 9 — Design: stack-detail synthetic chain + pool-row disclosure (deferred)
-
-**Goal:** approved Figma frames for two related stack-detail surfaces: the rendered services chain (showing `network_mode` rewrites and reclaimed ports) and the pool-row disclosure pattern (per-instance row reveal).
-
-Deliverables:
-- Figma frames showing how the rendered services chain is conveyed on the stack-detail page (app + caddy-auth + tailscale-web), including how `network_mode` rewrites and reclaimed ports are surfaced without operators having to read YAML.
-- Figma frames for the pool-row disclosure pattern — how a pool service row expands to show per-instance rows, including the 50-instance pool case.
-- Designer sign-off recorded in the Linear ticket.
-
-Reversibility: safe — design only.
-
-UI changes: none — pixels land in Phases 10 and 12.
-
-Done when: Figma link is attached to the Linear ticket and signed off by the designer.
-
-Verify in prod: `n/a — internal only`
-
-### Phase 10 — `caddy-auth` addon
+### Phase 7 — `caddy-auth` addon
 
 **Goal:** services can be gated by OIDC sign-in via a Caddy reverse proxy that owns the target's netns.
 
 Deliverables:
 - The `caddy-auth` addon directory under `server/src/services/stack-addons/caddy-auth/` with manifest, `targetIntegration: own-target-netns + reclaimTargetPorts: true`, `provision` (reads OIDC client config from Vault, renders Caddyfile gating on `allowedGroups` / exempting `publicPaths`, resolves IdP discovery / token / JWKS hostnames), and `buildServiceDefinition` (writes resolved IdP hostnames into `containerConfig.requiredEgress`).
 - The Vault path convention `secret/connected-services/oidc/<provider>` documented for v1 manual editing.
-- The rendered services chain visualisation on the stack-detail page (built against the Phase 9 Figma) — operators see the app + caddy-auth chain with `network_mode` rewrites and reclaimed ports surfaced without reading YAML.
+- The rendered services chain visualisation on the stack-detail page — operators see the app + caddy-auth chain with `network_mode` rewrites and reclaimed ports surfaced without reading YAML.
 - Operator documentation page covering the Vault path layout and a worked example for one IdP (Entra ID).
 
 Reversibility: forward-only — once a Caddy sidecar holds live sessions, removing the addon mid-flight drops in-flight authenticated sessions (Caddy's session state vanishes with the container). The PR itself is revertible until a service is deployed with the addon; afterwards, removing the addon from a live service is forward-only by nature.
 
 UI changes:
-- Stack detail page: rendered services list shows the chain (app + caddy-auth) with `network_mode` rewrites and reclaimed ports visible. [no design] — built against Phase 9 Figma.
+- Stack detail page: rendered services list shows the chain (app + caddy-auth) with `network_mode` rewrites and reclaimed ports visible. [design needed] — how to convey "caddy owns the target's netns and reclaimed its ports" without operators having to read YAML.
 - Operator docs page: Vault layout for `secret/connected-services/oidc/<provider>` plus a worked Entra ID example. [no design] — uses the existing user-docs article shell.
 
 Done when: a service with `addons: { caddy-auth: { provider: "entra", upstreamPort: 8080, allowedGroups: [...] } }` redirects unauthenticated browsers to the IdP, accepts authenticated users in `allowedGroups`, returns 403 for users not in `allowedGroups`, and forwards authenticated traffic to the app — verified against a real Entra ID tenant in dev.
 
 Verify in prod: at least one production service with `caddy-auth` rejects unauthenticated requests with the IdP redirect; an authenticated user in `allowedGroups` reaches the app; users outside `allowedGroups` get 403.
 
-### Phase 11 — `caddy-auth` ↔ `tailscale-web` cross-addon composition
+### Phase 8 — `caddy-auth` ↔ `tailscale-web` cross-addon composition
 
 **Goal:** services can layer `tailscale-web` and `caddy-auth` together so the chain `tailscale → caddy → app` works without manual config.
 
@@ -458,13 +409,13 @@ Deliverables:
 Reversibility: feature-flagged — the rewrite only fires when both addons are present on the same service. Either addon shipping alone behaves identically to before this phase.
 
 UI changes:
-- Stack detail page: rendered services list reflects three services in the chain (app + caddy-auth + tailscale-web) with the right rewrites visible. [no design] — uses the chain visualisation already built in Phase 10 against the Phase 9 Figma.
+- Stack detail page: rendered services list reflects three services in the chain (app + caddy-auth + tailscale-web) with the right rewrites visible. [no design] — uses the chain visualisation already built in Phase 7.
 
 Done when: a service with `addons: { caddy-auth: {…}, tailscale-web: {…} }` produces the chain `tailscale-web → caddy-auth → app` in the rendered definition; a tailnet-joined browser hitting `https://<host>.<tailnet>.ts.net` is redirected to the IdP, authenticates, and reaches the app.
 
 Verify in prod: at least one production service with both addons enabled is reachable via `https://<host>.<tailnet>.ts.net` only after IdP authentication; the rendered stack shows three services with the expected chain.
 
-### Phase 12 — Pool integration
+### Phase 9 — Pool integration
 
 **Goal:** addons declared on a pool service materialise per pool instance at spawn time.
 
@@ -474,13 +425,13 @@ Deliverables:
 - Per-instance addon sidecars carry `mini-infra.stack-id`, `mini-infra.service`, `mini-infra.pool-instance-id`, `mini-infra.addon: <kind-or-id>`, and `mini-infra.synthetic: true` labels.
 - `pool-instance-reaper.ts` extension: invokes addon `cleanup()` hooks and removes addon sidecar containers when instances are reaped.
 - Per-instance addon sidecars emit `containerConfig.requiredEgress` flowing into the env's policy reconcile the same way static addon services do (§4.7).
-- The pool-row disclosure on the Connect panel (built against the Phase 9 Figma): pool service rows expand to show per-instance rows with their own `ssh` / HTTPS actions.
+- The pool-row disclosure on the Connect panel: pool service rows expand to show per-instance rows with their own `ssh` / HTTPS actions.
 - Per-instance hostname displayed alongside the existing instance-id column on the pool detail page.
 
 Reversibility: safe — pool addon support is additive. Pools without `addons:` declarations are unaffected. Per-instance provisioning failures fail through the existing pool-spawn error path.
 
 UI changes:
-- Stack detail Connect panel: pool service rows expand to per-instance rows, each with their own `ssh` / HTTPS actions. [no design] — built against Phase 9 Figma.
+- Stack detail Connect panel: pool service rows expand to per-instance rows, each with their own `ssh` / HTTPS actions. [design needed] — disclosure pattern for a pool with N instances; how to handle 50-instance pools without flooding the panel.
 - Containers page: per-instance addon sidecars appear with `mini-infra.synthetic` and `mini-infra.pool-instance-id` labels visible. [no design] — fits existing container-row label rendering.
 - Pool detail: per-instance hostname (`{service}-{env}-{instance-id}`) shown alongside the existing instance-id column. [no design].
 
@@ -488,45 +439,27 @@ Done when: a pool service with `addons: { tailscale-ssh: {} }` spawns N instance
 
 Verify in prod: at least one production pool service with `tailscale-ssh` shows N tailnet devices for N instances, names match the `{service-name}-{env-name}-{instance-id}` pattern, and idle reaping removes both worker and sidecar within the ephemeral-cleanup window without orphan devices.
 
-### Phase 13 — Design: OIDC provider admin (deferred)
-
-**Goal:** approved Figma frames for the new OIDC provider admin area: list page, per-provider edit form (Entra / Auth0 / Google Workspace / generic OIDC), test sign-in modal.
-
-Deliverables:
-- Figma frames for `/connected-services/oidc-providers`: list, add, edit, delete views, with provider-specific field layouts.
-- Figma frames for the secret-rotation pattern.
-- Figma frames for the per-provider "Test sign-in" modal/dialog showing round-trip success or failure.
-- Designer sign-off recorded in the Linear ticket.
-
-Reversibility: safe — design only.
-
-UI changes: none — pixels land in Phases 14 and 16.
-
-Done when: Figma link is attached to the Linear ticket and signed off by the designer.
-
-Verify in prod: `n/a — internal only`
-
-### Phase 14 — `OidcProvider` model + admin UI (deferred)
+### Phase 10 — `OidcProvider` model + admin UI (deferred)
 
 **Goal:** admins can manage IdPs as a first-class connected service through the Mini Infra UI instead of editing Vault directly.
 
 Deliverables:
 - A new `OidcProvider` Prisma model + migration.
-- CRUD admin UI at `/connected-services/oidc-providers` (built against the Phase 13 Figma): list, add, edit, delete IdPs with provider-specific fields (Entra, Auth0, Google Workspace, generic OIDC).
+- CRUD admin UI at `/connected-services/oidc-providers`: list, add, edit, delete IdPs with provider-specific fields (Entra, Auth0, Google Workspace, generic OIDC).
 - Connected Services page card: new "OIDC Providers" entry alongside Tailscale / Cloudflare / etc.
 - An "import from Vault" affordance that pulls existing `secret/connected-services/oidc/<provider>` entries into the new model.
 
 Reversibility: forward-only — the new model coexists with the old Vault path layout for the duration of this phase. Reverting the PR purges `OidcProvider` rows via the migration's down-step; any provider authored only via the new UI is lost.
 
 UI changes:
-- New `/connected-services/oidc-providers` admin page: list, add, edit, delete. [no design] — built against Phase 13 Figma.
+- New `/connected-services/oidc-providers` admin page: list, add, edit, delete IdPs with provider-specific fields. [design needed] — full new page; per-provider form layout; secret-rotation pattern.
 - Connected Services page: new "OIDC Providers" entry alongside Tailscale / Cloudflare / etc. [no design] — fits the established connected-service card pattern.
 
 Done when: an admin can add an IdP through the new UI, see it in the list, edit / delete it, and import existing Vault-stored providers via the import affordance.
 
 Verify in prod: at least one IdP managed via the new UI; no operator edits against `secret/connected-services/oidc/<provider>` Vault paths after rollout (per the Vault audit log).
 
-### Phase 15 — `caddy-auth` provider-resolution swap (deferred)
+### Phase 11 — `caddy-auth` provider-resolution swap (deferred)
 
 **Goal:** the `caddy-auth` addon resolves OIDC providers via the `OidcProvider` model instead of direct Vault path lookup.
 
@@ -536,26 +469,26 @@ Deliverables:
 - A documented deprecation window for the old Vault path (read-only fallback for one release; removed afterwards).
 - The `caddy-auth` addon-config form's provider field becomes a dropdown sourced from the new `OidcProvider` model.
 
-Reversibility: forward-only — once the swap is live, services that authored against the old Vault path break unless migrated. Ship paired with the import-from-Vault affordance from Phase 14 and the documented deprecation window above.
+Reversibility: forward-only — once the swap is live, services that authored against the old Vault path break unless migrated. Ship paired with the import-from-Vault affordance from Phase 10 and the documented deprecation window above.
 
 UI changes:
 - `caddy-auth` addon config form: provider field becomes a dropdown sourced from the new `OidcProvider` model. [no design] — slots into existing addon-config form rendering.
 
-Done when: a service with `addons: { caddy-auth: { provider: "entra-prod" } }` resolves the provider via the `OidcProvider` model and authenticates correctly; the same config that previously used the Vault path migrates seamlessly via the Phase 14 import affordance.
+Done when: a service with `addons: { caddy-auth: { provider: "entra-prod" } }` resolves the provider via the `OidcProvider` model and authenticates correctly; the same config that previously used the Vault path migrates seamlessly via the Phase 10 import affordance.
 
 Verify in prod: every production `caddy-auth` application resolves its provider via the model after the deprecation window closes; `caddy-auth.vault_fallback` log emissions hit zero for 24 h.
 
-### Phase 16 — Per-provider Test sign-in flow (deferred)
+### Phase 12 — Per-provider Test sign-in flow (deferred)
 
 **Goal:** admins can verify an OIDC provider's round-trip from the connected-services UI without leaving the page.
 
 Deliverables:
-- A "Test sign-in" button per provider on `/connected-services/oidc-providers`: opens the IdP redirect in a new tab, captures the round-trip result, and reports success or failure in a modal/dialog (built against the Phase 13 Figma).
+- A "Test sign-in" button per provider on `/connected-services/oidc-providers`: opens the IdP redirect in a new tab, captures the round-trip result, and reports success or failure in a modal/dialog.
 
 Reversibility: safe — additive UI affordance.
 
 UI changes:
-- Per-provider "Test sign-in" button + modal/dialog showing test result. [no design] — built against Phase 13 Figma.
+- Per-provider "Test sign-in" button + modal/dialog showing test result. [design needed] — modal/dialog showing the test result is a new pattern for the connected-services area.
 
 Done when: an admin can click "Test sign-in" on a provider, complete the IdP flow in the new tab, and see the success / failure outcome reported in the modal.
 
@@ -563,34 +496,28 @@ Verify in prod: at least one production IdP admin uses the Test sign-in button a
 
 ## 7. Risks & open questions
 
-- **Connected Service config model.** Three Tailscale-specific columns on `ConnectedService` may be the wrong shape if other connected services need similar growth. Worth a 30-minute look at the existing connected-services directory before Phase 3 to decide between a shared-table extension and a per-type satellite table.
+- **Connected Service config model.** Three Tailscale-specific columns on `ConnectedService` may be the wrong shape if other connected services need similar growth. Worth a 30-minute look at the existing connected-services directory before Phase 2 to decide between a shared-table extension and a per-type satellite table.
 - **ACL bootstrap rendering.** JSON is parseable; HuJSON (Tailscale's commenting variant) is friendlier for the operator's eventual hand-editing but introduces a dependency. Default to JSON unless a user objects.
-- **Caddy image provenance.** Building our own `caddy-auth-sidecar` (Phase 8) pins the `caddy-security` plugin version and matches the existing sidecar pattern; pulling upstream `caddy:latest` is one less moving part. Mild preference for building, but worth confirming during Phase 8.
-- **Pool instance Tailscale state volume.** Per-instance state volumes are cheap, but pool instances are short-lived and authkeys are minted per-spawn. With ephemeral nodes auto-cleaning, the volume is effectively write-only. Phase 12 should validate that skipping the volume on pool instances doesn't introduce a re-registration race, and pick the cleaner of the two paths.
-- **Pool instance hostname collisions across stacks.** `worker-prod-u12345` in stack A and `worker-prod-u12345` in stack B produce duplicate device names in the tailnet. Per-stack tags prevent ACL crossover but the device list stays ambiguous. Phase 12 may need to prefix pool hostnames with the stack name and accept longer hostnames.
+- **Caddy image provenance.** Building our own `caddy-auth-sidecar` (Phase 6) pins the `caddy-security` plugin version and matches the existing sidecar pattern; pulling upstream `caddy:latest` is one less moving part. Mild preference for building, but worth confirming during Phase 6.
+- **Pool instance Tailscale state volume.** Per-instance state volumes are cheap, but pool instances are short-lived and authkeys are minted per-spawn. With ephemeral nodes auto-cleaning, the volume is effectively write-only. Phase 9 should validate that skipping the volume on pool instances doesn't introduce a re-registration race, and pick the cleaner of the two paths.
+- **Pool instance hostname collisions across stacks.** `worker-prod-u12345` in stack A and `worker-prod-u12345` in stack B produce duplicate device names in the tailnet. Per-stack tags prevent ACL crossover but the device list stays ambiguous. Phase 9 may need to prefix pool hostnames with the stack name and accept longer hostnames.
 - **Funnel-shaped follow-up.** Once Tailscale-only HTTPS is shipped, the smallest extension to reach the public internet is enabling Tailscale Funnel. It overlaps the Cloudflare tunnel feature, so a deliberate "when do you pick which?" call is needed before any post-v1 extension touches Funnel.
 - **Definition-hash determinism.** The rendered stack definition includes addon-derived services and target-integration rewrites. Provision values like authkeys are minted fresh on each render, which would oscillate the hash and force needless re-applies. Phase 1 must ensure the hash is computed from the *authored* definition (plus addon-config), not the rendered form, or that mint-once values are cached and reused across renders. Confirm during Phase 1 that the existing definition-hash logic naturally extends to the new field rather than drifting.
-- **Synthetic-service surface in the UI.** Addon-derived services appearing in the same lists as user-authored ones is the whole point, but they need clear visual distinction (a "from addon" badge) and edit affordances should be disabled. Phase 4 lands the badge against the Phase 2 design; further polish (status rollup, filter chips, copy-to-clipboard affordances) was scoped out during re-phasing — revisit after operator feedback if friction surfaces.
+- **Synthetic-service surface in the UI.** Addon-derived services appearing in the same lists as user-authored ones is the whole point, but they need clear visual distinction (a "from addon" badge) and edit affordances should be disabled. Phase 3 lands the badge; further polish (status rollup, filter chips, copy-to-clipboard affordances) was scoped out — revisit after operator feedback if friction surfaces.
 
 ## 8. Linear tracking
 
-Tracked under the [Service Addons — Tailscale and Caddy ingress addons](https://linear.app/altitude-devops/project/service-addons-tailscale-and-caddy-ingress-addons-a171d68a60ae) project on the Altitude Devops team.
+Phase issues will be created under the [Service Addons Framework](https://linear.app/altitude-devops/project/service-addons-framework-a171d68a60ae) project on the Altitude Devops team and linked here once filed.
 
 - ALT-_TBD_ — Phase 1: Addon framework
-- ALT-_TBD_ — Phase 2: Design: Tailscale settings + addon visual language
-- ALT-_TBD_ — Phase 3: Tailscale connected service  [blocks-by: 2]
-- [ALT-38](https://linear.app/altitude-devops/issue/ALT-38) — Phase 4: `tailscale-ssh` addon  [blocks-by: 1, 2, 3]
-- [ALT-39](https://linear.app/altitude-devops/issue/ALT-39) — Phase 5: `tailscale-web` and tailscale addon merging  [blocks-by: 4]
-- ALT-_TBD_ — Phase 6: Design: Connect panel  [blocks-by: 2]
-- ALT-_TBD_ — Phase 7: Connect panel + Tailscale device-status poller  [blocks-by: 5, 6]
-- ALT-_TBD_ — Phase 8: `caddy-auth-sidecar` image package
-- ALT-_TBD_ — Phase 9: Design: stack-detail synthetic chain + pool-row disclosure  [blocks-by: 2]
-- [ALT-40](https://linear.app/altitude-devops/issue/ALT-40) — Phase 10: `caddy-auth` addon  [blocks-by: 1, 8, 9]
-- ALT-_TBD_ — Phase 11: `caddy-auth` ↔ `tailscale-web` cross-addon composition  [blocks-by: 5, 10]
-- [ALT-41](https://linear.app/altitude-devops/issue/ALT-41) — Phase 12: Pool integration  [blocks-by: 4, 9]
-- ALT-_TBD_ — Phase 13: Design: OIDC provider admin
-- [ALT-43](https://linear.app/altitude-devops/issue/ALT-43) — Phase 14: `OidcProvider` model + admin UI  [blocks-by: 13]
-- ALT-_TBD_ — Phase 15: `caddy-auth` provider-resolution swap  [blocks-by: 10, 14]
-- ALT-_TBD_ — Phase 16: Per-provider Test sign-in flow  [blocks-by: 13, 14]
-
-*Re-phasing note for `plan-to-linear` update mode: [ALT-42](https://linear.app/altitude-devops/issue/ALT-42) (previously Phase 5: "UI polish and status surfacing") was removed from the plan during re-phasing — polish was scoped out in favour of initial-page-development focus only (see §3 Non-goals, last bullet). Surface for manual cancellation; this skill does not auto-delete.*
+- ALT-_TBD_ — Phase 2: Tailscale connected service  [blocks-by: 1]
+- ALT-_TBD_ — Phase 3: `tailscale-ssh` addon  [blocks-by: 1, 2]
+- ALT-_TBD_ — Phase 4: `tailscale-web` and tailscale addon merging  [blocks-by: 3]
+- ALT-_TBD_ — Phase 5: Connect panel + Tailscale device-status poller  [blocks-by: 4]
+- ALT-_TBD_ — Phase 6: `caddy-auth-sidecar` image package
+- ALT-_TBD_ — Phase 7: `caddy-auth` addon  [blocks-by: 1, 6]
+- ALT-_TBD_ — Phase 8: `caddy-auth` ↔ `tailscale-web` cross-addon composition  [blocks-by: 4, 7]
+- ALT-_TBD_ — Phase 9: Pool integration  [blocks-by: 3]
+- ALT-_TBD_ — Phase 10: `OidcProvider` model + admin UI (deferred)
+- ALT-_TBD_ — Phase 11: `caddy-auth` provider-resolution swap (deferred)  [blocks-by: 7, 10]
+- ALT-_TBD_ — Phase 12: Per-provider Test sign-in flow (deferred)  [blocks-by: 10]


### PR DESCRIPTION
## Summary

- **plan-to-linear** now auto-creates a paired `Backlog` design ticket for each phase whose UI changes block contains one or more `[design needed]` items, and wires it as a `blocked-by` edge on the impl ticket. Designers own those tickets; `execute-next-task` only picks from `Todo`, so they stay out of the execution queue.
- **brainstorm-to-plan** gains an anti-pattern row + a note on the UI-extractable rubric check steering plan authors away from writing standalone `Phase N — Design: …` phases — they should just tag the items inline.
- The `service-addons-plan.md` was re-shaped to use this convention (12 phases instead of the previous 6 / interim 16) and re-seeded into a fresh **Service Addons Framework** Linear project. §8 is now populated with [ALT-56](https://linear.app/altitude-devops/issue/ALT-56) – [ALT-67](https://linear.app/altitude-devops/issue/ALT-67) (impl) and ALT-68–ALT-74 (paired design tickets).

## Skill changes (the load-bearing part)

`plan-to-linear`:
- Phase 2 parsing: capture each `[design needed]` bullet verbatim per phase (becomes the body of the paired design ticket).
- Phase 6 confirmation: preview now shows the design ticket count and a separate list of design tickets to be created.
- **New Phase 8.1** — paired design ticket creation (title `Design: Phase N: <title>`, state `Backlog`, body lists the verbatim items + a "Blocks: Phase N" pointer back to the impl ticket).
- Phase 8 update mode: design ticket reconciliation table (refresh / create-new / orphan-don't-delete) keyed off the impl ticket's `blocked-by` graph.
- Phase 9: blocked-by edges are now the union of inter-phase edges from §8 ∪ design pairing edges. Design tickets themselves have no blockers — designers can start anytime.
- Hard rules: design tickets are auto-generated metadata, not in §8, and never auto-deleted.

`brainstorm-to-plan`:
- New anti-pattern row in the Phase 4 split heuristics: don't split design out as its own phase — `plan-to-linear` materialises tickets from the tags.
- Note appended to the UI-extractable rubric check pointing to the same.

## Plan revert + first-run seed

- `service-addons-plan.md` is now 12 phases (the prior 16-phase shape with explicit Design phases is gone). Phases 10–12 are deferred (OIDC provider management).
- The plan was reseeded into Linear via the updated `plan-to-linear` skill — the seed run confirmed the design-ticket auto-creation flow works end-to-end (7 design tickets, 18 blocked-by edges).
- §8 now has real ALT IDs and the project URL.

## Test plan

- [ ] Eyeball the [Service Addons Framework Linear project](https://linear.app/altitude-devops/project/service-addons-framework-0391849444a5) — 12 impl tickets + 7 design tickets with the right blocked-by graph.
- [ ] Confirm [ALT-56](https://linear.app/altitude-devops/issue/ALT-56) (Phase 1 — Addon framework) is the only unblocked `Todo` issue (so `execute-next-task` would start there).
- [ ] Brief a designer with the 7 `Design: Phase N — …` Backlog tickets to validate the body shape is workable.
- [ ] Read the retrospective comment on [ALT-56](https://linear.app/altitude-devops/issue/ALT-56) — calls out three small frictions worth tightening in a follow-up (re-seed into empty existing project; tighten Explorer prompt phase numbering; standardise §8 intro line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)