### PR TITLE
feat(skills): concrete smoke-test guidance for plan-to-linear and address-review

### DIFF
--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -183,7 +183,17 @@ For pure-docs fixes (no source files changed) the gate set may collapse to nothi
 
 ## Phase 8 — Live smoke the changes against the dev env
 
-This step is **required**. The fixup commit shouldn't push without verifying the changes actually work. Pick the recipe based on what was fixed:
+This step is **required**. The fixup commit shouldn't push without verifying the changes actually work. Build/lint/unit pass means the code compiles and the unit suite is green — it does **not** mean the fix is correct against the running app. Pick the channel(s) based on what was fixed; if a fix spans surfaces, hit all of them.
+
+**Validation channels available in the worktree dev env:**
+
+1. **Browser** via `playwright-cli` (or the `test-dev` skill that wraps it) — **mandatory** for any fix that touches `client/` or otherwise changes user-visible behaviour. Type-check + lint is **not** a substitute. URL comes from `environment-details.xml`.
+2. **API** via `curl` against the URL in `environment-details.xml`, with the admin key from `//admin/apiKey`. Best for route-only fixes or asserting response shape/status.
+3. **Server logs** — `grep '"subcomponent":"<name>"' logs/app.*.log`, or `docker logs mini-infra-<worktree>-server` — for boot-time / scheduled / background-emit fixes that don't surface through a route.
+4. **Container state** — `docker ps`, `docker logs <container>`, `docker exec <container> …` for stack-template, sidecar, and infra-container fixes. The dev env is a real Docker host; poke directly.
+5. **Full env rebuild** — `pnpm worktree-env delete <slug> --force && pnpm worktree-env start` blows the VM/distro away and provisions a fresh one. Use when the fix changed seeded data, migrations, or first-boot reconciliation; a warm env won't replay those paths.
+
+**Recipe by fix shape:**
 
 1. **Read the dev env URL from `environment-details.xml`** at the worktree root:
 
@@ -191,17 +201,21 @@ This step is **required**. The fixup commit shouldn't push without verifying the
    MINI_INFRA_URL=$(xmllint --xpath 'string(//environment/endpoints/ui)' environment-details.xml)
    ```
 
-2. **UI-side fixes** — use the `playwright-cli` skill to drive the change in a browser. Walk the user flow that exercises the fixed surface; check that the bug `/review` flagged is no longer reproducible. If the fix was a button-disabled rule, click the button. If the fix was an empty-state placeholder, clear the input. Match the verification to the fix.
+2. **UI-side fixes (anything in `client/`)** — **mandatory** browser smoke via `playwright-cli` (or invoke `test-dev`). Walk the user flow that exercises the fixed surface; check that the bug `/review` flagged is no longer reproducible. If the fix was a button-disabled rule, click the button. If the fix was an empty-state placeholder, clear the input. Match the verification to the fix. Build + lint passing does not count.
 
-3. **Route / API fixes** — `curl` against the relevant endpoint, with auth if needed. Verify the response shape, status code, side-effects.
+3. **Route / API fixes** — `curl` against the relevant endpoint, with auth if needed. Verify the response shape, status code, side-effects. If the fixed route is consumed by an existing UI page, also drive that page via `playwright-cli` so the wire-up is exercised end-to-end.
 
    ```bash
