### PR TITLE
fix(egress): clean fresh-seed for egress-gateway + fw-agent (MINI-42)

### DIFF
--- a/client/src/app/settings/egress-fw-agent/page.tsx
+++ b/client/src/app/settings/egress-fw-agent/page.tsx
@@ -134,7 +134,7 @@ export default function EgressFwAgentSettingsPage() {
           <div>
             <h1 className="text-3xl font-bold">Egress Firewall Agent</h1>
             <p className="text-muted-foreground">
-              Host-singleton sidecar that enforces L3/L4 egress rules via nftables
+              Blocks outbound traffic that breaks your egress rules and logs every block.
             </p>
           </div>
         </div>
@@ -149,8 +149,7 @@ export default function EgressFwAgentSettingsPage() {
               Container Status
             </CardTitle>
             <CardDescription>
-              Mini Infra manages this container's lifecycle. nftables rules and the persisted env store
-              survive container restarts via host kernel state and the shared `/var/run/mini-infra` volume.
+              Mini Infra manages this container. Your firewall rules persist across restarts.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
@@ -196,7 +195,7 @@ export default function EgressFwAgentSettingsPage() {
               Configuration
             </CardTitle>
             <CardDescription>
-              Database settings override the baked-in image tag. Changes take effect on the next restart.
+              Override the default image or turn off auto-start. Changes apply on the next restart.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">

--- a/client/src/lib/route-config.ts
+++ b/client/src/lib/route-config.ts
@@ -516,7 +516,7 @@ export const routeConfig: Record<string, RouteConfig> = {
     showInNav: true,
     navGroup: "main",
     navSection: "administration",
-    description: "Host-singleton firewall agent that enforces L3/L4 egress rules",
+    description: "Blocks outbound traffic that breaks your egress rules",
     helpDoc: "settings/egress-fw-agent",
   },
 

--- a/deployment/development/lib/seeder.ts
+++ b/deployment/development/lib/seeder.ts
@@ -7,12 +7,15 @@
 //   3. Complete the setup wizard (docker host) via POST /auth/setup/complete
 //   3b. Upsert docker_host_ip system setting (needed for application DNS)
 //   4. Upsert Azure / Cloudflare / GitHub credentials
-//   5. Create a local environment
-//   6. Instantiate + apply the built-in HAProxy stack template
-//   7. Instantiate + apply the built-in Vault + NATS stack template
-//   8. Bootstrap/unlock Vault and publish system policies
-//   9. Mark onboarding complete
-//   10. Write environment-details.xml at the project root.
+//   5. Instantiate + apply the built-in Vault + NATS stack template
+//   6. Bootstrap/unlock Vault and publish system policies
+//   7. Create a local environment — egress-gateway provisioning kicks off here
+//      and needs both Vault unlocked (to mint NATS creds) and NATS running.
+//   8. Instantiate + apply the built-in HAProxy stack template
+//   9. Apply the host-scoped egress-fw-agent stack (created at server boot;
+//      its background apply requires Vault + NATS, so it lands here).
+//   10. Mark onboarding complete
+//   11. Write environment-details.xml at the project root.
 //
 // Each step is idempotent-ish: already-configured state is skipped, but the
 // seeder does not back out partial state on failure — fix the env file and re-run.
@@ -762,6 +765,32 @@ export async function ensureVaultUnlocked(api: ApiClient): Promise<void> {
   }
 }
 
+/**
+ * Apply the host-scoped egress-fw-agent stack created by the server's
+ * `bootstrapFwAgentStack` at boot. The server fires the apply in the
+ * background but it requires NATS to be reachable within 30 s — on a fresh
+ * worktree NATS is still coming up, so the boot apply silently fails and the
+ * stack stays `undeployed`. Now that NATS is up the seeder retries.
+ *
+ * Idempotent: if the stack is missing (auto-start disabled, template not
+ * synced) we log-skip; if it's already Synced we skip.
+ */
+async function ensureFwAgentStackApplied(api: ApiClient): Promise<void> {
+  logInfo('Looking for existing egress-fw-agent host stack');
+  const list = await api.get<unknown>('/api/stacks');
+  if (list.status !== 200) {
+    logSkip(`GET /api/stacks returned ${list.status} — skipping fw-agent apply`);
+    return;
+  }
+  const items = pickItems<Stack>(list.body);
+  const fwAgent = items.find((s) => s.name === 'egress-fw-agent');
+  if (!fwAgent?.id) {
+    logSkip('egress-fw-agent stack not found (auto-start disabled or template not synced)');
+    return;
+  }
+  await applyAndWaitForSynced(api, fwAgent.id, 'Egress fw-agent');
+}
+
 async function markOnboardingComplete(api: ApiClient): Promise<void> {
   logInfo('Marking onboarding complete');
   const res = await api.post('/api/onboarding/complete', {});
@@ -814,16 +843,12 @@ export async function seed(input: SeederInput): Promise<SeederOutput> {
   await ensureDockerHostIp(api, env);
   await configureServices(api, env);
 
-  const localEnvId = await ensureLocalEnvironment(api, env);
-  const haproxyStackId = await ensureHaproxyStack(api, localEnvId, {
-    http: input.haproxyHttpPort,
-    https: input.haproxyHttpsPort,
-    stats: input.haproxyStatsPort,
-    dataplane: input.haproxyDataplanePort,
-  });
-  if (haproxyStackId) {
-    await applyAndWaitForSynced(api, haproxyStackId, 'HAProxy');
-  }
+  // Vault + NATS go up first. The egress-gateway stack apply (kicked off
+  // when the local env is created below) reads NATS creds via Vault, so
+  // Vault must be unlocked and NATS must be reachable before any env-scoped
+  // provisioning runs. Earlier ordering put env creation first and the
+  // egress-gateway stack landed in `error` with
+  // "Vault admin client unavailable: No Vault address configured".
   const vaultNatsStackId = await ensureVaultNatsStack(api, {
     vault: input.vaultPort,
     natsClient: input.natsClientPort,
@@ -845,6 +870,25 @@ export async function seed(input: SeederInput): Promise<SeederOutput> {
       force: true,
     });
   }
+
+  // Apply the host-scoped egress-fw-agent stack. The server's
+  // `bootstrapFwAgentStack` creates the stack row at boot and dispatches the
+  // apply in the background, but on a fresh worktree NATS isn't up within
+  // its 30 s wait window so the boot-time apply fails silently and the stack
+  // stays `undeployed`. NATS is up now — apply explicitly.
+  await ensureFwAgentStackApplied(api);
+
+  const localEnvId = await ensureLocalEnvironment(api, env);
+  const haproxyStackId = await ensureHaproxyStack(api, localEnvId, {
+    http: input.haproxyHttpPort,
+    https: input.haproxyHttpsPort,
+    stats: input.haproxyStatsPort,
+    dataplane: input.haproxyDataplanePort,
+  });
+  if (haproxyStackId) {
+    await applyAndWaitForSynced(api, haproxyStackId, 'HAProxy');
+  }
+
   await markOnboardingComplete(api);
 
   logInfo(`Writing ${input.detailsFile}`);

--- a/server/src/__tests__/egress-fw-agent-template.test.ts
+++ b/server/src/__tests__/egress-fw-agent-template.test.ts
@@ -23,7 +23,7 @@ describe("egress-fw-agent template", () => {
     expect(json.name).toBe("egress-fw-agent");
     expect(json.scope).toBe("host");
     expect(json.category).toBe("infrastructure");
-    expect(json.builtinVersion).toBe(1);
+    expect(json.builtinVersion).toBe(2);
 
     // The agent role declares the KV bucket Phase 2 needs.
     expect(json.nats.subjectPrefix).toBe("mini-infra.egress.fw");

--- a/server/src/services/environment/environment-manager.ts
+++ b/server/src/services/environment/environment-manager.ts
@@ -16,6 +16,7 @@ import { EgressPolicyLifecycleService } from '../egress/egress-policy-lifecycle'
 import { getEnvFirewallManager } from '../egress';
 import { StackReconciler } from '../stacks/stack-reconciler';
 import { runStackNatsApplyPhase } from '../stacks/stack-nats-apply-orchestrator';
+import { runStackVaultApplyPhase } from '../stacks/stack-vault-apply-orchestrator';
 import DockerService from '../docker';
 
 export class EnvironmentManager {
@@ -787,14 +788,31 @@ export class EnvironmentManager {
       // The egress-gateway template injects `NATS_CREDS` via dynamicEnv, which
       // requires a `NatsCredentialProfile` row to exist for this stack before
       // the reconciler resolves env. Normal user-driven applies go through
-      // `routes/stacks/stacks-apply-route.ts`, which calls
-      // `runStackNatsApplyPhase` for that purpose. The auto-provision shortcut
-      // here would otherwise skip it — fail-closed at `resolveVaultEnv` with
-      // "no NATS credential profile is bound". Phase 3 / ALT-28.
+      // `routes/stacks/stacks-apply-route.ts`, which calls both
+      // `runStackVaultApplyPhase` and `runStackNatsApplyPhase` for that purpose.
+      // We mirror that here — the NATS phase reads the operator key out of
+      // Vault, so without the Vault phase setting up the policy/lease the NATS
+      // phase fails closed with "Vault GET …/shared/nats-operator failed:
+      // permission denied". Phase 3 / ALT-28.
       try {
         const dockerExecutor = new DockerExecutorService();
         await dockerExecutor.initialize();
         const reconciler = new StackReconciler(dockerExecutor, this.prisma);
+
+        const vaultPhase = await runStackVaultApplyPhase(this.prisma, egressStack.id, {
+          triggeredBy: userId ?? 'system',
+        });
+        if (vaultPhase.status === 'error') {
+          this.logger.error(
+            { environmentId, stackId: egressStack.id, error: vaultPhase.error },
+            'Vault apply phase failed; aborting egress gateway provisioning',
+          );
+          await this.userEventService.appendLogs(
+            userEventId,
+            `[${new Date().toISOString()}] WARNING: Vault apply failed: ${vaultPhase.error ?? 'unknown'}`,
+          );
+          return;
+        }
 
         const natsPhase = await runStackNatsApplyPhase(this.prisma, egressStack.id, {
           triggeredBy: userId ?? 'system',

--- a/server/src/services/vault/vault-admin-service.ts
+++ b/server/src/services/vault/vault-admin-service.ts
@@ -78,10 +78,18 @@ export class VaultAdminService {
 
   /**
    * Set or replace the HTTP client (e.g. after the vault stack has been deployed
-   * and its address is known).
+   * and its address is known). Propagates the cached admin token onto the new
+   * client so in-flight callers (KV reads from the NATS apply orchestrator,
+   * the health watcher, etc.) don't see a brief "permission denied" window
+   * while a renewal sneaks in. Without this, the post-install
+   * `register-vault-address` action would replace the client mid-seed and the
+   * very next KV read would land on a tokenless connection.
    */
   useClient(address: string): VaultHttpClient {
     this.client = new VaultHttpClient(address);
+    if (this.adminToken) {
+      this.client.setToken(this.adminToken);
+    }
     return this.client;
   }
 

--- a/server/templates/egress-fw-agent/template.json
+++ b/server/templates/egress-fw-agent/template.json
@@ -1,10 +1,10 @@
 {
   "name": "egress-fw-agent",
   "displayName": "Egress Firewall Agent",
-  "builtinVersion": 1,
+  "builtinVersion": 2,
   "scope": "host",
   "category": "infrastructure",
-  "description": "Host-singleton firewall agent that enforces L3/L4 egress rules via nftables and emits NFLOG drop events. Runs in `network_mode: host` with NET_ADMIN/NET_RAW (required to manage the host's nftables namespace). Communicates with mini-infra-server over NATS — rule push via request/reply on `mini-infra.egress.fw.rules.apply`, NFLOG events via JetStream `EgressFwEvents`, 5 s heartbeat via KV bucket `egress-fw-health`.",
+  "description": "Blocks outbound network traffic that breaks your environment's egress rules. Runs once per host. Logs every blocked connection so you can see what was denied and why.",
   "parameters": [
     {
       "name": "log-level",


### PR DESCRIPTION
## Summary
- Reorder the dev seeder so `vault-nats` is applied (and Vault unlocked) before the local environment is created, so the egress-gateway provisioning that runs as part of env creation has a working Vault + NATS to talk to.
- Run `runStackVaultApplyPhase` in `provisionEgressGateway` (it was running only the NATS phase, half of what the standard apply route does), then explicitly apply the host-scoped `egress-fw-agent` stack from the seeder so it doesn't depend on the boot-time NATS-ready race window.
- Fix `VaultAdminService.useClient()` to copy the cached admin token onto the new HTTP client — without this, the post-install `register-vault-address` action on a vault-stack apply replaced the client mid-seed and the very next KV read landed on a tokenless connection ("permission denied" on `shared/nats-operator`).
- Rewrite the firewall agent's wall-of-text descriptions (template `description`, settings page header + status/configuration card subtitles, route-config description) into plain English; bump the template `builtinVersion`.

## Test plan
- [x] `pnpm --filter mini-infra-server build` / `lint` clean
- [x] `pnpm --filter mini-infra-client build` clean
- [x] `pnpm --filter mini-infra-server test` — 2061 tests pass
- [x] Live smoke on a fresh dev env (`pnpm worktree-env delete mini-42 --force` + start): seeder log shows no egress-gateway warnings; `GET /api/stacks` reports every stack (`vault-nats`, `egress-fw-agent`, `dataplane-network`, `haproxy-local`, `egress-gateway`) as `synced`; the `environment_create` UserEvent finishes with status `completed` and an `Egress gateway deployed successfully` log line.
- [x] Settings page (`/settings-egress-fw-agent`) renders the new copy — verified via Playwright snapshot.

Closes MINI-42

🤖 Generated with [Claude Code](https://claude.com/claude-code)