### PR TITLE
feat(skills): design-task auto-PRs the doc and moves ticket to In Review

### DIFF
--- a/.claude/skills/design-task/SKILL.md
+++ b/.claude/skills/design-task/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: design-task
-description: Design-exploration agent for a Linear ticket. Accepts an **optional issue ID** as an argument (e.g. `/design-task ALT-38`) — when supplied, the skill jumps straight to that issue and skips the picking flow; when omitted, it picks the next unblocked Todo issue from the user's Linear team (Altitude Devops), the same picking flow as `execute-next-task`. Reads the ticket body (Goal / Deliverables / Done when) and any plan-doc context if the parent project has a `Plan:` line. Instead of consuming per-component CLAUDE.md / ARCHITECTURE.md pointers like `execute-next-task` does, this skill **researches design patterns** — architectural / structural / behavioural patterns relevant to the task, plus existing patterns already used in the Mini Infra codebase that could be reused. Generates **two distinct design options**, each with pros/cons, key abstractions, file/component sketch, a rough implementation outline, and — for UI tickets — a wireframe written to a sibling SVG file (`<issue-id>-<slug>-option-<a|b>.svg` next to the markdown, referenced via `![](…)`) plus a "UI components to use" mapping that names existing `client/src/components/ui/*` primitives and feature components to wire up, written to `docs/designs/<issue-id>-<slug>.md` (single file with both options side-by-side), commits to a recommendation, posts a "design ready" comment on the impl ticket pointing at the file (so a future `execute-next-task` run finds it), and **marks the design ticket Done** — the design doc + recommendation are the deliverable, and the impl ticket unblocks immediately. Delegates worktree creation to the `setup-worktree` skill (with `--no-env`, since design is markdown-only and no dev env is needed). Does NOT open a PR — the user reviews the doc and commits/PRs it on their own cadence; the worktree can be torn down later via `finish-worktree` when the design has shipped. Use this skill whenever the user says "design ALT-NN", "design the next task", "explore design options for ALT-NN", "give me two designs for ALT-NN", "what are the design options for ALT-NN", "design-task", "come up with designs for the next ticket", or any equivalent request to brainstorm two alternative designs for a Linear-tracked task before execution begins. Do NOT trigger when the user wants to actually execute the work (use `execute-next-task` for that), or for non-Linear design questions, or for ad-hoc architecture discussions without a Linear ticket attached.
+description: Design-exploration agent for a Linear ticket. Accepts an **optional issue ID** as an argument (e.g. `/design-task ALT-38`) — when supplied, the skill jumps straight to that issue and skips the picking flow; when omitted, it picks the next unblocked Todo issue from the user's Linear team (Altitude Devops), the same picking flow as `execute-next-task`. Reads the ticket body (Goal / Deliverables / Done when) and any plan-doc context if the parent project has a `Plan:` line. Instead of consuming per-component CLAUDE.md / ARCHITECTURE.md pointers like `execute-next-task` does, this skill **researches design patterns** — architectural / structural / behavioural patterns relevant to the task, plus existing patterns already used in the Mini Infra codebase that could be reused. Generates **two distinct design options**, each with pros/cons, key abstractions, file/component sketch, a rough implementation outline, and — for UI tickets — a wireframe written to a sibling SVG file (`<issue-id>-<slug>-option-<a|b>.svg` next to the markdown, referenced via `![](…)`) plus a "UI components to use" mapping that names existing `client/src/components/ui/*` primitives and feature components to wire up, written to `docs/designs/<issue-id>-<slug>.md` (single file with both options side-by-side), commits to a recommendation, **commits + pushes + opens a PR** for the design artefacts (so reviewers have a real review surface), posts a "design ready" comment on the impl ticket pointing at the PR (so a future `execute-next-task` run finds it), and **moves the design ticket to In Review** — the design doc + recommendation are the deliverable, the PR is the review surface, and Linear's GitHub integration auto-flips the issue to Done (unblocking the impl ticket) when the PR merges via the `Closes ALT-NN` line in the commit. Delegates worktree creation to the `setup-worktree` skill (with `--no-env`, since design is markdown-only and no dev env is needed). The worktree is torn down later via `finish-worktree` once the PR has merged. Use this skill whenever the user says "design ALT-NN", "design the next task", "explore design options for ALT-NN", "give me two designs for ALT-NN", "what are the design options for ALT-NN", "design-task", "come up with designs for the next ticket", or any equivalent request to brainstorm two alternative designs for a Linear-tracked task before execution begins. Do NOT trigger when the user wants to actually execute the work (use `execute-next-task` for that), or for non-Linear design questions, or for ad-hoc architecture discussions without a Linear ticket attached.
 ---
 
 # Design Task
 
 You're a **design-exploration agent**. The Linear ticket describes *what* needs to happen (Goal, Deliverables, Done when). Your job is to propose *how* — by surveying relevant design patterns, finding what's already in the Mini Infra codebase that fits, writing up **two distinct design options**, and **committing to a recommendation**.
 
