### PR TITLE
feat(addons): tailscale-ssh addon (Phase 3, MINI-2)

### DIFF
--- a/client/src/app/applications/[id]/_components/service-row.tsx
+++ b/client/src/app/applications/[id]/_components/service-row.tsx
@@ -13,6 +13,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { TableCell, TableRow } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
+import { AddonBadge } from "@/components/stacks/addon-badge";
 import type {
   StackContainerStatus,
   StackServiceDefinition,
@@ -72,26 +73,46 @@ export function ServiceRow({ service, containers }: ServiceRowProps) {
   const restartPolicy = service.containerConfig?.restartPolicy ?? "—";
   const dependsOn = service.dependsOn ?? [];
   const envEntries = Object.entries(env);
+  const synthetic = service.synthetic;
+  // The first addon id is the canonical badge label. For merged groups
+  // (`kind: tailscale` collapsing `tailscale-ssh` + `tailscale-web` into
+  // one sidecar) `kind` is the better label; fall back to the first id
+  // when no kind is set.
+  const addonLabel = synthetic
+    ? synthetic.kind ?? synthetic.addonIds[0]
+    : undefined;
 
   return (
     <Fragment>
       <TableRow>
         <TableCell className="w-8 align-top">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-6 w-6"
-            onClick={() => setExpanded((v) => !v)}
-            aria-label={expanded ? "Collapse" : "Expand"}
-          >
-            {expanded ? (
-              <IconChevronDown className="h-4 w-4" />
-            ) : (
-              <IconChevronRight className="h-4 w-4" />
-            )}
-          </Button>
+          {!synthetic && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
+              onClick={() => setExpanded((v) => !v)}
+              aria-label={expanded ? "Collapse" : "Expand"}
+            >
+              {expanded ? (
+                <IconChevronDown className="h-4 w-4" />
+              ) : (
+                <IconChevronRight className="h-4 w-4" />
+              )}
+            </Button>
+          )}
         </TableCell>
-        <TableCell className="font-medium">{service.serviceName}</TableCell>
+        <TableCell className="font-medium">
+          <div className="flex items-center gap-2">
+            <span>{service.serviceName}</span>
+            {synthetic && addonLabel && (
+              <AddonBadge
+                addonName={addonLabel}
+                targetName={synthetic.targetService}
+              />
+            )}
+          </div>
+        </TableCell>
         <TableCell>
           <ServiceTypeBadge type={service.serviceType} />
         </TableCell>

--- a/client/src/app/containers/ContainerTable.tsx
+++ b/client/src/app/containers/ContainerTable.tsx
@@ -26,6 +26,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { ServerModal } from "@/components/postgres-server/server-modal";
+import { AddonBadge } from "@/components/stacks/addon-badge";
 import { toast } from "sonner";
 
 interface ContainerTableProps {
@@ -50,12 +51,18 @@ const ContainerNameCell = React.memo(
     postgresAction,
     onPostgresAction,
     isPoolInstance,
+    addonName,
+    addonTarget,
+    onAddonTargetClick,
   }: {
     name: string;
     selfRole?: string;
     postgresAction?: "add" | "manage";
     onPostgresAction?: () => void;
     isPoolInstance?: boolean;
+    addonName?: string;
+    addonTarget?: string;
+    onAddonTargetClick?: () => void;
   }) => (
     <div className="flex items-center gap-2 min-h-[2rem]">
       <span className="font-medium truncate">{name}</span>
@@ -68,6 +75,13 @@ const ContainerNameCell = React.memo(
         <span className="shrink-0 text-xs bg-amber-100 dark:bg-amber-900 text-amber-800 dark:text-amber-200 px-1.5 py-0.5 rounded">
           Pool
         </span>
+      )}
+      {addonName && (
+        <AddonBadge
+          addonName={addonName}
+          targetName={addonTarget}
+          onTargetClick={onAddonTargetClick}
+        />
       )}
       {postgresAction && onPostgresAction && (
         <Tooltip>
@@ -99,7 +113,9 @@ const ContainerNameCell = React.memo(
     prevProps.name === nextProps.name &&
     prevProps.selfRole === nextProps.selfRole &&
     prevProps.postgresAction === nextProps.postgresAction &&
-    prevProps.isPoolInstance === nextProps.isPoolInstance,
+    prevProps.isPoolInstance === nextProps.isPoolInstance &&
+    prevProps.addonName === nextProps.addonName &&
+    prevProps.addonTarget === nextProps.addonTarget,
 );
 
 ContainerNameCell.displayName = "ContainerNameCell";
@@ -315,6 +331,28 @@ export const ContainerTable = React.memo(function ContainerTable({
           }
 
           const isPoolInstance = container.labels?.["mini-infra.pool-instance"] === "true";
+          const addonName = container.labels?.["mini-infra.addon"];
+          const addonTarget = container.labels?.["mini-infra.addon-target"];
+
+          // Resolve target → container id by matching stack-id + service
+          // labels in the current containers list. When found, the
+          // back-reference button navigates to that container's detail
+          // route; when not (target hasn't materialised yet, or it's been
+          // removed), the back-reference renders as plain text.
+          let onAddonTargetClick: (() => void) | undefined;
+          if (addonTarget && containers) {
+            const stackId = container.labels?.["mini-infra.stack-id"];
+            const targetContainer = containers.find(
+              (c) =>
+                c.labels?.["mini-infra.stack-id"] === stackId &&
+                c.labels?.["mini-infra.service"] === addonTarget &&
+                c.labels?.["mini-infra.synthetic"] !== "true",
+            );
+            if (targetContainer) {
+              const targetId = targetContainer.id;
+              onAddonTargetClick = () => navigate(`/containers/${targetId}`);
+            }
+          }
 
           return (
             <ContainerNameCell
@@ -323,6 +361,9 @@ export const ContainerTable = React.memo(function ContainerTable({
               postgresAction={postgresAction}
               onPostgresAction={onPostgresAction}
               isPoolInstance={isPoolInstance}
+              addonName={addonName}
+              addonTarget={addonTarget}
+              onAddonTargetClick={onAddonTargetClick}
             />
           );
         },
@@ -363,7 +404,7 @@ export const ContainerTable = React.memo(function ContainerTable({
         ),
       },
     ],
-    [handleNameSort, handleStatusSort, handleImageSort, postgresContainerIds, managedContainerIds, managedContainerMap, handleAddPostgresServer, navigate],
+    [handleNameSort, handleStatusSort, handleImageSort, postgresContainerIds, managedContainerIds, managedContainerMap, handleAddPostgresServer, navigate, containers],
   );
 
   const sortingState = React.useMemo(

--- a/client/src/components/stacks/addon-badge.tsx
+++ b/client/src/components/stacks/addon-badge.tsx
@@ -1,0 +1,57 @@
+import { IconPuzzle } from "@tabler/icons-react";
+
+/**
+ * Marker pill shown on synthetic services materialised by the Service Addons
+ * render pipeline (Phase 3+). The visual language deliberately mirrors the
+ * existing amber `Pool` and blue self-role pills in the Containers page —
+ * one consistent treatment across the Stack-detail services table and the
+ * Containers page so an operator who sees the violet `IconPuzzle` pill on
+ * one surface recognises it instantly on the other.
+ *
+ * The optional `targetName` back-reference is rendered only when supplied.
+ * When `onTargetClick` is also passed, it renders as a button the operator
+ * can click to navigate to the target row (used on the Containers page,
+ * where target and synthetic rows are on different routes); otherwise it's
+ * plain text (used on the Stack-detail page, where both rows are on the
+ * same view).
+ */
+export function AddonBadge({
+  addonName,
+  targetName,
+  onTargetClick,
+}: {
+  addonName: string;
+  targetName?: string;
+  onTargetClick?: () => void;
+}) {
+  return (
+    <span
+      className="shrink-0 inline-flex items-center gap-1 text-xs bg-violet-100 dark:bg-violet-900 text-violet-800 dark:text-violet-200 px-1.5 py-0.5 rounded"
+      title={`Provisioned by the ${addonName} addon${
+        targetName ? ` attached to ${targetName}` : ""
+      }`}
+    >
+      <IconPuzzle className="h-3 w-3" aria-hidden="true" />
+      <span>from {addonName}</span>
+      {targetName ? (
+        onTargetClick ? (
+          <>
+            <span aria-hidden="true">·</span>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onTargetClick();
+              }}
+              className="underline-offset-2 hover:underline"
+            >
+              {targetName}
+            </button>
+          </>
+        ) : (
+          <span aria-hidden="true">· {targetName}</span>
+        )
+      ) : null}
+    </span>
+  );
+}

--- a/client/src/components/task-tracker/task-tracker-provider.tsx
+++ b/client/src/components/task-tracker/task-tracker-provider.tsx
@@ -19,6 +19,7 @@ import type {
 } from "@/lib/task-tracker-types";
 import type { OperationState, OperationStep } from "@/hooks/use-operation-progress";
 import { useSocketChannel, useSocketEvent } from "@/hooks/use-socket";
+import { ServerEvent } from "@mini-infra/types";
 import type { SocketChannel, ServerToClientEvents } from "@mini-infra/types";
 
 // Dynamic event name means the handler signature cannot be inferred at
@@ -147,6 +148,77 @@ function TaskEventListener({
       }));
     }) as AnyServerHandler,
     isExecuting && !!config.stepEvent,
+  );
+
+  // Service-Addons render-pass step events. The render pipeline emits
+  // `STACK_ADDON_PROVISIONED` / `STACK_ADDON_FAILED` once per addon
+  // application during stack apply / update — distinct from the per-action
+  // `STACK_APPLY_SERVICE_RESULT` step stream because addon expansion
+  // happens before any service action runs. The contract calls for these
+  // to surface under the same apply task in the tracker (Phase 3 of the
+  // Service Addons plan), so we listen on the same channel and append
+  // synthetic steps to the active task's completedSteps when the stackId
+  // matches. Only stack-apply / stack-update task types subscribe.
+  const isStackApplyLike =
+    task.type === "stack-apply" || task.type === "stack-update";
+  useSocketEvent(
+    ServerEvent.STACK_ADDON_PROVISIONED as keyof ServerToClientEvents,
+    ((data: AnyEventPayload) => {
+      if (!isStackApplyLike) return;
+      const payload = data as {
+        stackId: string;
+        serviceName: string;
+        addonIds: string[];
+        kind?: string;
+        syntheticServiceName: string;
+      };
+      if (payload.stackId !== task.id) return;
+      const label = payload.kind ?? payload.addonIds.join(", ");
+      onUpdate(task.id, (prev) => ({
+        ...prev,
+        operationState: {
+          ...prev.operationState,
+          completedSteps: [
+            ...prev.operationState.completedSteps,
+            {
+              step: `provisioned ${label} on ${payload.serviceName}`,
+              status: "completed",
+            },
+          ],
+        },
+      }));
+    }) as AnyServerHandler,
+    isExecuting && isStackApplyLike,
+  );
+  useSocketEvent(
+    ServerEvent.STACK_ADDON_FAILED as keyof ServerToClientEvents,
+    ((data: AnyEventPayload) => {
+      if (!isStackApplyLike) return;
+      const payload = data as {
+        stackId: string;
+        serviceName: string;
+        addonIds: string[];
+        kind?: string;
+        error: string;
+      };
+      if (payload.stackId !== task.id) return;
+      const label = payload.kind ?? payload.addonIds.join(", ");
+      onUpdate(task.id, (prev) => ({
+        ...prev,
+        operationState: {
+          ...prev.operationState,
+          completedSteps: [
+            ...prev.operationState.completedSteps,
+            {
+              step: `${label} addon failed on ${payload.serviceName}`,
+              status: "failed",
+              detail: payload.error,
+            },
+          ],
+        },
+      }));
+    }) as AnyServerHandler,
+    isExecuting && isStackApplyLike,
   );
 
   const applyTerminalResult = (

--- a/lib/types/socket-events.ts
+++ b/lib/types/socket-events.ts
@@ -339,11 +339,14 @@ export interface ServerToClientEvents {
   /**
    * One addon application provisioned successfully during stack apply.
    * Defined in Phase 1; emitted from the render pipeline starting Phase 3.
+   * `addonIds` is plural so merge-groups (`kind: tailscale` collapsing
+   * `tailscale-ssh` + `tailscale-web` into one sidecar) can carry every
+   * member id; solo applications carry a single-element array.
    */
   "stack:addon:provisioned": (data: {
     stackId: string;
     serviceName: string;
-    addonId: string;
+    addonIds: string[];
     kind?: string;
     syntheticServiceName: string;
   }) => void;
@@ -355,7 +358,7 @@ export interface ServerToClientEvents {
   "stack:addon:failed": (data: {
     stackId: string;
     serviceName: string;
-    addonId: string;
+    addonIds: string[];
     kind?: string;
     error: string;
   }) => void;

--- a/lib/types/stacks.ts
+++ b/lib/types/stacks.ts
@@ -631,6 +631,19 @@ export interface ApplyOptions {
   plan?: StackPlan;
   /** Called after each service or resource action completes */
   onProgress?: (result: ServiceApplyResult | ResourceResult, completedCount: number, totalActions: number) => void;
+  /**
+   * Service Addons render-pass plumbing. Both fields are typed `unknown`
+   * here so `lib/` stays runtime-dep-free; the server narrows them to
+   * `ExpansionProgress` / connected-services lookup before invoking the
+   * addon framework. Either field may be omitted — the addon framework
+   * tolerates a missing progress callback (no fan-out) and a missing
+   * connected-services lookup (any addon that requires one is rejected
+   * at applicability check time).
+   */
+  addonExpansion?: {
+    progress?: unknown;
+    connectedServices?: unknown;
+  };
 }
 
 export interface UpdateOptions {

--- a/lib/types/tailscale.ts
+++ b/lib/types/tailscale.ts
@@ -90,6 +90,78 @@ export type TailscaleErrorCode =
   (typeof TAILSCALE_ERROR_CODES)[keyof typeof TAILSCALE_ERROR_CODES];
 
 /**
+ * Tailscale control-plane hostnames an addon-materialised sidecar must reach
+ * for `tailscaled` to come up. Encoded once so the `tailscale-ssh` /
+ * `tailscale-web` addons emit the same `requiredEgress` set without
+ * duplicating the list at each call site, and so a future control-plane
+ * change is a one-line edit.
+ *
+ * Wildcard entries cover regional control-plane shards (`*.tailscale.com`)
+ * and DERP relays (`*.tailscale.io`); the explicit `controlplane.tailscale.com`
+ * entry guards against an environment whose egress firewall doesn't honour
+ * the matching wildcard.
+ */
+export const TAILSCALE_CONTROL_PLANE_HOSTNAMES: readonly string[] = [
+  "controlplane.tailscale.com",
+  "*.tailscale.com",
+  "*.tailscale.io",
+] as const;
+
+/**
+ * Merge the static `tag:mini-infra-managed` tag with operator-supplied
+ * `extraTags`, deduping and preserving order (default first). Used by the
+ * authkey minter and the addon framework's `provision()` hooks to compose
+ * the tag set for a freshly-minted authkey.
+ */
+export function buildTailscaleTagSet(extraTags: readonly string[] = []): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const tag of [TAILSCALE_DEFAULT_TAG, ...extraTags]) {
+    const trimmed = tag.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+/**
+ * Hostname-sanitise `{service}-{env}` for use as a Tailscale device hostname.
+ *
+ * RFC 1123 hostname rules: ≤63 octets, lowercase ASCII alphanumerics + hyphen,
+ * no leading or trailing hyphen. Tailscale further requires the hostname to
+ * be unique across the tailnet within the OAuth client's scope, so the
+ * combined `{service}-{env}` form encodes per-resource identity (the OAuth
+ * client tag set is fixed at `tag:mini-infra-managed`, see §Phase 3).
+ *
+ * Mirrors the spirit of `buildPoolContainerName` in pool-spawner.ts but lives
+ * here in lib/ because the addon framework is the only consumer that needs
+ * RFC-compliant Tailscale-specific output (pool spawner targets Docker
+ * container names which are looser).
+ */
+export function sanitizeTailscaleHostname(
+  serviceName: string,
+  envName: string,
+): string {
+  const raw = `${serviceName}-${envName}`;
+  // Lowercase, replace non-[a-z0-9-] with `-`, collapse runs of `-`.
+  const cleaned = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (cleaned.length === 0) {
+    throw new Error(
+      `Cannot derive Tailscale hostname from "${serviceName}-${envName}" — no valid characters`,
+    );
+  }
+  // Truncate to 63 octets; trim a trailing hyphen left after the cut.
+  return cleaned.length <= 63
+    ? cleaned
+    : cleaned.slice(0, 63).replace(/-+$/, "");
+}
+
+/**
  * Canonical Tailscale ACL bootstrap snippet for the operator to paste into
  * their tailnet policy file at https://login.tailscale.com/admin/acls.
  *
@@ -98,7 +170,7 @@ export type TailscaleErrorCode =
  * unit tests pin the output shape.
  */
 export function buildAclSnippet(extraTags: string[] = []): string {
-  const tags = [TAILSCALE_DEFAULT_TAG, ...extraTags];
+  const tags = buildTailscaleTagSet(extraTags);
   const acl = {
     tagOwners: Object.fromEntries(tags.map((t) => [t, ["autogroup:admin"]])),
     grants: [

--- a/server/src/routes/stacks/stacks-apply-route.ts
+++ b/server/src/routes/stacks/stacks-apply-route.ts
@@ -19,7 +19,11 @@ import {
   emitStackApplyServiceResult,
   emitStackApplyCompleted,
   emitStackApplyFailed,
+  emitStackAddonProvisioned,
+  emitStackAddonFailed,
 } from '../../services/stacks/stack-socket-emitter';
+import { TailscaleService } from '../../services/tailscale/tailscale-service';
+import type { ExpansionProgress } from '../../services/stack-addons';
 import {
   formatPlanStep,
   formatServiceStep,
@@ -195,10 +199,35 @@ async function runApplyInBackground(args: RunApplyArgs): Promise<void> {
         throw new Error(natsPhase.error ?? 'NATS reconciliation phase failed');
       }
 
+      // Service Addons render-pass plumbing — fan addon-provisioning
+      // events out on the stacks channel (Phase 3) and hand the addon
+      // framework a typed connected-services lookup so addons like
+      // `tailscale-ssh` can mint authkeys without re-fetching credentials
+      // here. Both fields tolerate absence — the framework no-ops the
+      // progress callback and rejects any addon whose required service
+      // is missing.
+      const addonExpansion: {
+        progress: ExpansionProgress;
+        connectedServices: { tailscale: TailscaleService };
+      } = {
+        progress: {
+          onProvisioned: (info) => {
+            emitStackAddonProvisioned({ stackId, ...info });
+          },
+          onFailed: (info) => {
+            emitStackAddonFailed({ stackId, ...info });
+          },
+        },
+        connectedServices: {
+          tailscale: new TailscaleService(prisma),
+        },
+      };
+
       const result = await reconciler.apply(stackId, {
         ...applyArgs,
         triggeredBy,
         plan,
+        addonExpansion,
         onProgress: (progressResult) => {
           emittedStepCount++;
           emitStackApplyServiceResult(

--- a/server/src/services/stack-addons/__tests__/tailscale-ssh.test.ts
+++ b/server/src/services/stack-addons/__tests__/tailscale-ssh.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TAILSCALE_CONTROL_PLANE_HOSTNAMES,
+  TAILSCALE_DEFAULT_TAG,
+  buildTailscaleTagSet,
+  sanitizeTailscaleHostname,
+  type ProvisionContext,
+  type StackServiceDefinition,
+} from '@mini-infra/types';
+import { createAddonRegistry } from '../registry';
+import { expandAddons } from '../expand-addons';
+import { tailscaleSshAddon } from '../tailscale-ssh';
+
+const baseContext = {
+  stack: { id: 'stack-1', name: 'web-stack' },
+  environment: { id: 'env-1', name: 'prod', networkType: 'local' as const },
+};
+
+function makeStateful(
+  name: string,
+  overrides: Partial<StackServiceDefinition> = {},
+): StackServiceDefinition {
+  return {
+    serviceName: name,
+    serviceType: 'Stateful',
+    dockerImage: 'nginx',
+    dockerTag: 'latest',
+    dependsOn: [],
+    order: 1,
+    containerConfig: { env: {}, restartPolicy: 'unless-stopped' },
+    ...overrides,
+  };
+}
+
+/**
+ * Stub Tailscale connected service implementing only the `mintAuthkey`
+ * method the addon exercises through `TailscaleAuthkeyMinter`. We replace
+ * the minter's fetch via duck-typed substitution at construction time —
+ * see how the addon imports it. For the unit test we instead stub the
+ * connectedServices lookup with an object whose minter behaviour we
+ * control.
+ */
+function makeStubTailscaleService(): unknown {
+  // Minimal duck-typed shape covering the calls TailscaleAuthkeyMinter
+  // makes against the real TailscaleService:
+  //   - getAccessToken(): Promise<string>
+  //   - getAllManagedTags(): Promise<string[]>
+  return {
+    getAccessToken: async () => 'stub-access-token',
+    getAllManagedTags: async () => [TAILSCALE_DEFAULT_TAG],
+  };
+}
+
+/**
+ * Stub the global fetch for the duration of a test so the
+ * `TailscaleAuthkeyMinter` POST returns a fake authkey response. The minter
+ * calls `fetch(url, { method: 'POST', ... })` against
+ * `https://api.tailscale.com/api/v2/tailnet/-/keys`.
+ */
+function withStubbedFetch<T>(
+  fn: () => Promise<T>,
+  authkey = 'tskey-auth-stub',
+): Promise<T> {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    return new Response(
+      JSON.stringify({
+        id: 'k-stub',
+        key: authkey,
+        created: '2026-01-01T00:00:00Z',
+        expires: '2026-01-01T01:00:00Z',
+        capabilities: {
+          devices: {
+            create: {
+              reusable: false,
+              ephemeral: true,
+              preauthorized: true,
+              tags: [TAILSCALE_DEFAULT_TAG],
+            },
+          },
+        },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  }) as typeof fetch;
+  return fn().finally(() => {
+    globalThis.fetch = original;
+  });
+}
+
+describe('tailscale-ssh addon', () => {
+  it('manifest declares the contract the framework expects', () => {
+    const m = tailscaleSshAddon.manifest;
+    expect(m.id).toBe('tailscale-ssh');
+    expect(m.kind).toBe('tailscale');
+    expect(m.requiresConnectedService).toBe('tailscale');
+    expect(m.appliesTo).toEqual(
+      expect.arrayContaining(['Stateful', 'StatelessWeb', 'Pool']),
+    );
+  });
+
+  it('rejects unknown config keys via the strict zod schema', () => {
+    const result = tailscaleSshAddon.configSchema.safeParse({ unknown: true });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts an empty config and an explicit extraTags list', () => {
+    expect(tailscaleSshAddon.configSchema.safeParse({}).success).toBe(true);
+    expect(
+      tailscaleSshAddon.configSchema.safeParse({
+        extraTags: ['tag:dev', 'tag:platform'],
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects extraTags that violate the tag:[a-z0-9-]+ shape', () => {
+    expect(
+      tailscaleSshAddon.configSchema.safeParse({ extraTags: ['no-prefix'] })
+        .success,
+    ).toBe(false);
+    expect(
+      tailscaleSshAddon.configSchema.safeParse({ extraTags: ['Tag:Bad'] })
+        .success,
+    ).toBe(false);
+  });
+
+  it('end-to-end render: expansion materialises the synthetic tailscaled sidecar', async () => {
+    const registry = createAddonRegistry();
+    registry.register(tailscaleSshAddon);
+
+    const target = makeStateful('web', {
+      addons: { 'tailscale-ssh': {} },
+    });
+
+    const rendered = await withStubbedFetch(() =>
+      expandAddons([target], {
+        ...baseContext,
+        registry,
+        connectedServices: { tailscale: makeStubTailscaleService() },
+      }),
+    );
+
+    expect(rendered).toHaveLength(2);
+    const sidecar = rendered.find((s) => s.serviceName === 'web-tailscale')!;
+    expect(sidecar).toBeDefined();
+    expect(sidecar.dockerImage).toBe('tailscale/tailscale');
+    expect(sidecar.synthetic).toEqual({
+      addonIds: ['tailscale-ssh'],
+      kind: undefined,
+      targetService: 'web',
+    });
+    // Authkey + hostname env are present and the hostname follows the
+    // `<service>-<env>` rule.
+    expect(sidecar.containerConfig.env).toMatchObject({
+      TS_AUTHKEY: 'tskey-auth-stub',
+      TS_HOSTNAME: 'web-prod',
+      TS_EXTRA_ARGS: '--ssh',
+    });
+    // Required egress lists the Tailscale control-plane hostnames (§4.7
+    // of the plan; firewalled-env smoke test).
+    expect(sidecar.containerConfig.requiredEgress).toEqual(
+      expect.arrayContaining([...TAILSCALE_CONTROL_PLANE_HOSTNAMES]),
+    );
+    // Synthetic-marker labels — the containers page reads these directly
+    // to render the AddonBadge.
+    expect(sidecar.containerConfig.labels).toMatchObject({
+      'mini-infra.addon': 'tailscale-ssh',
+      'mini-infra.synthetic': 'true',
+      'mini-infra.addon-target': 'web',
+    });
+  });
+
+  it('rejects expansion when the Tailscale connected service is missing', async () => {
+    const registry = createAddonRegistry();
+    registry.register(tailscaleSshAddon);
+
+    const target = makeStateful('web', {
+      addons: { 'tailscale-ssh': {} },
+    });
+
+    // No `connectedServices` lookup → applicability check fires before the
+    // provision call runs and surfaces a clear error.
+    await expect(
+      expandAddons([target], { ...baseContext, registry }),
+    ).rejects.toThrow(/connected service/);
+  });
+
+  it('build-service-definition is independent of the minted authkey value', () => {
+    // Smoke: buildServiceDefinition is a pure function of (ctx, provisioned).
+    // Pass the same shape twice with different authkeys and confirm only
+    // env.TS_AUTHKEY differs.
+    const def = tailscaleSshAddon.definition;
+    const ctx: ProvisionContext = {
+      stack: baseContext.stack,
+      environment: baseContext.environment,
+      service: { name: 'web', type: 'Stateful' },
+      addonConfig: {},
+      connectedServices: undefined,
+    };
+    const a = def.buildServiceDefinition(ctx, {
+      envForSidecar: { TS_AUTHKEY: 'a', TS_HOSTNAME: 'web-prod' },
+      templateVars: {},
+    });
+    const b = def.buildServiceDefinition(ctx, {
+      envForSidecar: { TS_AUTHKEY: 'b', TS_HOSTNAME: 'web-prod' },
+      templateVars: {},
+    });
+    expect({ ...a, containerConfig: { ...a.containerConfig, env: {} } })
+      .toEqual({ ...b, containerConfig: { ...b.containerConfig, env: {} } });
+    expect(a.containerConfig.env?.TS_AUTHKEY).toBe('a');
+    expect(b.containerConfig.env?.TS_AUTHKEY).toBe('b');
+  });
+});
+
+describe('lib/ helpers used by the tailscale-ssh addon', () => {
+  it('buildTailscaleTagSet always includes the static default tag', () => {
+    expect(buildTailscaleTagSet()).toEqual([TAILSCALE_DEFAULT_TAG]);
+    expect(buildTailscaleTagSet([])).toEqual([TAILSCALE_DEFAULT_TAG]);
+    expect(buildTailscaleTagSet(['tag:dev'])).toEqual([
+      TAILSCALE_DEFAULT_TAG,
+      'tag:dev',
+    ]);
+  });
+
+  it('buildTailscaleTagSet dedupes and trims', () => {
+    expect(
+      buildTailscaleTagSet([
+        TAILSCALE_DEFAULT_TAG,
+        ' tag:dev ',
+        'tag:dev',
+        '',
+      ]),
+    ).toEqual([TAILSCALE_DEFAULT_TAG, 'tag:dev']);
+  });
+
+  it('sanitizeTailscaleHostname enforces the {service}-{env} ≤63 char rule', () => {
+    expect(sanitizeTailscaleHostname('web', 'prod')).toBe('web-prod');
+    expect(sanitizeTailscaleHostname('Web_App', 'PROD')).toBe('web-app-prod');
+    expect(sanitizeTailscaleHostname('foo--bar', 'baz')).toBe('foo-bar-baz');
+  });
+
+  it('sanitizeTailscaleHostname truncates to ≤63 octets and trims trailing hyphens', () => {
+    const long = sanitizeTailscaleHostname('a'.repeat(70), 'b');
+    expect(long.length).toBeLessThanOrEqual(63);
+    expect(long).not.toMatch(/-$/);
+  });
+
+  it('sanitizeTailscaleHostname throws when no valid characters survive', () => {
+    expect(() => sanitizeTailscaleHostname('___', '___')).toThrow();
+  });
+});

--- a/server/src/services/stack-addons/index.ts
+++ b/server/src/services/stack-addons/index.ts
@@ -1,9 +1,9 @@
 // Service Addons framework — entry point for the render pipeline integration.
 //
-// Phase 1 ships the framework only; the production registry is empty so the
-// render pass is a no-op for every existing stack. Per-addon directories
-// (`tailscale-ssh/`, `tailscale-web/`, `caddy-auth/`) self-register into
-// `productionAddonRegistry` starting Phase 3.
+// Per-addon directories (`tailscale-ssh/`, `tailscale-web/`, `caddy-auth/`)
+// self-register into `productionAddonRegistry` on import. This barrel
+// imports them once so any consumer that imports from `./stack-addons`
+// automatically gets the production registry populated.
 
 export {
   AddonRegistry,
@@ -17,3 +17,6 @@ export {
   AddonExpansionError,
 } from './expand-addons';
 export type { ExpansionContext, ExpansionProgress } from './expand-addons';
+
+// Side-effect imports — populate `productionAddonRegistry`.
+import './tailscale-ssh';

--- a/server/src/services/stack-addons/tailscale-ssh/build-service-definition.ts
+++ b/server/src/services/stack-addons/tailscale-ssh/build-service-definition.ts
@@ -1,0 +1,77 @@
+import {
+  TAILSCALE_CONTROL_PLANE_HOSTNAMES,
+  type ProvisionContext,
+  type ProvisionedValues,
+  type StackServiceDefinition,
+} from '@mini-infra/types';
+
+/**
+ * The official Tailscale image. We run containerised `tailscaled` rather
+ * than embedding `tsnet` because `tsnet` is Go-only and the addon ships as
+ * a sidecar container, not a library inside the Node process. The image
+ * reads `TS_AUTHKEY`, `TS_HOSTNAME`, `TS_STATE_DIR`, and `TS_EXTRA_ARGS`
+ * from env at boot.
+ */
+const TAILSCALE_IMAGE = 'tailscale/tailscale';
+const TAILSCALE_TAG = 'stable';
+
+const STATE_VOLUME_MOUNT_PATH = '/var/lib/tailscale';
+
+/**
+ * Materialise the synthetic sidecar `StackServiceDefinition` for the
+ * `tailscale-ssh` addon. Inputs come from `provision()` (authkey + hostname
+ * env), the addon's static target integration, and the static control-plane
+ * `requiredEgress` constants from lib/.
+ */
+export function buildTailscaleSshServiceDefinition(
+  ctx: ProvisionContext,
+  provisioned: ProvisionedValues,
+): StackServiceDefinition {
+  const sidecarServiceName = `${ctx.service.name}-tailscale`;
+  // Per-application state volume — Tailscale persists node identity here so
+  // restarts re-use the same device record (when `ephemeral: false`); with
+  // `ephemeral: true` the node de-registers on shutdown and the volume just
+  // holds tailscaled's runtime state for the lifetime of the container.
+  const stateVolumeName = `${sidecarServiceName}-state`;
+
+  return {
+    serviceName: sidecarServiceName,
+    serviceType: 'Stateful',
+    dockerImage: TAILSCALE_IMAGE,
+    dockerTag: TAILSCALE_TAG,
+    containerConfig: {
+      env: {
+        ...(provisioned.envForSidecar ?? {}),
+      },
+      // `tailscaled` requires NET_ADMIN to bring up its userspace networking
+      // device, plus access to /dev/net/tun for kernel-mode networking. We
+      // run in kernel mode (TS_USERSPACE=false from provision) for best
+      // performance; the cap is needed regardless so the daemon can
+      // configure routes when SSH sessions traverse subnets.
+      capAdd: ['NET_ADMIN', 'SYS_MODULE'],
+      mounts: [
+        {
+          source: stateVolumeName,
+          target: STATE_VOLUME_MOUNT_PATH,
+          type: 'volume',
+        },
+      ],
+      labels: {
+        'mini-infra.addon': 'tailscale-ssh',
+        'mini-infra.synthetic': 'true',
+        'mini-infra.addon-target': ctx.service.name,
+      },
+      restartPolicy: 'unless-stopped',
+      // Tailscale control-plane and DERP relay hostnames — the sidecar must
+      // reach these for tailscaled to come up. The egress-policy reconciler
+      // picks them up as template-sourced rules in firewalled envs (§4.7),
+      // so the addon works without manual policy edits.
+      requiredEgress: [...TAILSCALE_CONTROL_PLANE_HOSTNAMES],
+    },
+    dependsOn: [ctx.service.name],
+    // High order so synthetic sidecars come up after authored services in
+    // the reconciler's create sequence — gives the target a head start on
+    // its DNS registration.
+    order: 1000,
+  };
+}

--- a/server/src/services/stack-addons/tailscale-ssh/index.ts
+++ b/server/src/services/stack-addons/tailscale-ssh/index.ts
@@ -1,0 +1,35 @@
+import type { AddonDefinition } from '@mini-infra/types';
+import { productionAddonRegistry, type RegisteredAddon } from '../registry';
+import {
+  tailscaleSshConfigSchema,
+  tailscaleSshManifest,
+  tailscaleSshTargetIntegration,
+} from './manifest';
+import { provisionTailscaleSsh } from './provision';
+import { buildTailscaleSshServiceDefinition } from './build-service-definition';
+
+/**
+ * `tailscale-ssh` addon — the first production addon in the framework
+ * (Phase 3 of the Service Addons plan). Registered into the production
+ * registry on import; tests opt out by constructing their own registry via
+ * `createAddonRegistry()` and choosing what to register into it.
+ */
+export const tailscaleSshDefinition: AddonDefinition = {
+  manifest: tailscaleSshManifest,
+  targetIntegration: tailscaleSshTargetIntegration,
+  provision: provisionTailscaleSsh,
+  buildServiceDefinition: buildTailscaleSshServiceDefinition,
+};
+
+export const tailscaleSshAddon: RegisteredAddon = {
+  manifest: tailscaleSshManifest,
+  configSchema: tailscaleSshConfigSchema,
+  definition: tailscaleSshDefinition,
+};
+
+// Self-register on import. `productionAddonRegistry` is the singleton the
+// render pipeline reads from when an `addons:` block is present on a stack
+// service. Importing this module from anywhere on the server (e.g. an
+// `import './services/stack-addons/tailscale-ssh'` from the bootstrap) is
+// sufficient to make the addon live.
+productionAddonRegistry.register(tailscaleSshAddon);

--- a/server/src/services/stack-addons/tailscale-ssh/manifest.ts
+++ b/server/src/services/stack-addons/tailscale-ssh/manifest.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+import type { AddonManifest, TargetIntegration } from '@mini-infra/types';
+
+/**
+ * User-supplied config for the `tailscale-ssh` addon. Both fields are
+ * optional — `addons: { tailscale-ssh: {} }` is the minimum viable form.
+ *
+ * `extraTags` is layered on top of the static `tag:mini-infra-managed` that
+ * the operator already assigned to their OAuth client in Phase 2; the addon
+ * never asks the operator for the default tag because the connected service
+ * owns it. Per-resource identity is encoded in the device hostname (see
+ * `sanitizeTailscaleHostname`), not in dynamic tags — Tailscale OAuth clients
+ * can only mint keys with tags pre-declared in the operator's ACL
+ * `tagOwners`, so dynamic per-stack/per-env/per-service tags would force
+ * unbounded ACL edits.
+ */
+export const tailscaleSshConfigSchema = z
+  .object({
+    /**
+     * Operator-supplied additional tags. Each must match the strict
+     * `tag:[a-z0-9-]+` shape Tailscale enforces and must already exist in
+     * the operator's ACL `tagOwners`. Empty / unspecified is the common
+     * case and uses the default tag set only.
+     */
+    extraTags: z
+      .array(
+        z
+          .string()
+          .regex(
+            /^tag:[a-z0-9-]+$/,
+            'tag must match tag:[a-z0-9-]+ (e.g. tag:dev-team)',
+          ),
+      )
+      .optional(),
+  })
+  .strict();
+
+export type TailscaleSshConfig = z.infer<typeof tailscaleSshConfigSchema>;
+
+export const tailscaleSshManifest: AddonManifest = {
+  id: 'tailscale-ssh',
+  kind: 'tailscale',
+  description:
+    'Operator SSH into the target service via Tailscale identity. Materialises a tailscaled sidecar joined to the target container, gated by the tailnet ACL ssh check policy.',
+  appliesTo: ['Stateful', 'StatelessWeb', 'Pool'],
+  requiresConnectedService: 'tailscale',
+};
+
+export const tailscaleSshTargetIntegration: TargetIntegration = {
+  // Sidecar joins the same Docker network as the target and reaches it by
+  // service-name DNS. The target itself is unmodified — no `network_mode`
+  // rewrite, no port reclamation. SSH sessions land inside the sidecar
+  // (where `tailscale up --ssh` runs the ssh server) and the sidecar can
+  // talk to the target by name on the shared bridge network.
+  network: 'peer-on-target-network',
+};

--- a/server/src/services/stack-addons/tailscale-ssh/provision.ts
+++ b/server/src/services/stack-addons/tailscale-ssh/provision.ts
@@ -1,0 +1,89 @@
+import {
+  TAILSCALE_DEFAULT_TAG,
+  buildTailscaleTagSet,
+  sanitizeTailscaleHostname,
+  type ProvisionContext,
+  type ProvisionedValues,
+} from '@mini-infra/types';
+import { TailscaleAuthkeyMinter } from '../../tailscale/tailscale-authkey-minter';
+import { TailscaleService } from '../../tailscale/tailscale-service';
+import type { TailscaleSshConfig } from './manifest';
+
+/**
+ * Connected-service lookup the addon framework hands into `provision()`.
+ * The addon expects the Tailscale connected service to be locatable under
+ * the `tailscale` key — the apply route builds the lookup before invoking
+ * `expandAddons`. Typed loosely (`unknown` → narrow on read) so the lib
+ * stays runtime-dep-free; this is the server-side narrowing surface.
+ */
+interface AddonConnectedServicesLookup {
+  tailscale?: TailscaleService;
+}
+
+function asLookup(input: unknown): AddonConnectedServicesLookup {
+  if (input && typeof input === 'object') {
+    return input as AddonConnectedServicesLookup;
+  }
+  return {};
+}
+
+/**
+ * Mint a one-time, ephemeral, preauthorized Tailscale authkey for the
+ * sidecar that's about to be materialised, and compute the device hostname
+ * the sidecar will register under.
+ *
+ * The default `tag:mini-infra-managed` is always present (asserted by the
+ * authkey minter); operator-supplied `extraTags` are merged on top via the
+ * shared lib helper. Per-resource identity rides on the device hostname
+ * (`<service>-<env>` sanitised, ≤63 chars), not on dynamic per-resource tags
+ * — Tailscale OAuth clients can only mint keys with tags pre-declared in
+ * the operator's ACL `tagOwners`, so dynamic tagging is infeasible.
+ */
+export async function provisionTailscaleSsh(
+  ctx: ProvisionContext,
+): Promise<ProvisionedValues> {
+  const config = ctx.addonConfig as TailscaleSshConfig;
+  const lookup = asLookup(ctx.connectedServices);
+  const tailscale = lookup.tailscale;
+  if (!tailscale) {
+    throw new Error(
+      'tailscale-ssh addon requires the Tailscale connected service to be configured',
+    );
+  }
+
+  // Hostname rule: `{service}-{env}` sanitised, ≤63 chars. For the rare
+  // case of a host-level stack (no environment) we fall back to the service
+  // name alone — which still encodes per-resource identity because there's
+  // only one host scope.
+  const envSlug = ctx.environment.name && ctx.environment.name.length > 0
+    ? ctx.environment.name
+    : 'host';
+  const hostname = sanitizeTailscaleHostname(ctx.service.name, envSlug);
+
+  const minter = new TailscaleAuthkeyMinter(tailscale);
+  const tagSet = buildTailscaleTagSet(config.extraTags ?? []);
+  const authkey = await minter.mintAuthkey({
+    tags: tagSet,
+    ephemeral: true,
+    preauthorized: true,
+    reusable: false,
+  });
+
+  return {
+    envForSidecar: {
+      TS_AUTHKEY: authkey.key,
+      TS_HOSTNAME: hostname,
+      TS_STATE_DIR: '/var/lib/tailscale',
+      TS_USERSPACE: 'false',
+      // `--ssh` enables the in-process ssh server backed by the tailnet ACL
+      // `ssh` stanza configured in Phase 2. `tailscale/tailscale` reads
+      // TS_EXTRA_ARGS at boot and appends to its `tailscale up` invocation.
+      TS_EXTRA_ARGS: '--ssh',
+    },
+    templateVars: {
+      tailscaleHostname: hostname,
+      tailscaleTags: tagSet,
+      tailscaleDefaultTag: TAILSCALE_DEFAULT_TAG,
+    },
+  };
+}

--- a/server/src/services/stacks/stack-reconciler.ts
+++ b/server/src/services/stacks/stack-reconciler.ts
@@ -136,7 +136,20 @@ export class StackReconciler {
 
       // Build maps for service definitions, hashes, and resolved configs
       const serviceMap = new Map(stack.services.map((s) => [s.serviceName, s]));
-      const { resolvedConfigsMap, resolvedDefinitions, serviceHashes } = await resolveServiceConfigs(stack.services, templateContext);
+      const { resolvedConfigsMap, resolvedDefinitions, serviceHashes } = await resolveServiceConfigs(
+        stack.services,
+        templateContext,
+        {
+          // Service Addons render-pass plumbing (Phase 3). The framework
+          // tolerates a missing progress callback or connected-services
+          // lookup — when both are absent (e.g. a stack with no `addons:`
+          // declarations) the expansion is a pure pass-through.
+          expansionProgress: options?.addonExpansion?.progress as
+            | import('../stack-addons').ExpansionProgress
+            | undefined,
+          connectedServices: options?.addonExpansion?.connectedServices,
+        },
+      );
 
       // 5a-i. Reconcile infra resource outputs (creates Docker networks + InfraResource records)
       const resourceOutputs = (stack.resourceOutputs as unknown as StackResourceOutput[]) ?? [];

--- a/server/src/services/stacks/stack-socket-emitter.ts
+++ b/server/src/services/stacks/stack-socket-emitter.ts
@@ -93,3 +93,37 @@ export function emitStackDestroyFailed(stackId: string, error: unknown, startTim
     error: message,
   });
 }
+
+export type StackAddonProvisionedPayload = {
+  stackId: string;
+  serviceName: string;
+  addonIds: string[];
+  kind?: string;
+  syntheticServiceName: string;
+};
+
+export function emitStackAddonProvisioned(
+  payload: StackAddonProvisionedPayload,
+): void {
+  try {
+    emitToChannel(
+      Channel.STACKS,
+      ServerEvent.STACK_ADDON_PROVISIONED,
+      payload,
+    );
+  } catch { /* never break the caller */ }
+}
+
+export type StackAddonFailedPayload = {
+  stackId: string;
+  serviceName: string;
+  addonIds: string[];
+  kind?: string;
+  error: string;
+};
+
+export function emitStackAddonFailed(payload: StackAddonFailedPayload): void {
+  try {
+    emitToChannel(Channel.STACKS, ServerEvent.STACK_ADDON_FAILED, payload);
+  } catch { /* never break the caller */ }
+}

--- a/server/src/services/stacks/utils.ts
+++ b/server/src/services/stacks/utils.ts
@@ -272,13 +272,21 @@ export interface ResolveServiceConfigsOptions {
   /**
    * Override the addon registry — tests use this to inject a registry
    * pre-populated with the no-op test addon. Defaults to
-   * `productionAddonRegistry`, which is empty at Phase 1.
+   * `productionAddonRegistry`, which now carries `tailscale-ssh` (Phase 3).
    */
   addonRegistry?: AddonRegistry;
   /** Per-(service, addon) progress callback; see `ExpansionProgress`. */
   expansionProgress?: ExpansionProgress;
   /** Pool-instance id when this expansion is for a single pool spawn. */
   instance?: { instanceId: string };
+  /**
+   * Connected-services lookup an addon's `provision()` may narrow at runtime
+   * (e.g. the `tailscale-ssh` addon reads `lookup.tailscale`). Typed
+   * `unknown` so the framework doesn't bind to a concrete server-side
+   * service surface; addon implementations narrow to their concrete type.
+   * Omitted in `plan()` flows where no provisioning runs.
+   */
+  connectedServices?: unknown;
 }
 
 /**
@@ -373,6 +381,7 @@ export async function resolveServiceConfigs(
           }
         : { id: '', name: '', networkType: 'local' },
       instance: options.instance,
+      connectedServices: options.connectedServices,
     },
     options.expansionProgress,
   );


### PR DESCRIPTION
## Summary
- First production addon in the Service Addons framework — `tailscale-ssh` materialises a `tailscale/tailscale` sidecar alongside any opt-in service so operators get tailnet-authenticated SSH via the ACL `check` policy from Phase 2.
- AddonBadge UI pill renders on synthetic services in the Stack-detail services table and the Containers page (Option B from MINI-23), with chevron / edit affordances disabled so addon-owned runtime configuration isn't presented as editable.
- Render pipeline emits `STACK_ADDON_PROVISIONED` / `STACK_ADDON_FAILED` and the task tracker surfaces them as additional steps under the active stack-apply task.

## Test plan
- [x] `pnpm build:lib`, `pnpm --filter mini-infra-server build`, `pnpm --filter mini-infra-client build` all green.
- [x] Server tests: `pnpm --filter mini-infra-server test` — **2073 passed** (12 new: tailscale-ssh end-to-end render + lib helper invariants).
- [x] Server lint + client lint clean.
- [ ] Live tailnet SSH from a tailnet-joined laptop — **not exercised**: dev env has no Tailscale OAuth client configured. Worth one manual run against a staged env with credentials before relying on the addon in prod (see Deviations note on the mk ticket).

Closes MINI-2