### PR TITLE
feat(addons): service addon framework + render pipeline (Phase 1, ALT-56)

### DIFF
--- a/lib/types/addons.ts
+++ b/lib/types/addons.ts
@@ -1,0 +1,199 @@
+// ====================
+// Service Addon Types
+// ====================
+//
+// The Service Addons framework lets a stack service opt into one or more named
+// capabilities (e.g. `tailscale-ssh`, `caddy-auth`) by adding entries to a
+// single `addons:` block on its definition. At apply / pool-spawn time the
+// render pipeline expands those declarations into rendered
+// `StackServiceDefinition`s — synthetic sidecars carrying `synthetic` metadata
+// — that flow through the existing reconciler without parallel plumbing.
+//
+// The runtime (server) consumes these types. The zod manifest schema lives on
+// the server because lib/ is type-only.
+
+import type { StackConfigFile, StackServiceDefinition, StackServiceType, SyntheticServiceInfo } from './stacks';
+
+export type { SyntheticServiceInfo };
+
+/**
+ * Connected-service prerequisite an addon may declare in its manifest.
+ *
+ * Listed as a string type rather than narrowing to the existing
+ * `services.ts` enum so that future addons (Tailscale, OIDC providers) can
+ * grow the set without forcing churn here. The runtime treats this as an
+ * opaque tag matched against `ConnectedService.type`.
+ */
+export type AddonRequiredConnectedService = string;
+
+/**
+ * Identity, applicability, and config-shape declaration for an addon.
+ *
+ * The runtime consumes `id` for registry lookup, `appliesTo` to gate
+ * applicability per service type, and `requiresConnectedService` to gate
+ * applicability per environment. `kind` controls merge-group behaviour at
+ * render time — addons sharing a `kind` collapse into one sidecar via the
+ * registered `AddonMergeStrategy`.
+ *
+ * The zod manifest schema lives in `server/src/services/stack-addons/` so
+ * `lib/` stays runtime-dep-free; the runtime stores it on the manifest at
+ * registration time.
+ */
+export interface AddonManifest {
+  /** Stable string id, e.g. "tailscale-ssh". */
+  id: string;
+  /** Optional grouping label. Addons sharing a kind on the same target merge. */
+  kind?: string;
+  description: string;
+  /**
+   * Service types this addon supports. The render pipeline rejects an
+   * application against a service whose `serviceType` is not in this list.
+   */
+  appliesTo: StackServiceType[];
+  /**
+   * Connected-service type that must be configured for this addon to apply.
+   * `undefined` means no external service prerequisite (e.g. the no-op test
+   * addon used in unit tests).
+   */
+  requiresConnectedService?: AddonRequiredConnectedService;
+}
+
+/**
+ * How a sidecar attaches to its target service. The runtime applies the
+ * declared mode in step 6 of the render pipeline (§4.4 of the plan).
+ *
+ * - `peer-on-target-network`: sidecar joins the same Docker network as the
+ *   target; reaches the target by service name. Target unchanged. Default for
+ *   non-intercepting addons.
+ * - `join-target-netns`: sidecar uses `network_mode: service:<target>`. Target
+ *   unchanged in shape; sidecar reaches target on 127.0.0.1. For outbound
+ *   interceptors and observers.
+ * - `own-target-netns`: target's `network_mode` rewritten to
+ *   `service:<sidecar>`. Target's published ports stripped (when
+ *   `reclaimTargetPorts` is set) and inherited by the sidecar. For
+ *   unbypassable ingress gates.
+ */
+export type AddonNetworkMode =
+  | 'peer-on-target-network'
+  | 'join-target-netns'
+  | 'own-target-netns';
+
+export interface TargetIntegration {
+  network: AddonNetworkMode;
+  envForTarget?: Record<string, string>;
+  mountsForTarget?: NonNullable<StackServiceDefinition['containerConfig']['mounts']>;
+  /** Valid only with `own-target-netns`. */
+  reclaimTargetPorts?: boolean;
+}
+
+/**
+ * Per-(service, addon) context handed to `provision()` and
+ * `buildServiceDefinition()`. The runtime fills in stack/env/service metadata;
+ * `instance` is populated only at pool-instance spawn time.
+ *
+ * `vault` and `connectedServices` are typed as `unknown` here so `lib/` keeps
+ * zero runtime deps — the server narrows them to its concrete service types
+ * before invoking the addon hooks.
+ */
+export interface ProvisionContext {
+  stack: { id: string; name: string };
+  service: { name: string; type: StackServiceType };
+  environment: {
+    id: string;
+    name: string;
+    networkType: 'local' | 'internet';
+  };
+  /** Already validated against the addon's `configSchema`. */
+  addonConfig: unknown;
+  /** Present iff this is a pool-instance spawn (Phase 9 of the plan). */
+  instance?: { instanceId: string };
+  /** VaultClient — narrowed by the server invoker. */
+  vault?: unknown;
+  /** ConnectedServiceLookup — narrowed by the server invoker. */
+  connectedServices?: unknown;
+}
+
+/**
+ * Output of `provision()`. The runtime threads these into
+ * `buildServiceDefinition()` and the target-integration step.
+ */
+export interface ProvisionedValues {
+  envForSidecar?: Record<string, string>;
+  /** Merged into `TargetIntegration.envForTarget` on the rendered target. */
+  envForTarget?: Record<string, string>;
+  /**
+   * Files written into the rendered sidecar's config-file mount. Use the
+   * existing `StackConfigFile` shape so the rendered sidecar's `configFiles`
+   * field is byte-compatible.
+   */
+  files?: StackConfigFile[];
+  /** Available to `buildServiceDefinition()` for interpolation / shaping. */
+  templateVars: Record<string, unknown>;
+}
+
+/**
+ * Status payload returned by an addon's optional `status()` hook. Phase 1
+ * does not consume this; the type is declared so `AddonDefinition.status`
+ * has a stable signature for later phases.
+ */
+export interface AddonStatus {
+  online: boolean;
+  detail?: string;
+}
+
+export interface StatusContext {
+  stack: { id: string; name: string };
+  service: { name: string; type: StackServiceType };
+  environment: {
+    id: string;
+    name: string;
+    networkType: 'local' | 'internet';
+  };
+  instance?: { instanceId: string };
+  connectedServices?: unknown;
+}
+
+/**
+ * What an addon directory exports. The render pipeline consumes:
+ *  1. `manifest` — registry lookup + applicability gating.
+ *  2. `targetIntegration` — how the sidecar binds to its target.
+ *  3. `provision()` — credential minting + per-application value computation.
+ *  4. `buildServiceDefinition()` — the rendered sidecar.
+ *  5. `cleanup()` — invoked on instance reap (Phase 9) / addon removal.
+ *  6. `status()` — Connect-panel live status (Phase 5).
+ */
+export interface AddonDefinition {
+  manifest: AddonManifest;
+  targetIntegration: TargetIntegration;
+  provision(ctx: ProvisionContext): Promise<ProvisionedValues>;
+  buildServiceDefinition(
+    ctx: ProvisionContext,
+    provisioned: ProvisionedValues,
+  ): StackServiceDefinition;
+  cleanup?(ctx: ProvisionContext, provisioned: ProvisionedValues): Promise<void>;
+  status?(ctx: StatusContext): Promise<AddonStatus>;
+}
+
+/**
+ * Strategy for collapsing multiple same-`kind` addons on one service into a
+ * single sidecar definition. Registered per kind alongside the addons that
+ * share it.
+ */
+export interface AddonMergeStrategy {
+  kind: string;
+  /** Single integration applied to the merged group. */
+  targetIntegration: TargetIntegration;
+  provision(
+    ctx: ProvisionContext,
+    members: Array<{ addonId: string; config: unknown }>,
+  ): Promise<ProvisionedValues>;
+  buildServiceDefinition(
+    ctx: ProvisionContext,
+    provisioned: ProvisionedValues,
+    members: Array<{ addonId: string; config: unknown }>,
+  ): StackServiceDefinition;
+}
+
+// `SyntheticServiceInfo` is declared in `./stacks` (next to
+// `StackServiceDefinition`) and re-exported above so the back-ref doesn't
+// create a circular dependency between stacks.ts and addons.ts.

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -71,6 +71,9 @@ export * from "./agent";
 // Stacks types
 export * from "./stacks";
 
+// Service Addons framework types
+export * from "./addons";
+
 // Stack Template types
 export * from "./stack-templates";
 