-This skill is the planning step that sits **between** ticket creation (`task-to-linear` / `plan-to-linear`) and execution (`execute-next-task`). It produces a design doc, posts a Linear comment pointing at it, and marks the design ticket **Done** so the impl ticket unblocks immediately. The recommendation in the doc is the call — there's no "user picks an option" step. If the user disagrees, they can edit the doc and re-comment; the default flow assumes the recommendation stands. **The skill creates a worktree** (via `setup-worktree --no-env`) so the design doc lives on its own branch in its own checkout — but it **opens no PR** and **does not commit** the doc. The user reviews and commits/PRs at their own pace, then runs `/finish-worktree alt-NN` to free the slot once the design has shipped.
+This skill is the planning step that sits **between** ticket creation (`task-to-linear` / `plan-to-linear`) and execution (`execute-next-task`). It produces a design doc, **commits + pushes the worktree branch and opens a PR**, posts Linear comments pointing at the PR, and moves the design ticket to **In Review**. The recommendation in the doc is the call — there's no "user picks an option" step. If the user disagrees, they can edit the PR and re-comment; the default flow assumes the recommendation stands. **The skill creates a worktree** (via `setup-worktree --no-env`) so the design doc lives on its own branch in its own checkout, then ships it as a PR. The user reviews and merges the PR on their own cadence — Linear's GitHub integration parses the `Closes ALT-NN` line in the commit and auto-flips the issue to Done on merge, unblocking the impl ticket. After the PR has merged, the user runs `/finish-worktree alt-NN` to free the slot.
 
-The Done-when in the ticket body (often "Figma frames signed off") is informational. The skill considers the design doc + recommendation to be the actual deliverable, and marks the Linear issue Done on that basis. If the team starts wanting Figma frames again, that's a future change to this skill.
+The Done-when in the ticket body (often "Figma frames signed off") is informational. The skill considers the design doc + recommendation to be the actual deliverable, and the design ticket completes on PR merge. If the team starts wanting Figma frames again, that's a future change to this skill.
 
 ## What "two distinct designs" means
 
@@ -40,7 +40,9 @@ ToolSearch(query: "linear", max_results: 30)
 
 You should see tools like `mcp__cd9fab4e-...__list_issues`, `__get_issue`, `__get_project`, `__list_comments`, `__save_comment`, `__save_issue`, `__list_issue_statuses`. If any of these are missing, stop and tell the user — don't fall back to anything else.
 
-Note: this skill calls `save_issue` exactly once, at the very end (Phase 8), to mark the issue Done. No other state transitions.
+Note: this skill calls `save_issue` exactly once, near the end (Phase 8), to move the issue to **In Review**. No other state transitions. The Done transition happens automatically when the PR merges, via Linear's GitHub integration parsing the `Closes ALT-NN` line in the commit.
+
+The phase order is deliberate: write the doc (Phase 5) → commit + push + PR (Phase 6) → Linear comments linking to the PR (Phase 7) → move to In Review (Phase 8). The Linear comments need the PR URL, so the PR must exist before they're posted; the In Review transition happens last so the comments post against the previous (Todo) state.
 
 ---
 
