### PR TITLE
feat(skills): extract /review out of execute-next-task

### DIFF
--- a/.claude/skills/execute-next-task/SKILL.md
+++ b/.claude/skills/execute-next-task/SKILL.md
@@ -242,9 +242,9 @@ If everything passes, move on. If anything fails, **fix it before continuing** �
 
 ---
 
-## Phase 10 — Commit, push, and run a code review
+## Phase 10 — Commit and push
 
-Smoke tests passed. Before opening the PR, the diff goes through a Sonnet-backed review pass so obvious issues get caught locally instead of becoming review noise on GitHub. The phase commits the implementation, pushes the branch (so the work is safely on the remote regardless of what happens next), runs the review subagent, then applies fixes for any medium / high / critical findings that hold up under scrutiny.
+Smoke tests passed. Commit the implementation and push the branch so the work is safely on the remote before the PR is opened. Code review is a separate concern — the user runs the `/review` skill against the PR or Linear ticket on their own cadence after this phase ships.
 
 ### 10.1 Commit the implementation
 
@@ -271,100 +271,13 @@ Stage and commit. Don't push yet — keep all of 10.1's commits local until 10.2
 git push -u origin claude/<slug>
 ```
 
-`-u` sets upstream so subsequent `git push` calls are bare. The work is now safe on the remote — even if the review phase explodes, nothing is lost.
-
-### 10.3 Spawn a Sonnet subagent to review the diff
-
-Use the `Agent` tool with `subagent_type: general-purpose` and `model: sonnet`. Sonnet is the right tier for review — fast, cheap, and the diff fits comfortably in its window.
-
-Prompt the subagent (substitute the branch name and the picked Linear issue ID):
-
-```
-Review the changes on branch `claude/<slug>` for issue <ALT-NN>.
-
-Compute the diff vs main with:
-  git fetch origin main
-  git diff origin/main...HEAD
-
-Read the relevant project conventions before reviewing:
-  - root CLAUDE.md (pnpm, worktree workflow, build invariants)
-  - server/CLAUDE.md if any server/ files changed (DockerService, ConfigurationServiceFactory, Channel.*/ServerEvent.*, userId on mutations, never raw dockerode)
-  - client/CLAUDE.md if any client/ files changed (TanStack Query patterns, no polling when socket connected, task tracker)
-  - any per-component CLAUDE.md / ARCHITECTURE.md that the touched dirs map to
-  - the Linear issue body for <ALT-NN> (Goal / Deliverables / Done when) so you can judge whether the diff actually does what was asked
-
-Look for:
-  - bugs (logic errors, off-by-one, null-deref, race conditions)
-  - security issues (injection, secrets, auth bypass, OWASP-top-10 patterns)
-  - convention violations (raw SDK calls bypassing service wrappers, raw dockerode, raw socket strings, missing userId on mutations, missing Plan: line patterns the codebase relies on)
-  - dead code / unused imports / leftover debug logging
-  - missing tests where the convention says they're required
-  - drift from the ticket's Deliverables (something asked for that didn't land, something landed that wasn't asked for)
-
-DO NOT flag:
-  - style nits the linter would catch
-  - opinions about "could be cleaner" without a concrete bug or convention violation
-  - missing comments or docstrings (the codebase defaults to no comments unless WHY is non-obvious)
-  - hypothetical future-extensibility concerns
-
-Return findings as a JSON array. One object per finding:
-  {
-    "severity": "critical" | "high" | "medium" | "low",
-    "file": "<path relative to repo root>",
-    "line": <line number on the new side, or null if file-level>,
-    "title": "<short imperative phrase>",
-    "detail": "<1-3 sentences: what's wrong, why it matters>",
-    "suggested_fix": "<concrete change — file/line + before/after, or null if non-obvious>"
-  }
-
-If you find nothing actionable, return an empty array `[]`. Do NOT pad with low-severity nits to look thorough. Empty is a great result.
-
-Return ONLY the JSON array. No preamble, no summary, no markdown fences.
-```
-
-### 10.4 Triage and apply fixes
-
-Parse the subagent's JSON. Filter to `severity in ["critical", "high", "medium"]`. Drop `low` — they're not worth a follow-up commit unless they coincidentally fall out of a higher-severity fix.
-
-For each remaining finding, **sanity-check before applying**. The subagent is right most of the time but occasionally:
-
-- Misreads a convention (e.g. flags `dockerode.getContainer()` when the wrapper *is* the surrounding code).
-- Misses context that's a few files away (e.g. flags a missing null-check that's enforced upstream).
-- Suggests a "fix" that's worse than the code it's fixing.
-
-Read the cited file, decide whether the finding is real:
-
-- **Holds up** → apply the suggested fix (or a better one). Add to a fixups list.
-- **Doesn't apply** → skip. Note it in the handoff comment (Phase 12) under "Review findings consciously dismissed" so the human reviewer knows the agent considered it.
-
-If every finding gets dismissed as not-applicable, that's fine — the code is fine. Move to 10.5 with no fixups.
-
-### 10.5 Commit and push the fixups (only if you applied any)
-
-If 10.4 produced changes, commit them as a separate commit so the diff history shows the implementation and the review-driven cleanup separately. Use a body that lists what was addressed:
-
-```
-review: address sonnet review findings (Phase N, ALT-NN)
-
-- <one bullet per applied finding>
-- <...>
-
-Co-Authored-By: <as configured>
-```
-
-Then push:
-
-```bash
-git push
-```
-
-If 10.4 produced no changes, this sub-phase is a no-op — proceed to Phase 11.
+`-u` sets upstream so subsequent `git push` calls are bare. The work is now safe on the remote.
 
 ---
 
 ## Phase 11 — Open the PR
 
-The branch is committed, pushed, and (where applicable) cleaned up by review. Now create the PR:
+The branch is committed and pushed. Now create the PR:
 
 ```bash
 gh pr create --title "<commit subject from Phase 10.1>" --body @- <<'EOF'