-   curl -fsSL "$MINI_INFRA_URL/api/<route>" -H "..." | jq .
+   curl -fsSL "$MINI_INFRA_URL/api/<route>" -H "x-api-key: $(xmllint --xpath 'string(//admin/apiKey)' environment-details.xml)" | jq .
    ```
 
-4. **Pure server logic / library changes** — re-run the unit test that covers the fixed path (`pnpm --filter mini-infra-server exec vitest run <file>`) and assert it now exercises the new behaviour. If no unit test covers it, write a focused one as part of this fixup commit — the codebase rule is "don't add tests for impossible cases", but a fix that lacks any verification is a different problem.
+4. **Server-service fixes (no route change)** — if the service is invoked from an existing route, hit that route. If it runs at boot or on a schedule, watch the server logs for the relevant subcomponent (`grep '"subcomponent":"<name>"' logs/app.*.log`, or `docker logs mini-infra-<worktree>-server`). Re-run the targeted unit test as well (`pnpm --filter mini-infra-server exec vitest run <file>`) — if no unit test covers the fixed path, write a focused one as part of this fixup commit.
 
-5. **Migration fixes** — apply the migration locally (`pnpm --filter mini-infra-server exec prisma migrate dev`) and check that the resulting schema matches the intent. If the fix was about migration safety, additionally run a load simulation appropriate to the table size.
+5. **Stack-template / infra-container fixes** — apply the affected stack from the dev UI (drive via `playwright-cli`) or via the API, then confirm `docker ps` shows the new containers in the expected state and `docker logs <container>` is clean. For destructive template changes, do a full rebuild (`pnpm worktree-env delete <slug> --force && pnpm worktree-env start`) so first-boot reconciliation is exercised.
+
+6. **Pure server logic / library changes (no surface)** — re-run the unit test that covers the fixed path (`pnpm --filter mini-infra-server exec vitest run <file>`) and assert it now exercises the new behaviour. If no unit test covers it, write a focused one as part of this fixup commit — the codebase rule is "don't add tests for impossible cases", but a fix that lacks any verification is a different problem.
+
+7. **Migration / seeded-data fixes** — apply the migration locally (`pnpm --filter mini-infra-server exec prisma migrate dev` then `prisma migrate status`) and check the resulting schema matches the intent. For destructive migrations, also do a full env rebuild and re-validate the affected feature through its primary channel (browser/API). If the fix was about migration safety, additionally run a load simulation appropriate to the table size.
 
 If the smoke fails, the fix is wrong. Iterate — re-read the code, refine the fix, re-smoke. Don't push something the smoke disagreed with.
 

--- a/.claude/skills/plan-to-linear/SKILL.md
+++ b/.claude/skills/plan-to-linear/SKILL.md
@@ -132,16 +132,27 @@ This is the difference between Reading 1 and Reading 2 of the populator design: 
 
 Map the same touched paths to the live-smoke recipe the executor should run after build/lint/unit tests pass. These go into the ticket's "Smoke tests" section. Pick whichever apply — multiple components → multiple recipes.
 
+**Validation channels available in the worktree dev env** — every recipe should explicitly say which channel(s) to use, not hand-wave with "verify it works":
+
+1. **Browser (mandatory for any user-visible UI change)** — drive the running dev UI with the `playwright-cli` skill (or the higher-level `test-dev` skill, which wraps it). Read the URL from `environment-details.xml`. Type checks and unit tests do **not** count as UI validation — if a phase touches `client/src/` or `client/public/` and the change is user-visible, the smoke recipe must drive a real browser. The only exception is pure refactors with zero rendered-output delta.
+2. **API (direct)** — `curl` against the URL in `environment-details.xml`, using the admin API key from `//admin/apiKey`. Best for route-only changes, headless service triggers, or asserting response shape.
+3. **Server logs** — `grep '"subcomponent":"<name>"' logs/app.*.log` (or `docker logs mini-infra-<worktree>-server`) for boot-time/scheduled work that doesn't surface through a route.
+4. **Container state** — `docker ps`, `docker logs <container>`, `docker exec <container> …` for stack-template, sidecar, and infra-container changes. The dev env is a real Docker host; you can poke at containers directly.
+5. **Full env rebuild (last-resort regression check)** — `pnpm worktree-env delete <slug> --force && pnpm worktree-env start` blows the VM/distro away and provisions a fresh one from scratch. Use this when the phase changes seeded data, migrations, or first-boot behaviour that wouldn't replay against a warm env. Document it in the recipe rather than expecting the executor to guess.
+
+For multi-channel changes (e.g. a new endpoint *and* a UI surface that calls it) list **all** the channels the executor should hit — API + browser, not just one.
+
 | Touched path pattern | Smoke recipe to recommend |
 |---|---|
