### PR TITLE
feat(security): replace ALLOW_INSECURE env var with HTTPS-only mode setting (Phase 4, MINI-40)

### DIFF
--- a/client/src/app/settings/system/page.tsx
+++ b/client/src/app/settings/system/page.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useEffectEvent, useMemo } from "react";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import {
@@ -24,14 +24,26 @@ import {
 } from "@/components/ui/form";
 import { Switch } from "@/components/ui/switch";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
   useSystemSettings,
   useCreateSystemSetting,
   useUpdateSystemSetting,
 } from "@/hooks/use-settings";
+import { useSystemInfo } from "@/hooks/use-system-info";
 import {
   IconAlertCircle,
   IconDeviceFloppy,
   IconLoader2,
+  IconLock,
   IconSettings,
   IconNetwork,
   IconShield,
@@ -44,11 +56,12 @@ import { SystemSettingsInfo } from "@mini-infra/types";
 
 // System settings schema
 const systemSettingsSchema = z.object({
-  // Public URL and CORS
+  // Public URL and security toggles
   publicUrl: z.string().optional().refine(
     (val) => !val || /^https?:\/\//.test(val),
     "Must be a valid URL starting with http:// or https://"
   ),
+  httpsOnlyMode: z.boolean(),
   corsEnabled: z.boolean(),
 
   // Production mode setting
@@ -77,6 +90,9 @@ type SystemSettingsFormData = z.infer<typeof systemSettingsSchema>;
 
 export default function SystemSettingsPage() {
   const [isSaving, setIsSaving] = useState(false);
+  const [pendingSubmit, setPendingSubmit] = useState<SystemSettingsFormData | null>(null);
+
+  const systemInfo = useSystemInfo();
 
   // Fetch existing system settings for system category
   const {
@@ -98,6 +114,7 @@ export default function SystemSettingsPage() {
     resolver: zodResolver(systemSettingsSchema),
     defaultValues: {
       publicUrl: "",
+      httpsOnlyMode: false,
       corsEnabled: false,
       isProduction: false,
       dockerHostIp: "",
@@ -125,6 +142,10 @@ export default function SystemSettingsPage() {
   const syncFormFromSettings = useEffectEvent(
     (settingsMap: Record<string, SystemSettingsInfo>) => {
       form.setValue("publicUrl", settingsMap.public_url?.value || "");
+      form.setValue(
+        "httpsOnlyMode",
+        settingsMap.https_only_mode?.value === "true",
+      );
       form.setValue(
         "corsEnabled",
         settingsMap.cors_enabled?.value === "true",
@@ -154,6 +175,12 @@ export default function SystemSettingsPage() {
           category: "system" as const,
           key: "public_url",
           value: data.publicUrl || "",
+          isEncrypted: false,
+        },
+        {
+          category: "system" as const,
+          key: "https_only_mode",
+          value: data.httpsOnlyMode.toString(),
           isEncrypted: false,
         },
         {
@@ -212,11 +239,45 @@ export default function SystemSettingsPage() {
       refetchSettings();
     } catch (error) {
       console.error("Failed to save system settings:", error);
-      toastWithCopy.error("Failed to save system settings");
+      const message = error instanceof Error ? error.message : "Failed to save system settings";
+      toastWithCopy.error(message);
     } finally {
       setIsSaving(false);
     }
   };
+
+  // Intercept submit so newly enabling HTTPS-only mode shows a confirm modal
+  // first — the lockout cost (HSTS pins for a year, page won't load over HTTP)
+  // is high enough that a typo on the toggle deserves a deliberate Yes.
+  const onFormSubmit = (data: SystemSettingsFormData) => {
+    const wasHttpsOnly = settings.https_only_mode?.value === "true";
+    if (!wasHttpsOnly && data.httpsOnlyMode) {
+      setPendingSubmit(data);
+      return;
+    }
+    return handleSubmit(data);
+  };
+
+  const confirmHttpsOnlyEnable = async () => {
+    if (!pendingSubmit) return;
+    const data = pendingSubmit;
+    setPendingSubmit(null);
+    await handleSubmit(data);
+  };
+
+  // Form-level guards on the security toggles. publicUrl must exist for either
+  // toggle; HTTPS-only additionally requires an https:// publicUrl. Returning
+  // helper text alongside makes the disabled reason discoverable in the UI
+  // rather than the user having to read the docs.
+  const watchedPublicUrl = useWatch({ control: form.control, name: "publicUrl" }) ?? "";
+  const corsToggleDisabled = !watchedPublicUrl;
+  const httpsOnlyToggleDisabled = !watchedPublicUrl || !watchedPublicUrl.startsWith("https://");
+  const corsHelperText = corsToggleDisabled
+    ? "Set the Public URL above to enable this option — that's the origin allowed past CORS."
+    : "When enabled, only the Public URL above is allowed as a cross-origin request source. When disabled, all origins are allowed.";
+  const httpsOnlyHelperText = httpsOnlyToggleDisabled
+    ? "Set the Public URL above to an https:// URL to enable this option."
+    : "When enabled, the server emits HSTS, upgrades insecure requests, and marks auth cookies Secure. Browsers will then refuse plain-HTTP access.";
 
 
   if (settingsError) {
@@ -238,6 +299,16 @@ export default function SystemSettingsPage() {
 
   return (
     <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
+      {systemInfo.forceInsecureOverride && (
+        <div className="px-4 lg:px-6">
+          <Alert variant="default" className="border-amber-500 text-amber-700 dark:text-amber-400">
+            <IconLock className="h-4 w-4" />
+            <AlertDescription>
+              Server is running with <code>MINI_INFRA_FORCE_INSECURE=true</code> — HTTPS-only mode is overridden at the process level. The toggle below is ignored until that env var is removed and the server restarted.
+            </AlertDescription>
+          </Alert>
+        </div>
+      )}
       <div className="px-4 lg:px-6">
         <div className="flex items-center gap-3 mb-6">
           <div className="p-3 rounded-md bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300">
@@ -271,18 +342,18 @@ export default function SystemSettingsPage() {
           ) : (
             <Form {...form}>
               <form
-                onSubmit={form.handleSubmit(handleSubmit)}
+                onSubmit={form.handleSubmit(onFormSubmit)}
                 className="space-y-6"
               >
-                {/* Public URL & CORS */}
+                {/* Public URL, HTTPS-only mode, CORS */}
                 <Card>
                   <CardHeader>
                     <CardTitle className="flex items-center space-x-2">
                       <IconWorld className="h-5 w-5" />
-                      <span>Public URL &amp; CORS</span>
+                      <span>Public URL &amp; security</span>
                     </CardTitle>
                     <CardDescription>
-                      Configure the externally-reachable URL for this instance and cross-origin request policy
+                      Configure the externally-reachable URL for this instance, HTTPS-only enforcement, and cross-origin request policy
                     </CardDescription>
                   </CardHeader>
                   <CardContent className="space-y-4">
@@ -307,6 +378,29 @@ export default function SystemSettingsPage() {
                     />
                     <FormField
                       control={form.control}
+                      name="httpsOnlyMode"
+                      render={({ field }) => (
+                        <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                          <div className="space-y-0.5">
+                            <FormLabel className="text-base">
+                              HTTPS-only mode
+                            </FormLabel>
+                            <FormDescription>
+                              {httpsOnlyHelperText}
+                            </FormDescription>
+                          </div>
+                          <FormControl>
+                            <Switch
+                              checked={field.value}
+                              onCheckedChange={field.onChange}
+                              disabled={httpsOnlyToggleDisabled && !field.value}
+                            />
+                          </FormControl>
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
                       name="corsEnabled"
                       render={({ field }) => (
                         <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
@@ -315,13 +409,14 @@ export default function SystemSettingsPage() {
                               Restrict CORS
                             </FormLabel>
                             <FormDescription>
-                              When enabled, only the Public URL above is allowed as a cross-origin request source. When disabled, all origins are allowed.
+                              {corsHelperText}
                             </FormDescription>
                           </div>
                           <FormControl>
                             <Switch
                               checked={field.value}
                               onCheckedChange={field.onChange}
+                              disabled={corsToggleDisabled && !field.value}
                             />
                           </FormControl>
                         </FormItem>
@@ -508,6 +603,59 @@ export default function SystemSettingsPage() {
         </div>
       </div>
 
+      <AlertDialog
+        open={pendingSubmit !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingSubmit(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <IconLock className="h-5 w-5" />
+              Enable HTTPS-only mode?
+            </AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="space-y-3">
+                <p>
+                  Saving will start enforcing HTTPS for this instance:
+                </p>
+                <ul className="list-disc list-inside text-sm space-y-1">
+                  <li>
+                    Browsers will be told to upgrade insecure requests (CSP <code>upgrade-insecure-requests</code>)
+                  </li>
+                  <li>
+                    HSTS will be sent — <strong>browsers will pin HTTPS for up to 1 year</strong>; disabling later won&apos;t immediately let HTTP back in until the pin expires or site data is cleared
+                  </li>
+                  <li>
+                    Auth cookies will be marked <code>Secure</code>; the browser will drop them on plain HTTP, which means anyone still on HTTP will be silently logged out
+                  </li>
+                </ul>
+                <p className="text-sm">
+                  Your current connection is{" "}
+                  {systemInfo.protocol === "https" ? (
+                    <span className="font-medium text-green-600 dark:text-green-400">HTTPS ✓</span>
+                  ) : (
+                    <span className="font-medium text-red-600 dark:text-red-400">HTTP ✗</span>
+                  )}
+                  .
+                </p>
+                {systemInfo.protocol !== "https" && (
+                  <p className="text-sm font-medium text-red-600 dark:text-red-400">
+                    The server will reject this change because the request itself is HTTP. Reload the page over HTTPS first.
+                  </p>
+                )}
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmHttpsOnlyEnable}>
+              Enable HTTPS-only mode
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/client/src/hooks/use-settings.ts
+++ b/client/src/hooks/use-settings.ts
@@ -109,7 +109,8 @@ async function createSystemSetting(
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to create system setting: ${response.statusText}`);
+    const body = await response.json().catch(() => null);
+    throw new Error(body?.message || `Failed to create system setting: ${response.statusText}`);
   }
 
   const data: SettingResponse = await response.json();
@@ -137,7 +138,8 @@ async function updateSystemSetting(
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to update system setting: ${response.statusText}`);
+    const body = await response.json().catch(() => null);
+    throw new Error(body?.message || `Failed to update system setting: ${response.statusText}`);
   }
 
   const data: SettingResponse = await response.json();

--- a/client/src/hooks/use-system-info.ts
+++ b/client/src/hooks/use-system-info.ts
@@ -1,0 +1,32 @@
+import { useQuery } from "@tanstack/react-query";
+
+interface HealthResponse {
+  status: string;
+  version: string;
+  forceInsecureOverride?: boolean;
+}
+
+export interface SystemInfo {
+  forceInsecureOverride: boolean;
+  protocol: "http" | "https";
+}
+
+export function useSystemInfo() {
+  const { data } = useQuery<HealthResponse>({
+    queryKey: ["app-health"],
+    queryFn: async () => {
+      const res = await fetch("/health");
+      if (!res.ok) throw new Error("Failed to fetch system info");
+      return res.json();
+    },
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const info: SystemInfo = {
+    forceInsecureOverride: data?.forceInsecureOverride ?? false,
+    protocol: typeof window !== "undefined" && window.location.protocol === "https:" ? "https" : "http",
+  };
+
+  return info;
+}

--- a/deployment/development/docker-compose.worktree.yaml
+++ b/deployment/development/docker-compose.worktree.yaml
@@ -41,7 +41,6 @@ services:
       - /var/run/mini-infra:/var/run/mini-infra
     environment:
       - LOG_LEVEL=debug
-      - ALLOW_INSECURE=true
       - ENABLE_DEV_API_KEY_ENDPOINT=true
       - BUNDLES_DRIVE_BUILTIN=true
       - MINI_INFRA_EGRESS_POOL_CIDR=${EGRESS_POOL_CIDR}

--- a/docs/planning/not-shipped/worktree-egress-subnet-allocation.md
+++ b/docs/planning/not-shipped/worktree-egress-subnet-allocation.md
@@ -111,7 +111,6 @@ If a profile is in slot `>= 64`, throw — pool exhausted, document the override
 ```yaml
 environment:
   - LOG_LEVEL=debug
-  - ALLOW_INSECURE=true
   - ENABLE_DEV_API_KEY_ENDPOINT=true
   - BUNDLES_DRIVE_BUILTIN=true
   - MINI_INFRA_EGRESS_POOL_CIDR=${EGRESS_POOL_CIDR}

--- a/server/.env.example
+++ b/server/.env.example
@@ -22,6 +22,7 @@ LOG_LEVEL=debug
 # Security
 # PUBLIC_URL and CORS origin are now configured via Settings in the UI.
 # If PUBLIC_URL is set here, it will be migrated to the database on first startup.
-# Set to true to disable HTTPS-enforcing headers (HSTS, CSP upgrade-insecure-requests) for HTTP-only environments
-# WARNING: Only use in development or trusted environments behind a reverse proxy
-ALLOW_INSECURE=false
+# HTTPS-only mode is configured via Settings in the UI (https_only_mode).
+# Recovery escape hatch: set to true to force-disable HTTPS-only mode regardless of the DB setting
+# (e.g. to recover from a bricked install where HTTPS-only was enabled without working TLS).
+MINI_INFRA_FORCE_INSECURE=false

--- a/server/src/app-factory.ts
+++ b/server/src/app-factory.ts
@@ -11,14 +11,14 @@ import pinoHttp from "pino-http";
 import expressListEndpoints from "express-list-endpoints";
 import path from "path";
 import { randomUUID } from "crypto";
-import appConfig, { securityConfig } from "./lib/config-new";
-import { createDynamicCorsOrigin } from "./lib/public-url-service";
+import appConfig from "./lib/config-new";
+import { createDynamicCorsOrigin, isForceInsecureOverride } from "./lib/public-url-service";
 import { buildPinoHttpOptions } from "./lib/logger-factory";
 import {
   requestContextMiddleware,
   type RequestWithId,
 } from "./middleware/request-context";
-import { createHelmetMiddleware } from "./lib/security";
+import { createHelmetDispatcher } from "./lib/security";
 import { errorHandler, notFoundHandler } from "./lib/error-handler";
 import { extractJwtUser } from "./lib/jwt-middleware";
 import authRoutes from "./routes/auth";
@@ -279,7 +279,7 @@ export function createApp(options: CreateAppOptions = {}): express.Application {
     }),
   );
 
-  app.use(createHelmetMiddleware(securityConfig.allowInsecure));
+  app.use(createHelmetDispatcher());
   app.use(
     cors({
       origin: createDynamicCorsOrigin(appConfig.server.nodeEnv),
@@ -299,6 +299,7 @@ export function createApp(options: CreateAppOptions = {}): express.Application {
       environment: appConfig.server.nodeEnv,
       uptime: process.uptime(),
       version: process.env.BUILD_VERSION || "dev",
+      forceInsecureOverride: isForceInsecureOverride(),
     });
   }) as RequestHandler);
 

--- a/server/src/lib/config-new.ts
+++ b/server/src/lib/config-new.ts
@@ -40,9 +40,6 @@ const configSchema = z.object({
   connectivity: z.object({
     checkInterval: z.number(),
   }),
-  security: z.object({
-    allowInsecure: z.boolean(),
-  }),
   agent: z.object({
     model: z.string(),
     thinking: z.enum(["adaptive", "enabled", "disabled"]),
@@ -131,12 +128,6 @@ const appConfig: Config = {
       | "high"
       | "max",
   },
-  security: {
-    allowInsecure: (() => {
-      const value = getConfigValue<string | boolean>("security.allowInsecure", "ALLOW_INSECURE", false);
-      return value === "true" || value === true;
-    })(),
-  },
 };
 
 // Validate the final configuration
@@ -145,9 +136,9 @@ let validatedConfig: Config;
 try {
   validatedConfig = configSchema.parse(appConfig);
 
-  // Log security configuration for transparency
-  if (validatedConfig.security.allowInsecure) {
-    console.log("⚠️  Security: Allowing insecure connections (configured via ALLOW_INSECURE)");
+  // Boot-time warning when the recovery escape hatch is in effect.
+  if (process.env.MINI_INFRA_FORCE_INSECURE === "true") {
+    console.log("⚠️  Security: MINI_INFRA_FORCE_INSECURE=true — HTTPS-only mode is overridden, all requests are treated as insecure");
   }
 } catch (error) {
   // Use console.error since logger isn't available yet
@@ -188,7 +179,6 @@ export const {
   docker: dockerConfig,
   azure: azureConfig,
   connectivity: connectivityConfig,
-  security: securityConfig,
   agent: agentConfig,
 } = validatedConfig;
 

--- a/server/src/lib/public-url-service.ts
+++ b/server/src/lib/public-url-service.ts
@@ -9,6 +9,7 @@ const cache = new NodeCache({ stdTTL: 1800, checkperiod: 120 });
 
 const CACHE_KEY_PUBLIC_URL = "public_url";
 const CACHE_KEY_CORS_ORIGIN = "cors_origin";
+const CACHE_KEY_HTTPS_ONLY = "https_only_mode";
 
 // Wrapper to distinguish "not cached" from "cached as null"
 interface CachedValue {
@@ -72,6 +73,45 @@ export function invalidatePublicUrlCache(): void {
 export function invalidateCorsEnabledCache(): void {
   cache.del(CACHE_KEY_CORS_ORIGIN);
   logger.info("cors_enabled cache invalidated");
+}
+
+/**
+ * Check if HTTPS-only mode is enabled. When enabled, the server emits CSP
+ * `upgrade-insecure-requests`, sends HSTS, and marks auth cookies `Secure`.
+ * Returns false when not configured (permissive — fresh HTTP installs work).
+ */
+export async function isHttpsOnlyEnabled(): Promise<boolean> {
+  const cached = cache.get<CachedValue>(CACHE_KEY_HTTPS_ONLY);
+  if (cached !== undefined) {
+    return cached.value === "true";
+  }
+
+  try {
+    const setting = await prisma.systemSettings.findFirst({
+      where: { category: "system", key: "https_only_mode", isActive: true },
+    });
+    const value = setting?.value || null;
+    cache.set(CACHE_KEY_HTTPS_ONLY, { value });
+    return value === "true";
+  } catch (error) {
+    logger.warn({ error: error instanceof Error ? error.message : "Unknown error" }, "Failed to read https_only_mode from DB, returning false");
+    return false;
+  }
+}
+
+export function invalidateHttpsOnlyCache(): void {
+  cache.del(CACHE_KEY_HTTPS_ONLY);
+  logger.info("https_only_mode cache invalidated");
+}
+
+/**
+ * Recovery escape hatch: when `MINI_INFRA_FORCE_INSECURE=true` is set on the
+ * server's environment, the Helmet dispatcher and cookie helper short-circuit
+ * to insecure regardless of the DB row. Used to recover from a bricked HTTP
+ * install where someone toggled HTTPS-only mode on without TLS in place.
+ */
+export function isForceInsecureOverride(): boolean {
+  return process.env.MINI_INFRA_FORCE_INSECURE === "true";
 }
 
 /** Dev CORS origins — used when no cors_origin setting is configured in development */

--- a/server/src/lib/security.ts
+++ b/server/src/lib/security.ts
@@ -1,8 +1,11 @@
 import helmet from "helmet";
+import type { RequestHandler } from "express";
+import { isHttpsOnlyEnabled, isForceInsecureOverride } from "./public-url-service";
 
-// Helmet security middleware configuration
-export const createHelmetMiddleware = (allowInsecure: boolean) => {
-  // Base CSP directives
+// Builds a Helmet middleware. `httpsOnly` true → CSP upgrade-insecure-requests
+// + HSTS + restricted connectSrc; false → permissive (allows HTTP fetches, no
+// HSTS).
+export const createHelmetMiddleware = (httpsOnly: boolean) => {
   const cspDirectives: Record<string, string[]> = {
     defaultSrc: ["'self'"],
     styleSrc: ["'self'", "'unsafe-inline'", "https:"],
@@ -16,32 +19,42 @@ export const createHelmetMiddleware = (allowInsecure: boolean) => {
     formAction: ["'self'", "https://github.com"],
   };
 
-  // Allow HTTP connections when insecure mode is enabled
-  if (allowInsecure) {
-    // Add http: to allowed sources for API calls
-    cspDirectives.connectSrc = ["'self'", "https:", "http:"];
-    // Explicitly disable upgradeInsecureRequests to prevent Helmet from adding it by default
-    cspDirectives.upgradeInsecureRequests = null as unknown as [];
-  } else {
-    // Force HTTPS upgrades in production/secure mode
+  if (httpsOnly) {
     cspDirectives.upgradeInsecureRequests = [];
+  } else {
+    cspDirectives.connectSrc = ["'self'", "https:", "http:"];
+    cspDirectives.upgradeInsecureRequests = null as unknown as [];
   }
 
   return helmet({
-    // Configure Content Security Policy
     contentSecurityPolicy: {
       directives: cspDirectives,
     },
-
-    // Configure other security headers
     crossOriginEmbedderPolicy: false,
-    // Disable HSTS when ALLOW_INSECURE is true to allow HTTP traffic
-    hsts: allowInsecure
-      ? false
-      : {
+    hsts: httpsOnly
+      ? {
           maxAge: 31536000,
           includeSubDomains: true,
           preload: true,
-        },
+        }
+      : false,
   });
+};
+
+// Pre-builds both Helmet variants once and dispatches per request based on the
+// cached `https_only_mode` setting. The `MINI_INFRA_FORCE_INSECURE` env var, if
+// set, short-circuits to the permissive variant regardless of the DB row —
+// recovery escape hatch when an HTTPS-only toggle has bricked an HTTP install.
+export const createHelmetDispatcher = (): RequestHandler => {
+  const strict = createHelmetMiddleware(true);
+  const permissive = createHelmetMiddleware(false);
+
+  return (req, res, next) => {
+    if (isForceInsecureOverride()) {
+      return permissive(req, res, next);
+    }
+    isHttpsOnlyEnabled()
+      .then((httpsOnly) => (httpsOnly ? strict : permissive)(req, res, next))
+      .catch(next);
+  };
 };

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -10,7 +10,8 @@ import Docker from "dockerode";
 import os from "os";
 import passport from "../lib/passport";
 import { getLogger } from "../lib/logger-factory";
-import { serverConfig, securityConfig, authConfig } from "../lib/config-new";
+import { serverConfig, authConfig } from "../lib/config-new";
+import { isHttpsOnlyEnabled, isForceInsecureOverride } from "../lib/public-url-service";
 import { generateToken } from "../lib/jwt";
 import prisma from "../lib/prisma";
 import {
@@ -53,13 +54,18 @@ function serializeUserProfile(user: JWTUser & { mustResetPwd?: boolean }): UserP
   };
 }
 
-// Cookie helper
-function getSecureCookieFlag(): boolean {
-  return serverConfig.nodeEnv === "production" && !securityConfig.allowInsecure;
+// Cookie helper. Production + HTTPS-only mode → Secure + SameSite=Strict.
+// Anything else (dev, or production with HTTPS-only off) → permissive cookies
+// so the browser still sends them over HTTP. The MINI_INFRA_FORCE_INSECURE env
+// var short-circuits to permissive regardless of DB state.
+async function getSecureCookieFlag(): Promise<boolean> {
+  if (serverConfig.nodeEnv !== "production") return false;
+  if (isForceInsecureOverride()) return false;
+  return await isHttpsOnlyEnabled();
 }
 
-function setAuthCookie(res: Response, token: string): void {
-  const secure = getSecureCookieFlag();
+async function setAuthCookie(res: Response, token: string): Promise<void> {
+  const secure = await getSecureCookieFlag();
   res.cookie("auth-token", token, {
     httpOnly: true,
     secure,
@@ -150,7 +156,7 @@ router.post("/setup", (async (req: Request, res: Response) => {
       createdAt: result.createdAt.toISOString(),
     };
     const token = generateToken(profile);
-    setAuthCookie(res, token);
+    await setAuthCookie(res, token);
 
     logger.info({ userId: result.id, email: result.email }, "Initial user created during setup");
     res.status(201).json({ success: true });
@@ -391,7 +397,7 @@ router.post("/login", (async (req: Request, res: Response) => {
     const token = generateToken(profile, {
       mustResetPwd: user.mustResetPwd,
     });
-    setAuthCookie(res, token);
+    await setAuthCookie(res, token);
 
     logger.info({ userId: user.id }, "Local login successful");
     res.json({ success: true, mustResetPwd: user.mustResetPwd });
@@ -584,7 +590,7 @@ router.post("/change-password", requireAuth, (async (req: Request, res: Response
       createdAt: user.createdAt.toISOString(),
     };
     const token = generateToken(profile);
-    setAuthCookie(res, token);
+    await setAuthCookie(res, token);
 
     logger.info({ userId }, "Password changed successfully");
     res.json({ success: true });
@@ -632,7 +638,7 @@ router.get("/google", (async (req: Request, res: Response, next: NextFunction) =
   const statePayload = JSON.stringify({ nonce, redirect: redirectPath });
   const state = Buffer.from(statePayload).toString("base64");
 
-  const secure = getSecureCookieFlag();
+  const secure = await getSecureCookieFlag();
   res.cookie("oauth-state", nonce, {
     httpOnly: true,
     secure,
@@ -713,7 +719,7 @@ router.get("/google/callback", ((req: Request, res: Response, next: NextFunction
         (await getPublicUrlForRedirect()) ||
         (serverConfig.nodeEnv === "development" ? "http://localhost:3000" : "");
 
-      setAuthCookie(res, token);
+      await setAuthCookie(res, token);
       res.redirect(`${frontendUrl}${redirectPath}`);
     } catch (error) {
       logger.error({ error }, "Error generating JWT after OAuth");
@@ -734,9 +740,9 @@ router.get("/failure", (async (req: Request, res: Response) => {
 // ==========================================
 // Logout
 // ==========================================
-router.post("/logout", ((req: Request, res: Response) => {
+router.post("/logout", (async (req: Request, res: Response) => {
   try {
-    const secure = getSecureCookieFlag();
+    const secure = await getSecureCookieFlag();
     res.clearCookie("auth-token", {
       httpOnly: true,
       secure,

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -110,6 +110,65 @@ const updateSettingSchema = z.object({
   isEncrypted: z.boolean().optional(),
 });
 
+interface SecuritySettingValidationError {
+  status: number;
+  code: string;
+  message: string;
+}
+
+/**
+ * Gate enabling the security-sensitive system settings — `https_only_mode`
+ * and `cors_enabled` — to prevent users locking themselves out. HTTPS-only
+ * mode further requires the inbound request itself to be HTTPS, so a user
+ * still on HTTP can't flip the toggle and be unable to load the page.
+ */
+async function validateSecuritySettingChange(
+  req: Request,
+  category: string,
+  key: string,
+  value: string,
+): Promise<SecuritySettingValidationError | null> {
+  if (category !== "system" || value !== "true") return null;
+
+  const { getPublicUrl } = await import("../lib/public-url-service");
+
+  if (key === "https_only_mode") {
+    if (req.protocol !== "https") {
+      return {
+        status: 400,
+        code: "https_required",
+        message:
+          "HTTPS-only mode can't be enabled over an HTTP connection. Set up TLS for this instance and reload the page over HTTPS first.",
+      };
+    }
+    const publicUrl = await getPublicUrl();
+    if (!publicUrl || !publicUrl.startsWith("https://")) {
+      return {
+        status: 400,
+        code: "public_url_must_be_https",
+        message:
+          "HTTPS-only mode requires the Public URL to be set and start with https://.",
+      };
+    }
+    return null;
+  }
+
+  if (key === "cors_enabled") {
+    const publicUrl = await getPublicUrl();
+    if (!publicUrl) {
+      return {
+        status: 400,
+        code: "public_url_required",
+        message:
+          "Restrict CORS requires the Public URL to be set — that's the origin allowed past CORS.",
+      };
+    }
+    return null;
+  }
+
+  return null;
+}
+
 /**
  * GET /api/settings - List system settings with filtering and pagination
  */
@@ -284,6 +343,17 @@ router.post("/", requirePermission('settings:write') as RequestHandler, (async (
 
     const { category, key, value, isEncrypted } = bodyValidation.data;
 
+    const securityValidation = await validateSecuritySettingChange(req, category, key, value);
+    if (securityValidation) {
+      return res.status(securityValidation.status).json({
+        error: "Bad Request",
+        code: securityValidation.code,
+        message: securityValidation.message,
+        timestamp: new Date().toISOString(),
+        requestId,
+      });
+    }
+
     // Check if setting with same category/key already exists
     const existingSetting = await prisma.systemSettings.findUnique({
       where: {
@@ -328,9 +398,10 @@ router.post("/", requirePermission('settings:write') as RequestHandler, (async (
 
     // Invalidate caches for known dynamic settings
     if (category === "system") {
-      const { invalidatePublicUrlCache, invalidateCorsEnabledCache } = await import("../lib/public-url-service");
+      const { invalidatePublicUrlCache, invalidateCorsEnabledCache, invalidateHttpsOnlyCache } = await import("../lib/public-url-service");
       if (key === "public_url") invalidatePublicUrlCache();
       if (key === "cors_enabled") invalidateCorsEnabledCache();
+      if (key === "https_only_mode") invalidateHttpsOnlyCache();
     }
 
     logger.debug(
@@ -553,6 +624,22 @@ router.put("/:id", requirePermission('settings:write') as RequestHandler, (async
       updateData.isEncrypted = isEncrypted;
     }
 
+    const securityValidation = await validateSecuritySettingChange(
+      req,
+      existingSetting.category,
+      existingSetting.key,
+      value,
+    );
+    if (securityValidation) {
+      return res.status(securityValidation.status).json({
+        error: "Bad Request",
+        code: securityValidation.code,
+        message: securityValidation.message,
+        timestamp: new Date().toISOString(),
+        requestId,
+      });
+    }
+
     // Update the setting
     const updatedSetting = await prisma.systemSettings.update({
       where: { id: settingId },
@@ -561,9 +648,10 @@ router.put("/:id", requirePermission('settings:write') as RequestHandler, (async
 
     // Invalidate caches for known dynamic settings
     if (existingSetting.category === "system") {
-      const { invalidatePublicUrlCache, invalidateCorsEnabledCache } = await import("../lib/public-url-service");
+      const { invalidatePublicUrlCache, invalidateCorsEnabledCache, invalidateHttpsOnlyCache } = await import("../lib/public-url-service");
       if (existingSetting.key === "public_url") invalidatePublicUrlCache();
       if (existingSetting.key === "cors_enabled") invalidateCorsEnabledCache();
+      if (existingSetting.key === "https_only_mode") invalidateHttpsOnlyCache();
     }
 
     logger.debug(
@@ -672,9 +760,10 @@ router.delete("/:id", requirePermission('settings:write') as RequestHandler, (as
 
     // Invalidate caches for known dynamic settings
     if (existingSetting.category === "system") {
-      const { invalidatePublicUrlCache, invalidateCorsEnabledCache } = await import("../lib/public-url-service");
+      const { invalidatePublicUrlCache, invalidateCorsEnabledCache, invalidateHttpsOnlyCache } = await import("../lib/public-url-service");
       if (existingSetting.key === "public_url") invalidatePublicUrlCache();
       if (existingSetting.key === "cors_enabled") invalidateCorsEnabledCache();
+      if (existingSetting.key === "https_only_mode") invalidateHttpsOnlyCache();
     }
 
     logger.debug(


### PR DESCRIPTION
## Summary
- Replaces boot-only `ALLOW_INSECURE` env var with a runtime-configurable `https_only_mode` DB setting; Helmet + cookie `Secure` flag flip without restart via a dispatcher pattern reading a 30-min cache (invalidated on save).
- Adds an independent `Restrict CORS` toggle (reuses existing `cors_enabled` key); both toggles gated on a non-empty Public URL — HTTPS-only also requires `https://`. Server-side validation rejects enabling HTTPS-only over an HTTP request (distinct error codes so the UI can surface targeted messages).
- Pre-save confirm modal for HTTPS-only with CSP / HSTS-pinning / cookie consequences and a live request-scheme indicator. `MINI_INFRA_FORCE_INSECURE=true` is the recovery escape hatch and surfaces a persistent UI banner via the existing `/health` endpoint.

## Test plan
- [x] `pnpm --filter mini-infra-server build`, `pnpm --filter mini-infra-server lint` — clean
- [x] `pnpm --filter mini-infra-client build`, `pnpm --filter mini-infra-client lint` — clean
- [x] Server unit tests: 19 unit-test files fail identically on `main` and `claude/mini-40` (pre-existing zod / module-init failures, not introduced by this change)
- [x] Live smoke (HTTP dev env): `/health` exposes `forceInsecureOverride`, default response has no HSTS / no `upgrade-insecure-requests`, `Set-Cookie` has no `Secure` — fresh HTTP install boots clean
- [x] Validation gates over `curl`: HTTPS-only over HTTP rejected with `https_required`, Restrict CORS without Public URL rejected with `public_url_required`, Restrict CORS with Public URL set succeeds
- [x] UI smoke: two toggles render in the Public URL & security card; pre-save modal shows HSTS pinning warning + live "your connection is HTTP ✗" + "the server will reject this change" copy; failed save logs the server error message into the toast
- [ ] Full restart-with-env-var smoke for the escape hatch — wired through `isForceInsecureOverride()` (single env-var read shared by dispatcher + cookie helper + `/health` body); not exercised end-to-end here. Worth doing on a host that actually has TLS configured.
- [ ] Headers flipping live with HTTPS-only ON — dev env is HTTP-only so this couldn't be verified end-to-end. Dispatcher logic is straightforward (per-request middleware swap on cached value) but the curl-over-HTTPS check belongs in a TLS-equipped pre-merge run.

Closes MINI-40

🤖 Generated with [Claude Code](https://claude.com/claude-code)