@@ -378,7 +291,7 @@ Closes ALT-NN
 EOF
 ```
 
-PR title matches the implementation commit's subject (not the `review:` follow-up). PR body must:
+PR title matches the implementation commit's subject. PR body must:
 
 - Have a Summary section (1–3 bullets) describing the change.
 - Have a Test plan section (markdown checklist).
@@ -412,9 +325,6 @@ Use this template. Omit any section that genuinely has nothing to report — don
 
 ## Deviations from the spec
 <places where what you shipped diverges from the ticket's Deliverables or Done-when (and, if a plan doc was loaded in Phase 3, from its `### Phase N` section). For each: what the spec said, what you shipped, why. When a plan doc is in play, this section is also the input a re-integration agent uses to fold the drift back into the doc — keep it precise. **Omit this section entirely** when there's no spec drift to report.>
-
-## Review findings consciously dismissed
-<medium / high / critical findings the Phase 10 review subagent surfaced but you decided not to apply. For each: what the subagent said, why you concluded it didn't apply (e.g. it misread the surrounding context, the convention is actually being followed a few files away, the suggested fix was worse than the original). One bullet each. **Omit this section entirely** when the review returned no findings, or when every finding was applied.>
 ```
 
 If Phase 3 found no plan doc (standalone ticket), the handoff still uses this template — the "Deviations from the spec" wording covers both cases. There's just no re-integration agent involvement to plan for; the comment is purely for the human reviewer.
@@ -485,7 +395,7 @@ The retrospective is a feedback loop, not a gate. If the subagent fails — scri
 
 ## Phase 14 — Clean up the worktree (success path only, delegated to `finish-worktree`)
 
-**Only run this if every previous phase succeeded** — build/lint/unit passed, smoke passed, review fixups applied (if any), the PR is open, the issue is In Review, the handoff comment posted. If anything failed or stopped earlier, **skip this phase entirely** and leave the worktree alive so the user can investigate. The retrospective phase (13) is best-effort and doesn't gate this — a failed retrospective still counts as a successful run.
+**Only run this if every previous phase succeeded** — build/lint/unit passed, smoke passed, the PR is open, the issue is In Review, the handoff comment posted. If anything failed or stopped earlier, **skip this phase entirely** and leave the worktree alive so the user can investigate. The retrospective phase (13) is best-effort and doesn't gate this — a failed retrospective still counts as a successful run.
 
 The worktree's purpose is to host the build + smoke for this phase. Once the PR is open and in review, the work that needs the dev env is over — review happens in GitHub on the diff, not in the worktree. Tear it down to free the VM/distro slot and keep `pnpm worktree-env list` tidy.
 
@@ -516,9 +426,8 @@ Append a final line to the run report:
 These are non-negotiable. If you find yourself wanting to break one, stop and ask the user instead.
 
 - **Never produce an ExitPlanMode block.** This is an execution agent. Planning happened when the ticket was created (in `plan-to-linear` for phased tickets, in `task-to-linear` for standalone ones, or by the user filing it directly).
-- **Never run Phase 14 (cleanup) on a failure path.** If smoke failed, the review subagent errored fatally, the PR didn't open, the In Review transition didn't go through, or you stopped to ask the user mid-phase — leave the worktree alive. The user needs it to investigate. Cleanup is the *reward* for a fully successful run. (Phase 13, the retrospective, also only runs on the success path, but a failure inside Phase 13 itself does not block Phase 14 — the retrospective is best-effort.)
+- **Never run Phase 14 (cleanup) on a failure path.** If smoke failed, the PR didn't open, the In Review transition didn't go through, or you stopped to ask the user mid-phase — leave the worktree alive. The user needs it to investigate. Cleanup is the *reward* for a fully successful run. (Phase 13, the retrospective, also only runs on the success path, but a failure inside Phase 13 itself does not block Phase 14 — the retrospective is best-effort.)
 - **Never edit the plan doc.** When a plan doc was loaded in Phase 3, the doc under `docs/planning/` is read-only for this skill. If your implementation drifts from the spec, capture the drift in the handoff comment (Phase 12 — Deviations from the spec section). A separate re-integration agent will fold those notes back into the plan doc; don't pre-empt that. (When no plan doc was loaded, this rule is vacuous — there's nothing to edit.)
-- **Never blindly apply review subagent findings.** Phase 10.4 requires a sanity check on every medium/high/critical finding before fixing. The subagent is a second pair of eyes, not an oracle — if a finding misreads context, dismiss it (and note it in the handoff comment). Equally, never *skip* a finding because the fix is inconvenient — the dismissal must be justifiable.
 - **Never auto-roll-back the In Progress transition.** Phase 2.1 marks the issue In Progress before any other work begins. If the run later hard-fails, leave it In Progress and report — don't quietly flip it back to Todo. The user decides whether to retry, hand off, or revert state.
 - **Never merge PRs** — even if checks pass and the PR looks great. Merging is a human decision.
 - **Never create new Linear issues** or split phases on the fly. If scope is too big for one phase, stop and report — splitting is a planning decision, not an execution decision.
@@ -554,11 +463,11 @@ These are non-negotiable. If you find yourself wanting to break one, stop and as
 >
 > *Implements. Runs build/lint/unit tests. Backgrounded env is up by now — runs the ticket's smoke test (publish a test backup-run request, confirm the consumer side fires).*
 >
-> *Phase 10: commits with `feat(nats): pg-az-backup progress + result events (Phase 4, ALT-29)`, pushes the branch with `-u`. Spawns a Sonnet review subagent prompted to diff `claude/alt-29` against main. Subagent returns two findings: one `medium` (a missing try/catch around a socket emit, which is real) and one `high` (a "raw dockerode call bypassing DockerService" — but on inspection that's actually inside a test helper that intentionally pokes the daemon, so it's dismissed). Skill applies the medium fix, commits as `review: address sonnet review findings (Phase 4, ALT-29)`, and pushes again.*
+> *Phase 10: commits with `feat(nats): pg-az-backup progress + result events (Phase 4, ALT-29)`, pushes the branch with `-u`. Code review is left to a separate `/review` run that the user kicks off after the PR is open.*
 >
 > *Phase 11: opens PR with the implementation commit's title and `Closes ALT-29` in the body.*
 >
-> *Phase 12: marks ALT-29 In Review. Posts the handoff comment: PR URL, plus a Deviations section noting that the optional retry-on-transient-failure deliverable was deferred to a follow-up issue per the plan doc's wording, plus a "Review findings consciously dismissed" section explaining the test-helper carve-out. The plan doc itself is left untouched; the re-integration agent will fold the Deviations back later. Reports the PR URL.*
+> *Phase 12: marks ALT-29 In Review. Posts the handoff comment: PR URL, plus a Deviations section noting that the optional retry-on-transient-failure deliverable was deferred to a follow-up issue per the plan doc's wording. The plan doc itself is left untouched; the re-integration agent will fold the Deviations back later. Reports the PR URL.*
 >
 > *Phase 13: captures `$CLAUDE_SESSION_ID` (the parent session), spawns a `general-purpose` subagent on Sonnet, and tells it to invoke the `session-retrospective` skill with `--session-id <parent-id> --linear-issue ALT-29`. The skill loads the Linear MCP, runs `scripts/get-session.sh` against the parent JSONL, generates retrospective markdown, resolves the Altitude Devops team / Backlog state / `retro` label, and creates a new issue `ALT-42 — Retro: ALT-29 — Phase 4: pg-az-backup progress + result events` with the markdown body and a Source link back to ALT-29. Then adds a `relatedTo` relation between ALT-42 and ALT-29 so both issues show the link in their Linear side panel. Subagent returns the URL of ALT-42; skill appends it to the run report.*
 >

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: review
+description: Independent code-review skill for a Linear-tracked PR. Accepts a Linear issue ID (`ALT-NN`), a GitHub PR number (`372` or `#372`), a branch name (`claude/alt-32`), or **no argument** (reviews the current branch's open PR). Resolves the input to the triple {Linear issue, PR, branch}, reads the ticket as the contract — Goal / Deliverables / Done when, plus any **Design ready** comment from `design-task` pointing at a design doc under `docs/designs/` — pulls `gh pr diff <PR>`, reads the project conventions that bear on the touched directories (root CLAUDE.md always; server/CLAUDE.md when `server/` files change; client/CLAUDE.md when `client/` files change; per-component pointers from the ticket's "Relevant docs"; ICONOGRAPHY.md when UI changes), and reviews the diff for **bugs and logic errors** (off-by-one, null-deref, race conditions, broken control flow, swapped arguments, error-swallowing `try/catch`), **security** (injection, secret leakage, auth bypass, OWASP-top-10 patterns), **convention violations** (raw `dockerode` vs `DockerService.getInstance()`, raw `docker.pull()` vs `pullImageWithAutoAuth()`, raw socket strings vs `Channel.*`/`ServerEvent.*`, missing `userId` on config-service mutations, polling when a socket is connected, missing task-tracker registry entries for new long-running ops, `any`-typed code), **duplication** (logic that was inlined when an existing helper or shared type would have done, types duplicated client-side and server-side instead of pulled from `@mini-infra/types`), **drift from the contract** (deliverables that didn't land, scope creep that wasn't asked for, design doc's recommendation not followed), and **dead code / debug leftovers** (commented blocks, `console.log`, unused imports, narration-style comments). Posts a single structured comment on the Linear issue with severity-labelled findings (`critical | high | medium | low`), an empty review when the diff is fine, and a closing one-liner verdict. **Makes no code changes** — auto-fixing was deliberately separated from this skill so a fix-up pass can be done by hand or by a different skill afterwards. **Does not check test coverage** — that's a separate concern. **Does not check doc-artefact drift** beyond a one-line pointer; `api-change-check` owns that sweep. Use this skill whenever the user says "review ALT-NN", "review PR 372", "review the current branch", "review my PR", "code review for ALT-NN", "have a look at the changes for ALT-NN", "what's wrong with this PR", "any bugs in ALT-32", "did I break anything", "would you ship this", or any equivalent ask to get an independent pair of eyes on a change. Trigger even when the user doesn't say the word "review" but is clearly asking for one. Do NOT trigger for ad-hoc "look at this code" without a Linear issue or PR / branch reference, for tasks about producing changes (use `execute-next-task` or `fix-and-validate` for that), or for design exploration (use `design-task`).
+---
+
+# Review
+
+You're a **code-review agent**. The Linear ticket says what was supposed to ship; the PR diff says what actually shipped. Your job is to read both and surface anything that looks wrong — bugs, logic errors, security holes, convention violations, duplication, drift from the contract, dead code — as a single structured comment on the Linear issue.
+
+You make **no code changes**. The findings are for the user (or a separate fix-up skill) to act on later. Empty findings is a great result — don't pad with low-severity nits to look thorough.
+
+The team is hardcoded as **Altitude Devops**.
+
+---
+
+## Phase 1 — Load the Linear MCP tools
+
+The Linear MCP tools are deferred at session start. Load them in one bulk call:
+
+```
+ToolSearch(query: "linear", max_results: 30)
+```
+
+You should see `__list_issues`, `__get_issue`, `__get_project`, `__list_comments`, `__save_comment`. If any of these are missing, stop and tell the user — without Linear we can't post the deliverable.
+
+---
+
+## Phase 2 — Resolve the input to {Linear issue, PR, branch}
+
+The skill needs all three: the **issue** is the contract, the **PR** is the diff, the **branch** is the ref. Resolve them by argument shape.
+
+**`ALT-NN`** (matches `ALT-\d+` case-insensitive, surrounding text fine):
+1. `get_issue(id: <ALT-NN>)`. If 404, stop.
+2. Find the PR: scan `attachments[]` on the issue for a GitHub URL (`design-task` and `execute-next-task` post the PR as an attachment when they ship). If none, fall back to `gh pr list --search "ALT-NN" --state open --json number,headRefName,title -L 5` and take the most recent open match. If multiple match and the choice isn't obvious, list them and ask.
+3. The PR's `headRefName` is the branch.
+
+**PR number** (matches `^\d+$` or `^#\d+$`): `gh pr view <N> --json number,headRefName,title,body`. Pull the Linear ID from the PR title (the `(ALT-NN)` suffix the project's commit convention uses) or the `Closes ALT-NN` line in the body. If neither is present, ask which Linear issue this PR belongs to — don't guess.
+
+**Branch name** (anything else looking like a ref, e.g. `claude/alt-32`): `gh pr list --head <branch> --state open --json number`. Pull the Linear ID the same way as the PR-number flow.
+
+**No argument**: resolve from the current shell.
+- `git rev-parse --abbrev-ref HEAD` — current branch.
+- `gh pr view --json number,title,body,headRefName` from inside the worktree — finds the PR for that branch.
+- Pull the Linear ID from the branch (`claude/alt-NN` → `ALT-NN`) or the PR body.
+- If the current branch is `main` or has no open PR, stop and ask which target to review.
+
+**State the resolved triple before proceeding** so the user can intercept if the resolution is wrong:
+
+> Reviewing ALT-NN ("<ticket title>") — PR #N, branch `<branch>`.
+
+---
+
+## Phase 3 — Read the contract
+
+The Linear ticket is the contract. Pull these from the issue body:
+
+- **Goal** — what outcome the work is supposed to achieve
+- **Deliverables** — the concrete things that have to exist
+- **Done when** — the testable acceptance criterion
+- **Source** — plan-doc anchor, if present
+- **Relevant docs** — per-component CLAUDE.md / ARCHITECTURE.md pointers
+
+Then skim `list_comments(issueId: <ALT-NN>)` for two things:
+
+1. **A `**Design ready (PR open):**` comment from `design-task`** — pointer to a design doc under `docs/designs/<id>-<slug>.md`. If you find one, the doc's **Recommendation** + **Key abstractions** + **File / component sketch** + **States, failure modes & lifecycle** sections are part of the contract. Drift between the design doc's recommendation and the actual diff is a finding worth flagging at `medium` or `high` depending on how load-bearing the divergence is.
+
+   Read the doc. If the design PR has merged, it's on `main`; if still open, fetch via `gh pr view <design-PR> --json headRefName -q .headRefName`, then `git fetch origin <branch> && git show origin/<branch>:docs/designs/<filename>.md`.
+
+2. **Any `execute-next-task` handoff comment** — has sections like "Deviations from the spec" and "Work deferred". These name choices the executor consciously made; if you flag something the handoff already explained as a deliberate deviation, mention that you saw the explanation rather than restating the finding as if it weren't disclosed.
+
+If the parent project has a `Plan:` line (`get_project` → `description`), and the ticket's **Source** points at a `### Phase N` section in that plan doc, read the matching section as supplemental context. The ticket body still wins on what specifically was supposed to ship.
+
+---
+
+## Phase 4 — Pull the diff
+
+```bash
+gh pr diff <PR-number> > /tmp/review-<PR>.diff
+```
+
+Capture it on disk so it's stable across re-reads. Then capture the changed-files list — Phase 5 needs it:
+
+```bash
+gh pr view <PR-number> --json files -q '.files[].path' | sort -u > /tmp/review-<PR>.files
+```
+
+Don't rely on the local working tree — fetch from origin so the review covers exactly what's on the PR. If the PR has multiple commits, the diff is the *combined* diff vs main; that's the right unit of review.
+
+---
+
+## Phase 5 — Read the project conventions that bear on the diff
+
+The skill should not review against generic best-practice — it should review against **what this codebase says is right**. Read CLAUDE.md files based on which directories the diff touches.
+
+- **Always** — root [CLAUDE.md](CLAUDE.md). pnpm + worktree workflow, the Critical Coding Patterns block (`pullImageWithAutoAuth`, `DockerService.getInstance()`, `ConfigurationServiceFactory`, `Channel.*`/`ServerEvent.*`, no `any`).
+- **Any `server/` change** — [server/CLAUDE.md](server/CLAUDE.md) (service wrappers, audit trail with `userId`, Socket.IO emission patterns, schema rules).
+- **Any `client/` change** — [client/CLAUDE.md](client/CLAUDE.md) (TanStack Query data-fetching, no polling when socket connected, `useSocketChannel`/`useSocketEvent` lifecycle, task-tracker registry, `useOperationProgress` hook).
+- **Any sidecar change** (`update-sidecar/`, `agent-sidecar/`, `egress-gateway/`, `egress-fw-agent/`) — local conventions doc if one exists.
+- **Per-component pointers** the ticket lists under "Relevant docs" — read them, they were chosen because they apply.
+- **UI changes** — [claude-guidance/ICONOGRAPHY.md](claude-guidance/ICONOGRAPHY.md). Naming icons by Tabler convention and using the listed glyphs is a real rule the codebase follows.
+
+Don't read every CLAUDE.md in the repo — only the ones the diff touches. A `docs/`-only diff doesn't need server/ conventions loaded.
+
+---
+
+## Phase 6 — Review the diff
+
+Walk the diff and apply the checklist below. Be honest and concise — the reviewer's job is to flag **what's actually wrong**, not to demonstrate thoroughness. Empty findings is the right answer when the diff is fine; don't pad.
+
+### What to flag
+
+**Bugs and logic errors.** This is the highest-value category — name them clearly and cite the line. Off-by-one, null-deref, race conditions, wrong loop bounds, swapped arguments, broken control flow, branches that can never trigger, conditions that are tautologically true / false, error-swallowing `try/catch` blocks, typos that compile but mean the wrong thing, missing `await` on a Promise-returning call, missing cleanup in a `finally`, `Promise.all` over an array of side effects when sequencing matters, accidental shared state across requests, time-of-check / time-of-use windows.
+
+**Security.** Injection (SQL, command, prompt, HTML), secret leakage (logged credentials, hardcoded tokens, secrets in error messages, secrets in git history), auth bypass (missing auth check, wrong scope, role escalation), OWASP-top-10 patterns. Be specific. "This looks insecure" is not a finding; "this concatenates `req.body.name` into a `LIKE` clause without parameterising" is.
+
+**Convention violations** (codebase-specific, from Phase 5's reading):
+- Raw `dockerode` calls instead of `DockerService.getInstance()` wrappers.
+- Raw `docker.pull()` instead of `DockerExecutorService.pullImageWithAutoAuth()`.
+- Raw socket-event strings (`io.emit("foo:bar")`) instead of `Channel.*` / `ServerEvent.*` constants from `lib/types/socket-events.ts`.
+- Mutating config services without the `userId` parameter (audit trail rule).
+- Frontend polling with `refetchInterval` when a socket channel is connected.
+- New long-running operation without a task-tracker registry entry in `client/src/lib/task-type-registry.ts`.
+- `any` types where a real type was straightforward — flag at `medium` if it masks a real signature, `low` if it's a one-off escape hatch.
+
+**Duplication.** Logic inlined when an existing helper / service / hook in the same component would have done. Types or constants duplicated client-side and server-side instead of pulled from `@mini-infra/types`. Same for `egress-shared/` between the egress gateway and agent. New utility code that pattern-matches an existing utility somewhere else in the repo.
+
+**Drift from the contract.**
+- Deliverables in the ticket that aren't in the diff.
+- Things in the diff that aren't in any Deliverable / Done-when (scope creep).
+- If a design doc was posted, the **Recommendation** says which option was picked — implementing the *other* option is a finding. Specific failure-mode wording, configured-state strategy, or named abstractions in the doc that the diff doesn't follow are also findings.
+- "Done when" criterion that the diff visibly fails to satisfy.
+
+**Dead code / debug leftovers.** `console.log`. Commented-out blocks (delete them — git remembers). Unused imports / exports / types. `// TODO: remove this` left in. Half-finished implementations referenced from production code. Empty `if` branches. Functions that are defined but never called.
+
+**Comment quality.** The codebase rule is "default to no comments unless WHY is non-obvious." A comment that just narrates what the next line does is a finding. A comment that references a removed PR / ticket / function is a finding. Multi-paragraph docstrings are a finding.
+
+### What NOT to flag
+
+- **Style nits the linter would catch.** The project has Prettier + ESLint; trust them.
+- **"Could be cleaner"** without a concrete bug or convention violation. Personal taste is not a finding.
+- **Missing tests.** Test coverage is explicitly out of scope for this skill — the user asked for `/review` to focus on bugs / logic / security / conventions, not coverage.
+- **Hypothetical future-extensibility.** Today's diff for today's contract; the project's CLAUDE.md actively discourages designing for hypothetical future requirements.
+- **Backwards-compatibility shims and feature flags.** The CLAUDE.md says "don't use feature flags or backwards-compatibility shims when you can just change the code." Don't request them.
+- **Missing tests for new behaviour, error handling for impossible cases, validation for non-boundary inputs.** All explicitly discouraged by root CLAUDE.md.
+- **Doc-artefact drift.** That's `api-change-check`'s territory. If the diff touches API routes or `lib/types/permissions.ts`, mention it as a one-line pointer in the final comment's "Out of scope" section — don't enumerate every missing doc bullet.
+
+### Severity calibration
+
+Use `critical | high | medium | low` honestly. Calibration matters more than total finding count.
+
+- **`critical`** — would break production or leak data on first run. SQL injection, auth bypass, infinite loop on a hot path, a migration that drops data, a credential committed to the repo. If you flag `critical`, the rationale must be airtight; spurious `critical` burns trust faster than any other miscalibration.
+- **`high`** — a real bug or convention violation that will bite the next person to read the code or use the feature. Wrong default value, missing `userId` on a config mutation, polling racing with socket invalidation, a code path that throws on the happy path, a deliverable from the ticket that didn't land.
+- **`medium`** — a real issue that's not yet biting anyone. Duplicated logic that should be extracted, drift from the design doc on a non-critical detail, dead code that's not load-bearing, an `any` that masks a real signature, a convention violation that's narrow in blast radius.
+- **`low`** — minor cleanup. Leftover `console.log`, unused import, comment that just narrates the code, typo in a string the user might never see. Group these together at the end of the comment.
+
+If you have to debate `medium` vs `low`, default to `low`.
+
+---
+
+## Phase 7 — Format and post the Linear comment
+
+The comment is the deliverable. One comment per review run, posted on the Linear issue.
+
+```
+save_comment(issueId: <ALT-NN>, body: <see template>)
+```
+
+Template — omit a section that's empty rather than write "None.":
+
+```markdown
+**Review of [`<PR title>`](<PR URL>)** — <N> finding(s).
+
+<one-sentence summary of the diff: shape of the work and rough size, e.g. "Adds the new `tailscale` connected-service settings page (one new page, two new shared primitives, ~600 lines across client/ and server/).">
+
+### Critical
+- **<short imperative title>** — `<file>:<line>`.
+  <1–3 sentences: what's wrong, why it matters, what the fix looks like.>
+
+### High
+- **<title>** — `<file>:<line>`.
+  <…>
+
+### Medium
+- **<title>** — `<file>:<line>`.
+  <…>
+
+### Low
+<one short paragraph or compact list, e.g. "Unused import in `foo.ts:12`. Stray `console.log` in `bar.ts:88`. Comment at `baz.ts:34` narrates the code rather than a non-obvious why.">
+
+### Out of scope (run separately)
+- API routes / permissions changed in this diff — run `/api-change-check` for the doc-artefact sweep.
+- <other deferred concerns, if any>
+
+---
+
+_<one-line verdict: "Looks ready to ship after the two `high` findings are addressed." or "Empty review — nothing to do." Don't manufacture a verdict if the bar is somewhere between; one short honest sentence.>_
+```
+
+Empty review:
+
+```markdown
+**Review of [`<PR title>`](<PR URL>)** — no findings.
+
+<one-sentence summary of the diff>.
+
+Looks ready to ship.
+```
+
+Don't pad an empty review with low-priority "I noticed an unused import" findings. Empty really is the best result.
+
+---
+
+## Phase 8 — Final report to the user
+
+Tight summary in chat:
+
+```
+Review posted on ALT-NN (<finding count> finding(s)): <Linear comment URL>
+
+Breakdown: <C> critical, <H> high, <M> medium, <L> low.
+<one-line top finding if there is one — "Highest-severity: SQL injection in server/src/services/foo.ts:142.">
+
+Run /review again after fixes land to re-check.
+```
+
+If empty:
+
+```
+Review posted on ALT-NN (no findings): <Linear comment URL>.
+Looks ready to ship.
+```
+
+That's the run.
+
+---
+
+## Hard rules
+
+- **Make no code changes.** The skill reads, reviews, and writes one Linear comment. It does not edit files, run `git add`, commit, push, or open / merge / close PRs. Auto-fixing was deliberately separated out of this flow.
+- **Be honest about empty.** If the diff is fine, post an empty review. Padding produces noise that makes future reviews easier to ignore.
+- **Calibrate severity.** Critical means "breaks production" — everything else is below that. A spurious `critical` finding burns trust and makes the user re-derive whether to take the next one seriously.
+- **Don't flag what you didn't read.** If a hunk is too noisy to follow without reading the whole file, read the whole file. Findings based on incomplete reading are worse than findings on a smaller set you actually understood.
+- **Cite file + line, always.** `<file>:<line>` notation; the user copies it straight into their editor. A finding without a path is not actionable.
+- **One comment per run.** Don't post multiple comments for one review. If you re-run after fixes, post a fresh comment — don't edit the previous one.
+- **Stop on missing inputs.** No Linear ID, no PR, ambiguous resolution → stop and ask. Don't guess past these.
+- **Never produce an ExitPlanMode block.** This is a review skill; the Linear comment is the deliverable.
+
+---
+
+## Example
+
+> User: `/review ALT-32`
+>
+> *Skill loads Linear MCP. Resolves: ALT-32 ("Phase 4: pg-az-backup progress + result events"), PR #412, branch `claude/alt-32`. Confirms: "Reviewing ALT-32 — PR #412, branch `claude/alt-32`."*
+>
+> *Phase 3: reads the ticket. Goal: emit progress + result events for pg-az-backup. Deliverables: three new socket events, task-tracker registry entry, server emitter. No design comment on this ticket — backend-only work. One handoff comment from execute-next-task notes the optional retry-on-transient-failure deliverable was deferred to a follow-up.*
+>
+> *Phase 4: `gh pr diff 412 > /tmp/review-412.diff`. 7 files changed, mostly under `server/src/services/backup/` plus one update to `client/src/lib/task-type-registry.ts`.*
+>
+> *Phase 5: reads root CLAUDE.md, server/CLAUDE.md, and client/CLAUDE.md. Notes the `Channel.*`/`ServerEvent.*` constants rule and the task-tracker pattern.*
+>
+> *Phase 6: walks the diff. Finds:*
+> - **High** — `server/src/services/backup/backup-progress-emitter.ts:47` — emitter swallows error when `db.event.create` fails (`console.error` then returns), so failed inserts never surface; project pattern is to log + throw and let the caller decide.
+> - **Medium** — `server/src/services/backup/backup-executor.ts:208` — duplicates the step-name normalisation already at `cert-issuance/cert-issuance-executor.ts:412`; should be extracted into `server/src/services/operation-step.ts`.
+> - **Low** — leftover `console.log("emitter wired up")` in `backup-progress-emitter.ts:12`.
+>
+> *Phase 7: posts the comment. Three sections (High / Medium / Low), closing line "Looks ready to ship after the high finding is addressed."*
+>
+> Skill: "Review posted on ALT-32 (3 findings): <link>. Breakdown: 0 critical, 1 high, 1 medium, 1 low. Highest-severity: error swallowing in `backup-progress-emitter.ts:47`. Run /review again after fixes land to re-check."


### PR DESCRIPTION
## Summary
- **Strip the review subagent + auto-fixup loop out of \`execute-next-task\`.** Phases 10.3 / 10.4 / 10.5 are gone; Phase 10 is now commit + push only. Phase 11 / 12 / hard rules / Example updated to match. The "Review findings consciously dismissed" section comes out of the handoff template since nothing populates it now.
- **Add a new \`/review\` skill** that takes a Linear issue ID (\`ALT-NN\`), PR number (\`372\`), branch name, or no argument (current branch's PR), resolves to {issue, PR, branch}, reads the ticket + any \`Design ready\` comment from \`design-task\` as the contract, pulls \`gh pr diff\`, reads the project conventions that bear on the touched directories, and posts a single structured Linear comment with severity-labelled findings (\`critical | high | medium | low\`).
- **Focus**: bugs / logic errors, security, convention violations, duplication, drift from the contract, dead code. **Out of scope**: test coverage, doc-artefact drift (\`api-change-check\` is the right tool there).
- **Makes no code changes** — the user (or another skill) addresses findings on their own cadence.

## Test plan
- [ ] Read \`.claude/skills/review/SKILL.md\` end-to-end — phases 1–8 read cleanly.
- [ ] Confirm \`execute-next-task\` no longer references "review subagent" / "review fixups" / "Review findings consciously dismissed" anywhere.
- [ ] Run \`/review\` against a recent PR (#370, #371, or #372) and check the Linear comment — severity calibration honest, file:line citations everywhere, empty review handled cleanly when there's nothing to flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)