### PR TITLE
feat(skills): worktree skills + retro/design relations + design label

### DIFF
--- a/.claude/skills/design-task/SKILL.md
+++ b/.claude/skills/design-task/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: design-task
-description: Design-exploration agent for a Linear ticket. Accepts an **optional issue ID** as an argument (e.g. `/design-task ALT-38`) — when supplied, the skill jumps straight to that issue and skips the picking flow; when omitted, it picks the next unblocked Todo issue from the user's Linear team (Altitude Devops), the same picking flow as `execute-next-task`. Reads the ticket body (Goal / Deliverables / Done when) and any plan-doc context if the parent project has a `Plan:` line. Instead of consuming per-component CLAUDE.md / ARCHITECTURE.md pointers like `execute-next-task` does, this skill **researches design patterns** — architectural / structural / behavioural patterns relevant to the task, plus existing patterns already used in the Mini Infra codebase that could be reused. Generates **two distinct design options**, each with pros/cons, key abstractions, file/component sketch, and a rough implementation outline, written to `docs/designs/<issue-id>-<slug>.md` (single file with both options side-by-side), commits to a recommendation, posts a "design ready" comment on the impl ticket pointing at the file (so a future `execute-next-task` run finds it), and **marks the design ticket Done** — the design doc + recommendation are the deliverable, and the impl ticket unblocks immediately. Does NOT create a worktree, does NOT open a PR — the user reviews the doc and commits/PRs it on their own cadence. Use this skill whenever the user says "design ALT-NN", "design the next task", "explore design options for ALT-NN", "give me two designs for ALT-NN", "what are the design options for ALT-NN", "design-task", "come up with designs for the next ticket", or any equivalent request to brainstorm two alternative designs for a Linear-tracked task before execution begins. Do NOT trigger when the user wants to actually execute the work (use `execute-next-task` for that), or for non-Linear design questions, or for ad-hoc architecture discussions without a Linear ticket attached.
+description: Design-exploration agent for a Linear ticket. Accepts an **optional issue ID** as an argument (e.g. `/design-task ALT-38`) — when supplied, the skill jumps straight to that issue and skips the picking flow; when omitted, it picks the next unblocked Todo issue from the user's Linear team (Altitude Devops), the same picking flow as `execute-next-task`. Reads the ticket body (Goal / Deliverables / Done when) and any plan-doc context if the parent project has a `Plan:` line. Instead of consuming per-component CLAUDE.md / ARCHITECTURE.md pointers like `execute-next-task` does, this skill **researches design patterns** — architectural / structural / behavioural patterns relevant to the task, plus existing patterns already used in the Mini Infra codebase that could be reused. Generates **two distinct design options**, each with pros/cons, key abstractions, file/component sketch, and a rough implementation outline, written to `docs/designs/<issue-id>-<slug>.md` (single file with both options side-by-side), commits to a recommendation, posts a "design ready" comment on the impl ticket pointing at the file (so a future `execute-next-task` run finds it), and **marks the design ticket Done** — the design doc + recommendation are the deliverable, and the impl ticket unblocks immediately. Delegates worktree creation to the `setup-worktree` skill (with `--no-env`, since design is markdown-only and no dev env is needed). Does NOT open a PR — the user reviews the doc and commits/PRs it on their own cadence; the worktree can be torn down later via `finish-worktree` when the design has shipped. Use this skill whenever the user says "design ALT-NN", "design the next task", "explore design options for ALT-NN", "give me two designs for ALT-NN", "what are the design options for ALT-NN", "design-task", "come up with designs for the next ticket", or any equivalent request to brainstorm two alternative designs for a Linear-tracked task before execution begins. Do NOT trigger when the user wants to actually execute the work (use `execute-next-task` for that), or for non-Linear design questions, or for ad-hoc architecture discussions without a Linear ticket attached.
 ---
 
 # Design Task
 
 You're a **design-exploration agent**. The Linear ticket describes *what* needs to happen (Goal, Deliverables, Done when). Your job is to propose *how* — by surveying relevant design patterns, finding what's already in the Mini Infra codebase that fits, writing up **two distinct design options**, and **committing to a recommendation**.
 
-This skill is the planning step that sits **between** ticket creation (`task-to-linear` / `plan-to-linear`) and execution (`execute-next-task`). It produces a design doc, posts a Linear comment pointing at it, and marks the design ticket **Done** so the impl ticket unblocks immediately. The recommendation in the doc is the call — there's no "user picks an option" step. If the user disagrees, they can edit the doc and re-comment; the default flow assumes the recommendation stands. **The skill creates no worktree and opens no PR** — the user reviews the doc and commits/PRs it at their own pace.
+This skill is the planning step that sits **between** ticket creation (`task-to-linear` / `plan-to-linear`) and execution (`execute-next-task`). It produces a design doc, posts a Linear comment pointing at it, and marks the design ticket **Done** so the impl ticket unblocks immediately. The recommendation in the doc is the call — there's no "user picks an option" step. If the user disagrees, they can edit the doc and re-comment; the default flow assumes the recommendation stands. **The skill creates a worktree** (via `setup-worktree --no-env`) so the design doc lives on its own branch in its own checkout — but it **opens no PR** and **does not commit** the doc. The user reviews and commits/PRs at their own pace, then runs `/finish-worktree alt-NN` to free the slot once the design has shipped.
 
 The Done-when in the ticket body (often "Figma frames signed off") is informational. The skill considers the design doc + recommendation to be the actual deliverable, and marks the Linear issue Done on that basis. If the team starts wanting Figma frames again, that's a future change to this skill.
 
@@ -261,17 +261,21 @@ lib/types/<thing>.ts                           (changed)    — <what>
 
 ### 5.4 Where to write it
 
-The user's repo policy: if you're on `main`, switch to a branch before writing. If you're already on a non-main branch (including a worktree branch like `claude/alt-NN`), just write the file on the current branch.
+Delegate worktree creation to the **`setup-worktree`** skill with `--no-env` (design is markdown-only, no dev env required):
 
-**Do not commit** the file automatically. The point of the design doc is to be reviewed and iterated on — committing it locks it in before that happens. Leave the file unstaged; the user will commit (or ask you to) after they've read it.
-
-If the user is on `main`, before writing the file:
-
-```bash
-git checkout -b design/alt-NN-<slug>
+```
+Skill(skill: "setup-worktree", args: "<ALT-NN> --no-env")
 ```
 
-Use `design/` as the branch prefix (parallel to `claude/` for execution branches) so it's obvious from the branch name what kind of work is in flight.
+When the skill returns, you're `cd`ed into `.claude/worktrees/alt-<NN>` on branch `claude/alt-<NN>`, with `pnpm install` complete. Write the design doc inside that worktree at `docs/designs/<filename>.md`.
+
+If `setup-worktree` stops because the worktree or branch already exists, that's almost always a previous design or execution session. Surface the collision and ask the user how to proceed (resume the existing worktree if the design was in flight, or run `/finish-worktree alt-<NN>` to clear the stale one). Don't auto-recover.
+
+If `setup-worktree` stops for any other reason (dirty tree, non-default branch on the calling shell, `pnpm install` failure), surface the failure and stop — don't fall back to writing the doc on the current branch.
+
+**Do not commit** the file automatically. The design doc is meant to be reviewed and iterated on — committing locks it in before that happens. Leave the file unstaged; the user commits (or asks you to) after reading.
+
+The branch is `claude/alt-<NN>` (matching execute-next-task's convention), not the legacy `design/...` shape — using one prefix for both flows simplifies cleanup via `/finish-worktree`.
 
 ---
 
@@ -350,7 +354,7 @@ The Done-when on the ticket body (often "Figma frames signed off") is **informat
 End the run with a tight summary so the user knows what landed:
 
 ```
-✓ Design doc written: docs/designs/<filename>.md
+✓ Design doc written: docs/designs/<filename>.md (in worktree .claude/worktrees/alt-<NN>, branch claude/alt-<NN>, unstaged)
 ✓ Linear comment posted on design ticket <ALT-NN>
 ✓ "Design ready" comment posted on impl ticket <ALT-MM>
 ✓ <ALT-NN> marked Done (impl ticket <ALT-MM> unblocked)