--- a/lib/types/socket-events.ts
+++ b/lib/types/socket-events.ts
@@ -177,6 +177,9 @@ export const ServerEvent = {
   STACK_APPLY_COMPLETED: "stack:apply:completed",
   STACK_DESTROY_STARTED: "stack:destroy:started",
   STACK_DESTROY_COMPLETED: "stack:destroy:completed",
+  // Stack Addon provisioning (Phase 1: defined; emitted from Phase 3 onward)
+  STACK_ADDON_PROVISIONED: "stack:addon:provisioned",
+  STACK_ADDON_FAILED: "stack:addon:failed",
   // HAProxy
   HAPROXY_BACKENDS_LIST: "haproxy:backends:list",
   HAPROXY_FRONTENDS_LIST: "haproxy:frontends:list",
@@ -333,6 +336,29 @@ export interface ServerToClientEvents {
   "stack:destroy:started": (data: { stackId: string; stackName: string }) => void;
   /** Stack destroy completed */
   "stack:destroy:completed": (data: DestroyResult) => void;
+  /**
+   * One addon application provisioned successfully during stack apply.
+   * Defined in Phase 1; emitted from the render pipeline starting Phase 3.
+   */
+  "stack:addon:provisioned": (data: {
+    stackId: string;
+    serviceName: string;
+    addonId: string;
+    kind?: string;
+    syntheticServiceName: string;
+  }) => void;
+  /**
+   * One addon application failed during stack apply (validation, provision,
+   * or build). Defined in Phase 1; emitted from the render pipeline starting
+   * Phase 3.
+   */
+  "stack:addon:failed": (data: {
+    stackId: string;
+    serviceName: string;
+    addonId: string;
+    kind?: string;
+    error: string;
+  }) => void;
 
   // ── HAProxy ────────────────────────────────────────
   /** HAProxy backends list updated */

--- a/lib/types/stack-templates.ts
+++ b/lib/types/stack-templates.ts
@@ -349,6 +349,8 @@ export interface StackTemplateServiceInfo {
   natsRole?: string | null;
   /** Symbolic signer name from nats.signers[]; auto-injects NATS_SIGNER_SEED dynamicEnv at apply time. */
   natsSigner?: string | null;
+  /** Service Addons authoring block; null when no addons declared on this template service. */
+  addons?: Record<string, unknown> | null;
 }
 
 export interface StackTemplateConfigFileInfo {

--- a/lib/types/stacks.ts
+++ b/lib/types/stacks.ts
@@ -324,6 +324,8 @@ export interface StackService {
   natsCredentialId: string | null;
   natsCredentialRef: string | null;
   poolManagementTokenHash: string | null;
+  /** Service Addons authoring block; null when no addons declared. */
+  addons: Record<string, unknown> | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -377,6 +379,8 @@ export interface StackServiceInfo {
   routing: StackServiceRouting | null;
   adoptedContainer: AdoptedContainerRef | null;
   poolConfig: PoolConfig | null;
+  /** Service Addons authoring block; null when no addons declared. */
+  addons: Record<string, unknown> | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/lib/types/stacks.ts
+++ b/lib/types/stacks.ts
@@ -383,6 +383,25 @@ export interface StackServiceInfo {
 
 // Portable definition types (no DB fields — used for snapshots/export)
 
+/**
+ * Back-reference attached to rendered addon-derived services produced by the
+ * Service Addons render pipeline (`server/src/services/stack-addons/`).
+ * Authored services never carry this — its presence is the canonical
+ * "synthetic" signal that downstream UI / RBAC code branches on.
+ *
+ * Declared here (rather than in `./addons.ts`) so `stacks.ts` has no inbound
+ * dependency on the addon module — `addons.ts` re-exports this type for
+ * addon-framework consumers.
+ */
+export interface SyntheticServiceInfo {
+  /** Addon ids that produced this sidecar — multiple when merged by kind. */
+  addonIds: string[];
+  /** Merge-strategy kind for grouped addons; absent for solo applications. */
+  kind?: string;
+  /** Service name of the target this sidecar wraps. */
+  targetService: string;
+}
+
 export interface StackServiceDefinition {
   serviceName: string;
   serviceType: StackServiceType;
@@ -410,6 +429,20 @@ export interface StackServiceDefinition {
   /** Symbolic reference to a nats.signers[].name. Causes NATS_SIGNER_SEED to
    *  be auto-injected as dynamicEnv at apply time. */
   natsSigner?: string | null;
+  /**
+   * Service Addons declarations — a map of addon-id → addon-config. The
+   * authored stack carries only this terse block; the render pipeline
+   * (`server/src/services/stack-addons/expand-addons.ts`) materialises each
+   * declaration into one or more synthetic sidecar definitions appended to
+   * the rendered services list. With the production registry empty the
+   * render pass is a no-op for every existing stack.
+   */
+  addons?: Record<string, unknown>;
+  /**
+   * Back-reference set on rendered addon-derived services. `undefined` on
+   * authored services. See `SyntheticServiceInfo` above.
+   */
+  synthetic?: SyntheticServiceInfo;
 }
 
 export interface StackDefinition {

--- a/server/prisma/migrations/20260503000000_addons_on_stack_service/migration.sql
+++ b/server/prisma/migrations/20260503000000_addons_on_stack_service/migration.sql
@@ -1,0 +1,14 @@
+-- Service Addons framework (Phase 1, ALT-56). Adds the authoring `addons:`
+-- block — a map of addon-id → addon-config — to each stack service.
+--
+-- Nullable: existing rows have no addons declarations yet. The render
+-- pipeline in `server/src/services/stack-addons/expand-addons.ts` reads
+-- this column and materialises synthetic sidecars; with the production
+-- registry empty at Phase 1, every existing row continues to render
+-- byte-identical to its authored form.
+ALTER TABLE "stack_services" ADD COLUMN "addons" JSONB;
+
+-- Same column on the template-side service row so user templates and
+-- file-loaded built-in templates can also declare addons; resolved into
+-- synthetic sidecars when the template is instantiated.
+ALTER TABLE "stack_template_services" ADD COLUMN "addons" JSONB;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1422,6 +1422,10 @@ model StackService {
   natsCredentialId            String?
   natsCredential              NatsCredentialProfile? @relation("ServiceNatsCredential", fields: [natsCredentialId], references: [id], onDelete: SetNull)
   natsCredentialRef           String?
+  // Service Addons authoring block (Phase 1, ALT-56). Map of addon-id →
+  // addon-config; expanded into synthetic sidecars by the render pipeline
+  // in `server/src/services/stack-addons/expand-addons.ts`.
+  addons                      Json?
   createdAt       DateTime         @default(now())
   updatedAt       DateTime         @updatedAt
 
@@ -1645,6 +1649,10 @@ model StackTemplateService {
   // NATS_SIGNER_SEED dynamicEnv. Mutually exclusive with natsCredentialRef.
   natsRole          String?
   natsSigner        String?
+  // Service Addons authoring block (Phase 1, ALT-56). Map of addon-id →
+  // addon-config; rendered into synthetic sidecars at apply time when the
+  // template is instantiated into a stack.
+  addons            Json?
 
   @@unique([versionId, serviceName])
   @@index([versionId])

--- a/server/src/__tests__/service-schema-drift.test.ts
+++ b/server/src/__tests__/service-schema-drift.test.ts
@@ -48,6 +48,11 @@ const commonFieldFixture = {
   // file-loader's stricter refine; the field itself still belongs to the
   // common base).
   vaultAppRoleRef: 'web-approle',
+  // Empty addons block — exercises the field's presence on the common
+  // base without requiring a registered addon. Per-entry validation
+  // against the (empty) production registry only fires when the block
+  // has entries; a literal `{}` round-trips cleanly.
+  addons: {},
 };
 
 const COMMON_FIELDS = [
@@ -64,6 +69,7 @@ const COMMON_FIELDS = [
   'natsCredentialRef',
   'natsRole',
   'natsSigner',
+  'addons',
 ] as const;
 
 // Every key in COMMON_FIELDS must also be a key of the shared base. If

--- a/server/src/__tests__/stack-templates-draft-route-addons.integration.test.ts
+++ b/server/src/__tests__/stack-templates-draft-route-addons.integration.test.ts
@@ -1,0 +1,147 @@
+/**
+ * HTTP regression test for POST /api/stack-templates/:templateId/draft —
+ * Service Addons authoring block (Phase 1, ALT-56).
+ *
+ * Mirrors the convention pinned in `server/CLAUDE.md` and `service-schema-
+ * drift.test.ts`: a field that must round-trip from a real POST body to a
+ * Prisma column has to be tested via supertest, not by seeding the DB
+ * directly. Direct seeding bypasses the Zod boundary that previously
+ * silently stripped `vaultAppRoleRef`; the same trap applies to `addons`.
+ *
+ * The test registers a no-op addon into `productionAddonRegistry` so the
+ * schema's per-entry `superRefine` accepts the block. Vitest's `pool:
+ * 'forks'` configuration isolates this mutation to one test file process.
+ */
+
+import supertest from 'supertest';
+import express, { type Request, type Response, type NextFunction } from 'express';
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { testPrisma } from './integration-test-helpers';
+import { productionAddonRegistry } from '../services/stack-addons/registry';
+import { noopAddon } from '../services/stack-addons/test-addons/noop';
+
+vi.mock('../middleware/auth', () => ({
+  requirePermission: () => (req: Request, _res: Response, next: NextFunction) => {
+    (req as Request & { user?: { id: string } }).user = { id: 'session-user' };
+    next();
+  },
+}));
+
+vi.mock('../lib/prisma', () => ({ default: testPrisma }));
+
+import stackTemplateRouter from '../routes/stack-templates';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/stack-templates', stackTemplateRouter);
+  return app;
+}
+
+async function createUserTemplateRow(): Promise<string> {
+  const templateId = createId();
+  await testPrisma.stackTemplate.create({
+    data: {
+      id: templateId,
+      name: `tpl-${templateId.slice(0, 6)}`,
+      displayName: 'Addons Route Test Template',
+      source: 'user',
+      scope: 'environment',
+      currentVersionId: null,
+      draftVersionId: null,
+    },
+  });
+  return templateId;
+}
+
+const baseService = {
+  serviceName: 'web',
+  serviceType: 'Stateful',
+  dockerImage: 'nginx',
+  dockerTag: 'latest',
+  containerConfig: {},
+  dependsOn: [],
+  order: 0,
+};
+
+describe('POST /api/stack-templates/:templateId/draft — addons persistence', () => {
+  beforeAll(() => {
+    // Vitest forks each test file into its own process, so this mutation is
+    // confined to this file's worker. Registry is a runtime-only structure;
+    // no clean-up needed because the worker exits at file end.
+    if (!productionAddonRegistry.has('noop')) {
+      productionAddonRegistry.register(noopAddon);
+    }
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('persists the addons block on the StackTemplateService row when noop addon is registered', async () => {
+    const templateId = await createUserTemplateRow();
+
+    const draftBody = {
+      networks: [],
+      volumes: [],
+      services: [{ ...baseService, addons: { noop: { label: 'phase-1' } } }],
+    };
+
+    const res = await supertest(buildApp())
+      .post(`/api/stack-templates/${templateId}/draft`)
+      .send(draftBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const tmpl = await testPrisma.stackTemplate.findUnique({ where: { id: templateId } });
+    expect(tmpl?.draftVersionId).not.toBeNull();
+
+    const row = await testPrisma.stackTemplateService.findFirst({
+      where: { versionId: tmpl!.draftVersionId! },
+    });
+    expect(row).not.toBeNull();
+    expect(row!.addons).toEqual({ noop: { label: 'phase-1' } });
+  });
+
+  it('returns 400 when the addons block references an unregistered addon id', async () => {
+    const templateId = await createUserTemplateRow();
+
+    const draftBody = {
+      networks: [],
+      volumes: [],
+      services: [{ ...baseService, addons: { 'does-not-exist': {} } }],
+    };
+
+    const res = await supertest(buildApp())
+      .post(`/api/stack-templates/${templateId}/draft`)
+      .send(draftBody);
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    const issueMessages = (res.body.issues as Array<{ message: string }>).map((i) => i.message);
+    expect(issueMessages.some((m) => m.includes('does-not-exist'))).toBe(true);
+  });
+
+  it('round-trips an empty addons block (no entries) on the column', async () => {
+    const templateId = await createUserTemplateRow();
+
+    const draftBody = {
+      networks: [],
+      volumes: [],
+      services: [{ ...baseService, addons: {} }],
+    };
+
+    const res = await supertest(buildApp())
+      .post(`/api/stack-templates/${templateId}/draft`)
+      .send(draftBody);
+
+    expect(res.status).toBe(200);
+    const tmpl = await testPrisma.stackTemplate.findUnique({ where: { id: templateId } });
+    const row = await testPrisma.stackTemplateService.findFirst({
+      where: { versionId: tmpl!.draftVersionId! },
+    });
+    expect(row!.addons).toEqual({});
+  });
+});

--- a/server/src/services/stack-addons/__tests__/expand-addons.test.ts
+++ b/server/src/services/stack-addons/__tests__/expand-addons.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import type { StackServiceDefinition } from '@mini-infra/types';
+import { createAddonRegistry } from '../registry';
+import { expandAddons, AddonExpansionError } from '../expand-addons';
+import { noopAddon } from '../test-addons/noop';
+
+/**
+ * Phase 1 round-trip invariants for the Service Addons render pipeline.
+ *
+ * These tests pin two properties from the plan's Done-when:
+ *   1. A stack service with `addons: { noop: {} }` renders into the original
+ *      target (untouched) plus a synthetic sidecar carrying the addon's
+ *      back-reference and `synthetic: true`.
+ *   2. A stack with no `addons:` declarations on any service round-trips
+ *      through `expandAddons` byte-identical (modulo the always-stripped
+ *      authored `addons` field, which is undefined for these inputs anyway).
+ */
+
+const baseContext = {
+  stack: { id: 'stack-test', name: 'test-stack' },
+  environment: {
+    id: 'env-test',
+    name: 'dev',
+    networkType: 'local' as const,
+  },
+};
+
+function makeStateful(name: string, overrides: Partial<StackServiceDefinition> = {}): StackServiceDefinition {
+  return {
+    serviceName: name,
+    serviceType: 'Stateful',
+    dockerImage: 'nginx',
+    dockerTag: 'latest',
+    dependsOn: [],
+    order: 1,
+    containerConfig: {
+      env: { FOO: 'bar' },
+      restartPolicy: 'unless-stopped',
+    },
+    ...overrides,
+  };
+}
+
+describe('expandAddons (Phase 1)', () => {
+  it('appends a synthetic sidecar for a noop-addon application and leaves the target untouched', async () => {
+    const registry = createAddonRegistry();
+    registry.register(noopAddon);
+
+    const target = makeStateful('web', {
+      addons: { noop: { label: 'phase-1-test' } },
+    });
+    const rendered = await expandAddons([target], { ...baseContext, registry });
+
+    expect(rendered).toHaveLength(2);
+    const renderedTarget = rendered.find((s) => s.serviceName === 'web');
+    const sidecar = rendered.find((s) => s.serviceName === 'web-noop');
+    expect(renderedTarget).toBeDefined();
+    expect(sidecar).toBeDefined();
+
+    // Target carries no `addons` field on the rendered output (the authored
+    // block is an authoring artifact stripped during render) and is otherwise
+    // identical to its authored form.
+    expect(renderedTarget!.addons).toBeUndefined();
+    expect(renderedTarget!.synthetic).toBeUndefined();
+    expect(renderedTarget!.containerConfig).toEqual(target.containerConfig);
+
+    // Synthetic sidecar carries the back-reference and the addon-supplied env.
+    expect(sidecar!.synthetic).toEqual({
+      addonIds: ['noop'],
+      targetService: 'web',
+    });
+    expect(sidecar!.containerConfig.env).toMatchObject({
+      NOOP_TARGET: 'web',
+      NOOP_LABEL: 'phase-1-test',
+    });
+  });
+
+  it('round-trips an authored stack with no addons declarations byte-identical', async () => {
+    const registry = createAddonRegistry();
+    registry.register(noopAddon);
+
+    const services: StackServiceDefinition[] = [
+      makeStateful('web'),
+      makeStateful('worker', { dockerImage: 'busybox' }),
+    ];
+    const rendered = await expandAddons(services, { ...baseContext, registry });
+
+    expect(rendered).toHaveLength(services.length);
+    for (const original of services) {
+      const out = rendered.find((s) => s.serviceName === original.serviceName);
+      expect(out).toBeDefined();
+      // No `addons` block on input, so output should match the input
+      // (with the always-undefined `addons` field absent in both).
+      expect(out).toEqual(original);
+    }
+  });
+
+  it('rejects an unregistered addon id with a structured AddonExpansionError', async () => {
+    const registry = createAddonRegistry();
+    const target = makeStateful('web', { addons: { 'does-not-exist': {} } });
+
+    await expect(expandAddons([target], { ...baseContext, registry })).rejects.toBeInstanceOf(
+      AddonExpansionError,
+    );
+  });
+
+  it('rejects an addon applied to an unsupported service type', async () => {
+    const registry = createAddonRegistry();
+    registry.register({
+      ...noopAddon,
+      manifest: { ...noopAddon.manifest, appliesTo: ['Pool'] },
+    });
+
+    const target = makeStateful('web', { addons: { noop: {} } });
+    await expect(expandAddons([target], { ...baseContext, registry })).rejects.toThrow(
+      /does not apply to service type "Stateful"/,
+    );
+  });
+
+  it('rejects an invalid addon config via the manifest configSchema', async () => {
+    const registry = createAddonRegistry();
+    registry.register(noopAddon);
+
+    const target = makeStateful('web', {
+      addons: { noop: { label: 12345 as unknown as string } },
+    });
+    await expect(expandAddons([target], { ...baseContext, registry })).rejects.toThrow(
+      /Invalid config/,
+    );
+  });
+
+  it('emits onProvisioned progress callbacks per successful application', async () => {
+    const registry = createAddonRegistry();
+    registry.register(noopAddon);
+
+    const target = makeStateful('web', { addons: { noop: {} } });
+    const provisioned: Array<{ serviceName: string; addonIds: string[] }> = [];
+    await expandAddons(
+      [target],
+      { ...baseContext, registry },
+      {
+        onProvisioned: (info) =>
+          provisioned.push({ serviceName: info.serviceName, addonIds: info.addonIds }),
+      },
+    );
+    expect(provisioned).toEqual([{ serviceName: 'web', addonIds: ['noop'] }]);
+  });
+});

--- a/server/src/services/stack-addons/__tests__/expand-addons.test.ts
+++ b/server/src/services/stack-addons/__tests__/expand-addons.test.ts
@@ -129,6 +129,34 @@ describe('expandAddons (Phase 1)', () => {
     );
   });
 
+  it('fires onFailed before re-throwing when addon validation fails (resolveGroups path)', async () => {
+    const registry = createAddonRegistry();
+    registry.register(noopAddon);
+
+    const target = makeStateful('web', {
+      addons: { 'does-not-exist': {} },
+    });
+    const failed: Array<{ serviceName: string; addonIds: string[]; error: string }> = [];
+    await expect(
+      expandAddons(
+        [target],
+        { ...baseContext, registry },
+        {
+          onFailed: (info) =>
+            failed.push({
+              serviceName: info.serviceName,
+              addonIds: info.addonIds,
+              error: info.error,
+            }),
+        },
+      ),
+    ).rejects.toBeInstanceOf(AddonExpansionError);
+    expect(failed).toHaveLength(1);
+    expect(failed[0].serviceName).toBe('web');
+    expect(failed[0].addonIds).toEqual(['does-not-exist']);
+    expect(failed[0].error).toMatch(/not registered/);
+  });
+
   it('emits onProvisioned progress callbacks per successful application', async () => {
     const registry = createAddonRegistry();
     registry.register(noopAddon);

--- a/server/src/services/stack-addons/expand-addons.ts
+++ b/server/src/services/stack-addons/expand-addons.ts
@@ -117,7 +117,33 @@ export async function expandAddons(
   for (const authored of authoredDefinitions) {
     if (!authored.addons || Object.keys(authored.addons).length === 0) continue;
 
-    const groups = await resolveGroups(authored, authored.addons, context);
+    // resolveGroups throws AddonExpansionError directly on validation /
+    // applicability / connected-service / merge-strategy issues. Surface
+    // those through progress.onFailed before re-throwing so Phase 3+
+    // socket emission of STACK_ADDON_FAILED captures the most common
+    // user-facing error class — "addon X isn't registered" or "config Y
+    // is invalid" — which fires before any provision() runs.
+    let groups: ResolvedGroup[];
+    try {
+      groups = await resolveGroups(authored, authored.addons, context);
+    } catch (err) {
+      const e =
+        err instanceof AddonExpansionError
+          ? err
+          : new AddonExpansionError(
+              authored.serviceName,
+              [],
+              err instanceof Error ? err.message : String(err),
+              err,
+            );
+      progress.onFailed?.({
+        serviceName: e.serviceName,
+        addonIds: e.addonIds,
+        error: e.message,
+      });
+      throw e;
+    }
+
     for (const group of groups) {
       try {
         await applyGroup(group, context, rendered, progress);

--- a/server/src/services/stack-addons/expand-addons.ts
+++ b/server/src/services/stack-addons/expand-addons.ts
@@ -1,0 +1,426 @@
+import type {
+  AddonMergeStrategy,
+  ProvisionContext,
+  ProvisionedValues,
+  StackServiceDefinition,
+  SyntheticServiceInfo,
+  TargetIntegration,
+} from '@mini-infra/types';
+import type { AddonRegistry, RegisteredAddon } from './registry';
+
+/**
+ * Per-stack metadata the render pipeline carries into every addon's
+ * `provision()` call. `vault` and `connectedServices` are typed `unknown` so
+ * the framework can be exercised in unit tests without standing up either —
+ * Phase 3+ addon implementations narrow them to their concrete service types.
+ */
+export interface ExpansionContext {
+  stack: { id: string; name: string };
+  environment: {
+    id: string;
+    name: string;
+    networkType: 'local' | 'internet';
+  };
+  registry: AddonRegistry;
+  /** Present iff this expansion is for a single pool-instance spawn. */
+  instance?: { instanceId: string };
+  vault?: unknown;
+  connectedServices?: unknown;
+}
+
+/**
+ * Per-addon-application progress callback. The render pipeline invokes this
+ * after each successful provision and after each failure so callers can
+ * fan-out the existing `STACK_ADDON_PROVISIONED` / `STACK_ADDON_FAILED`
+ * events without re-implementing the success/failure book-keeping.
+ *
+ * Phase 1 declares the callback shape but doesn't wire it to socket emission;
+ * Phase 3 (`tailscale-ssh`) is the first phase to emit the events.
+ */
+export interface ExpansionProgress {
+  onProvisioned?: (info: {
+    serviceName: string;
+    addonIds: string[];
+    kind?: string;
+    syntheticServiceName: string;
+  }) => void;
+  onFailed?: (info: {
+    serviceName: string;
+    addonIds: string[];
+    kind?: string;
+    error: string;
+  }) => void;
+}
+
+/** Internal: one pending application before merge-group resolution. */
+interface PendingApplication {
+  addonId: string;
+  config: unknown;
+  registered: RegisteredAddon;
+}
+
+/** Internal: a merge group that survived applicability checks. */
+type ResolvedGroup =
+  | {
+      kind: 'solo';
+      target: StackServiceDefinition;
+      application: PendingApplication;
+    }
+  | {
+      kind: 'merged';
+      target: StackServiceDefinition;
+      kindLabel: string;
+      members: PendingApplication[];
+      strategy: AddonMergeStrategy;
+    };
+
+/**
+ * Render-pipeline step that materialises each `addons:` declaration into one
+ * or more synthetic `StackServiceDefinition`s appended to the rendered
+ * services list.
+ *
+ * Implements §4.4 of the Service Addons plan:
+ *   1. validate     — manifest's configSchema parses the user-supplied config
+ *   2. applicability — serviceType in `appliesTo`, prerequisites configured
+ *   3. merge-group  — same-`kind` addons on one service collapse via strategy
+ *   4. provision    — credential mint / file render / template-var compute
+ *   5. materialise  — call `buildServiceDefinition()`, attach `synthetic` ref
+ *   6. target ints. — `peer-on-target-network` / `join-target-netns` / …
+ *
+ * Step 7 (cross-addon rewrites) and the §5 production addons land in later
+ * phases. Phase 1 ships only the framework; production registries are empty.
+ *
+ * Returns the **rendered** services list. Pure function — input is not
+ * mutated. Authored services without `addons:` flow through byte-identical.
+ */
+export async function expandAddons(
+  authoredDefinitions: StackServiceDefinition[],
+  context: ExpansionContext,
+  progress: ExpansionProgress = {},
+): Promise<StackServiceDefinition[]> {
+  // Single output buffer keyed by serviceName so we can mutate target
+  // definitions in-place when an addon's TargetIntegration rewrites them
+  // (env / mounts / network_mode). Authored services land first; synthetic
+  // sidecars are appended later.
+  const rendered = new Map<string, StackServiceDefinition>();
+  for (const def of authoredDefinitions) {
+    // Authored services may carry an `addons:` block. We strip it on the
+    // *rendered* output because addons are an authoring artifact — once
+    // expanded, the rendered definition is a flat services list. The
+    // authored block is preserved on the original input via the immutable
+    // input contract; the rendered map is the function's only output.
+    const { addons: _stripped, ...withoutAddons } = def;
+    void _stripped;
+    rendered.set(def.serviceName, { ...withoutAddons });
+  }
+
+  for (const authored of authoredDefinitions) {
+    if (!authored.addons || Object.keys(authored.addons).length === 0) continue;
+
+    const groups = await resolveGroups(authored, authored.addons, context);
+    for (const group of groups) {
+      try {
+        await applyGroup(group, context, rendered, progress);
+      } catch (err) {
+        const memberIds =
+          group.kind === 'solo'
+            ? [group.application.addonId]
+            : group.members.map((m) => m.addonId);
+        const message = err instanceof Error ? err.message : String(err);
+        progress.onFailed?.({
+          serviceName: authored.serviceName,
+          addonIds: memberIds,
+          kind: group.kind === 'merged' ? group.kindLabel : undefined,
+          error: message,
+        });
+        throw new AddonExpansionError(
+          authored.serviceName,
+          memberIds,
+          message,
+          err,
+        );
+      }
+    }
+  }
+
+  return [...rendered.values()];
+}
+
+/**
+ * Thrown when an addon application fails validation, applicability, or
+ * provision/build. Carries enough context for the apply orchestrator to
+ * surface a clear error in the task tracker without re-deriving identifiers.
+ */
+export class AddonExpansionError extends Error {
+  constructor(
+    public readonly serviceName: string,
+    public readonly addonIds: string[],
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(
+      `Addon expansion failed on service "${serviceName}" (addons: ${addonIds.join(', ')}): ${message}`,
+    );
+    this.name = 'AddonExpansionError';
+  }
+}
+
+async function resolveGroups(
+  target: StackServiceDefinition,
+  addonsBlock: Record<string, unknown>,
+  context: ExpansionContext,
+): Promise<ResolvedGroup[]> {
+  const applications: PendingApplication[] = [];
+
+  for (const [addonId, rawConfig] of Object.entries(addonsBlock)) {
+    const registered = context.registry.get(addonId);
+    if (!registered) {
+      throw new AddonExpansionError(
+        target.serviceName,
+        [addonId],
+        `Addon "${addonId}" is not registered`,
+      );
+    }
+
+    // Step 1 — config validation. Throws ZodError with a field-pathed message
+    // if the user-supplied config doesn't fit the manifest's schema.
+    const parsed = registered.configSchema.safeParse(rawConfig);
+    if (!parsed.success) {
+      throw new AddonExpansionError(
+        target.serviceName,
+        [addonId],
+        `Invalid config: ${parsed.error.issues.map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`).join('; ')}`,
+      );
+    }
+
+    // Step 2 — applicability. Reject early when the addon doesn't support
+    // this service's type or requires a connected service that isn't
+    // configured. Connected-service presence is checked from the
+    // expansion context — Phase 3 narrows `connectedServices` to the
+    // concrete lookup type.
+    if (!registered.manifest.appliesTo.includes(target.serviceType)) {
+      throw new AddonExpansionError(
+        target.serviceName,
+        [addonId],
+        `Addon "${addonId}" does not apply to service type "${target.serviceType}" (allowed: ${registered.manifest.appliesTo.join(', ')})`,
+      );
+    }
+    if (
+      registered.manifest.requiresConnectedService &&
+      !connectedServiceConfigured(
+        registered.manifest.requiresConnectedService,
+        context.connectedServices,
+      )
+    ) {
+      throw new AddonExpansionError(
+        target.serviceName,
+        [addonId],
+        `Addon "${addonId}" requires connected service "${registered.manifest.requiresConnectedService}" but it is not configured`,
+      );
+    }
+
+    applications.push({ addonId, config: parsed.data, registered });
+  }
+
+  // Step 3 — merge-group resolution. Group by `kind`; solo applications go
+  // through verbatim. Two members of the same kind without a registered
+  // strategy is a hard error (configuration mistake at registry-build time).
+  const byKind = new Map<string, PendingApplication[]>();
+  const solos: PendingApplication[] = [];
+  for (const app of applications) {
+    const kind = app.registered.manifest.kind;
+    if (!kind) {
+      solos.push(app);
+      continue;
+    }
+    const bucket = byKind.get(kind);
+    if (bucket) bucket.push(app);
+    else byKind.set(kind, [app]);
+  }
+
+  const groups: ResolvedGroup[] = [];
+  for (const solo of solos) {
+    groups.push({ kind: 'solo', target, application: solo });
+  }
+  for (const [kind, members] of byKind) {
+    if (members.length === 1) {
+      groups.push({ kind: 'solo', target, application: members[0] });
+      continue;
+    }
+    const strategy = context.registry.getMergeStrategy(kind);
+    if (!strategy) {
+      throw new AddonExpansionError(
+        target.serviceName,
+        members.map((m) => m.addonId),
+        `${members.length} addons of kind "${kind}" declared on the same service but no merge strategy is registered`,
+      );
+    }
+    groups.push({ kind: 'merged', target, kindLabel: kind, members, strategy });
+  }
+
+  return groups;
+}
+
+async function applyGroup(
+  group: ResolvedGroup,
+  context: ExpansionContext,
+  rendered: Map<string, StackServiceDefinition>,
+  progress: ExpansionProgress,
+): Promise<void> {
+  // Step 4–5 — provision and materialise.
+  let provisioned: ProvisionedValues;
+  let sidecar: StackServiceDefinition;
+  let integration: TargetIntegration;
+  let synthetic: SyntheticServiceInfo;
+  let memberIds: string[];
+
+  if (group.kind === 'solo') {
+    const def = group.application.registered.definition;
+    const provisionCtx = buildProvisionContext(
+      group.target,
+      group.application.config,
+      context,
+    );
+    provisioned = await def.provision(provisionCtx);
+    sidecar = def.buildServiceDefinition(provisionCtx, provisioned);
+    integration = def.targetIntegration;
+    memberIds = [group.application.addonId];
+    synthetic = {
+      addonIds: memberIds,
+      targetService: group.target.serviceName,
+    };
+  } else {
+    const provisionCtx = buildProvisionContext(
+      group.target,
+      // For merged groups the `addonConfig` slot is unused — the strategy
+      // reads each member's config through the `members` parameter — but
+      // we still set it to the group's combined member configs for
+      // observability inside `provision()`.
+      group.members.map((m) => ({ addonId: m.addonId, config: m.config })),
+      context,
+    );
+    const memberPairs = group.members.map((m) => ({
+      addonId: m.addonId,
+      config: m.config,
+    }));
+    provisioned = await group.strategy.provision(provisionCtx, memberPairs);
+    sidecar = group.strategy.buildServiceDefinition(
+      provisionCtx,
+      provisioned,
+      memberPairs,
+    );
+    integration = group.strategy.targetIntegration;
+    memberIds = group.members.map((m) => m.addonId);
+    synthetic = {
+      addonIds: memberIds,
+      kind: group.kindLabel,
+      targetService: group.target.serviceName,
+    };
+  }
+
+  // Tag the sidecar with its synthetic back-reference. The render pipeline
+  // is the only authority that sets this field — authored services never
+  // carry it.
+  const renderedSidecar: StackServiceDefinition = {
+    ...sidecar,
+    synthetic,
+  };
+
+  // Sidecar serviceName conflicts with an authored or already-rendered
+  // service: hard fail. Naming is the addon author's responsibility, but a
+  // collision means the render output is ambiguous and the reconciler will
+  // misbehave.
+  if (rendered.has(renderedSidecar.serviceName)) {
+    throw new Error(
+      `Synthetic service name "${renderedSidecar.serviceName}" collides with an existing service in the rendered stack`,
+    );
+  }
+  rendered.set(renderedSidecar.serviceName, renderedSidecar);
+
+  // Step 6 — target integration. Apply env / mounts / network_mode rewrites
+  // to the rendered target (looked up via the rendered map so prior
+  // applications' rewrites are preserved). The authored input is never
+  // mutated.
+  applyTargetIntegration(group.target.serviceName, integration, provisioned, rendered);
+
+  progress.onProvisioned?.({
+    serviceName: group.target.serviceName,
+    addonIds: memberIds,
+    kind: group.kind === 'merged' ? group.kindLabel : undefined,
+    syntheticServiceName: renderedSidecar.serviceName,
+  });
+}
+
+function buildProvisionContext(
+  target: StackServiceDefinition,
+  addonConfig: unknown,
+  context: ExpansionContext,
+): ProvisionContext {
+  return {
+    stack: context.stack,
+    service: { name: target.serviceName, type: target.serviceType },
+    environment: context.environment,
+    addonConfig,
+    instance: context.instance,
+    vault: context.vault,
+    connectedServices: context.connectedServices,
+  };
+}
+
+function applyTargetIntegration(
+  targetName: string,
+  integration: TargetIntegration,
+  provisioned: ProvisionedValues,
+  rendered: Map<string, StackServiceDefinition>,
+): void {
+  const target = rendered.get(targetName);
+  if (!target) {
+    // Defensive: the target was authored, so it must be in the rendered
+    // map. If it isn't, something is structurally wrong with the caller.
+    throw new Error(`Target service "${targetName}" missing from rendered map`);
+  }
+
+  // Merge env-for-target from both the static integration declaration and
+  // the dynamic provisioned values. Static integration wins on key collision
+  // — provisioned values are computed-defaults that an integration spec can
+  // override deliberately.
+  const envForTarget: Record<string, string> = {
+    ...(provisioned.envForTarget ?? {}),
+    ...(integration.envForTarget ?? {}),
+  };
+  const mountsForTarget = integration.mountsForTarget ?? [];
+
+  if (Object.keys(envForTarget).length > 0 || mountsForTarget.length > 0) {
+    target.containerConfig = {
+      ...target.containerConfig,
+      env: { ...(target.containerConfig.env ?? {}), ...envForTarget },
+      mounts: [...(target.containerConfig.mounts ?? []), ...mountsForTarget],
+    };
+  }
+
+  // Network-mode rewrites are scoped to specific integration kinds.
+  // `peer-on-target-network` does NOT touch the target. Phase 3+ wires up
+  // the `join-target-netns` and `own-target-netns` rewrites on the rendered
+  // sidecar / target as the §5 addons land. Phase 1 only ships the
+  // peer-on-target-network plumbing because the no-op test addon uses it.
+}
+
+/**
+ * Connected-service presence check. The expansion context carries
+ * `connectedServices` as `unknown` (lib/ stays runtime-dep-free), so the
+ * concrete lookup is performed via duck-typing here. Phase 3+ may swap this
+ * for a strongly-typed lookup once the connected-services API surface is
+ * imported into the addon framework.
+ */
+function connectedServiceConfigured(
+  type: string,
+  connectedServices: unknown,
+): boolean {
+  if (!connectedServices) return false;
+  if (typeof connectedServices === 'object') {
+    const lookup = connectedServices as { has?: (t: string) => boolean } & Record<string, unknown>;
+    if (typeof lookup.has === 'function') return lookup.has(type);
+    return type in lookup;
+  }
+  return false;
+}

--- a/server/src/services/stack-addons/index.ts
+++ b/server/src/services/stack-addons/index.ts
@@ -1,0 +1,19 @@
+// Service Addons framework — entry point for the render pipeline integration.
+//
+// Phase 1 ships the framework only; the production registry is empty so the
+// render pass is a no-op for every existing stack. Per-addon directories
+// (`tailscale-ssh/`, `tailscale-web/`, `caddy-auth/`) self-register into
+// `productionAddonRegistry` starting Phase 3.
+
+export {
+  AddonRegistry,
+  createAddonRegistry,
+  productionAddonRegistry,
+} from './registry';
+export type { RegisteredAddon } from './registry';
+
+export {
+  expandAddons,
+  AddonExpansionError,
+} from './expand-addons';
+export type { ExpansionContext, ExpansionProgress } from './expand-addons';

--- a/server/src/services/stack-addons/registry.ts
+++ b/server/src/services/stack-addons/registry.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+import type {
+  AddonDefinition,
+  AddonManifest,
+  AddonMergeStrategy,
+} from '@mini-infra/types';
+
+/**
+ * Manifest paired with the zod schema used to validate user-supplied addon
+ * config. The runtime keeps zod off the shared `AddonManifest` interface so
+ * `lib/` stays runtime-dep-free; this server-side wrapper holds the schema.
+ */
+export interface RegisteredAddon {
+  manifest: AddonManifest;
+  configSchema: z.ZodTypeAny;
+  definition: AddonDefinition;
+}
+
+/**
+ * Live registry of active addons + merge strategies. A stack template's
+ * `addons:` block is validated and rendered against this registry.
+ *
+ * The production registry is empty at Phase 1 — the render pass is a no-op
+ * for every existing stack. Per-addon directories register themselves into
+ * the production singleton starting Phase 3 (`tailscale-ssh`).
+ *
+ * Tests construct their own registries via `createAddonRegistry()` so they
+ * don't pollute the production singleton.
+ */
+export class AddonRegistry {
+  private addons = new Map<string, RegisteredAddon>();
+  private mergeStrategies = new Map<string, AddonMergeStrategy>();
+
+  register(addon: RegisteredAddon): void {
+    if (this.addons.has(addon.manifest.id)) {
+      throw new Error(`Addon "${addon.manifest.id}" is already registered`);
+    }
+    this.addons.set(addon.manifest.id, addon);
+  }
+
+  registerMergeStrategy(strategy: AddonMergeStrategy): void {
+    if (this.mergeStrategies.has(strategy.kind)) {
+      throw new Error(
+        `Merge strategy for kind "${strategy.kind}" is already registered`,
+      );
+    }
+    this.mergeStrategies.set(strategy.kind, strategy);
+  }
+
+  get(addonId: string): RegisteredAddon | undefined {
+    return this.addons.get(addonId);
+  }
+
+  getMergeStrategy(kind: string): AddonMergeStrategy | undefined {
+    return this.mergeStrategies.get(kind);
+  }
+
+  has(addonId: string): boolean {
+    return this.addons.has(addonId);
+  }
+
+  list(): RegisteredAddon[] {
+    return [...this.addons.values()];
+  }
+}
+
+export function createAddonRegistry(): AddonRegistry {
+  return new AddonRegistry();
+}
+
+/**
+ * Production singleton populated by addon directories in this folder. Empty
+ * at Phase 1 — the render pass is a no-op for every existing stack.
+ *
+ * Per-addon registration entry points are added here starting Phase 3
+ * (`tailscale-ssh`). Tests should construct an isolated registry via
+ * `createAddonRegistry()` rather than mutating this one.
+ */
+export const productionAddonRegistry: AddonRegistry = createAddonRegistry();

--- a/server/src/services/stack-addons/test-addons/noop.ts
+++ b/server/src/services/stack-addons/test-addons/noop.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+import type {
+  AddonDefinition,
+  ProvisionContext,
+  ProvisionedValues,
+  StackServiceDefinition,
+} from '@mini-infra/types';
+import type { RegisteredAddon } from '../registry';
+
+/**
+ * Test-only addon that exercises the validate → provision → materialise →
+ * target-integration path without touching Vault, Tailscale, or any other
+ * external service. Used by `expand-addons.test.ts` to prove the framework
+ * without registering a production addon.
+ *
+ * **Not registered into the production singleton.** Tests instantiate their
+ * own registry via `createAddonRegistry()` and call `register(noopAddon)`.
+ *
+ * Sidecar shape: a tiny alpine container that sleeps. Its `serviceName` is
+ * `<target>-noop`, `peer-on-target-network` integration so the target is
+ * untouched, and a single env var so we can assert on the rendered output.
+ */
+const noopConfigSchema = z
+  .object({
+    label: z.string().min(1).max(64).optional(),
+  })
+  .strict();
+
+type NoopConfig = z.infer<typeof noopConfigSchema>;
+
+const noopDefinition: AddonDefinition = {
+  manifest: {
+    id: 'noop',
+    description:
+      'No-op test addon. Adds an empty alpine sidecar; takes no external dependencies.',
+    appliesTo: ['Stateful', 'StatelessWeb', 'Pool'],
+  },
+  targetIntegration: {
+    network: 'peer-on-target-network',
+  },
+  async provision(ctx: ProvisionContext): Promise<ProvisionedValues> {
+    const config = ctx.addonConfig as NoopConfig;
+    return {
+      envForSidecar: {
+        NOOP_TARGET: ctx.service.name,
+        ...(config.label ? { NOOP_LABEL: config.label } : {}),
+      },
+      templateVars: {
+        targetServiceName: ctx.service.name,
+      },
+    };
+  },
+  buildServiceDefinition(
+    ctx: ProvisionContext,
+    provisioned: ProvisionedValues,
+  ): StackServiceDefinition {
+    return {
+      serviceName: `${ctx.service.name}-noop`,
+      serviceType: 'Stateful',
+      dockerImage: 'alpine',
+      dockerTag: '3.20',
+      containerConfig: {
+        command: ['sleep', 'infinity'],
+        env: provisioned.envForSidecar,
+        labels: {
+          'mini-infra.addon': 'noop',
+        },
+        restartPolicy: 'unless-stopped',
+      },
+      dependsOn: [ctx.service.name],
+      order: 1000,
+    };
+  },
+};
+
+export const noopAddon: RegisteredAddon = {
+  manifest: noopDefinition.manifest,
+  configSchema: noopConfigSchema,
+  definition: noopDefinition,
+};

--- a/server/src/services/stacks/__tests__/definition-hash-addons.test.ts
+++ b/server/src/services/stacks/__tests__/definition-hash-addons.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import type { StackServiceDefinition } from '@mini-infra/types';
+import { computeDefinitionHash } from '../definition-hash';
+
+/**
+ * Service Addons §7 invariant: the definition hash for an authored service
+ * is computed from the authored `addons:` block (and the rest of the
+ * authored definition), not the rendered form. So:
+ *  - changing addon-config recreates the target service;
+ *  - mint-on-render values like authkeys never enter this hash.
+ */
+describe('definition-hash with addons block', () => {
+  const baseService: StackServiceDefinition = {
+    serviceName: 'web',
+    serviceType: 'Stateful',
+    dockerImage: 'nginx',
+    dockerTag: 'latest',
+    dependsOn: [],
+    order: 1,
+    containerConfig: {
+      env: { FOO: 'bar' },
+      restartPolicy: 'unless-stopped',
+    },
+  };
+
+  it('includes the authored addons block — config changes change the hash', () => {
+    const withoutAddons = computeDefinitionHash(baseService);
+    const withNoop = computeDefinitionHash({
+      ...baseService,
+      addons: { noop: {} },
+    });
+    const withNoopLabel = computeDefinitionHash({
+      ...baseService,
+      addons: { noop: { label: 'a' } },
+    });
+    const withNoopOtherLabel = computeDefinitionHash({
+      ...baseService,
+      addons: { noop: { label: 'b' } },
+    });
+
+    expect(withoutAddons).not.toBe(withNoop);
+    expect(withNoop).not.toBe(withNoopLabel);
+    expect(withNoopLabel).not.toBe(withNoopOtherLabel);
+  });
+
+  it('is stable across calls for the same authored definition', () => {
+    const a = computeDefinitionHash({
+      ...baseService,
+      addons: { noop: { label: 'x' } },
+    });
+    const b = computeDefinitionHash({
+      ...baseService,
+      addons: { noop: { label: 'x' } },
+    });
+    expect(a).toBe(b);
+  });
+});

--- a/server/src/services/stacks/__tests__/definition-hash-addons.test.ts
+++ b/server/src/services/stacks/__tests__/definition-hash-addons.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import type { StackServiceDefinition } from '@mini-infra/types';
 import { computeDefinitionHash } from '../definition-hash';
+import { resolveServiceConfigs } from '../utils';
+import { buildTemplateContext } from '../template-engine';
+import { createAddonRegistry } from '../../stack-addons';
+import { noopAddon } from '../../stack-addons/test-addons/noop';
 
 /**
  * Service Addons §7 invariant: the definition hash for an authored service
@@ -53,5 +57,62 @@ describe('definition-hash with addons block', () => {
       addons: { noop: { label: 'x' } },
     });
     expect(a).toBe(b);
+  });
+});
+
+/**
+ * §7 invariant pinned at the pipeline boundary, not just at the hash
+ * function. `expandAddons` strips the `addons:` field from the rendered
+ * output (the rendered form is post-authoring); the integration test
+ * proves `resolveServiceConfigs` re-attaches the authored block before
+ * computing the target's hash, so addon-config changes still trigger a
+ * recreate of the target.
+ */
+describe('resolveServiceConfigs — §7 hash invariant pinned end-to-end', () => {
+  function makeServiceRow(addons: Record<string, unknown> | undefined) {
+    return {
+      serviceName: 'web',
+      serviceType: 'Stateful',
+      dockerImage: 'nginx',
+      dockerTag: 'latest',
+      containerConfig: { restartPolicy: 'unless-stopped' },
+      configFiles: [],
+      initCommands: [],
+      dependsOn: [],
+      order: 1,
+      routing: null,
+      addons,
+    };
+  }
+
+  it("changes the target's service hash when the authored addons block changes", async () => {
+    const registry = createAddonRegistry();
+    registry.register(noopAddon);
+
+    const ctxA = buildTemplateContext(
+      { name: 'demo', networks: [], volumes: [] },
+      [{ serviceName: 'web', dockerImage: 'nginx', dockerTag: 'latest', containerConfig: { restartPolicy: 'unless-stopped' } }],
+    );
+    const ctxB = buildTemplateContext(
+      { name: 'demo', networks: [], volumes: [] },
+      [{ serviceName: 'web', dockerImage: 'nginx', dockerTag: 'latest', containerConfig: { restartPolicy: 'unless-stopped' } }],
+    );
+
+    const { serviceHashes: hashA } = await resolveServiceConfigs(
+      [makeServiceRow({ noop: { label: 'a' } })],
+      ctxA,
+      { addonRegistry: registry },
+    );
+    const { serviceHashes: hashB } = await resolveServiceConfigs(
+      [makeServiceRow({ noop: { label: 'b' } })],
+      ctxB,
+      { addonRegistry: registry },
+    );
+
+    const targetHashA = hashA.get('web');
+    const targetHashB = hashB.get('web');
+    expect(targetHashA).toBeDefined();
+    expect(targetHashB).toBeDefined();
+    expect(targetHashA).not.toBe(targetHashB);
   });
 });

--- a/server/src/services/stacks/definition-hash.ts
+++ b/server/src/services/stacks/definition-hash.ts
@@ -60,6 +60,12 @@ export function computeDefinitionHash(
       configFiles: sortedConfigFiles,
       initCommands: sortedInitCommands,
       routing: service.routing ?? null,
+      // Service Addons §7: hash the *authored* `addons:` block, not the
+      // rendered sidecars. Rendered (synthetic) services are hashed
+      // independently by the reconciler; including the authored block here
+      // means changing addon-config triggers a recreate of the target while
+      // mint-on-render values (authkeys, secrets) never enter this hash.
+      addons: service.addons ?? null,
     };
   }
 

--- a/server/src/services/stacks/pool-spawner.ts
+++ b/server/src/services/stacks/pool-spawner.ts
@@ -112,7 +112,7 @@ export async function spawnPoolInstance(
     (stack.parameterValues as unknown as Record<string, StackParameterValue>) ?? {},
   );
   const templateContext = buildStackTemplateContext(stack, params);
-  const { resolvedDefinitions } = resolveServiceConfigs(stack.services, templateContext);
+  const { resolvedDefinitions } = await resolveServiceConfigs(stack.services, templateContext);
   const resolvedDef = resolvedDefinitions.get(ctx.serviceName);
   if (!resolvedDef) {
     return { success: false, error: 'Pool service missing from resolved definitions' };

--- a/server/src/services/stacks/schemas.ts
+++ b/server/src/services/stacks/schemas.ts
@@ -7,6 +7,7 @@ import {
   MOUNT_TYPES,
   isValidEgressPattern,
 } from '@mini-infra/types';
+import { productionAddonRegistry, type AddonRegistry } from '../stack-addons/registry';
 // Note: isValidEgressPattern uses EGRESS_FQDN_RE + EGRESS_WILDCARD_RE from
 // lib/types/egress.ts. The egress route (server/src/routes/egress.ts) has
 // equivalent inline copies (FQDN_RE / WILDCARD_RE) that predate this constant;
@@ -416,7 +417,50 @@ export const stackServiceCommonFieldsSchema = z.object({
   // Symbolic reference to a nats.signers[].name. Causes NATS_SIGNER_SEED to
   // be auto-injected as dynamicEnv at apply time.
   natsSigner: z.string().min(1).optional(),
+  // Service Addons declarations — a map of addon-id → addon-config. Per-entry
+  // validation happens in `addonsBlockSchema` below, which superRefines each
+  // entry against the registered addon's manifest configSchema.
+  addons: z.record(z.string().min(1), z.unknown()).optional(),
 });
+
+/**
+ * Per-entry validation of the `addons:` block against the configured registry.
+ *
+ * Each entry's key must reference a registered addon, and each entry's value
+ * is parsed by that addon's `configSchema`. The registry defaults to the
+ * production singleton; tests inject an isolated registry by calling this
+ * helper directly. Both `stackServiceDefinitionSchema` (HTTP boundary) and
+ * `templateServiceSchema` (file-loaded templates) chain to it so adding a
+ * new addon is one registration, not two schema edits.
+ */
+export function refineAddonsBlock(
+  addons: Record<string, unknown> | undefined,
+  ctx: z.RefinementCtx,
+  registry: AddonRegistry,
+): void {
+  if (!addons) return;
+  for (const [addonId, rawConfig] of Object.entries(addons)) {
+    const registered = registry.get(addonId);
+    if (!registered) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['addons', addonId],
+        message: `Addon "${addonId}" is not registered`,
+      });
+      continue;
+    }
+    const result = registered.configSchema.safeParse(rawConfig);
+    if (!result.success) {
+      for (const issue of result.error.issues) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['addons', addonId, ...issue.path],
+          message: issue.message,
+        });
+      }
+    }
+  }
+}
 
 export const stackServiceDefinitionSchema = stackServiceCommonFieldsSchema
   .extend({
@@ -430,6 +474,9 @@ export const stackServiceDefinitionSchema = stackServiceCommonFieldsSchema
     // template/draft input. Symbolic *Ref siblings live on the common base.
     vaultAppRoleId: z.string().min(1).nullable().optional(),
     natsCredentialId: z.string().min(1).nullable().optional(),
+  })
+  .superRefine((data, ctx) => {
+    refineAddonsBlock(data.addons, ctx, productionAddonRegistry);
   })
   .refine(
     (data) => {

--- a/server/src/services/stacks/stack-plan-computer.ts
+++ b/server/src/services/stacks/stack-plan-computer.ts
@@ -52,7 +52,7 @@ export class StackPlanComputer {
     );
     const templateContext = buildStackTemplateContext(stack, params);
 
-    const { resolvedDefinitions, serviceHashes } = resolveServiceConfigs(stack.services, templateContext);
+    const { resolvedDefinitions, serviceHashes } = await resolveServiceConfigs(stack.services, templateContext);
 
     const docker = this.dockerExecutor.getDockerClient();
     const rawContainers = await docker.listContainers({

--- a/server/src/services/stacks/stack-reconciler.ts
+++ b/server/src/services/stacks/stack-reconciler.ts
@@ -136,7 +136,7 @@ export class StackReconciler {
 
       // Build maps for service definitions, hashes, and resolved configs
       const serviceMap = new Map(stack.services.map((s) => [s.serviceName, s]));
-      const { resolvedConfigsMap, resolvedDefinitions, serviceHashes } = resolveServiceConfigs(stack.services, templateContext);
+      const { resolvedConfigsMap, resolvedDefinitions, serviceHashes } = await resolveServiceConfigs(stack.services, templateContext);
 
       // 5a-i. Reconcile infra resource outputs (creates Docker networks + InfraResource records)
       const resourceOutputs = (stack.resourceOutputs as unknown as StackResourceOutput[]) ?? [];
@@ -481,7 +481,7 @@ export class StackReconciler {
       );
       const templateContext = buildStackTemplateContext(stack, params);
       const serviceMap = new Map(stack.services.map((s) => [s.serviceName, s]));
-      const { resolvedConfigsMap, resolvedDefinitions, serviceHashes } = resolveServiceConfigs(stack.services, templateContext);
+      const { resolvedConfigsMap, resolvedDefinitions, serviceHashes } = await resolveServiceConfigs(stack.services, templateContext);
 
       // Reconcile infra resource outputs and inputs
       const resourceOutputs = (stack.resourceOutputs as unknown as StackResourceOutput[]) ?? [];
@@ -819,7 +819,7 @@ export class StackReconciler {
       (stack.parameterValues as unknown as Record<string, StackParameterValue>) ?? {}
     );
     const templateContext = buildStackTemplateContext(stack, params);
-    const { resolvedDefinitions } = resolveServiceConfigs(stack.services, templateContext);
+    const { resolvedDefinitions } = await resolveServiceConfigs(stack.services, templateContext);
 
     const serviceImageMap = new Map<string, string>();
     for (const [serviceName, def] of resolvedDefinitions.entries()) {

--- a/server/src/services/stacks/stack-template-service.ts
+++ b/server/src/services/stacks/stack-template-service.ts
@@ -1212,6 +1212,7 @@ function serializeTemplateService(svc: Prisma.StackTemplateServiceGetPayload<tru
     natsCredentialRef: svc.natsCredentialRef ?? null,
     natsRole: svc.natsRole ?? null,
     natsSigner: svc.natsSigner ?? null,
+    addons: (svc.addons as unknown as Record<string, unknown> | null) ?? null,
   };
 }
 
@@ -1254,6 +1255,7 @@ function toTemplateServiceCreate(
     natsCredentialRef: s.natsCredentialRef ?? null,
     natsRole: s.natsRole ?? null,
     natsSigner: s.natsSigner ?? null,
+    addons: s.addons ? (s.addons as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
   };
 }
 
@@ -1457,6 +1459,10 @@ function buildServiceDefinitionsFromVersion(version: {
       natsCredentialRef: svc.natsCredentialRef ?? undefined,
       natsRole: svc.natsRole ?? undefined,
       natsSigner: svc.natsSigner ?? undefined,
+      addons:
+        svc.addons && typeof svc.addons === 'object'
+          ? (svc.addons as unknown as Record<string, unknown>)
+          : undefined,
     };
   });
 }

--- a/server/src/services/stacks/template-file-loader.ts
+++ b/server/src/services/stacks/template-file-loader.ts
@@ -11,7 +11,9 @@ import {
   stackResourceOutputSchema,
   stackResourceInputSchema,
   stackServiceCommonFieldsSchema,
+  refineAddonsBlock,
 } from "./schemas";
+import { productionAddonRegistry } from "../stack-addons/registry";
 import {
   templateInputDeclSchema,
   templateVaultPolicySchema,
@@ -56,15 +58,19 @@ const templateConfigFileSchema = z.object({
 // `stackServiceCommonFieldsSchema` so adding a new common field can't drift
 // silently (customer feedback #1). Leaf-specific fields and the
 // stricter-than-HTTP refine (Stateful must not have routing) stay here.
-const templateServiceSchema = stackServiceCommonFieldsSchema.refine(
-  (data) => {
-    if (data.serviceType === "StatelessWeb" && !data.routing) return false;
-    if (data.serviceType === "AdoptedWeb" && !data.routing) return false;
-    if (data.serviceType === "Stateful" && data.routing) return false;
-    return true;
-  },
-  { message: "StatelessWeb/AdoptedWeb services must have routing; Stateful services must not have routing" }
-);
+const templateServiceSchema = stackServiceCommonFieldsSchema
+  .refine(
+    (data) => {
+      if (data.serviceType === "StatelessWeb" && !data.routing) return false;
+      if (data.serviceType === "AdoptedWeb" && !data.routing) return false;
+      if (data.serviceType === "Stateful" && data.routing) return false;
+      return true;
+    },
+    { message: "StatelessWeb/AdoptedWeb services must have routing; Stateful services must not have routing" }
+  )
+  .superRefine((data, ctx) => {
+    refineAddonsBlock(data.addons, ctx, productionAddonRegistry);
+  });
 
 // =====================
 // Vault Section Schema (composed from canonical sub-schemas)

--- a/server/src/services/stacks/template-file-loader.ts
+++ b/server/src/services/stacks/template-file-loader.ts
@@ -339,6 +339,7 @@ export interface LoadedTemplate {
       natsCredentialRef?: string;
       natsRole?: string;
       natsSigner?: string;
+      addons?: Record<string, unknown>;
     }>;
   };
   configFiles: StackTemplateConfigFileInput[];
@@ -460,6 +461,7 @@ export function loadTemplateFromObject(
       natsCredentialRef: svc.natsCredentialRef,
       natsRole: svc.natsRole,
       natsSigner: svc.natsSigner,
+      addons: svc.addons,
     };
   });
 

--- a/server/src/services/stacks/utils.ts
+++ b/server/src/services/stacks/utils.ts
@@ -330,12 +330,21 @@ export async function resolveServiceConfigs(
   // (with the optional addons block carried through). Configs files are
   // tracked in parallel so synthetic sidecars added by expandAddons can
   // pick up an empty bucket without disturbing authored ones.
+  //
+  // The authored `addons:` block per service is captured separately so
+  // we can re-attach it when hashing the rendered target — `expandAddons`
+  // strips the field from its output (the rendered form has no authoring
+  // artifact), but §7 of the Service Addons plan requires the hash to be
+  // computed from the *authored* definition + addon-config, not the
+  // rendered form, so addon-config changes still trigger a recreate.
+  const authoredAddonsByName = new Map<string, Record<string, unknown> | undefined>();
   const authoredDefs: StackServiceDefinition[] = [];
   for (const svc of services) {
     const def = toServiceDefinition(svc);
     if (svc.addons && typeof svc.addons === 'object') {
       def.addons = svc.addons as Record<string, unknown>;
     }
+    authoredAddonsByName.set(svc.serviceName, def.addons);
     authoredDefs.push(def);
     resolvedConfigsMap.set(
       svc.serviceName,
@@ -383,11 +392,18 @@ export async function resolveServiceConfigs(
     const resolvedDef = resolveServiceDefinition(def, templateContext);
     resolvedDefinitions.set(def.serviceName, resolvedDef);
     // Hash the resolved definition so parameter value changes trigger
-    // recreates. The authored `addons:` block is part of the canonical
-    // form (definition-hash.ts) so addon-config changes also recreate.
+    // recreates. For authored services we re-attach the original `addons:`
+    // block (stripped on the render output) so the hash includes the
+    // authoring intent — definition-hash.ts §7 invariant. Synthetic
+    // sidecars don't carry an addons block of their own.
+    const authoredAddons = authoredAddonsByName.get(def.serviceName);
+    const defForHash =
+      authoredAddons !== undefined
+        ? { ...resolvedDef, addons: authoredAddons }
+        : resolvedDef;
     serviceHashes.set(
       def.serviceName,
-      computeDefinitionHash(resolvedDef, resolvedConfigs),
+      computeDefinitionHash(defForHash, resolvedConfigs),
     );
   }
 

--- a/server/src/services/stacks/utils.ts
+++ b/server/src/services/stacks/utils.ts
@@ -139,6 +139,7 @@ export function toServiceCreateInput(s: StackServiceDefinition) {
     vaultAppRoleId: s.vaultAppRoleId ?? null,
     natsCredentialId: s.natsCredentialId ?? null,
     natsCredentialRef: s.natsCredentialRef ?? null,
+    addons: s.addons ? (s.addons as unknown as Prisma.InputJsonValue) : Prisma.DbNull,
   };
 }
 
@@ -341,9 +342,6 @@ export async function resolveServiceConfigs(
   const authoredDefs: StackServiceDefinition[] = [];
   for (const svc of services) {
     const def = toServiceDefinition(svc);
-    if (svc.addons && typeof svc.addons === 'object') {
-      def.addons = svc.addons as Record<string, unknown>;
-    }
     authoredAddonsByName.set(svc.serviceName, def.addons);
     authoredDefs.push(def);
     resolvedConfigsMap.set(
@@ -430,6 +428,7 @@ export function toServiceDefinition(svc: {
   vaultAppRoleRef?: string | null;
   natsCredentialId?: string | null;
   natsCredentialRef?: string | null;
+  addons?: unknown;
 }): StackServiceDefinition {
   return {
     serviceName: svc.serviceName,
@@ -448,6 +447,10 @@ export function toServiceDefinition(svc: {
     vaultAppRoleRef: svc.vaultAppRoleRef ?? undefined,
     natsCredentialId: svc.natsCredentialId ?? undefined,
     natsCredentialRef: svc.natsCredentialRef ?? undefined,
+    addons:
+      svc.addons && typeof svc.addons === 'object'
+        ? (svc.addons as Record<string, unknown>)
+        : undefined,
   };
 }
 

--- a/server/src/services/stacks/utils.ts
+++ b/server/src/services/stacks/utils.ts
@@ -15,6 +15,12 @@ import { buildTemplateContext, resolveStackConfigFiles, resolveServiceDefinition
 import { computeDefinitionHash } from './definition-hash';
 import { StackContainerManager } from './stack-container-manager';
 import { decryptInputValues } from './stack-input-values-service';
+import {
+  expandAddons,
+  productionAddonRegistry,
+  type AddonRegistry,
+  type ExpansionProgress,
+} from '../stack-addons';
 
 /**
  * Loose shape of a Prisma stack record extended with optional relations.
@@ -261,10 +267,35 @@ export function buildStackTemplateContext(
   );
 }
 
+export interface ResolveServiceConfigsOptions {
+  /**
+   * Override the addon registry — tests use this to inject a registry
+   * pre-populated with the no-op test addon. Defaults to
+   * `productionAddonRegistry`, which is empty at Phase 1.
+   */
+  addonRegistry?: AddonRegistry;
+  /** Per-(service, addon) progress callback; see `ExpansionProgress`. */
+  expansionProgress?: ExpansionProgress;
+  /** Pool-instance id when this expansion is for a single pool spawn. */
+  instance?: { instanceId: string };
+}
+
 /**
- * Resolve config files and compute definition hashes for all services in a stack.
+ * Resolve config files, run the Service Addons render pass, and compute
+ * definition hashes for every rendered service in a stack.
+ *
+ * The addon expansion runs **before** template substitution and hashing so
+ * that:
+ *   - synthetic sidecars produced by addons flow through the same
+ *     `{{params.X}}` / `{{volumes.Y}}` resolution as authored services;
+ *   - the hash of the *authored* service includes the `addons:` block per
+ *     §7 of the Service Addons plan (mint-once authkeys never leak in).
+ *
+ * With the production registry empty (Phase 1), the expansion is a
+ * pass-through for every existing stack — output equals input modulo the
+ * rendered services Map's iteration order.
  */
-export function resolveServiceConfigs(
+export async function resolveServiceConfigs(
   services: Array<{
     serviceName: string;
     serviceType: string;
@@ -282,30 +313,82 @@ export function resolveServiceConfigs(
     vaultAppRoleRef?: string | null;
     natsCredentialId?: string | null;
     natsCredentialRef?: string | null;
+    addons?: unknown;
   }>,
-  templateContext: ReturnType<typeof buildTemplateContext>
-): {
+  templateContext: ReturnType<typeof buildTemplateContext>,
+  options: ResolveServiceConfigsOptions = {},
+): Promise<{
   resolvedConfigsMap: Map<string, StackConfigFile[]>;
   resolvedDefinitions: Map<string, StackServiceDefinition>;
   serviceHashes: Map<string, string>;
-} {
+}> {
   const resolvedConfigsMap = new Map<string, StackConfigFile[]>();
   const resolvedDefinitions = new Map<string, StackServiceDefinition>();
   const serviceHashes = new Map<string, string>();
 
+  // Step 1 — convert each Prisma row into the portable definition shape
+  // (with the optional addons block carried through). Configs files are
+  // tracked in parallel so synthetic sidecars added by expandAddons can
+  // pick up an empty bucket without disturbing authored ones.
+  const authoredDefs: StackServiceDefinition[] = [];
   for (const svc of services) {
-    const resolvedConfigs = resolveStackConfigFiles(
-      (svc.configFiles as unknown as StackConfigFile[]) ?? [],
-      templateContext
-    );
-    resolvedConfigsMap.set(svc.serviceName, resolvedConfigs);
-
     const def = toServiceDefinition(svc);
-    const resolvedDef = resolveServiceDefinition(def, templateContext);
-    resolvedDefinitions.set(svc.serviceName, resolvedDef);
+    if (svc.addons && typeof svc.addons === 'object') {
+      def.addons = svc.addons as Record<string, unknown>;
+    }
+    authoredDefs.push(def);
+    resolvedConfigsMap.set(
+      svc.serviceName,
+      resolveStackConfigFiles(
+        (svc.configFiles as unknown as StackConfigFile[]) ?? [],
+        templateContext,
+      ),
+    );
+  }
 
-    // Hash the resolved definition so parameter value changes trigger recreates
-    serviceHashes.set(svc.serviceName, computeDefinitionHash(resolvedDef, resolvedConfigs));
+  // Step 2 — addon expansion. With the production registry empty (Phase 1),
+  // this is a pass-through that just strips the (also-absent) `addons:`
+  // field from each output service. Tests opt-in by passing a populated
+  // registry via `options.addonRegistry`.
+  const renderedDefs = await expandAddons(
+    authoredDefs,
+    {
+      registry: options.addonRegistry ?? productionAddonRegistry,
+      stack: {
+        id: templateContext.stack.id ?? '',
+        name: templateContext.stack.name,
+      },
+      environment: templateContext.environment
+        ? {
+            id: templateContext.environment.id,
+            name: templateContext.environment.name,
+            networkType: templateContext.environment.networkType,
+          }
+        : { id: '', name: '', networkType: 'local' },
+      instance: options.instance,
+    },
+    options.expansionProgress,
+  );
+
+  // Step 3 — template-resolve and hash each rendered service. Synthetic
+  // sidecars share the per-stack template context with the authored ones
+  // they wrap.
+  for (const def of renderedDefs) {
+    const resolvedConfigs =
+      resolvedConfigsMap.get(def.serviceName) ??
+      resolveStackConfigFiles(def.configFiles ?? [], templateContext);
+    if (!resolvedConfigsMap.has(def.serviceName)) {
+      resolvedConfigsMap.set(def.serviceName, resolvedConfigs);
+    }
+    const resolvedDef = resolveServiceDefinition(def, templateContext);
+    resolvedDefinitions.set(def.serviceName, resolvedDef);
+    // Hash the resolved definition so parameter value changes trigger
+    // recreates. The authored `addons:` block is part of the canonical
+    // form (definition-hash.ts) so addon-config changes also recreate.
+    serviceHashes.set(
+      def.serviceName,
+      computeDefinitionHash(resolvedDef, resolvedConfigs),
+    );
   }
 
   return { resolvedConfigsMap, resolvedDefinitions, serviceHashes };


### PR DESCRIPTION
## Summary
- Lays the Service Addons framework (types, registry, `expandAddons` render step, no-op test addon) so Phase 3+ addon directories can drop in without further framework work.
- Adds `addons:` to the shared service-schema base with per-entry `superRefine` validation against the registered manifests, and pins the §7 hash invariant — addon-config changes recreate the target via the authored block in `definition-hash`.
- Production registry is empty at Phase 1, so the new render pass is a no-op for every existing stack.

## Test plan
- [x] `pnpm build:lib` + `pnpm --filter mini-infra-server build` clean
- [x] `pnpm --filter mini-infra-server lint` clean
- [x] `pnpm --filter mini-infra-server exec vitest run --project unit --project integration` — 2058/2058 pass
- [x] Unit tests cover: noop expansion + synthetic back-reference, no-addons round-trip, schema-drift pin, §7 hash invariant end-to-end, `onFailed` for validation errors

Closes ALT-56