### PR TITLE
fix(worktree-env): remove environment-details.xml on delete

### DIFF
--- a/deployment/development/worktree-delete.ts
+++ b/deployment/development/worktree-delete.ts
@@ -303,6 +303,22 @@ export async function run(argv: string[]): Promise<void> {
     logSkip('--keep-vm specified — leaving VM running.');
   }
 
+  if (entry.worktree_path) {
+    const detailsFile = path.join(entry.worktree_path, 'environment-details.xml');
+    if (fs.existsSync(detailsFile)) {
+      try {
+        fs.rmSync(detailsFile, { force: true });
+        logOk(`Removed ${detailsFile}.`);
+      } catch (err) {
+        logWarn(
+          `Failed to remove ${detailsFile}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    } else {
+      logSkip(`No environment-details.xml at ${entry.worktree_path}.`);
+    }
+  }
+
   if (removeEntry(profile)) {
     logOk(`Removed '${profile}' from registry.`);
   } else {


### PR DESCRIPTION
## Summary
- `pnpm worktree-env delete` now removes `environment-details.xml` from the worktree root alongside the compose project, VM, and registry entry, so teardown leaves no stale port/URL state behind for skills (`test-dev`, `diagnose-dev`) that resolve from it.
- Runs in both default and `--keep-vm` modes — once compose is down or the registry entry is gone, the file is invalid either way.

## Test plan
- [ ] `pnpm worktree-env start --description "test"` in a throwaway worktree, confirm `environment-details.xml` exists at the worktree root
- [ ] `pnpm worktree-env delete <profile> --force`, confirm log line `Removed …/environment-details.xml.` and the file is gone
- [ ] Re-run `pnpm worktree-env delete <profile> --force` (or run on a worktree that never started) and confirm the `No environment-details.xml at …` skip line

🤖 Generated with [Claude Code](https://claude.com/claude-code)