@@ -361,6 +365,7 @@ Two options:
 
 Picked: Option <X> — <one-line reason>.
 
+Next: review the doc, commit + PR + merge it on your cadence, then run /finish-worktree alt-<NN> to free the slot.
 If you disagree with the pick, edit the doc and re-comment / reopen the ticket.
 ```
 
@@ -373,9 +378,9 @@ That's the whole skill. Keep the output short — the design doc is the substant
 ## Hard rules
 
 - **Only one Linear state transition per run, and only at the end.** The skill calls `save_issue` exactly once, in Phase 7, to set the issue to `Done`. Never set `In Progress`, never re-transition during the run, never call `save_issue` for any other field.
-- **Never create a worktree.** This is a planning step. The user runs `execute-next-task` later, which handles worktree creation. If the design surfaces something the executor needs to know, capture it in the design doc — not in environment setup.
+- **Never create a worktree manually.** Worktree creation is delegated to `setup-worktree --no-env` (Phase 5.4). Don't run `git worktree add`, `git checkout -b`, or any other branch/worktree operation directly — the delegated skill owns the convention.
 - **Never auto-commit the design doc.** The user reviews + commits + PRs at their own pace; pre-committing locks the doc in before they've seen it. Stage nothing.
-- **Never `git checkout main` or modify other branches.** The only branch operation allowed is `git checkout -b design/alt-NN-<slug>` from a clean main, and only when on main.
+- **Never open a PR for the design doc.** The doc is for review and iteration; the user opens the PR (or asks you to) once the design has settled. The worktree is torn down separately via `/finish-worktree alt-<NN>` after the design has shipped.
 - **Never collapse two options into one.** If you genuinely can't think of two distinct approaches, surface that and ask the user whether to write one with a "rejected alternatives" appendix instead. Forcing a weak second option produces noise.
 - **Never punt the recommendation back to the user.** The §Recommendation section must commit to one option. "No strong preference" / "either works" / "user picks" are invalid outputs — pick one and name what would flip the call. The skill marks the issue Done on this basis; it cannot do that if it hasn't picked.
 - **Never skip the prior-art search (Phase 4.3).** Designs that ignore the existing codebase are usually wrong about what's expensive vs. cheap. Even if you find nothing reusable, the search itself should inform your options.
@@ -392,9 +397,9 @@ That's the whole skill. Keep the output short — the design doc is the substant
 >
 > *Phase 4: identifies the dominant pattern axis as "where does the override live and how does it propagate to apply-time" — i.e. a state-placement + propagation question. Surveys two candidate shapes: (i) override stored on the StackService row, propagated through the existing apply pipeline; (ii) override stored on a new `EgressOverride` table keyed by service, looked up at apply-time. Searches the codebase for similar override patterns: finds `server/src/services/networking/haproxy-frontend-overrides.ts` (per-frontend overrides on the frontend row, similar to option (i)) and `server/src/services/registry/registry-credential-resolver.ts` (separate-table indirection lookup, similar to option (ii)). Cites both.*
 >
-> *Phase 5: writes `docs/designs/alt-38-egress-per-container-override.md`. Option A is the row-extension shape (cheap, follows the haproxy pattern, but couples the override to the service row's lifecycle). Option B is the separate-table shape (heavier, needs a new migration and model, but cleaner audit trail and easier to extend with override types later). Each option has Key abstractions / File sketch / Implementation outline / Pros / Cons / Prior art. **Recommendation: Option A** — the team has no plans for other override types and the cheaper change is the right call for the ticket as scoped; flip to B if a second override type lands on the roadmap. One Open question: "do we want overrides to survive a service rename?" — answer changes which option wins. Two items in Out-of-scope: bulk override import (different ticket), override expiry (no Deliverable for it).*
+> *Phase 5.4: invokes `Skill(setup-worktree, args: "ALT-38 --no-env")`. The setup-worktree skill pre-flights main, pulls, creates the worktree at `.claude/worktrees/alt-38` on `claude/alt-38`, runs `pnpm install`, and skips the dev-env spin-up. Returns control with cwd = the worktree.*
 >
-> *Skill is on the goofy-thompson worktree branch (not main), so no branch switch needed. File written, not staged.*
+> *Phase 5: writes `docs/designs/alt-38-egress-per-container-override.md` inside the worktree. Option A is the row-extension shape (cheap, follows the haproxy pattern, but couples the override to the service row's lifecycle). Option B is the separate-table shape (heavier, needs a new migration and model, but cleaner audit trail and easier to extend with override types later). Each option has Key abstractions / File sketch / Implementation outline / Pros / Cons / Prior art. **Recommendation: Option A** — the team has no plans for other override types and the cheaper change is the right call for the ticket as scoped; flip to B if a second override type lands on the roadmap. One Open question: "do we want overrides to survive a service rename?" — answer changes which option wins. Two items in Out-of-scope: bulk override import (different ticket), override expiry (no Deliverable for it). File left unstaged.*
 >
 > *Phase 6.1: posts a comment on ALT-38 (the design ticket): "Designs drafted: …relative-path… A — Service-row column; B — Separate EgressOverride table. **Picked: Option A** — cheap, leans on the haproxy override pattern; flip to B only if a second override type lands. Marking this design ticket Done — `/execute-next-task ALT-39` (the impl ticket) is unblocked."*
 >

--- a/.claude/skills/execute-next-task/SKILL.md
+++ b/.claude/skills/execute-next-task/SKILL.md
@@ -136,80 +136,23 @@ The Linear ticket body is your contract. Read it end to end and treat it as auth
 
 ---
 
-## Phase 4 — Pre-flight on main
+## Phase 4 — Set up the worktree (delegated to `setup-worktree`)
 
-The skill assumes you start at the **main checkout root**, on `main`, with a clean tree. The first job is to confirm that and pull the latest.
+The pre-flight, pull, worktree creation, `pnpm install`, and the backgrounded `pnpm worktree-env start` are all owned by the **`setup-worktree`** skill (its own SKILL.md is the single source of truth for the mechanics). Invoke it via the `Skill` tool with the picked Linear issue ID:
 
-```bash
-pwd
-git rev-parse --abbrev-ref HEAD
-git status
+```
+Skill(skill: "setup-worktree", args: "<ALT-NN>")
 ```
 
-Required state:
+If the picked phase is **docs-only** (only touches `docs/`, a README, or a SKILL.md — no smoke tests will need a running env), pass `--no-env` so the skill skips the dev-env spin-up:
 