-| `client/src/`, `client/public/` | Invoke the `test-dev` skill walking the affected user flow in the dev environment. Don't re-implement what `test-dev` does. |
-| `server/src/routes/` | Hit the affected endpoint(s) with `curl` against the URL in `environment-details.xml`. Use the admin API key from `//admin/apiKey` in the same file. |
-| `server/src/services/` (no route change) | If the service runs at boot or on a schedule, watch the server logs for the relevant subcomponent (`grep '"subcomponent":"<name>"' logs/app.*.log`). If it's invoked from a route that already exists, hit that route. |
-| `server/templates/` | Confirm the affected stack reconciles cleanly: `docker ps` shows the new containers, no errors in the relevant container's logs (`docker logs <container>`). |
-| `egress-gateway/`, `egress-fw-agent/`, `egress-shared/` | Confirm the binary builds, the container starts, and the egress page in dev shows the agent/gateway healthy. |
-| Server NATS subjects (`server/src/services/nats/`, `lib/types/nats-subjects.ts`) | Publish a test message via `NatsBus` (or the smoke ping `mini-infra.system.ping`) and verify the consumer side fires. Reference `docs/architecture/internal-messaging.md` for the subject inventory. |
-| `update-sidecar/`, `agent-sidecar/` | Run the sidecar's npm tests (`cd <dir> && npm test`). Live smoke is component-specific; if the phase exercises a runtime path, drive it from the server side. |
-| `pg-az-backup/` | Trigger a backup from the dev UI (or via the API) and confirm the run completes; check Azure Blob if the env has Azure configured, otherwise just confirm the runner exited cleanly. |
+| `client/src/`, `client/public/` | **Mandatory:** drive the browser via `playwright-cli` (or invoke the `test-dev` skill, which wraps it) walking the affected user flow against the URL in `environment-details.xml`. Don't re-implement what `test-dev` does. Type-check + lint pass is **not** a substitute. If the phase also adds an API surface, validate that with `curl` first, then assert the UI consumes it correctly. |
+| `server/src/routes/` | Hit the affected endpoint(s) with `curl` against the URL in `environment-details.xml`. Use the admin API key from `//admin/apiKey` in the same file. If the route is reachable from a UI page that exists today, also smoke that page via `playwright-cli` to confirm the wire-up. |
+| `server/src/services/` (no route change) | If the service runs at boot or on a schedule, watch the server logs for the relevant subcomponent (`grep '"subcomponent":"<name>"' logs/app.*.log`, or `docker logs mini-infra-<worktree>-server` if file logs aren't mounted). If it's invoked from a route that already exists, hit that route with `curl`. If the change only takes effect on first boot, do a full rebuild (`pnpm worktree-env delete <slug> --force && pnpm worktree-env start`) and re-check the logs. |
+| `server/templates/` | Apply the affected stack from the dev UI (or via the API), then confirm: `docker ps` shows the new containers in the expected state, `docker logs <container>` is clean, and `docker exec <container> …` can probe runtime config if the template wires any. For destructive template changes (volumes, schema), include a full rebuild step so first-boot reconciliation is exercised. |
+| `egress-gateway/`, `egress-fw-agent/`, `egress-shared/` | Confirm the binary builds, the container starts (`docker ps`, `docker logs <container>` clean), and the egress page in the dev UI (drive via `playwright-cli`) shows the agent/gateway healthy. |
+| Server NATS subjects (`server/src/services/nats/`, `lib/types/nats-subjects.ts`) | Publish a test message via `NatsBus` (or the smoke ping `mini-infra.system.ping`) and verify the consumer side fires — assert via server logs (`grep '"subject":"<subject>"' logs/app.*.log`) or by tailing `docker logs` on the consumer container. Reference `docs/architecture/internal-messaging.md` for the subject inventory. |
+| `update-sidecar/`, `agent-sidecar/` | Run the sidecar's npm tests (`cd <dir> && npm test`). Live smoke is component-specific; if the phase exercises a runtime path, drive it from the server side (API + log inspection). UI surfaces in the agent sidecar still need `playwright-cli` validation. |
+| `pg-az-backup/` | Trigger a backup from the dev UI (drive via `playwright-cli`) or via the API and confirm the run completes; check Azure Blob if the env has Azure configured, otherwise just confirm the runner exited cleanly via `docker logs`. |
+| Prisma schema / migrations (`server/prisma/`) | Run `pnpm --filter mini-infra-server exec prisma migrate status` to confirm the migration applied cleanly. For destructive migrations, do a full rebuild (`pnpm worktree-env delete <slug> --force && pnpm worktree-env start`) so the migration replays against a fresh DB. |
 | `lib/types/` only | No live smoke needed; build pass = types compile. |
 | `docs/`, README, SKILL.md, root configs only | No live smoke; build/lint is enough. The phase is docs-only — also tell the executor to skip the backgrounded `pnpm worktree-env start`. |
 
@@ -524,13 +535,23 @@ This is an execution-agent ticket — no separate planning phase. Read the docs 
 
 ## Smoke tests (run after build/lint/unit tests pass)
 
+Build/lint/unit pass means the code compiles and the unit suite is green — it does **not** mean the feature works. Every recipe below names the validation channel(s) the executor must use; don't substitute one for another.
+
+Available channels in the worktree dev env:
+- **Browser** via `playwright-cli` (or the `test-dev` skill that wraps it) — **mandatory** for any user-visible UI change. URL comes from `environment-details.xml`.
+- **API** via `curl` against the same URL, with the admin key from `//admin/apiKey` in `environment-details.xml`.
+- **Server logs** — `grep '"subcomponent":"<name>"' logs/app.*.log`, or `docker logs mini-infra-<worktree>-server`.
+- **Container state** — `docker ps`, `docker logs <container>`, `docker exec <container> …`.
+- **Full env rebuild** — `pnpm worktree-env delete <slug> --force && pnpm worktree-env start` for first-boot / migration / seeded-data regressions.
+
 <bullets generated from Phase 3.2's smoke-recipe map for this phase's touched components.
  Examples by component:>
 
-- **Server route changes** → `curl -H "x-api-key: <admin>" $MINI_INFRA_URL/api/<route>` and verify response shape.
-- **UI changes** → invoke the `test-dev` skill on the affected page; walk the golden path.
-- **Stack template changes** → `docker ps` shows the new containers, `docker logs <container>` clean.
-- **NATS subject changes** → publish via `NatsBus`, confirm consumer fires; baseline with `mini-infra.system.ping`.
+- **Server route changes** → `curl -H "x-api-key: <admin>" $MINI_INFRA_URL/api/<route>` and verify response shape. If a UI page already consumes this route, also drive that page with `playwright-cli`.
+- **UI changes** → drive the affected page with `playwright-cli` (or invoke the `test-dev` skill); walk the golden path. Type-check + lint is **not** a substitute.
+- **Stack template changes** → apply the stack, then `docker ps` shows the new containers in the expected state and `docker logs <container>` is clean. For destructive template changes, also do a full rebuild and re-check.
+- **NATS subject changes** → publish via `NatsBus`, confirm consumer fires via server logs or `docker logs` on the consumer; baseline with `mini-infra.system.ping`.
+- **Migration / seeded-data changes** → full rebuild (`pnpm worktree-env delete <slug> --force && pnpm worktree-env start`), then `prisma migrate status` clean and the affected feature validated through its primary channel (browser/API).
 - ...
 
 If none of the recipes match, the populator emits `<no recipe — confirm with user before merging>` here and the executor will surface that.


### PR DESCRIPTION
## Summary
- Both skills now spell out the validation channels available in a worktree dev env: **browser** (mandatory for UI changes via `playwright-cli`/`test-dev`), **API** (`curl` against `environment-details.xml`), **server logs**, **container state** (`docker ps`/`logs`/`exec`), and **full env rebuild** (`pnpm worktree-env delete <slug> --force && pnpm worktree-env start`) for first-boot/migration/seeded-data regressions.
- `plan-to-linear` §3.2 smoke-recipe table now lists multi-channel recipes where appropriate (e.g. route + UI page that consumes it), explicitly forbids treating type-check as UI validation, and adds a Prisma-migration row.
- `address-review` Phase 8 recipe list mirrors the same channels and adds a stack-template recipe plus a migration recipe; UI-side fixes are explicitly mandatory-browser-smoke.
- The render template in `plan-to-linear`'s Workflow section now teaches the channel framework directly so executor tickets carry it forward.

## Test plan
- [ ] Read both updated SKILL.md files end-to-end and confirm the channel framework reads consistently
- [ ] Next time `plan-to-linear` seeds a project, confirm the seeded tickets carry concrete recipes (not the old hand-wave)
- [ ] Next time `address-review` runs, confirm Phase 8 picks the right channel for the fix shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)