@@ -75,9 +77,9 @@ Same rule as `execute-next-task`: state = `Todo`, no unfinished `blocked-by`. No
 
 ### 2.1 No state transition at the start
 
-Unlike `execute-next-task`, this skill does **not** transition the issue to In Progress when it picks the ticket. Design exploration is fast and one-shot — the only state change happens at the very end (Phase 8), when the doc is written and the recommendation is settled, and the issue moves straight from `Todo` to `Done`. There's no "In Progress" leg because there's no useful window where the design ticket is half-done.
+Unlike `execute-next-task`, this skill does **not** transition the issue to In Progress when it picks the ticket. Design exploration is fast and one-shot — the only state change this skill makes is at the very end (Phase 8), when the doc is written, the PR is open, and the issue moves from `Todo` to `In Review`. There's no "In Progress" leg because there's no useful window where the design ticket is half-done. The terminal `Done` transition is left to Linear's GitHub integration parsing the PR's `Closes ALT-NN` line on merge.
 
-If the user is re-running design on a ticket that is already `In Progress` or `Done` (per the soft validations above), respect their confirmation and proceed — the final Phase 8 transition still runs and re-asserts `Done`.
+If the user is re-running design on a ticket that is already `In Progress`, `In Review`, or `Done` (per the soft validations above), respect their confirmation and proceed — the final Phase 8 transition still runs and re-asserts `In Review`.
 
 ---
 
@@ -378,17 +380,88 @@ If `setup-worktree` stops because the worktree or branch already exists, that's 
 
 If `setup-worktree` stops for any other reason (dirty tree, non-default branch on the calling shell, `pnpm install` failure), surface the failure and stop — don't fall back to writing the doc on the current branch.
 