-- **`pwd` is the repo root**, not under `.claude/worktrees/`. If you're already in a worktree, you don't need this skill — exit to the root and re-run.
-- **Branch is the repo's default** (usually `main`; confirm with `git symbolic-ref refs/remotes/origin/HEAD --short` if you need to be sure).
-- **Working tree is clean** — no uncommitted changes.
-
-If any of these fail, **stop with a clear message**. Don't auto-stash, auto-checkout, or guess.
-
-Then update main:
-
-```bash
-git pull --ff-only origin main
+```
+Skill(skill: "setup-worktree", args: "<ALT-NN> --no-env")
 ```
 
-Use `--ff-only` so a stale local main with non-pushed commits surfaces as an error instead of being merged silently. If it fails, stop and tell the user.
+When the skill returns successfully, you'll be `cd`ed into `.claude/worktrees/<slug>`, dependencies installed, and the env warming in the background (or skipped). The current working directory is the worktree for the rest of this run; the slug is `alt-<NN>` (lowercase) and the branch is `claude/<slug>`.
 
----
-
-## Phase 5 — Create the worktree
-
-Derive the worktree slug from the picked Linear issue ID:
-
-- **Slug**: `alt-<NN>` (lowercase). For `ALT-29`, slug is `alt-29`.
-- **Worktree path**: `.claude/worktrees/<slug>` — relative to the repo root. (The repo's existing convention puts worktrees here; root `CLAUDE.md` walks through the layout.)
-- **Branch**: `claude/<slug>` — namespaces it as agent-created, matching the other `claude/...` branches.
-
-Create the worktree off the freshly-pulled main:
-
-```bash
-git worktree add .claude/worktrees/<slug> -b claude/<slug>
-cd .claude/worktrees/<slug>
-```
-
-`cd` into it for the rest of the skill. Every later step runs from this directory.
-
-If the directory or branch already exists, **stop and ask** — don't auto-resume someone else's worktree, and don't reuse a stale branch name silently. The user's `pnpm worktree-env delete` (root `CLAUDE.md`) is the right tool to clean up first.
-
----
-
-## Phase 6 — Set up the environment (in parallel with starting work)
-
-This phase runs **before** marking In Progress so the env is warming while you read more code and start writing.
-
-### 6.1 Install dependencies
-
-Fresh worktrees do not share `node_modules` with the main checkout (per root `CLAUDE.md`). Always run:
-
-```bash
-pnpm install
-```
-
-This is required before any other `pnpm` command including `pnpm worktree-env` (which runs through `tsx`, which lives in `node_modules`). Run it synchronously — you need it to finish before anything else.
-
-### 6.2 Spin up the dev environment in the background
-
-`pnpm worktree-env start` takes a few minutes the first time, building the per-worktree VM/distro. Kick it off in the background **now** so it's ready when smoke tests need it later. Use the `Bash` tool's `run_in_background: true` and capture the shell id:
-
-```bash
-pnpm worktree-env start --description "<short summary, ≤10 words>"
-```
-
-Derive the description from the Linear issue title (truncate to ≤10 words; the CLI requires it on first run). Don't wait for it. Move on to the work; you'll check the status before running smoke tests in Phase 9. The command is idempotent — safe to re-run.
-
-If the phase is **docs-only** (e.g. only touches `docs/`, a README, or a SKILL.md), skip 6.2 — no smoke tests will need a running env.
+If `setup-worktree` stops — dirty tree, non-default branch, worktree/branch collision, `pnpm install` failure — surface the failure and stop. Don't auto-recover. The issue is already In Progress from Phase 2.1; leave it that way per the hard rule on auto-rollback (the user decides whether to retry, hand off, or revert state).
 
 ---
 
@@ -221,7 +164,7 @@ The state transition already happened in Phase 2.1 (right after the pick) — at
 save_comment(issue_id: <issue-id>, body: "Worktree ready.\n- Worktree: <path>\n- Branch: <branch>\n- Env startup: backgrounded (`pnpm worktree-env start`)")
 ```
 
-If the phase is **docs-only** and Phase 6.2 was skipped, drop the env-startup line.
+If the phase is **docs-only** and the dev-env spin-up was skipped (you passed `--no-env` to `setup-worktree`), drop the env-startup line.
 
 ---
 
@@ -509,6 +452,14 @@ The skill will:
   3. Create a NEW Linear issue in the Altitude Devops team's Backlog, tagged "retro",
      titled "Retro: <ALT-NN> — <original-issue-title>", with a Source link back to
      <ALT-NN> at the top of the description.