-**Do not commit** the file automatically. The design doc is meant to be reviewed and iterated on — committing locks it in before that happens. Leave the file unstaged; the user commits (or asks you to) after reading.
+Leave the file unstaged at this point — Phase 6 is responsible for the commit + push + PR. Don't `git add` from inside Phase 5.
 
 The branch is `claude/alt-<NN>` (matching execute-next-task's convention), not the legacy `design/...` shape — using one prefix for both flows simplifies cleanup via `/finish-worktree`.
 
 ---
 
-## Phase 6 — Comment on the design ticket *and* the impl ticket
+## Phase 6 — Commit, push, open a PR
 
-Two comments here, not one. Both are short navigation aids — the design doc itself is the artefact.
+The design doc is the deliverable; reviewers want it on a PR they can comment on inline, not as a stash sitting in a worktree. Commit the design artefacts, push the branch, and open a PR via `gh pr create`. The PR URL feeds the Linear comments in Phase 7, so this phase has to run before commenting.
 
-### 6.1 Comment on the design ticket
+### 6.1 Stage and commit
+
+From the worktree (you're already `cd`ed in from Phase 5.4):
+
+```bash
+git add docs/designs/<filename>.md \
+        docs/designs/<filename>-option-a.svg \
+        docs/designs/<filename>-option-b.svg
+```
+
+Adjust the SVG paths to match what was actually written — drop them entirely if neither option had a wireframe; include only one if the options shared a wireframe; include extras if the design has more wireframes (e.g. a separate state-flow diagram). **Don't `git add .`** — keep the commit scoped to the design artefacts so a stale `pnpm-lock.yaml` change or anything else picked up by the worktree doesn't sneak in.
+
+Commit using the `docs(designs):` prefix the repo's existing design-doc commits use (run `git log --oneline -- docs/designs/` if you want to confirm the style):
+
+```bash
+git commit -m "$(cat <<'EOF'
+docs(designs): <short title> (<ALT-NN>)
+
+<1–2 sentences: what was explored, what was picked, the why-in-one-line.
+Pull from §Recommendation; don't restate the whole doc.>
+
+Closes <ALT-NN>.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+The `Closes <ALT-NN>` line is what wires Linear's GitHub integration into the auto-Done flip when the PR merges — without it, Phase 8's In Review move would stick around until manually closed. Don't omit it.
+
+### 6.2 Push the branch
+
+```bash
+git push -u origin claude/alt-<NN>
+```
+
+`-u` sets the upstream so subsequent pushes don't need it. If the push fails (network, permissions, branch-protection rule), surface the error and stop. Phase 7's Linear comments depend on a pushed branch and a real PR URL; don't fall back to relative-path links unless the user explicitly asks you to (which Phase 7's URL-derivation already supports as a manual override).
+
+### 6.3 Open the PR
+
+```bash
+gh pr create --title "docs(designs): <short title> (<ALT-NN>)" --body "$(cat <<'EOF'
+## Summary
+- <1-line: what's being designed>
+- **Option A — <name>** — <one-line gist>
+- **Option B — <name>** — <one-line gist>
+- **Recommendation: Option <X>** — <one-sentence reason>
+
+## Test plan
+- [ ] Skim `docs/designs/<filename>.md` end-to-end.
+- [ ] Open the sibling SVG wireframe(s) in a previewer.
+- [ ] Confirm the recommendation lines up with the relevant plan-doc deliverables.
+- [ ] <one bullet per Open question in the doc — these are choices the reviewer should resolve before the impl ticket starts>
+
+Closes <ALT-NN>.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+`gh pr create` prints the PR URL on success — **capture it**, you'll need it in Phase 7. The PR title mirrors the commit title so the PR list reads cleanly.
+
+If `gh pr create` fails (no `gh` auth, repo settings, branch-protection rules), surface the error and stop. Don't retry silently. The user can authenticate `gh` and re-run the skill, or open the PR manually and paste the URL into Phase 7's comments — but don't try to half-ship by posting Linear comments without a PR.
+
+---
+
+Two comments here, not one. Both are short navigation aids — the design PR is the artefact.
+
+The PR URL captured in Phase 6.3 is what both comments link to. Reviewers can read the doc rendered in GitHub, comment inline on either the markdown or the SVG wireframes, and merge from one place — that's strictly better than pointing at a blob URL on a feature branch.
+
+### 7.1 Comment on the design ticket
 
 ```
 save_comment(issueId: <design-ALT-NN>, body: <see template>)
@@ -397,7 +470,7 @@ save_comment(issueId: <design-ALT-NN>, body: <see template>)
 Template:
 
 ```markdown
-**Designs drafted:** [`docs/designs/<filename>.md`](<https URL to file on the design branch, if pushed; otherwise the relative path>)
+**Designs drafted (PR open):** [`<PR title>`](<PR URL captured in Phase 6.3>)
 
 Two options explored:
 - **Option A — <name>** — <one-line gist>
@@ -405,14 +478,14 @@ Two options explored:
 
 **Picked: Option <X>** — <one-sentence reason from §Recommendation>.
 
-Marking this design ticket Done — `/execute-next-task <impl-ALT-NN>` is unblocked. If you disagree with the pick, edit the doc and reopen the ticket.
+Moving this design ticket to In Review — once the PR merges, Linear's GitHub integration auto-closes it via `Closes <ALT-NN>` and `/execute-next-task <impl-ALT-NN>` becomes unblocked. If you disagree with the pick, comment on the PR or reopen the ticket.
 ```
 
-If the parent ticket lists an impl ticket it blocks (look at the issue's `relations.blocks[]` from the original `get_issue` call), name that ticket explicitly so the user has a one-click follow-up. If there's no blocked impl ticket, drop that clause.
+If the parent ticket lists an impl ticket it blocks (look at the issue's `relations.blocks[]` from the original `get_issue` call), name that ticket explicitly so the user has a one-click follow-up. If there's no blocked impl ticket, drop the impl-ticket clause.
 
-### 6.2 Comment on the impl ticket (if there is one)
+### 7.2 Comment on the impl ticket (if there is one)
 
-`execute-next-task` reads the impl ticket's body as the contract and skims its comments. The impl ticket needs a pointer to the design doc, otherwise a future executor opens the ticket cold and has no idea a design pass happened. Don't edit the impl ticket's body — comments are sufficient and don't risk corrupting the contract.
+`execute-next-task` reads the impl ticket's body as the contract and skims its comments. The impl ticket needs a pointer to the design PR, otherwise a future executor opens the ticket cold and has no idea a design pass happened. Don't edit the impl ticket's body — comments are sufficient and don't risk corrupting the contract.
 
 If `relations.blocks[]` on the design issue contains exactly one impl ticket (the typical shape produced by `plan-to-linear`), post:
 
@@ -423,46 +496,43 @@ save_comment(issueId: <impl-ALT-NN>, body: <see template>)
 Template:
 
 ```markdown
-**Design ready:** [`docs/designs/<filename>.md`](<https URL on design branch, if pushed; else relative path>)
+**Design ready (PR open):** [`<PR title>`](<PR URL captured in Phase 6.3>) — design doc at `docs/designs/<filename>.md` once merged.
 
 **Picked: Option <X>** — <one-sentence reason from §Recommendation>.
 
-Read this before starting implementation — it includes Key abstractions, File / component sketch, and Implementation outline that the design doc commits to. Open questions in the doc are unresolved choices that may matter at implementation time.
+Read this before starting implementation — it includes Key abstractions, File / component sketch, and Implementation outline that the design doc commits to. Open questions in the doc are unresolved choices that may matter at implementation time. Wait for the design PR to merge before kicking off `/execute-next-task` — the doc lands on `main` at that point and the design ticket auto-closes.
 ```
 
-If `relations.blocks[]` is empty (standalone design, no impl ticket), skip 6.2. If it contains more than one impl ticket (rare — usually a planning mistake), post the comment on each one and surface the multi-target case to the user in the final report.
-
-### 6.3 URL derivation
-
-If the design branch has been pushed to the remote, link to the file via its GitHub URL (`https://github.com/<owner>/<repo>/blob/<branch>/docs/designs/...md`) so both comments are clickable from Linear. If it hasn't been pushed, the relative path is fine — the user can always view it locally.
-
-Derive the GitHub URL by reading `git remote get-url origin` and combining with the current branch name.
+If `relations.blocks[]` is empty (standalone design, no impl ticket), skip 7.2. If it contains more than one impl ticket (rare — usually a planning mistake), post the comment on each one and surface the multi-target case to the user in the final report.
 
 ---
 
-## Phase 7 — Mark the issue Done
+## Phase 8 — Move the issue to In Review
 
-The design doc + recommendation are the deliverable, so the design ticket is now finished. Transition the issue from its current state straight to `Done`:
+The PR is open, the comments are posted. Move the design ticket from `Todo` to `In Review` so the Linear board reflects the actual state of play:
 
 ```
-save_issue(id: <ALT-NN>, state: "Done")
+save_issue(id: <ALT-NN>, state: "In Review")
 ```
 
-That single call is all this phase does. It unblocks any impl ticket that had this design ticket as a `blocked-by` edge — `execute-next-task` can pick the impl ticket up immediately. If `save_issue` errors (e.g. workspace permissions changed), surface the error to the user and tell them to mark Done manually; do not retry silently.
+That single call is all this phase does. The Done transition is **not** this skill's job — Linear's GitHub integration parses the `Closes <ALT-NN>` line in the merge commit and auto-flips the issue to Done when the PR merges, at which point any impl ticket that had this design ticket as a `blocked-by` edge becomes pickable by `execute-next-task`.
+
+If `save_issue` errors (e.g. workspace permissions changed, "In Review" doesn't exist as a state in the team — verify with `list_issue_statuses(team: "Altitude Devops")` if you suspect this), surface the error to the user and tell them to move the issue manually; do not retry silently and do not fall back to a different state without asking.
 
 The Done-when on the ticket body (often "Figma frames signed off") is **informational, not gating**. The recommendation in the doc is what the team is going to ship; treating Figma sign-off as a hard gate would only stall the impl ticket. If a future user wants Figma in the loop they'll change the skill, not the per-run behaviour.
 
 ---
 
-## Phase 8 — Final report to the user
+## Phase 9 — Final report to the user
 
 End the run with a tight summary so the user knows what landed:
 
 ```
-✓ Design doc written: docs/designs/<filename>.md (in worktree .claude/worktrees/alt-<NN>, branch claude/alt-<NN>, unstaged)
+✓ Design doc written + committed: docs/designs/<filename>.md (worktree .claude/worktrees/alt-<NN>, branch claude/alt-<NN>)
+✓ PR opened: <PR URL>
 ✓ Linear comment posted on design ticket <ALT-NN>
 ✓ "Design ready" comment posted on impl ticket <ALT-MM>
-✓ <ALT-NN> marked Done (impl ticket <ALT-MM> unblocked)
+✓ <ALT-NN> moved to In Review (auto-closes when the PR merges; impl ticket <ALT-MM> unblocks then)
 
 Two options:
   A) <name> — <one-line>
@@ -470,24 +540,25 @@ Two options:
 
 Picked: Option <X> — <one-line reason>.
 
-Next: review the doc, commit + PR + merge it on your cadence, then run /finish-worktree alt-<NN> to free the slot.
-If you disagree with the pick, edit the doc and re-comment / reopen the ticket.
+Next: review and merge the PR on your cadence. After merge, run /finish-worktree alt-<NN> to tear down the worktree.
+If you disagree with the pick, comment on the PR or close it and reopen the ticket.
 ```
 
-If there's no impl ticket the design ticket was blocking, drop both the impl-ticket comment line and the "(impl ticket … unblocked)" clause.
+If there's no impl ticket the design ticket was blocking, drop the impl-ticket comment line and the "impl ticket … unblocks then" clause.
 
-That's the whole skill. Keep the output short — the design doc is the substantive thing; the chat reply just navigates to it.
+That's the whole skill. Keep the output short — the design PR is the substantive thing; the chat reply just navigates to it.
 
 ---
 
 ## Hard rules
 
-- **Only one Linear state transition per run, and only at the end.** The skill calls `save_issue` exactly once, in Phase 7, to set the issue to `Done`. Never set `In Progress`, never re-transition during the run, never call `save_issue` for any other field.
+- **Only one Linear state transition per run, and only at the end.** The skill calls `save_issue` exactly once, in Phase 8, to set the issue to `In Review`. Never set `In Progress`, never set `Done` directly (Linear's GitHub integration handles that on PR merge), never re-transition during the run, never call `save_issue` for any other field.
 - **Never create a worktree manually.** Worktree creation is delegated to `setup-worktree --no-env` (Phase 5.4). Don't run `git worktree add`, `git checkout -b`, or any other branch/worktree operation directly — the delegated skill owns the convention.
-- **Never auto-commit the design doc.** The user reviews + commits + PRs at their own pace; pre-committing locks the doc in before they've seen it. Stage nothing.
-- **Never open a PR for the design doc.** The doc is for review and iteration; the user opens the PR (or asks you to) once the design has settled. The worktree is torn down separately via `/finish-worktree alt-<NN>` after the design has shipped.
+- **Always commit + push + open a PR before posting Linear comments.** Phase 6 must complete before Phase 7. The Linear comments link to the PR URL — without a PR, the comments would point at a blob URL on a feature branch that may never reach `main`. If `gh pr create` fails, stop the whole run; don't half-ship.
+- **Commit only the design artefacts.** `git add` the design `.md` and any sibling `.svg` files explicitly. Never `git add .` — a stale `pnpm-lock.yaml` change or other in-flight worktree noise must not land in the design commit.
+- **Always include `Closes <ALT-NN>` in the commit message.** It's what wires Linear's GitHub integration to flip the issue from In Review to Done on PR merge. Without it, the issue sticks in In Review until manually closed.
 - **Never collapse two options into one.** If you genuinely can't think of two distinct approaches, surface that and ask the user whether to write one with a "rejected alternatives" appendix instead. Forcing a weak second option produces noise.
-- **Never punt the recommendation back to the user.** The §Recommendation section must commit to one option. "No strong preference" / "either works" / "user picks" are invalid outputs — pick one and name what would flip the call. The skill marks the issue Done on this basis; it cannot do that if it hasn't picked.
+- **Never punt the recommendation back to the user.** The §Recommendation section must commit to one option. "No strong preference" / "either works" / "user picks" are invalid outputs — pick one and name what would flip the call. The PR body and Linear comments depend on the recommendation; the skill cannot ship them if it hasn't picked.
 - **Never skip the prior-art search (Phase 4.4).** Designs that ignore the existing codebase are usually wrong about what's expensive vs. cheap. Even if you find nothing reusable, the search itself should inform your options.
 - **Never overwrite an existing design doc silently.** If `docs/designs/<filename>.md` already exists (or a comment from a previous design pass exists on the ticket), stop and ask.
 - **Never produce an ExitPlanMode block.** The design doc *is* the plan. ExitPlanMode is for implementation plans presented in chat; this skill writes a markdown file instead.
@@ -504,12 +575,14 @@ That's the whole skill. Keep the output short — the design doc is the substant
 >
 > *Phase 5.4: invokes `Skill(setup-worktree, args: "ALT-38 --no-env")`. The setup-worktree skill pre-flights main, pulls, creates the worktree at `.claude/worktrees/alt-38` on `claude/alt-38`, runs `pnpm install`, and skips the dev-env spin-up. Returns control with cwd = the worktree.*
 >
-> *Phase 5: writes `docs/designs/alt-38-egress-per-container-override.md` inside the worktree. Option A is the row-extension shape (cheap, follows the haproxy pattern, but couples the override to the service row's lifecycle). Option B is the separate-table shape (heavier, needs a new migration and model, but cleaner audit trail and easier to extend with override types later). Each option has Key abstractions / File sketch / Implementation outline / Pros / Cons. **Recommendation: Option A** — the team has no plans for other override types and the cheaper change is the right call for the ticket as scoped; flip to B if a second override type lands on the roadmap. One Open question: "do we want overrides to survive a service rename?" — answer changes which option wins. Two items in Out-of-scope: bulk override import (different ticket), override expiry (no Deliverable for it). File left unstaged.*
+> *Phase 5: writes `docs/designs/alt-38-egress-per-container-override.md` inside the worktree. Option A is the row-extension shape (cheap, follows the haproxy pattern, but couples the override to the service row's lifecycle). Option B is the separate-table shape (heavier, needs a new migration and model, but cleaner audit trail and easier to extend with override types later). Each option has Key abstractions / File sketch / Implementation outline / Pros / Cons. **Recommendation: Option A** — the team has no plans for other override types and the cheaper change is the right call for the ticket as scoped; flip to B if a second override type lands on the roadmap. One Open question: "do we want overrides to survive a service rename?" — answer changes which option wins. Two items in Out-of-scope: bulk override import (different ticket), override expiry (no Deliverable for it).*
 >
-> *Phase 6.1: posts a comment on ALT-38 (the design ticket): "Designs drafted: …relative-path… A — Service-row column; B — Separate EgressOverride table. **Picked: Option A** — cheap, leans on the haproxy override pattern; flip to B only if a second override type lands. Marking this design ticket Done — `/execute-next-task ALT-39` (the impl ticket) is unblocked."*
+> *Phase 6: stages the design `.md`, commits with `docs(designs): egress per-container override (ALT-38)` and a `Closes ALT-38` line, pushes `claude/alt-38`, opens PR #371 via `gh pr create`. Captures the PR URL.*
 >
-> *Phase 6.2: ALT-38 has `relations.blocks: [ALT-39]`. Posts a comment on ALT-39 (the impl ticket): "**Design ready:** `docs/designs/alt-38-egress-per-container-override.md`. Picked: Option A — Service-row column. Read this before starting implementation — it includes Key abstractions, File / component sketch, and Implementation outline. Open questions in the doc are unresolved choices that may matter at implementation time." A future `/execute-next-task ALT-39` skim of comments will see this immediately.*
+> *Phase 7.1: posts a comment on ALT-38 (the design ticket): "Designs drafted (PR open): #371. A — Service-row column; B — Separate EgressOverride table. **Picked: Option A** — cheap, leans on the haproxy override pattern; flip to B only if a second override type lands. Moving this design ticket to In Review — once the PR merges, Linear's GitHub integration auto-closes it via `Closes ALT-38` and `/execute-next-task ALT-39` becomes unblocked."*
 >
-> *Phase 7: `save_issue(id: "ALT-38", state: "Done")`. The single state transition. Impl ticket ALT-39 is now picker-eligible.*
+> *Phase 7.2: ALT-38 has `relations.blocks: [ALT-39]`. Posts a comment on ALT-39 (the impl ticket): "**Design ready (PR open):** #371 — design doc at `docs/designs/alt-38-egress-per-container-override.md` once merged. Picked: Option A — Service-row column. Read this before starting implementation … Wait for the design PR to merge before kicking off `/execute-next-task` — the doc lands on `main` at that point and the design ticket auto-closes." A future `/execute-next-task ALT-39` skim of comments will see this immediately.*
 >
-> Skill: "✓ Design doc written: `docs/designs/alt-38-egress-per-container-override.md`. ✓ Linear comment posted on design ticket ALT-38. ✓ 'Design ready' comment posted on impl ticket ALT-39. ✓ ALT-38 marked Done (impl ticket ALT-39 unblocked). Two options: A) Service-row column. B) Separate EgressOverride table. Picked: A — cheap, leans on the haproxy override pattern. If you disagree, edit the doc and reopen the ticket."
+> *Phase 8: `save_issue(id: "ALT-38", state: "In Review")`. The single state transition. ALT-38 will auto-flip to Done when PR #371 merges; ALT-39 becomes picker-eligible at that point.*
+>
+> Skill: "✓ Design doc written + committed: `docs/designs/alt-38-egress-per-container-override.md`. ✓ PR opened: #371. ✓ Linear comment posted on design ticket ALT-38. ✓ 'Design ready' comment posted on impl ticket ALT-39. ✓ ALT-38 moved to In Review (auto-closes when PR merges; ALT-39 unblocks then). Two options: A) Service-row column. B) Separate EgressOverride table. Picked: A — cheap, leans on the haproxy override pattern. Next: review and merge the PR; after merge, `/finish-worktree alt-38`."


### PR DESCRIPTION
## Summary
- New **Phase 6** in `design-task` stages the design `.md` + sibling SVGs, commits with `Closes ALT-NN`, pushes the branch, and runs `gh pr create`.
- **Phase 7** Linear comments now link to the PR URL captured in Phase 6, not relative paths.
- **Phase 8** moves the issue from `Todo` to **In Review** (was `Done`). Linear's GitHub integration auto-flips the issue to Done when the PR merges, via the `Closes ALT-NN` line.
- Hard rules, frontmatter, opening paragraphs, and the worked example all updated to reflect the new flow.

## Test plan
- [ ] Skim `.claude/skills/design-task/SKILL.md` end-to-end — phase numbering 1–9 reads cleanly with no stale "Phase 8 = Mark Done" / "Stage nothing" leftovers.
- [ ] Verify the description/opening still accurately summarises the flow.
- [ ] Run `/design-task <ALT-NN>` against a fresh design ticket and confirm: PR is opened automatically, both Linear comments link to the PR, and the design ticket lands in In Review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)