+  4. After the retro issue is created, link it to <ALT-NN> using Linear's `relatedTo`
+     relation (via `save_issue` on the new retro issue with a `relations` entry of
+     type `related` targeting <ALT-NN>'s issue ID). This creates a first-class
+     "Related" edge between the two issues so anyone viewing <ALT-NN> in Linear sees
+     the retro in the side panel, not just buried in the description body. The
+     in-body Source link stays — it survives if the relation is later deleted, and
+     it's the clickable target most readers reach for first — but the relation is
+     the structured, queryable link.
 
 Return ONLY the new retro issue's URL. Do NOT return the markdown body.
 ```
@@ -525,29 +476,23 @@ The retrospective is a feedback loop, not a gate. If the subagent fails — scri
 
 ---
 
-## Phase 14 — Clean up the worktree (success path only)
+## Phase 14 — Clean up the worktree (success path only, delegated to `finish-worktree`)
 
 **Only run this if every previous phase succeeded** — build/lint/unit passed, smoke passed, review fixups applied (if any), the PR is open, the issue is In Review, the handoff comment posted. If anything failed or stopped earlier, **skip this phase entirely** and leave the worktree alive so the user can investigate. The retrospective phase (13) is best-effort and doesn't gate this — a failed retrospective still counts as a successful run.
 
-The worktree's purpose is to host the build + smoke for this phase. Once the PR is open and in review, the work that needs the dev env is over — review happens in GitHub on the diff, not in the worktree. So we tear it down to free the VM/distro slot and keep `pnpm worktree-env list` tidy.
+The worktree's purpose is to host the build + smoke for this phase. Once the PR is open and in review, the work that needs the dev env is over — review happens in GitHub on the diff, not in the worktree. Tear it down to free the VM/distro slot and keep `pnpm worktree-env list` tidy.
 
-```bash
-cd <repo-root>                                      # back out of the worktree
-pnpm worktree-env delete <slug> --force             # wipes VM/distro + registry entry
-git worktree remove .claude/worktrees/<slug>        # removes the directory + git's tracking
+The mechanics (cd back to root, `pnpm worktree-env delete`, `git worktree remove`, defensive checks for uncommitted/unpushed work) are owned by the **`finish-worktree`** skill. Invoke it with the slug from Phase 4:
+
+```
+Skill(skill: "finish-worktree", args: "<slug>")
 ```
 
-`<repo-root>` is the directory you started from in Phase 4. `<slug>` is the `alt-<NN>` from Phase 5. `--force` skips the interactive confirmation. The branch on the remote stays untouched — that's where the PR points; it must remain.
+The skill `cd`s back to the repo root, runs `pnpm worktree-env delete <slug> --force`, then `git worktree remove .claude/worktrees/<slug>`. The remote `claude/<slug>` branch stays untouched — that's where the PR points; it must remain.
 
-If review feedback arrives later and you need to address it, recreate the worktree from the same branch:
+If `finish-worktree`'s defensive checks flag uncommitted changes, unpushed commits, or a missing PR, that's a real signal — something went wrong earlier in this run. Don't push past the warning; surface it to the user and stop. Cleanup can be retried after the discrepancy is resolved.
 
-```bash
-git fetch origin claude/<slug>
-git worktree add .claude/worktrees/<slug> claude/<slug>
-cd .claude/worktrees/<slug>
-pnpm install
-pnpm worktree-env start
-```
+If review feedback arrives later and the worktree needs to come back, the user can recreate it from the same branch — `finish-worktree`'s SKILL.md walks through that case.
 
 Append a final line to the run report:
 
@@ -555,7 +500,7 @@ Append a final line to the run report:
 ✓ Cleaned up worktree .claude/worktrees/<slug> and the dev-env VM.
 ```
 
-**Macos users** who run the bulk `pnpm worktree-env cleanup` command (or installed the hourly launchd agent) can rely on that to clean merged-PR worktrees on a schedule and skip Phase 14 by interrupting the skill before it runs. For Windows / WSL2 users without an equivalent agent, this phase is the cleanup mechanism.
+**Macos users** who run the bulk `pnpm worktree-env cleanup` command (or installed the hourly launchd agent) can rely on that to clean merged-PR worktrees on a schedule and skip this phase by interrupting the skill before it runs. For Windows / WSL2 users without an equivalent agent, this phase is the cleanup mechanism.
 
 ---
 
@@ -571,8 +516,8 @@ These are non-negotiable. If you find yourself wanting to break one, stop and as
 - **Never merge PRs** — even if checks pass and the PR looks great. Merging is a human decision.
 - **Never create new Linear issues** or split phases on the fly. If scope is too big for one phase, stop and report — splitting is a planning decision, not an execution decision.
 - **Never override the ticket's Deferrals.** If the ticket (or its plan-doc section, when one exists) says "Defer X to follow-up", that X is deferred. Don't quietly include it because it seemed easy.
-- **Never `git checkout main`, `git stash`, or create a new branch.** Worktree lifecycle is the user's responsibility — this skill assumes the worktree is already up. (`pnpm install` and the backgrounded `pnpm worktree-env start` are the *only* environment setup the skill performs, and only inside the existing worktree.)
-- **Never skip pre-flight checks** by running on `main` or with a dirty tree. Stop and ask.
+- **Never `git checkout main`, `git stash`, or create a new branch outside the delegated worktree flow.** Worktree creation is owned by `setup-worktree` (Phase 4) and cleanup by `finish-worktree` (Phase 14); this skill does no other branch manipulation. Once inside the worktree, you stay on `claude/<slug>` until cleanup.
+- **Never skip pre-flight checks** by running on `main` or with a dirty tree. `setup-worktree` enforces this — if it stops, surface the failure.
 - **Never use `--no-verify` or skip hooks.** If a hook fails, investigate.
 - **Never guess at the contract.** If the ticket has no Goal/Deliverables/Done-when sections, **stop and report** — the ticket wasn't populated correctly. (A missing `Plan:` line on the project, or a missing `### Phase N` section in the plan doc, is *not* a stop condition under the looser flow — see Phase 3 for the rules.)
 
@@ -596,7 +541,7 @@ These are non-negotiable. If you find yourself wanting to break one, stop and as
 >
 > *Skill fetches ALT-29 + parent project. Project description: `Plan: [docs/planning/not-shipped/internal-nats-messaging-plan.md](https://github.com/...)`. Skill reads the ticket body (Goal, Deliverables, Done when, Relevant docs, Smoke tests). The plan-doc resolves and its `### Phase 4` section matches the ticket — read as supplemental context. Reads each linked CLAUDE.md / ARCHITECTURE.md. Reads `git log` for `Phase 1`/`Phase 2`/`Phase 3` shipped commits to learn the area tag (`nats`) and PR title shape.*
 >
-> *Pre-flight: pwd is the repo root, branch is main, tree clean. Runs `git pull --ff-only origin main`. Creates worktree: `git worktree add .claude/worktrees/alt-29 -b claude/alt-29`, then `cd` into it. Runs `pnpm install` synchronously, then kicks off `pnpm worktree-env start --description "Phase 4 — pg-az-backup progress + result events"` in the background. Posts the worktree-details follow-up comment on ALT-29.*
+> *Phase 4: invokes `Skill(setup-worktree, args: "ALT-29")`. The setup-worktree skill pre-flights main, runs `git pull --ff-only origin main`, creates the worktree at `.claude/worktrees/alt-29` on `claude/alt-29`, runs `pnpm install` synchronously, then backgrounds `pnpm worktree-env start --description "Phase 4 — pg-az-backup progress + result events"` (description derived from the Linear title). Returns control with cwd = the worktree. Skill posts the worktree-details follow-up comment on ALT-29.*
 >
 > Skill: "Implementing Phase 4 — adding `mini-infra.backup.run` request handler and JetStream `BackupHistory` stream. Touching `server/src/services/backup/backup-executor.ts` first, then `server/src/services/nats/payload-schemas.ts`, then the boot sequence."
 >
@@ -608,6 +553,6 @@ These are non-negotiable. If you find yourself wanting to break one, stop and as
 >
 > *Phase 12: marks ALT-29 In Review. Posts the handoff comment: PR URL, plus a Deviations section noting that the optional retry-on-transient-failure deliverable was deferred to a follow-up issue per the plan doc's wording, plus a "Review findings consciously dismissed" section explaining the test-helper carve-out. The plan doc itself is left untouched; the re-integration agent will fold the Deviations back later. Reports the PR URL.*
 >
-> *Phase 13: captures `$CLAUDE_SESSION_ID` (the parent session), spawns a `general-purpose` subagent on Sonnet, and tells it to invoke the `session-retrospective` skill with `--session-id <parent-id> --linear-issue ALT-29`. The skill loads the Linear MCP, runs `scripts/get-session.sh` against the parent JSONL, generates retrospective markdown, resolves the Altitude Devops team / Backlog state / `retro` label, and creates a new issue `ALT-42 — Retro: ALT-29 — Phase 4: pg-az-backup progress + result events` with the markdown body and a Source link back to ALT-29. Subagent returns the URL of ALT-42; skill appends it to the run report.*
+> *Phase 13: captures `$CLAUDE_SESSION_ID` (the parent session), spawns a `general-purpose` subagent on Sonnet, and tells it to invoke the `session-retrospective` skill with `--session-id <parent-id> --linear-issue ALT-29`. The skill loads the Linear MCP, runs `scripts/get-session.sh` against the parent JSONL, generates retrospective markdown, resolves the Altitude Devops team / Backlog state / `retro` label, and creates a new issue `ALT-42 — Retro: ALT-29 — Phase 4: pg-az-backup progress + result events` with the markdown body and a Source link back to ALT-29. Then adds a `relatedTo` relation between ALT-42 and ALT-29 so both issues show the link in their Linear side panel. Subagent returns the URL of ALT-42; skill appends it to the run report.*
 >
-> *Phase 14: every prior phase succeeded, so the skill `cd`s back to the repo root, runs `pnpm worktree-env delete alt-29 --force`, then `git worktree remove .claude/worktrees/alt-29`. Reports cleanup done. The `claude/alt-29` branch stays on the remote (the PR points at it).*
+> *Phase 14: every prior phase succeeded, so the skill invokes `Skill(finish-worktree, args: "alt-29")`. The finish-worktree skill verifies the tree is clean, the branch is fully pushed, and the PR exists; then `cd`s back to the repo root, runs `pnpm worktree-env delete alt-29 --force` and `git worktree remove .claude/worktrees/alt-29`. Reports cleanup done. The `claude/alt-29` branch stays on the remote (the PR points at it).*

--- a/.claude/skills/finish-worktree/SKILL.md
+++ b/.claude/skills/finish-worktree/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: finish-worktree
+description: Tears down a finished agent worktree — `cd`s back to the repo root, runs `pnpm worktree-env delete <slug> --force` to wipe the per-worktree VM/distro and registry entry, then `git worktree remove .claude/worktrees/<slug>` to remove the directory and git's tracking. The remote branch is left untouched (the PR points at it). Takes a slug or Linear issue ID as the argument (e.g. `/finish-worktree alt-32` or `/finish-worktree ALT-32`). This skill is the cleanup half of `execute-next-task` (Phase 14) extracted so it can be invoked manually after any worktree-based flow finishes — `fix-and-validate`, ad-hoc bugfixes, design exploration, anything where the worktree's purpose is over and the slot should be freed for the next run. Use this skill whenever the user says "finish worktree", "clean up worktree", "tear down worktree", "remove worktree", "done with worktree", "delete worktree alt-NN", "wrap up the alt-NN worktree", or any equivalent ask to dispose of a finished worktree. Do **not** trigger when there's still active work in the worktree, when the PR hasn't been opened yet, or when the run failed — leaving the worktree alive is the right answer in those cases. The skill itself defensively checks for uncommitted changes, unpushed commits, and missing PR before destroying anything, and stops to ask if it sees any of those.
+---
+
+# Finish Worktree
+
+This is a **cleanup skill**, not an execution agent. It tears down a finished agent worktree and frees the VM/distro slot. It's the cleanup half of `execute-next-task` (Phase 14) carved out so any worktree-based flow can dispose of its worktree at the end.
+
+The worktree's purpose is to host the build + smoke for some piece of work. Once the PR is open and review has moved to GitHub, the worktree is dead weight — it's holding a Colima profile / WSL2 distro slot, and `pnpm worktree-env list` clutters up. This skill removes it.
+
+The remote branch is **left alone** — that's where the PR points; it must remain.
+
+## Arguments
+
+The skill takes one required argument:
+
+- **`<slug-or-issue-id>`** — either the worktree slug (`alt-32`) or the Linear issue ID it was created from (`ALT-32`). The skill normalises both to the slug `alt-NN` (lowercase). Accepts surrounding text containing the pattern.
+
+If no argument is supplied, **stop and ask**. The skill never auto-picks "the most recent worktree" — that's the kind of guess that ends with someone's WIP being deleted.
+
+---
+
+## Phase 1 — Resolve and validate the target
+
+Normalise the argument to a slug:
+
+- `ALT-32` → `alt-32`
+- `alt-32` → `alt-32`
+- `pick up alt-32 please` → `alt-32` (extract the pattern)
+
+Then check that the worktree actually exists:
+
+```bash
+git worktree list
+```
+
+The output should contain `.claude/worktrees/<slug>` on branch `claude/<slug>`. If it doesn't:
+
+- **Worktree directory missing but branch exists** → maybe `git worktree remove` already ran but `pnpm worktree-env delete` didn't. Surface that and offer to run only the env-delete half.
+- **Neither exists** → the cleanup has already happened (or the slug is wrong). Tell the user and stop.
+
+---
+
+## Phase 2 — Defensive checks
+
+The hard rule from `execute-next-task` is *only run cleanup on the success path*. The skill can't fully verify "success" from outside the run, but it can catch the obvious mistakes — uncommitted changes, unpushed commits, missing PR — that mean the worktree shouldn't be destroyed yet.
+
+Run these checks from the worktree directory (`cd .claude/worktrees/<slug>` first, then `cd` back when you're done with the checks):
+
+1. **Uncommitted changes?**
+
+   ```bash
+   git status --porcelain
+   ```
+
+   Any output means there's work that would be lost. **Stop and surface the changes.** Ask the user whether to proceed (they may have intentionally abandoned the work) or abort so they can salvage it.
+
+2. **Unpushed commits?**
+
+   ```bash
+   git log @{u}..HEAD --oneline 2>/dev/null || git log --oneline
+   ```
+
+   The first form lists commits ahead of the upstream. If the branch has no upstream (never pushed), the fallback lists every commit on the branch — also a stop signal. Either way, surface what's unpushed and ask before proceeding.
+
+3. **PR open?**
+
+   ```bash
+   gh pr view --json url,state -q '.url + " (" + .state + ")"' 2>/dev/null
+   ```
+
+   If `gh` returns no PR, the work probably hasn't been shipped yet. Surface that and ask before proceeding. (`gh pr view` from inside the worktree finds the PR for the current branch.)
+
+If all three checks pass, proceed silently to Phase 3. If any check fails, the skill **stops and asks** rather than auto-proceeding — the cost of getting this wrong (lost work, deleted branch with unpushed commits) is much higher than the cost of one extra confirmation.
+
+---
+
+## Phase 3 — Tear down
+
+Run from the **repo root** (not the worktree — you can't delete the worktree you're standing in):
+
+```bash
+cd <repo-root>                                      # back out of the worktree
+pnpm worktree-env delete <slug> --force             # wipes VM/distro + registry entry
+git worktree remove .claude/worktrees/<slug>        # removes the directory + git's tracking
+```
+
+`<repo-root>` is the directory containing the `.claude/worktrees/` folder (the main checkout). `--force` skips the interactive confirmation that `pnpm worktree-env delete` would otherwise prompt for.
+
+The two commands do different things and both are needed:
+
+- **`pnpm worktree-env delete`** wipes the runtime — runs `docker compose down -v` against the worktree's project, deletes the per-worktree VM/distro (Colima profile on macOS, WSL2 distro on Windows), and removes the entry from `~/.mini-infra/worktrees.yaml`.
+- **`git worktree remove`** removes the working-tree directory and clears git's internal tracking of it.
+
+Skipping the first leaves a dead VM/distro slot. Skipping the second leaves a stale `.claude/worktrees/<slug>` directory and a `git worktree list` entry that points at nothing.
+
+If `git worktree remove` complains that the directory is "dirty" or has untracked files (which means Phase 2's checks missed something), **stop**. Don't auto-pass `--force` to git — investigate first; it usually means a build artifact or local config the user might want.
+
+---
+
+## Phase 4 — Report
+
+State what was cleaned up:
+
+```
+✓ Cleaned up worktree .claude/worktrees/<slug> and the dev-env VM.
+  Branch claude/<slug> remains on the remote (PR points at it).
+```
+
+If review feedback later requires changes on the same branch, the user (or another skill) can recreate the worktree from the same branch:
+
+```bash
+git fetch origin claude/<slug>
+git worktree add .claude/worktrees/<slug> claude/<slug>
+cd .claude/worktrees/<slug>
+pnpm install
+pnpm worktree-env start
+```
+
+Mention this in the report only if it seems relevant (e.g. the user is mid-review-cycle); otherwise the simple "cleaned up" line is enough.
+
+---
+
+## Hard rules
+
+- **Never run cleanup on a failure path.** If smoke failed, the PR didn't open, the work isn't shipped, or the user is mid-investigation, leave the worktree alive. Phase 2's defensive checks catch the obvious cases; if the user invokes the skill anyway and confirms past a warning, that's their call.
+- **Never delete the remote branch.** The PR points at it. Cleanup is local-only (worktree dir + VM/distro + registry entry).
+- **Never delete a worktree you're standing in.** `cd` to the repo root before running `git worktree remove`. Otherwise git refuses and you waste a turn diagnosing.
+- **Never auto-pick a worktree to delete.** The skill needs an explicit slug or issue ID. Guessing "the latest one" is how WIP gets nuked.
+- **Never pass `--force` to `git worktree remove` automatically.** If git refuses because the worktree is dirty, that's signal — investigate, don't override.
+- **Never produce an ExitPlanMode block.** This is a cleanup skill, not a planning skill.
+
+---
+
+## Example
+
+> User: `/finish-worktree ALT-29`
+>
+> *Skill normalises to slug `alt-29`. Runs `git worktree list`, sees `.claude/worktrees/alt-29` on `claude/alt-29`.*
+>
+> *Skill `cd`s into the worktree and runs the three defensive checks: `git status --porcelain` (clean), `git log @{u}..HEAD --oneline` (no unpushed commits), `gh pr view` (PR #412 open). All clear.*
+>
+> *Skill `cd`s back to the repo root. Runs `pnpm worktree-env delete alt-29 --force`, then `git worktree remove .claude/worktrees/alt-29`.*
+>
+> Skill: "✓ Cleaned up worktree `.claude/worktrees/alt-29` and the dev-env VM. Branch `claude/alt-29` remains on the remote (PR #412 points at it)."
+
+> User: `/finish-worktree alt-58`
+>
+> *Skill normalises (already a slug). Worktree exists. Defensive checks: `git status --porcelain` returns `M server/src/foo.ts`. **Stop.***
+>
+> Skill: "Worktree `alt-58` has uncommitted changes:
+>
+> ```
+> M server/src/foo.ts
+> ```
+>
+> Cleaning up will lose them. Proceed anyway, or do you want to handle them first?"

--- a/.claude/skills/plan-to-linear/SKILL.md
+++ b/.claude/skills/plan-to-linear/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan-to-linear
-description: Reads a phased markdown planning document under `docs/planning/` and either seeds Linear with a matching project plus one issue per phase (**create mode** — §8 has `ALT-_TBD_` placeholders) or refreshes an already-seeded project's issue bodies and dependency edges from the plan doc (**update mode** — §8 has real `ALT-NN` IDs). Each issue carries the phase's Goal / Deliverables / Reversibility / UI changes / Done when / Verify in prod, the relevant per-component CLAUDE.md and ARCHITECTURE.md pointers (server vs client vs lib vs go sidecars), a **Source-code touchpoints** section produced by a per-phase codebase exploration (best-guess New / Modify / Read paths) plus a **Shared-library opportunities** sub-section flagging types/constants/helpers that should land in `lib/` or `egress-shared/` rather than be duplicated, a Workflow section (worktree pre-flight, `pnpm install`, background `pnpm worktree-env start`), phase-specific smoke-test recipes derived from which directories the phase touches, prior-art commit references, and the commit/PR conventions — enough context that the `execute-next-task` skill can execute the issue without re-planning the high-level scope or re-exploring from scratch. Phases whose UI changes block contains one or more `[design needed]` items also get a **paired design ticket** auto-created in `Backlog` (designer-owned, kept out of the execute-next-task queue) and wired up as a `blocked-by` edge on the impl ticket — plan authors don't write standalone "Design: …" phases. Update mode preserves issue state, assignee, cycle, estimate, labels, and all prior comments (retros, handoff notes); only the body, title (if changed), and blocked-by edges are refreshed, and orphan issues (phases removed from the plan since seeding) are surfaced for manual handling rather than auto-deleted. In create mode, rewrites the plan doc's §8 to replace `ALT-_TBD_` placeholders with real issue IDs. Use this skill whenever the user says "populate linear from plan", "create the linear tickets", "plan to linear", "scaffold linear from this plan", "turn this plan into linear issues", "refresh linear from plan", "update linear issues", "re-sync linear from plan", "plan-to-linear refresh", or any equivalent request to seed *or* refresh Linear from a plan markdown. Do NOT trigger for one-off issue creation, for plans that aren't phased, or when the user wants to ad-hoc-edit a single Linear issue (use the Linear UI directly).
+description: Reads a phased markdown planning document under `docs/planning/` and either seeds Linear with a matching project plus one issue per phase (**create mode** — §8 has `ALT-_TBD_` placeholders) or refreshes an already-seeded project's issue bodies and dependency edges from the plan doc (**update mode** — §8 has real `ALT-NN` IDs). Each issue carries the phase's Goal / Deliverables / Reversibility / UI changes / Done when / Verify in prod, the relevant per-component CLAUDE.md and ARCHITECTURE.md pointers (server vs client vs lib vs go sidecars), a **Source-code touchpoints** section produced by a per-phase codebase exploration (best-guess New / Modify / Read paths) plus a **Shared-library opportunities** sub-section flagging types/constants/helpers that should land in `lib/` or `egress-shared/` rather than be duplicated, a Workflow section (worktree pre-flight, `pnpm install`, background `pnpm worktree-env start`), phase-specific smoke-test recipes derived from which directories the phase touches, prior-art commit references, and the commit/PR conventions — enough context that the `execute-next-task` skill can execute the issue without re-planning the high-level scope or re-exploring from scratch. Phases whose UI changes block contains one or more `[design needed]` items also get a **paired design ticket** auto-created in `Backlog` (designer-owned, kept out of the execute-next-task queue), tagged with the team's `design` label so designers can filter their queue with one chip, and wired up to the impl ticket via two relation edges — a `blocked-by` (the hard ordering constraint the picker reads) and a `related` (the soft "this design is for that work" link that stays visible in both issues' side panels even after the design has shipped). Plan authors don't write standalone "Design: …" phases. Update mode preserves issue state, assignee, cycle, estimate, labels, and all prior comments (retros, handoff notes); only the body, title (if changed), and blocked-by edges are refreshed, and orphan issues (phases removed from the plan since seeding) are surfaced for manual handling rather than auto-deleted. In create mode, rewrites the plan doc's §8 to replace `ALT-_TBD_` placeholders with real issue IDs. Use this skill whenever the user says "populate linear from plan", "create the linear tickets", "plan to linear", "scaffold linear from this plan", "turn this plan into linear issues", "refresh linear from plan", "update linear issues", "re-sync linear from plan", "plan-to-linear refresh", or any equivalent request to seed *or* refresh Linear from a plan markdown. Do NOT trigger for one-off issue creation, for plans that aren't phased, or when the user wants to ad-hoc-edit a single Linear issue (use the Linear UI directly).
 ---
 
 # Plan to Linear
@@ -58,9 +58,12 @@ Linear MCP tools are deferred. Load them in bulk before doing anything else:
 ToolSearch(query: "linear", max_results: 30)
 ```
 
-You need at minimum: `list_issues`, `get_issue`, `list_projects`, `get_project`, `save_project`, `save_issue`, `list_issue_statuses`. If any are missing, stop and tell the user.
+You need at minimum: `list_issues`, `get_issue`, `list_projects`, `get_project`, `save_project`, `save_issue`, `list_issue_statuses`, `list_issue_labels`. If any are missing, stop and tell the user.
 
-Also fetch the team's issue statuses once (`list_issue_statuses` for Altitude Devops) — you'll need the canonical names for `Todo` and `Backlog`. Different teams capitalise / name them differently.
+Also fetch, once each:
+
+- **Team issue statuses** via `list_issue_statuses` for Altitude Devops — you'll need the canonical names for `Todo` and `Backlog`. Different teams capitalise / name them differently.
+- **The `design` label** via `list_issue_labels` for Altitude Devops — used to tag every paired design ticket created in Phase 8.1 so designers can filter their queue with one label. If a label literally named `design` (case-insensitive) doesn't exist on the team, **create it** via `create_issue_label` with name `design` and a sensible colour (use the same blue/purple family Linear's UI suggests; if unsure, omit `color` and let Linear pick). Capture the label's ID — every design-ticket `save_issue` call in Phase 8.1 (and Phase 8 update-mode reconciliation when a new design ticket is born) will pass `labels: [<design-label-id>]`.
 
 ---
 
@@ -559,6 +562,8 @@ After the impl ticket is created, scan its UI changes block for items tagged `[d
 
 **State:** `Backlog`. Designers own these tickets; `execute-next-task` only picks from `Todo`, so `Backlog` keeps the design ticket out of the execution queue while letting designers transition through their own states normally.
 
+**Labels:** include the `design` label resolved in Phase 1 — pass `labels: [<design-label-id>]` on the `save_issue` call. Every paired design ticket carries this label so designers can filter their queue with one chip across all projects (and the user can build a single saved view for "what's on my plate"). The `execute-next-task` picker doesn't filter on this label — it filters on state — so the label is purely for designer ergonomics.
+
 **Description body:**
 
 ```markdown
@@ -632,37 +637,47 @@ Capture, for the Phase 11 report:
 
 ---
 
-## Phase 9 — Set blocking relationships
+## Phase 9 — Set blocking relationships and design↔impl relations
 
-Use the dependency graph you parsed in Phase 2, plus the design pairings from Phase 8.1, to compute the **desired** set of `blocked-by` edges for each impl ticket — the union of:
+Use the dependency graph you parsed in Phase 2, plus the design pairings from Phase 8.1, to compute the **desired** set of relationship edges. There are two relation types in play, and they answer different questions:
+
+- **`blocked-by`** — hard ordering constraint. The impl ticket cannot start until its blockers are Done. This is what the `execute-next-task` picker reads.
+- **`related`** (Linear's `relatedTo`) — soft "these belong together" link. Doesn't gate work; just makes the connection visible in both issues' side panels and queryable as a relation. Designers viewing a design ticket immediately see *which impl ticket consumes this design*, even after the design has shipped (and the blocked-by edge has resolved).
+
+Compute the **desired blocked-by set** for each impl ticket as the union of:
 
 - **Inter-phase edges from §8.** If §8 has `[blocks-by: N, M]` brackets, that's the source of truth — each phase wants a `blocked-by` edge to each listed phase. Else if prose hints exist, apply them ("Phase 1 blocks all later phases", "Phase N also blocks on Phase M"). Else default to **strictly sequential** — each phase from 2 onward is `blocked-by` the previous.
 - **Design pairing edge from Phase 8.1.** If the phase has a paired design ticket, the impl ticket also gets a `blocked-by` edge to that design ticket's ALT-NN.
 
+Compute the **desired related set** for each design↔impl pair created in Phase 8.1: a single `related` edge between the design ticket and the impl ticket. Linear treats `related` as symmetric, so adding it once on either side surfaces it on both. Add it on the design ticket pointing at the impl ticket — that mirrors the doc-style "this design is *for* that work" reading.
+
 Optional/deferred phases still get blocked-by relationships — being in `Backlog` doesn't mean unblocked. The blocker just means "even when promoted to Todo, wait for the predecessor".
 
-Design tickets themselves have **no `blocked-by` edges** — designers can start the moment the ticket is filed.
+Design tickets themselves have **no `blocked-by` edges** — designers can start the moment the ticket is filed. They only carry the `related` edge to their impl ticket.
 
 ### Create mode
 
-Add the desired edges in order via the Linear API. There's nothing to compare against — the issues were just created and have no relationships yet. The design→impl pairing edges are added alongside the inter-phase edges in the same pass.
+Add the desired edges in order via the Linear API. There's nothing to compare against — the issues were just created and have no relationships yet. The design→impl `blocked-by` edges and the design↔impl `related` edges are added in the same pass alongside the inter-phase edges.
 
 ### Update mode
 
-Existing edges may not match the desired graph — §8 brackets may have changed since seeding. Compute and apply the delta:
+Existing edges may not match the desired graph — §8 brackets may have changed since seeding. Compute and apply the delta for **both relation types** (`blocked-by` and `related`) independently:
 
-1. **Fetch existing relationships** for each issue in the project (`get_issue` returns relations on most Linear MCP implementations; otherwise use whatever relation-listing tool is loaded).
-2. **Compute the desired edge set** as above (from current §8 / prose / strict-sequential default).
-3. **Apply the delta**:
+1. **Fetch existing relationships** for each issue in the project (`get_issue` returns relations on most Linear MCP implementations; otherwise use whatever relation-listing tool is loaded). Read both relation types — `blocked-by` and `related` — into separate sets.
+2. **Compute the desired edge sets** as above:
+   - desired `blocked-by` set per impl ticket (inter-phase from §8 ∪ design pairing)
+   - desired `related` set per design↔impl pair from Phase 8.1
+3. **Apply the delta** independently per relation type:
    - **Add** edges that are desired but missing.
-   - **Remove** edges that exist but are no longer desired.
+   - **Remove** `blocked-by` edges that exist but are no longer desired (e.g. §8 brackets changed).
+   - For `related` edges: **add** when missing, **never remove**. The `related` link is cheap to keep around even if the impl ticket gets repurposed; deleting it costs context for designers, and Linear's UI lets users manually unrelate if they truly want to.
    - **Leave alone** edges that are correct.
    If the loaded MCP toolkit doesn't expose edge removal, surface the unremoved edges in the Phase 11 report and proceed — the user can clean them up manually rather than having the run fail.
-4. **Cross-project edges** (issues in this project blocked by issues in *other* projects) are out of scope for this skill — leave them untouched even if §8 makes no mention of them. They were added deliberately; we won't second-guess.
+4. **Cross-project edges** (issues in this project blocked by issues in *other* projects) are out of scope for this skill — leave them untouched even if §8 makes no mention of them. They were added deliberately; we won't second-guess. Same rule for cross-project `related` edges — humans add those; the skill doesn't touch them.
 
 For phases newly created during this update run (Phase 8 update-mode tail), apply their desired edges from scratch (same as create mode for those issues).
 
-For design tickets newly created during the Phase 8 update-mode design reconciliation (a phase newly has `[design needed]` items), add the design→impl `blocked-by` edge from scratch. For impl tickets whose paired design ticket was just created, add the new design→impl edge alongside any other edge changes — the impl ticket's `blocked-by` set is recomputed end-to-end (inter-phase from §8 ∪ design pairing), and the delta logic above handles add/remove/leave-alone uniformly.
+For design tickets newly created during the Phase 8 update-mode design reconciliation (a phase newly has `[design needed]` items), add both the design→impl `blocked-by` edge and the design↔impl `related` edge from scratch. For impl tickets whose paired design ticket was just created, the impl ticket's `blocked-by` set is recomputed end-to-end (inter-phase from §8 ∪ design pairing), and the delta logic above handles add/remove/leave-alone uniformly.
 
 ---
 

--- a/.claude/skills/setup-worktree/SKILL.md
+++ b/.claude/skills/setup-worktree/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: setup-worktree
+description: Sets up a fresh git worktree for a Linear issue — pre-flights main, pulls latest, creates the worktree at `.claude/worktrees/alt-NN` on branch `claude/alt-NN`, runs `pnpm install`, and (by default) kicks off `pnpm worktree-env start` in the background to warm the dev VM/distro. Takes a Linear issue ID as the argument (e.g. `/setup-worktree ALT-32`). Pass `--no-env` to skip the dev-env spin-up — useful for docs-only changes or when the caller doesn't need a running stack. This skill is the worktree-prep half of `execute-next-task` (Phases 4 through 6) extracted so it can be reused by other skills (e.g. `fix-and-validate`, ad-hoc bugfix flows) and called directly by the user when they want a worktree without the full execute-end-to-end loop. Use this skill whenever the user says "set up a worktree", "setup a worktree for ALT-NN", "create a worktree", "spin up a worktree", "new worktree for ALT-NN", "worktree for ALT-NN", "make me a worktree", or any equivalent ask to scaffold a fresh agent worktree from main. Do **not** trigger when the user is already inside a worktree and wants to keep working there, or when they want the full execute-next-task flow (which already calls this internally).
+---
+
+# Setup Worktree
+
+This is a **scaffolding skill**, not an execution agent. It gets a fresh worktree from `main` ready for work — pre-flights, pulls, creates the worktree and branch, installs deps, and (by default) warms the dev environment in the background — then hands control back to the caller. It does **not** read Linear tickets, do code changes, or open PRs.
+
+It's the worktree-prep half of `execute-next-task` (Phases 4–6) carved out so other flows can reuse it: `fix-and-validate` for issue-driven bugfixes, ad-hoc "fix this thing" sessions, design-doc PR flows, anything that needs an isolated worktree without the full execute-end-to-end loop.
+
+## Arguments
+
+The skill takes one required argument and one optional flag:
+
+- **`<ALT-NN>`** (required) — the Linear issue ID this worktree is for. Used to derive the slug (`alt-NN`, lowercased) and branch (`claude/alt-NN`). Accepts `ALT-32`, `alt-32`, or surrounding text containing the pattern.
+- **`--no-env`** (optional) — skip Phase 4 (the `pnpm worktree-env start` background warm-up). Use this when the caller knows the change is docs-only or when they explicitly don't want a running dev stack.
+
+The skill also accepts an optional `--description "<short summary>"` to pass through to `pnpm worktree-env start`. If omitted, the skill tries to fetch the Linear issue title (when the Linear MCP is loaded) and derives a ≤10-word description from it. If the title isn't available and no description was passed, prompt the user once for one — `pnpm worktree-env start` requires a description on first run for a new worktree.
+
+If `ALT-NN` isn't supplied, **stop and ask** — there's no reasonable default. The slug and branch name come from the issue ID, so the skill can't proceed without it.
+
+---
+
+## Phase 1 — Pre-flight on main
+
+The skill assumes you start at the **main checkout root**, on `main`, with a clean tree. The first job is to confirm that and pull the latest. (This phase is identical to Phase 4 of `.claude/skills/execute-next-task/SKILL.md` — see there for the full reasoning.)
+
+```bash
+pwd
+git rev-parse --abbrev-ref HEAD
+git status
+```
+
+Required state:
+
+- **`pwd` is the repo root**, not under `.claude/worktrees/`. If you're already in a worktree, exit to the root and re-run.
+- **Branch is the repo's default** (usually `main`; confirm with `git symbolic-ref refs/remotes/origin/HEAD --short` if unsure).
+- **Working tree is clean** — no uncommitted changes.
+
+If any of these fail, **stop with a clear message**. Don't auto-stash, auto-checkout, or guess — the user's WIP elsewhere matters more than this skill's convenience.
+
+Then update main:
+
+```bash
+git pull --ff-only origin main
+```
+
+`--ff-only` means a stale local main with non-pushed commits surfaces as an error rather than being silently merged. If it fails, stop and tell the user.
+
+---
+
+## Phase 2 — Create the worktree
+
+Derive the worktree slug from the Linear issue ID:
+
+- **Slug**: `alt-<NN>` (lowercase). For `ALT-29`, slug is `alt-29`.
+- **Worktree path**: `.claude/worktrees/<slug>` — relative to the repo root. (The repo's existing convention puts worktrees here; root `CLAUDE.md` walks through the layout.)
+- **Branch**: `claude/<slug>` — namespaces it as agent-created, matching the other `claude/...` branches.
+
+Create the worktree off the freshly-pulled main:
+
+```bash
+git worktree add .claude/worktrees/<slug> -b claude/<slug>
+cd .claude/worktrees/<slug>
+```
+
+`cd` into it for the rest of the skill — every later step runs from this directory.
+
+If the directory or branch already exists, **stop and ask** — don't auto-resume someone else's worktree, and don't reuse a stale branch silently. The user's `pnpm worktree-env delete <slug>` (root `CLAUDE.md`) is the right tool to clean up first; or, if there's actual work on the existing branch, the user may want to `cd` into the existing worktree and continue rather than recreate.
+
+---
+
+## Phase 3 — Install dependencies
+
+Fresh worktrees do not share `node_modules` with the main checkout (per root `CLAUDE.md`). Always run:
+
+```bash
+pnpm install
+```
+
+This is required before any other `pnpm` command — including `pnpm worktree-env` itself, which runs through `tsx` (which lives in `node_modules`). Run synchronously; you need it to finish before Phase 4 can use the CLI.
+
+If `pnpm install` fails, stop and surface the output. Don't paper over with `--force` or `--shamefully-hoist` — figure out why.
+
+---
+
+## Phase 4 — Spin up the dev environment in the background (skip if `--no-env`)
+
+If the caller passed `--no-env`, **skip this phase entirely** and proceed to Phase 5. State that explicitly so the user knows the env wasn't started.
+
+Otherwise, kick off the dev env in the background. `pnpm worktree-env start` takes a few minutes the first time, building the per-worktree VM/distro — backgrounding it lets the caller get on with code reads / file edits while the env warms. Use the `Bash` tool's `run_in_background: true`:
+
+```bash
+pnpm worktree-env start --description "<short summary, ≤10 words>"
+```
+
+Pick the description in this order:
+
+1. If the caller passed `--description "..."`, use it verbatim.
+2. Otherwise, if the Linear MCP is loaded and `ALT-NN` resolves, fetch the issue title with `mcp__claude_ai_Linear__get_issue` and truncate to ≤10 words.
+3. Otherwise, prompt the user once for a description.
+
+Don't wait for the background task to finish — the caller will check on it (or use the smoke-test phase of whichever flow invoked this skill). The command is idempotent and safe to re-run.
+
+---
+
+## Phase 5 — Report and hand back
+
+State the final scaffolding result so the caller knows where it is:
+
+- Worktree path: `.claude/worktrees/<slug>`
+- Branch: `claude/<slug>`
+- `pnpm install` status: done
+- Env startup: backgrounded *(or "skipped — `--no-env`" if Phase 4 was skipped)*
+- Current working directory: the worktree
+
+The skill's job ends here. The caller (another skill or the user) takes it from this state.
+
+---
+
+## Hard rules
+
+These mirror the rules in `execute-next-task` for the same reasons:
+
+- **Never run on a dirty tree or a non-default branch.** Phase 1 stops; don't auto-stash or auto-checkout to make it work.
+- **Never reuse an existing worktree directory or branch silently.** If `.claude/worktrees/<slug>` or `claude/<slug>` already exists, stop and ask. The right cleanup is `pnpm worktree-env delete <slug>` and (if needed) `git worktree remove`, then re-run.
+- **Never `git checkout main`, `git stash`, or create a branch outside the worktree convention.** Worktree lifecycle is the user's responsibility — the skill's only environment side-effects are `pnpm install` and the optional backgrounded `pnpm worktree-env start`, both inside the new worktree.
+- **Never skip `pnpm install`.** Worktrees do not share `node_modules`. Skipping breaks every subsequent `pnpm` command, including the `worktree-env` CLI itself.
+- **Never wait for `pnpm worktree-env start` synchronously.** It takes minutes; backgrounding is the whole point. (If the caller genuinely needs the env up before continuing, that's the caller's problem to solve via Bash status checks.)
+- **Never produce an ExitPlanMode block.** This is a scaffolding skill, not a planning skill.
+
+---
+
+## Example
+
+> User: `/setup-worktree ALT-47`
+>
+> *Skill runs `pwd`, `git rev-parse --abbrev-ref HEAD`, `git status`. Repo root, on `main`, clean.*
+>
+> *Skill runs `git pull --ff-only origin main`. Already up to date.*
+>
+> *Skill runs `git worktree add .claude/worktrees/alt-47 -b claude/alt-47`, then `cd .claude/worktrees/alt-47`.*
+>
+> *Skill runs `pnpm install` synchronously. Done in 12s.*
+>
+> *Skill calls `mcp__claude_ai_Linear__get_issue(id: "ALT-47")` to get the title — "Phase 2: tunnel reconciler retry budget" — and truncates to "tunnel reconciler retry budget".*
+>
+> *Skill runs `pnpm worktree-env start --description "tunnel reconciler retry budget"` in the background.*
+>
+> Skill: "Worktree ready at `.claude/worktrees/alt-47` on branch `claude/alt-47`. `pnpm install` done. Dev env warming in the background. Working directory is the worktree."
+
+> User: `/setup-worktree ALT-58 --no-env`
+>
+> *Skill runs Phases 1–3 as above, then skips Phase 4.*
+>
+> Skill: "Worktree ready at `.claude/worktrees/alt-58` on branch `claude/alt-58`. `pnpm install` done. Dev env startup skipped (`--no-env`). Working directory is the worktree."


### PR DESCRIPTION
## Summary
- New `setup-worktree` and `finish-worktree` skills extracted from `execute-next-task`'s worktree-prep (Phases 4–6) and cleanup (Phase 14) so other flows can reuse them. `setup-worktree` defaults to backgrounding `pnpm worktree-env start`; pass `--no-env` to skip for docs-only callers. `finish-worktree` defensively checks for uncommitted changes, unpushed commits, and missing PR before tearing down.
- `execute-next-task` and `design-task` now delegate through the new skills. `design-task` drops the manual `git checkout -b design/...` flow and writes designs inside a `claude/alt-NN` worktree.
- Linear relation upgrades:
  - `execute-next-task` Phase 13.2 instructs the retro subagent to add a `relatedTo` edge between the new retro issue and the original ALT-NN.
  - `plan-to-linear` tags every paired design ticket with the team's `design` label (auto-created if missing) and adds a `related` edge between design and impl alongside the existing `blocked-by`. Update-mode delta is add-only for `related` to avoid unrelating things humans curated.

## Test plan
- [ ] Run `/setup-worktree ALT-NN` end-to-end on a fresh main checkout — confirm worktree at `.claude/worktrees/alt-NN`, branch `claude/alt-NN`, `pnpm install` ran, env warming in background.
- [ ] Run `/setup-worktree ALT-NN --no-env` — confirm env is skipped, otherwise identical.
- [ ] Run `/finish-worktree alt-NN` against a worktree that's clean / fully pushed / has an open PR — confirm cleanup completes and remote branch survives.
- [ ] Run `/finish-worktree alt-NN` against a dirty worktree — confirm it stops and asks before destroying anything.
- [ ] Run `/execute-next-task ALT-NN` end-to-end on a small docs-only ticket — confirm setup-worktree and finish-worktree fire correctly.
- [ ] Run `/design-task ALT-NN` — confirm design doc lands inside a worktree on `claude/alt-NN`, unstaged.
- [ ] Run `plan-to-linear` create-mode on a fresh plan with a `[design needed]` phase — confirm the design ticket gets the `design` label and the Linear side panel shows both blocked-by and Related edges to the impl ticket.
- [ ] Run a successful `execute-next-task` to completion and confirm the retro issue and original issue both show the `relatedTo` link in their Linear side panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)