### PR TITLE
feat(addons): tailscale-web addon + tailscale merge strategy (Phase 4, MINI-3)

### DIFF
--- a/server/src/services/stack-addons/__tests__/tailscale-web.test.ts
+++ b/server/src/services/stack-addons/__tests__/tailscale-web.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TAILSCALE_CONTROL_PLANE_HOSTNAMES,
+  TAILSCALE_DEFAULT_TAG,
+  type StackServiceDefinition,
+} from '@mini-infra/types';
+import { createAddonRegistry } from '../registry';
+import { expandAddons } from '../expand-addons';
+import { tailscaleWebAddon } from '../tailscale-web';
+
+const baseContext = {
+  stack: { id: 'stack-1', name: 'web-stack' },
+  environment: { id: 'env-1', name: 'prod', networkType: 'local' as const },
+};
+
+function makeStateful(
+  name: string,
+  overrides: Partial<StackServiceDefinition> = {},
+): StackServiceDefinition {
+  return {
+    serviceName: name,
+    serviceType: 'Stateful',
+    dockerImage: 'nginx',
+    dockerTag: 'latest',
+    dependsOn: [],
+    order: 1,
+    containerConfig: { env: {}, restartPolicy: 'unless-stopped' },
+    ...overrides,
+  };
+}
+
+function makeStubTailscaleService(searchPaths: string[] = []): unknown {
+  return {
+    getAccessToken: async () => 'stub-access-token',
+    getAllManagedTags: async () => [TAILSCALE_DEFAULT_TAG],
+    getTailnetDomain: async () => searchPaths[0] ?? null,
+  };
+}
+
+function withStubbedFetch<T>(
+  fn: () => Promise<T>,
+  authkey = 'tskey-auth-stub',
+): Promise<T> {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    return new Response(
+      JSON.stringify({
+        id: 'k-stub',
+        key: authkey,
+        created: '2026-01-01T00:00:00Z',
+        expires: '2026-01-01T01:00:00Z',
+        capabilities: {
+          devices: {
+            create: {
+              reusable: false,
+              ephemeral: true,
+              preauthorized: true,
+              tags: [TAILSCALE_DEFAULT_TAG],
+            },
+          },
+        },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  }) as typeof fetch;
+  return fn().finally(() => {
+    globalThis.fetch = original;
+  });
+}
+
+describe('tailscale-web addon', () => {
+  it('manifest declares the kind:"tailscale" merge group', () => {
+    const m = tailscaleWebAddon.manifest;
+    expect(m.id).toBe('tailscale-web');
+    expect(m.kind).toBe('tailscale');
+    expect(m.requiresConnectedService).toBe('tailscale');
+    expect(m.appliesTo).toEqual(
+      expect.arrayContaining(['Stateful', 'StatelessWeb', 'Pool']),
+    );
+  });
+
+  it('rejects unknown config keys via the strict zod schema', () => {
+    expect(
+      tailscaleWebAddon.configSchema.safeParse({
+        port: 8080,
+        unknown: true,
+      }).success,
+    ).toBe(false);
+  });
+
+  it('requires the port field', () => {
+    expect(tailscaleWebAddon.configSchema.safeParse({}).success).toBe(false);
+    expect(tailscaleWebAddon.configSchema.safeParse({ port: 8080 }).success).toBe(
+      true,
+    );
+  });
+
+  it('rejects out-of-range ports and paths without a leading slash', () => {
+    expect(
+      tailscaleWebAddon.configSchema.safeParse({ port: 0 }).success,
+    ).toBe(false);
+    expect(
+      tailscaleWebAddon.configSchema.safeParse({ port: 70_000 }).success,
+    ).toBe(false);
+    expect(
+      tailscaleWebAddon.configSchema.safeParse({ port: 8080, path: 'no-slash' })
+        .success,
+    ).toBe(false);
+    expect(
+      tailscaleWebAddon.configSchema.safeParse({ port: 8080, path: '/api' })
+        .success,
+    ).toBe(true);
+  });
+
+  it('end-to-end render: solo web addon mounts serve.json and sets TS_SERVE_CONFIG', async () => {
+    const registry = createAddonRegistry();
+    registry.register(tailscaleWebAddon);
+
+    const target = makeStateful('web', {
+      addons: { 'tailscale-web': { port: 8080 } },
+    });
+    const rendered = await withStubbedFetch(() =>
+      expandAddons([target], {
+        ...baseContext,
+        registry,
+        connectedServices: {
+          tailscale: makeStubTailscaleService(['ts-tailnet.ts.net']),
+        },
+      }),
+    );
+
+    expect(rendered).toHaveLength(2);
+    const sidecar = rendered.find((s) => s.serviceName === 'web-tailscale')!;
+    expect(sidecar.dockerImage).toBe('tailscale/tailscale');
+    expect(sidecar.synthetic).toEqual({
+      addonIds: ['tailscale-web'],
+      kind: undefined,
+      targetService: 'web',
+    });
+
+    expect(sidecar.containerConfig.env).toMatchObject({
+      TS_AUTHKEY: 'tskey-auth-stub',
+      TS_HOSTNAME: 'web-prod',
+      TS_SERVE_CONFIG: '/etc/tailscale/serve.json',
+    });
+    expect(sidecar.containerConfig.env?.TS_EXTRA_ARGS).toBeUndefined();
+
+    // Required egress reuses the Phase 3 control-plane list.
+    expect(sidecar.containerConfig.requiredEgress).toEqual(
+      expect.arrayContaining([...TAILSCALE_CONTROL_PLANE_HOSTNAMES]),
+    );
+
+    // serve.json contents — ${TS_CERT_DOMAIN} stays literal so tailscaled
+    // substitutes it at boot.
+    expect(sidecar.configFiles).toHaveLength(1);
+    const file = sidecar.configFiles![0];
+    expect(file.path).toBe('/etc/tailscale/serve.json');
+    expect(file.volumeName).toBe('web-tailscale-config');
+    expect(JSON.parse(file.content)).toMatchObject({
+      Web: {
+        '${TS_CERT_DOMAIN}:443': {
+          Handlers: { '/': { Proxy: 'http://web:8080' } },
+        },
+      },
+    });
+
+    // Synthetic-marker labels — addon-badge consumes 'mini-infra.addon'.
+    expect(sidecar.containerConfig.labels).toMatchObject({
+      'mini-infra.addon': 'tailscale-web',
+      'mini-infra.synthetic': 'true',
+      'mini-infra.addon-target': 'web',
+    });
+  });
+
+  it('rejects expansion when the Tailscale connected service is missing', async () => {
+    const registry = createAddonRegistry();
+    registry.register(tailscaleWebAddon);
+
+    const target = makeStateful('web', {
+      addons: { 'tailscale-web': { port: 8080 } },
+    });
+    await expect(
+      expandAddons([target], { ...baseContext, registry }),
+    ).rejects.toThrow(/connected service/);
+  });
+});

--- a/server/src/services/stack-addons/__tests__/tailscale-web.test.ts
+++ b/server/src/services/stack-addons/__tests__/tailscale-web.test.ts
@@ -154,7 +154,10 @@ describe('tailscale-web addon', () => {
     // substitutes it at boot.
     expect(sidecar.configFiles).toHaveLength(1);
     const file = sidecar.configFiles![0];
-    expect(file.path).toBe('/etc/tailscale/serve.json');
+    // `path` is the location *inside the volume* — the volume is mounted at
+    // /etc/tailscale on the sidecar, so the file appears at
+    // /etc/tailscale/serve.json (matching TS_SERVE_CONFIG).
+    expect(file.path).toBe('/serve.json');
     expect(file.volumeName).toBe('web-tailscale-config');
     expect(JSON.parse(file.content)).toMatchObject({
       Web: {
@@ -163,6 +166,19 @@ describe('tailscale-web addon', () => {
         },
       },
     });
+
+    // The sidecar mounts the config volume at /etc/tailscale so tailscaled
+    // can read serve.json. Without this mount, TS_SERVE_CONFIG points at a
+    // non-existent path and the HTTPS surface won't come up.
+    expect(sidecar.containerConfig.mounts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: 'web-tailscale-config',
+          target: '/etc/tailscale',
+          type: 'volume',
+        }),
+      ]),
+    );
 
     // Synthetic-marker labels — addon-badge consumes 'mini-infra.addon'.
     expect(sidecar.containerConfig.labels).toMatchObject({

--- a/server/src/services/stack-addons/index.ts
+++ b/server/src/services/stack-addons/index.ts
@@ -20,3 +20,8 @@ export type { ExpansionContext, ExpansionProgress } from './expand-addons';
 
 // Side-effect imports — populate `productionAddonRegistry`.
 import './tailscale-ssh';
+import './tailscale-web';
+import { productionAddonRegistry } from './registry';
+import { tailscaleMergeStrategy } from './merge-strategies/tailscale';
+
+productionAddonRegistry.registerMergeStrategy(tailscaleMergeStrategy);

--- a/server/src/services/stack-addons/merge-strategies/__tests__/tailscale.test.ts
+++ b/server/src/services/stack-addons/merge-strategies/__tests__/tailscale.test.ts
@@ -152,10 +152,14 @@ describe('tailscale merge strategy (kind:"tailscale")', () => {
     expect(mintCalls).toBe(1);
 
     // serve.json is mounted with the rendered HTTPS proxy → http://web:8080.
+    // `path` is the location inside the volume; the volume is mounted at
+    // /etc/tailscale on the sidecar so the file appears at
+    // /etc/tailscale/serve.json (matching TS_SERVE_CONFIG).
     expect(sidecar.configFiles).toBeDefined();
     expect(sidecar.configFiles).toHaveLength(1);
     const serveFile = sidecar.configFiles![0];
-    expect(serveFile.path).toBe('/etc/tailscale/serve.json');
+    expect(serveFile.path).toBe('/serve.json');
+    expect(serveFile.volumeName).toBe('web-tailscale-config');
     const parsed = JSON.parse(serveFile.content) as Record<string, unknown>;
     expect(parsed).toMatchObject({
       TCP: { '443': { HTTPS: true } },
@@ -166,13 +170,24 @@ describe('tailscale merge strategy (kind:"tailscale")', () => {
       },
     });
 
-    // Single state volume mount (one device → one state directory).
-    expect(sidecar.containerConfig.mounts).toHaveLength(1);
-    expect(sidecar.containerConfig.mounts?.[0]).toMatchObject({
-      source: 'web-tailscale-state',
-      target: '/var/lib/tailscale',
-      type: 'volume',
-    });
+    // Two volume mounts — the always-on state volume AND the config volume
+    // that holds serve.json. Without the config mount, TS_SERVE_CONFIG
+    // points at a non-existent path and the HTTPS surface fails to come up.
+    expect(sidecar.containerConfig.mounts).toHaveLength(2);
+    expect(sidecar.containerConfig.mounts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: 'web-tailscale-state',
+          target: '/var/lib/tailscale',
+          type: 'volume',
+        }),
+        expect.objectContaining({
+          source: 'web-tailscale-config',
+          target: '/etc/tailscale',
+          type: 'volume',
+        }),
+      ]),
+    );
 
     // Merged-marker labels — the kind, a comma-separated member list, and
     // the standard synthetic markers.

--- a/server/src/services/stack-addons/merge-strategies/__tests__/tailscale.test.ts
+++ b/server/src/services/stack-addons/merge-strategies/__tests__/tailscale.test.ts
@@ -1,0 +1,378 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TAILSCALE_DEFAULT_TAG,
+  type StackServiceDefinition,
+} from '@mini-infra/types';
+import { createAddonRegistry } from '../../registry';
+import { expandAddons } from '../../expand-addons';
+import { tailscaleSshAddon } from '../../tailscale-ssh';
+import { tailscaleWebAddon } from '../../tailscale-web';
+import { tailscaleMergeStrategy } from '../tailscale';
+
+const baseContext = {
+  stack: { id: 'stack-1', name: 'web-stack' },
+  environment: { id: 'env-1', name: 'prod', networkType: 'local' as const },
+};
+
+function makeStateful(
+  name: string,
+  overrides: Partial<StackServiceDefinition> = {},
+): StackServiceDefinition {
+  return {
+    serviceName: name,
+    serviceType: 'Stateful',
+    dockerImage: 'nginx',
+    dockerTag: 'latest',
+    dependsOn: [],
+    order: 1,
+    containerConfig: { env: {}, restartPolicy: 'unless-stopped' },
+    ...overrides,
+  };
+}
+
+interface StubFetchOptions {
+  authkey?: string;
+  searchPaths?: string[];
+  /** When `true`, the searchpaths endpoint returns 500. */
+  searchPathsError?: boolean;
+}
+
+function makeStubTailscaleService(opts: StubFetchOptions = {}) {
+  return {
+    getAccessToken: async () => 'stub-access-token',
+    getAllManagedTags: async () => [TAILSCALE_DEFAULT_TAG],
+    getTailnetDomain: async () => {
+      if (opts.searchPathsError) {
+        throw new Error('searchpaths fetch failed');
+      }
+      const first = opts.searchPaths?.[0];
+      return first ? first.replace(/\.$/, '') : null;
+    },
+  };
+}
+
+let mintCalls = 0;
+
+function withStubbedFetch<T>(
+  fn: () => Promise<T>,
+  opts: StubFetchOptions = {},
+): Promise<T> {
+  mintCalls = 0;
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (url: string) => {
+    if (typeof url === 'string' && url.endsWith('/keys')) {
+      mintCalls += 1;
+      return new Response(
+        JSON.stringify({
+          id: `k-stub-${mintCalls}`,
+          key: opts.authkey ?? `tskey-auth-stub-${mintCalls}`,
+          created: '2026-01-01T00:00:00Z',
+          expires: '2026-01-01T01:00:00Z',
+          capabilities: {
+            devices: {
+              create: {
+                reusable: false,
+                ephemeral: true,
+                preauthorized: true,
+                tags: [TAILSCALE_DEFAULT_TAG],
+              },
+            },
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    if (typeof url === 'string' && url.endsWith('/dns/searchpaths')) {
+      return new Response(
+        JSON.stringify({ searchPaths: opts.searchPaths ?? [] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    return new Response('not found', { status: 404 });
+  }) as typeof fetch;
+  return fn().finally(() => {
+    globalThis.fetch = original;
+  });
+}
+
+function buildRegistry() {
+  const registry = createAddonRegistry();
+  registry.register(tailscaleSshAddon);
+  registry.register(tailscaleWebAddon);
+  registry.registerMergeStrategy(tailscaleMergeStrategy);
+  return registry;
+}
+
+describe('tailscale merge strategy (kind:"tailscale")', () => {
+  it('collapses tailscale-ssh + tailscale-web into one merged sidecar', async () => {
+    const registry = buildRegistry();
+    const target = makeStateful('web', {
+      addons: {
+        'tailscale-ssh': {},
+        'tailscale-web': { port: 8080 },
+      },
+    });
+
+    const rendered = await withStubbedFetch(
+      () =>
+        expandAddons([target], {
+          ...baseContext,
+          registry,
+          connectedServices: {
+            tailscale: makeStubTailscaleService({ searchPaths: ['ts-tailnet.ts.net'] }),
+          },
+        }),
+      { searchPaths: ['ts-tailnet.ts.net'] },
+    );
+
+    // Exactly one synthetic sidecar — the whole point of the merge.
+    const sidecars = rendered.filter((s) => s.serviceName !== 'web');
+    expect(sidecars).toHaveLength(1);
+    const sidecar = sidecars[0];
+    expect(sidecar.serviceName).toBe('web-tailscale');
+    expect(sidecar.dockerImage).toBe('tailscale/tailscale');
+
+    // Synthetic back-ref carries both addon ids and the kind label.
+    expect(sidecar.synthetic).toEqual({
+      addonIds: expect.arrayContaining(['tailscale-ssh', 'tailscale-web']),
+      kind: 'tailscale',
+      targetService: 'web',
+    });
+
+    // Env carries BOTH --ssh and TS_SERVE_CONFIG — the contract for "one
+    // sidecar, two surfaces".
+    expect(sidecar.containerConfig.env).toMatchObject({
+      TS_AUTHKEY: expect.stringMatching(/^tskey-auth-stub-/),
+      TS_HOSTNAME: 'web-prod',
+      TS_EXTRA_ARGS: '--ssh',
+      TS_SERVE_CONFIG: '/etc/tailscale/serve.json',
+    });
+
+    // Exactly one authkey was minted across both addons (single device).
+    expect(mintCalls).toBe(1);
+
+    // serve.json is mounted with the rendered HTTPS proxy → http://web:8080.
+    expect(sidecar.configFiles).toBeDefined();
+    expect(sidecar.configFiles).toHaveLength(1);
+    const serveFile = sidecar.configFiles![0];
+    expect(serveFile.path).toBe('/etc/tailscale/serve.json');
+    const parsed = JSON.parse(serveFile.content) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      TCP: { '443': { HTTPS: true } },
+      Web: {
+        '${TS_CERT_DOMAIN}:443': {
+          Handlers: { '/': { Proxy: 'http://web:8080' } },
+        },
+      },
+    });
+
+    // Single state volume mount (one device → one state directory).
+    expect(sidecar.containerConfig.mounts).toHaveLength(1);
+    expect(sidecar.containerConfig.mounts?.[0]).toMatchObject({
+      source: 'web-tailscale-state',
+      target: '/var/lib/tailscale',
+      type: 'volume',
+    });
+
+    // Merged-marker labels — the kind, a comma-separated member list, and
+    // the standard synthetic markers.
+    expect(sidecar.containerConfig.labels).toMatchObject({
+      'mini-infra.addon': 'tailscale',
+      'mini-infra.addon-kind': 'tailscale',
+      'mini-infra.addon-members': 'tailscale-ssh,tailscale-web',
+      'mini-infra.synthetic': 'true',
+      'mini-infra.addon-target': 'web',
+    });
+  });
+
+  it('renders serve.json with the configured path when web addon supplies one', async () => {
+    const registry = buildRegistry();
+    const target = makeStateful('api', {
+      addons: {
+        'tailscale-ssh': {},
+        'tailscale-web': { port: 9090, path: '/v1' },
+      },
+    });
+
+    const rendered = await withStubbedFetch(() =>
+      expandAddons([target], {
+        ...baseContext,
+        registry,
+        connectedServices: { tailscale: makeStubTailscaleService() },
+      }),
+    );
+    const sidecar = rendered.find((s) => s.serviceName === 'api-tailscale')!;
+    const parsed = JSON.parse(sidecar.configFiles![0].content) as {
+      Web: Record<string, { Handlers: Record<string, { Proxy: string }> }>;
+    };
+    expect(parsed.Web['${TS_CERT_DOMAIN}:443'].Handlers['/v1']).toEqual({
+      Proxy: 'http://api:9090',
+    });
+  });
+
+  it('tolerates a tailnet-domain lookup failure — sidecar still renders', async () => {
+    const registry = buildRegistry();
+    const target = makeStateful('web', {
+      addons: {
+        'tailscale-ssh': {},
+        'tailscale-web': { port: 8080 },
+      },
+    });
+
+    const rendered = await withStubbedFetch(
+      () =>
+        expandAddons([target], {
+          ...baseContext,
+          registry,
+          connectedServices: {
+            tailscale: makeStubTailscaleService({ searchPathsError: true }),
+          },
+        }),
+      { searchPathsError: true },
+    );
+    const sidecar = rendered.find((s) => s.serviceName === 'web-tailscale');
+    expect(sidecar).toBeDefined();
+    // The serve.json itself uses runtime-substituted ${TS_CERT_DOMAIN} so the
+    // data path is unaffected by the lookup failure.
+    expect(sidecar!.containerConfig.env?.TS_SERVE_CONFIG).toBe(
+      '/etc/tailscale/serve.json',
+    );
+  });
+
+  it('idempotency: expanding the same authored stack twice yields equivalent sidecar shape', async () => {
+    const registry = buildRegistry();
+    const makeTarget = (): StackServiceDefinition =>
+      makeStateful('web', {
+        addons: {
+          'tailscale-ssh': {},
+          'tailscale-web': { port: 8080 },
+        },
+      });
+
+    const a = await withStubbedFetch(
+      () =>
+        expandAddons([makeTarget()], {
+          ...baseContext,
+          registry,
+          connectedServices: { tailscale: makeStubTailscaleService() },
+        }),
+      { authkey: 'tskey-a' },
+    );
+    const b = await withStubbedFetch(
+      () =>
+        expandAddons([makeTarget()], {
+          ...baseContext,
+          registry,
+          connectedServices: { tailscale: makeStubTailscaleService() },
+        }),
+      { authkey: 'tskey-b' },
+    );
+
+    const stripVolatile = (def: StackServiceDefinition) => {
+      const env = { ...(def.containerConfig.env ?? {}) };
+      delete env.TS_AUTHKEY; // freshly minted on every render
+      return { ...def, containerConfig: { ...def.containerConfig, env } };
+    };
+
+    const aSidecar = a.find((s) => s.serviceName === 'web-tailscale')!;
+    const bSidecar = b.find((s) => s.serviceName === 'web-tailscale')!;
+    expect(stripVolatile(aSidecar)).toEqual(stripVolatile(bSidecar));
+  });
+
+  it('isolation: tailscale-ssh alone keeps its solo shape (no merge)', async () => {
+    const registry = buildRegistry();
+    const target = makeStateful('web', {
+      addons: { 'tailscale-ssh': {} },
+    });
+
+    const rendered = await withStubbedFetch(() =>
+      expandAddons([target], {
+        ...baseContext,
+        registry,
+        connectedServices: { tailscale: makeStubTailscaleService() },
+      }),
+    );
+    const sidecar = rendered.find((s) => s.serviceName === 'web-tailscale')!;
+    expect(sidecar.synthetic).toEqual({
+      addonIds: ['tailscale-ssh'],
+      kind: undefined,
+      targetService: 'web',
+    });
+    // Solo-ssh has no TS_SERVE_CONFIG and no serve.json file.
+    expect(sidecar.containerConfig.env?.TS_SERVE_CONFIG).toBeUndefined();
+    expect(sidecar.configFiles).toBeUndefined();
+    // Solo labels are addon-id-flavoured, not kind-flavoured.
+    expect(sidecar.containerConfig.labels?.['mini-infra.addon']).toBe(
+      'tailscale-ssh',
+    );
+  });
+
+  it('isolation: tailscale-web alone keeps its solo shape (no merge)', async () => {
+    const registry = buildRegistry();
+    const target = makeStateful('web', {
+      addons: { 'tailscale-web': { port: 8080 } },
+    });
+
+    const rendered = await withStubbedFetch(() =>
+      expandAddons([target], {
+        ...baseContext,
+        registry,
+        connectedServices: { tailscale: makeStubTailscaleService() },
+      }),
+    );
+    const sidecar = rendered.find((s) => s.serviceName === 'web-tailscale')!;
+    expect(sidecar.synthetic).toEqual({
+      addonIds: ['tailscale-web'],
+      kind: undefined,
+      targetService: 'web',
+    });
+    // Solo-web has TS_SERVE_CONFIG but no --ssh.
+    expect(sidecar.containerConfig.env?.TS_SERVE_CONFIG).toBe(
+      '/etc/tailscale/serve.json',
+    );
+    expect(sidecar.containerConfig.env?.TS_EXTRA_ARGS).toBeUndefined();
+    expect(sidecar.configFiles).toHaveLength(1);
+    expect(sidecar.containerConfig.labels?.['mini-infra.addon']).toBe(
+      'tailscale-web',
+    );
+  });
+
+  it('unions extraTags across members and dedupes', async () => {
+    const registry = buildRegistry();
+    const target = makeStateful('web', {
+      addons: {
+        'tailscale-ssh': { extraTags: ['tag:dev', 'tag:shared'] },
+        'tailscale-web': { port: 80, extraTags: ['tag:platform', 'tag:shared'] },
+      },
+    });
+
+    const rendered = await withStubbedFetch(() =>
+      expandAddons([target], {
+        ...baseContext,
+        registry,
+        connectedServices: { tailscale: makeStubTailscaleService() },
+      }),
+    );
+    const sidecar = rendered.find((s) => s.serviceName === 'web-tailscale')!;
+    // Only one authkey mint → only one chance to assert tags. Validate the
+    // sidecar's hostname is present and synthetic info is right; the tag
+    // dedup is exercised by the buildTailscaleTagSet contract test.
+    expect(sidecar.containerConfig.env?.TS_HOSTNAME).toBe('web-prod');
+    expect(mintCalls).toBe(1);
+  });
+
+  it('rejects expansion when the Tailscale connected service is missing', async () => {
+    const registry = buildRegistry();
+    const target = makeStateful('web', {
+      addons: {
+        'tailscale-ssh': {},
+        'tailscale-web': { port: 8080 },
+      },
+    });
+    // No `connectedServices` → applicability check on each member fires
+    // before merge resolution and surfaces the error.
+    await expect(
+      expandAddons([target], { ...baseContext, registry }),
+    ).rejects.toThrow(/connected service/);
+  });
+});

--- a/server/src/services/stack-addons/merge-strategies/tailscale.ts
+++ b/server/src/services/stack-addons/merge-strategies/tailscale.ts
@@ -13,11 +13,11 @@ import { TailscaleAuthkeyMinter } from '../../tailscale/tailscale-authkey-minter
 import { TailscaleService } from '../../tailscale/tailscale-service';
 import { getLogger } from '../../../lib/logger-factory';
 import { buildTailscaleSidecarDefinition } from '../shared/tailscale-sidecar';
-import { tailscaleSidecarServiceName } from '../shared/sidecar-naming';
 import {
   TAILSCALE_SERVE_CONFIG_PATH,
+  buildServeConfigArtifacts,
   renderServeJson,
-  tailscaleConfigVolumeName,
+  type TailscaleSidecarMount,
 } from '../tailscale-web/serve-config';
 import type { TailscaleSshConfig } from '../tailscale-ssh/manifest';
 import type { TailscaleWebConfig } from '../tailscale-web/manifest';
@@ -124,21 +124,19 @@ async function provisionTailscaleMerged(
   let tailnetDomain: string | null = null;
   let targetPort: number | undefined;
   let targetPath: string | undefined;
+  let serveConfigMount: TailscaleSidecarMount | undefined;
   if (resolved.web) {
     targetPort = resolved.web.port;
     targetPath = resolved.web.path ?? '/';
     env.TS_SERVE_CONFIG = TAILSCALE_SERVE_CONFIG_PATH;
-    const sidecarServiceName = tailscaleSidecarServiceName(ctx.service.name);
-    files.push({
-      volumeName: tailscaleConfigVolumeName(sidecarServiceName),
-      path: TAILSCALE_SERVE_CONFIG_PATH,
-      content: renderServeJson({
-        targetService: ctx.service.name,
-        targetPort: resolved.web.port,
-        path: resolved.web.path,
-      }),
-      permissions: '0644',
+    const serveJson = renderServeJson({
+      targetService: ctx.service.name,
+      targetPort: resolved.web.port,
+      path: resolved.web.path,
     });
+    const artifacts = buildServeConfigArtifacts(ctx.service.name, serveJson);
+    files.push(artifacts.configFile);
+    serveConfigMount = artifacts.configMount;
     try {
       tailnetDomain = await tailscale.getTailnetDomain();
     } catch (err) {
@@ -159,6 +157,10 @@ async function provisionTailscaleMerged(
       tailnetDomain,
       mergedAddonIds: members.map((m) => m.addonId),
       ...(targetPort !== undefined ? { targetPort, targetPath } : {}),
+      // Carried into buildServiceDefinition so the merged sidecar mounts the
+      // serve.json volume. Without this, tailscaled boots with
+      // TS_SERVE_CONFIG pointing at a non-existent path.
+      ...(serveConfigMount ? { serveConfigMount } : {}),
     },
   };
 }
@@ -169,10 +171,14 @@ function buildMergedServiceDefinition(
   members: ReadonlyArray<{ addonId: string; config: unknown }>,
 ): StackServiceDefinition {
   const memberIds = members.map((m) => m.addonId).sort();
+  const serveConfigMount = provisioned.templateVars.serveConfigMount as
+    | TailscaleSidecarMount
+    | undefined;
   return buildTailscaleSidecarDefinition({
     ctx,
     env: { ...(provisioned.envForSidecar ?? {}) },
     files: provisioned.files ?? [],
+    extraMounts: serveConfigMount ? [serveConfigMount] : [],
     labels: {
       // Merged sidecars are identified by their kind, not a specific addon
       // id — the AddonBadge falls back to `synthetic.kind` when present, so

--- a/server/src/services/stack-addons/merge-strategies/tailscale.ts
+++ b/server/src/services/stack-addons/merge-strategies/tailscale.ts
@@ -1,0 +1,208 @@
+import {
+  TAILSCALE_DEFAULT_TAG,
+  buildTailscaleTagSet,
+  sanitizeTailscaleHostname,
+  type AddonMergeStrategy,
+  type ProvisionContext,
+  type ProvisionedValues,
+  type StackConfigFile,
+  type StackServiceDefinition,
+  type TargetIntegration,
+} from '@mini-infra/types';
+import { TailscaleAuthkeyMinter } from '../../tailscale/tailscale-authkey-minter';
+import { TailscaleService } from '../../tailscale/tailscale-service';
+import { getLogger } from '../../../lib/logger-factory';
+import { buildTailscaleSidecarDefinition } from '../shared/tailscale-sidecar';
+import { tailscaleSidecarServiceName } from '../shared/sidecar-naming';
+import {
+  TAILSCALE_SERVE_CONFIG_PATH,
+  renderServeJson,
+  tailscaleConfigVolumeName,
+} from '../tailscale-web/serve-config';
+import type { TailscaleSshConfig } from '../tailscale-ssh/manifest';
+import type { TailscaleWebConfig } from '../tailscale-web/manifest';
+
+const TAILSCALE_KIND = 'tailscale';
+
+interface AddonConnectedServicesLookup {
+  tailscale?: TailscaleService;
+}
+
+function asLookup(input: unknown): AddonConnectedServicesLookup {
+  if (input && typeof input === 'object') {
+    return input as AddonConnectedServicesLookup;
+  }
+  return {};
+}
+
+interface ResolvedMembers {
+  ssh?: TailscaleSshConfig;
+  web?: TailscaleWebConfig;
+  /** Union of every member's `extraTags`, deduped, in declaration order. */
+  extraTags: string[];
+}
+
+function resolveMembers(
+  members: ReadonlyArray<{ addonId: string; config: unknown }>,
+): ResolvedMembers {
+  const result: ResolvedMembers = { extraTags: [] };
+  const seenTags = new Set<string>();
+  for (const m of members) {
+    if (m.addonId === 'tailscale-ssh') {
+      result.ssh = (m.config ?? {}) as TailscaleSshConfig;
+    } else if (m.addonId === 'tailscale-web') {
+      result.web = (m.config ?? {}) as TailscaleWebConfig;
+    } else {
+      // Future Tailscale-kind addons land here; for now refuse to merge an
+      // unknown member rather than silently dropping it from the rendered
+      // sidecar.
+      throw new Error(
+        `Unknown member "${m.addonId}" for kind:"tailscale" merge group`,
+      );
+    }
+    const config = (m.config ?? {}) as { extraTags?: string[] };
+    for (const tag of config.extraTags ?? []) {
+      if (!seenTags.has(tag)) {
+        seenTags.add(tag);
+        result.extraTags.push(tag);
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Provision a single tailnet device for the merged group: one authkey, one
+ * hostname, one optional `serve.json` (only when `tailscale-web` is a
+ * member). The merged env composes flags from each member — `TS_EXTRA_ARGS`
+ * for `tailscale-ssh`'s `--ssh` and `TS_SERVE_CONFIG` for `tailscale-web`'s
+ * `serve.json` — so the rendered sidecar runs both surfaces under one
+ * tailscaled process.
+ */
+async function provisionTailscaleMerged(
+  ctx: ProvisionContext,
+  members: ReadonlyArray<{ addonId: string; config: unknown }>,
+): Promise<ProvisionedValues> {
+  const resolved = resolveMembers(members);
+  const lookup = asLookup(ctx.connectedServices);
+  const tailscale = lookup.tailscale;
+  if (!tailscale) {
+    throw new Error(
+      'kind:"tailscale" merge requires the Tailscale connected service to be configured',
+    );
+  }
+
+  const envSlug =
+    ctx.environment.name && ctx.environment.name.length > 0
+      ? ctx.environment.name
+      : 'host';
+  const hostname = sanitizeTailscaleHostname(ctx.service.name, envSlug);
+
+  const tagSet = buildTailscaleTagSet(resolved.extraTags);
+  const minter = new TailscaleAuthkeyMinter(tailscale);
+  const authkey = await minter.mintAuthkey({
+    tags: tagSet,
+    ephemeral: true,
+    preauthorized: true,
+    reusable: false,
+  });
+
+  const env: Record<string, string> = {
+    TS_AUTHKEY: authkey.key,
+    TS_HOSTNAME: hostname,
+    TS_STATE_DIR: '/var/lib/tailscale',
+    TS_USERSPACE: 'false',
+  };
+
+  // tailscale-ssh contribution.
+  if (resolved.ssh) {
+    env.TS_EXTRA_ARGS = '--ssh';
+  }
+
+  // tailscale-web contribution.
+  const files: StackConfigFile[] = [];
+  let tailnetDomain: string | null = null;
+  let targetPort: number | undefined;
+  let targetPath: string | undefined;
+  if (resolved.web) {
+    targetPort = resolved.web.port;
+    targetPath = resolved.web.path ?? '/';
+    env.TS_SERVE_CONFIG = TAILSCALE_SERVE_CONFIG_PATH;
+    const sidecarServiceName = tailscaleSidecarServiceName(ctx.service.name);
+    files.push({
+      volumeName: tailscaleConfigVolumeName(sidecarServiceName),
+      path: TAILSCALE_SERVE_CONFIG_PATH,
+      content: renderServeJson({
+        targetService: ctx.service.name,
+        targetPort: resolved.web.port,
+        path: resolved.web.path,
+      }),
+      permissions: '0644',
+    });
+    try {
+      tailnetDomain = await tailscale.getTailnetDomain();
+    } catch (err) {
+      getLogger('integrations', 'tailscale-merge-provision').warn(
+        { error: err instanceof Error ? err.message : String(err) },
+        'Failed to resolve tailnet MagicDNS suffix during merged provision',
+      );
+    }
+  }
+
+  return {
+    envForSidecar: env,
+    files,
+    templateVars: {
+      tailscaleHostname: hostname,
+      tailscaleTags: tagSet,
+      tailscaleDefaultTag: TAILSCALE_DEFAULT_TAG,
+      tailnetDomain,
+      mergedAddonIds: members.map((m) => m.addonId),
+      ...(targetPort !== undefined ? { targetPort, targetPath } : {}),
+    },
+  };
+}
+
+function buildMergedServiceDefinition(
+  ctx: ProvisionContext,
+  provisioned: ProvisionedValues,
+  members: ReadonlyArray<{ addonId: string; config: unknown }>,
+): StackServiceDefinition {
+  const memberIds = members.map((m) => m.addonId).sort();
+  return buildTailscaleSidecarDefinition({
+    ctx,
+    env: { ...(provisioned.envForSidecar ?? {}) },
+    files: provisioned.files ?? [],
+    labels: {
+      // Merged sidecars are identified by their kind, not a specific addon
+      // id — the AddonBadge falls back to `synthetic.kind` when present, so
+      // this label keeps the container-list rendering in sync with the
+      // service-row rendering for the merged case.
+      'mini-infra.addon': TAILSCALE_KIND,
+      'mini-infra.addon-kind': TAILSCALE_KIND,
+      'mini-infra.addon-members': memberIds.join(','),
+      'mini-infra.synthetic': 'true',
+      'mini-infra.addon-target': ctx.service.name,
+    },
+  });
+}
+
+const tailscaleMergedTargetIntegration: TargetIntegration = {
+  // Both `tailscale-ssh` and `tailscale-web` use `peer-on-target-network` —
+  // the merged sidecar inherits the same shape.
+  network: 'peer-on-target-network',
+};
+
+/**
+ * Merge strategy for `kind: "tailscale"`. Collapses any combination of
+ * `tailscale-ssh` and `tailscale-web` declared on the same target service
+ * into a single tailscaled sidecar — one authkey, one hostname, one tailnet
+ * device, one state volume, one rendered service row — sharing whichever of
+ * `--ssh` and `TS_SERVE_CONFIG` the declared members ask for.
+ */
+export const tailscaleMergeStrategy: AddonMergeStrategy = {
+  kind: TAILSCALE_KIND,
+  targetIntegration: tailscaleMergedTargetIntegration,
+  provision: provisionTailscaleMerged,
+  buildServiceDefinition: buildMergedServiceDefinition,
+};

--- a/server/src/services/stack-addons/shared/sidecar-naming.ts
+++ b/server/src/services/stack-addons/shared/sidecar-naming.ts
@@ -1,0 +1,26 @@
+/**
+ * Naming conventions for Tailscale-addon sidecars. Centralised so the
+ * `tailscale-ssh` addon, the `tailscale-web` addon, and the `kind: tailscale`
+ * merge strategy all emit the same service / volume names — a merged sidecar
+ * shares one device record, one state volume, and one rendered service row
+ * with whichever solo addon application would have produced it on its own.
+ */
+
+/**
+ * Synthetic sidecar service name for the tailscale family. Solo and merged
+ * applications both render under `<target>-tailscale` so the rendered stack
+ * has at most one sidecar per target service regardless of which Tailscale
+ * addons are declared.
+ */
+export function tailscaleSidecarServiceName(targetServiceName: string): string {
+  return `${targetServiceName}-tailscale`;
+}
+
+/**
+ * Per-application state volume name. tailscaled persists node identity here
+ * so restarts re-use the same device record (with `ephemeral: true` the node
+ * de-registers on shutdown and the volume just holds runtime state).
+ */
+export function tailscaleStateVolumeName(sidecarServiceName: string): string {
+  return `${sidecarServiceName}-state`;
+}

--- a/server/src/services/stack-addons/shared/tailscale-sidecar.ts
+++ b/server/src/services/stack-addons/shared/tailscale-sidecar.ts
@@ -1,0 +1,88 @@
+import {
+  TAILSCALE_CONTROL_PLANE_HOSTNAMES,
+  type ProvisionContext,
+  type StackConfigFile,
+  type StackServiceDefinition,
+} from '@mini-infra/types';
+import {
+  tailscaleSidecarServiceName,
+  tailscaleStateVolumeName,
+} from './sidecar-naming';
+
+/**
+ * Official Tailscale image. We run containerised `tailscaled` rather than
+ * embedding `tsnet` because `tsnet` is Go-only and the addon ships as a
+ * sidecar container, not a library inside the Node process.
+ */
+const TAILSCALE_IMAGE = 'tailscale/tailscale';
+const TAILSCALE_TAG = 'stable';
+
+const STATE_VOLUME_MOUNT_PATH = '/var/lib/tailscale';
+
+/**
+ * Inputs shared between the solo addons and the `kind: tailscale` merge
+ * strategy. The caller supplies the env, optional files (e.g. `serve.json`),
+ * and the labels that distinguish solo vs merged sidecars; the helper owns
+ * the image, capabilities, state-volume mount, restart policy, dependsOn,
+ * order, and the Tailscale control-plane `requiredEgress` set.
+ */
+export interface BuildTailscaleSidecarInput {
+  ctx: ProvisionContext;
+  env: Record<string, string>;
+  /** Optional config files (e.g. rendered `serve.json` for `tailscale-web`). */
+  files?: StackConfigFile[];
+  /** Synthetic-marker labels — vary by solo addon vs merged group. */
+  labels: Record<string, string>;
+}
+
+/**
+ * Materialise the common sidecar `StackServiceDefinition` for a Tailscale
+ * addon (solo or merged). Single source of truth for the image, capability
+ * set, state-volume mount, restart policy, dependsOn, order, and the
+ * control-plane `requiredEgress` list — so future changes (e.g. a pinned
+ * image tag, an extra control-plane hostname) only land in one place.
+ */
+export function buildTailscaleSidecarDefinition(
+  input: BuildTailscaleSidecarInput,
+): StackServiceDefinition {
+  const sidecarServiceName = tailscaleSidecarServiceName(input.ctx.service.name);
+  const stateVolumeName = tailscaleStateVolumeName(sidecarServiceName);
+
+  const def: StackServiceDefinition = {
+    serviceName: sidecarServiceName,
+    serviceType: 'Stateful',
+    dockerImage: TAILSCALE_IMAGE,
+    dockerTag: TAILSCALE_TAG,
+    containerConfig: {
+      env: { ...input.env },
+      // tailscaled requires NET_ADMIN to bring up its userspace networking
+      // device, plus access to /dev/net/tun for kernel-mode networking. We
+      // run in kernel mode (TS_USERSPACE=false) for best performance.
+      capAdd: ['NET_ADMIN', 'SYS_MODULE'],
+      mounts: [
+        {
+          source: stateVolumeName,
+          target: STATE_VOLUME_MOUNT_PATH,
+          type: 'volume',
+        },
+      ],
+      labels: { ...input.labels },
+      restartPolicy: 'unless-stopped',
+      // Tailscale control-plane and DERP relay hostnames — the sidecar must
+      // reach these for tailscaled to come up. The egress-policy reconciler
+      // picks them up as template-sourced rules in firewalled envs.
+      requiredEgress: [...TAILSCALE_CONTROL_PLANE_HOSTNAMES],
+    },
+    dependsOn: [input.ctx.service.name],
+    // High order so synthetic sidecars come up after authored services in
+    // the reconciler's create sequence — gives the target a head start on
+    // its DNS registration.
+    order: 1000,
+  };
+
+  if (input.files && input.files.length > 0) {
+    def.configFiles = [...input.files];
+  }
+
+  return def;
+}

--- a/server/src/services/stack-addons/shared/tailscale-sidecar.ts
+++ b/server/src/services/stack-addons/shared/tailscale-sidecar.ts
@@ -2,12 +2,15 @@ import {
   TAILSCALE_CONTROL_PLANE_HOSTNAMES,
   type ProvisionContext,
   type StackConfigFile,
+  type StackContainerConfig,
   type StackServiceDefinition,
 } from '@mini-infra/types';
 import {
   tailscaleSidecarServiceName,
   tailscaleStateVolumeName,
 } from './sidecar-naming';
+
+type SidecarMount = NonNullable<StackContainerConfig['mounts']>[number];
 
 /**
  * Official Tailscale image. We run containerised `tailscaled` rather than
@@ -31,6 +34,13 @@ export interface BuildTailscaleSidecarInput {
   env: Record<string, string>;
   /** Optional config files (e.g. rendered `serve.json` for `tailscale-web`). */
   files?: StackConfigFile[];
+  /**
+   * Mounts beyond the always-on state volume — e.g. the config-file volume
+   * holding `serve.json` for `tailscale-web`. Without these, a file in
+   * `files` is written into a volume the sidecar never mounts and
+   * tailscaled can't read it.
+   */
+  extraMounts?: SidecarMount[];
   /** Synthetic-marker labels — vary by solo addon vs merged group. */
   labels: Record<string, string>;
 }
@@ -65,6 +75,7 @@ export function buildTailscaleSidecarDefinition(
           target: STATE_VOLUME_MOUNT_PATH,
           type: 'volume',
         },
+        ...(input.extraMounts ?? []),
       ],
       labels: { ...input.labels },
       restartPolicy: 'unless-stopped',

--- a/server/src/services/stack-addons/tailscale-web/build-service-definition.ts
+++ b/server/src/services/stack-addons/tailscale-web/build-service-definition.ts
@@ -7,19 +7,21 @@ import { buildTailscaleSidecarDefinition } from '../shared/tailscale-sidecar';
 
 /**
  * Materialise the synthetic sidecar `StackServiceDefinition` for the
- * `tailscale-ssh` addon. The image, state volume, capabilities, and
+ * `tailscale-web` addon. The image, state volume, capabilities, and
  * control-plane egress all come from the shared helper; this function only
- * varies the env (incl. `TS_EXTRA_ARGS=--ssh`) and the addon-id labels.
+ * varies the env (incl. `TS_SERVE_CONFIG`), the rendered `serve.json` config
+ * file, and the addon-id labels.
  */
-export function buildTailscaleSshServiceDefinition(
+export function buildTailscaleWebServiceDefinition(
   ctx: ProvisionContext,
   provisioned: ProvisionedValues,
 ): StackServiceDefinition {
   return buildTailscaleSidecarDefinition({
     ctx,
     env: { ...(provisioned.envForSidecar ?? {}) },
+    files: provisioned.files ?? [],
     labels: {
-      'mini-infra.addon': 'tailscale-ssh',
+      'mini-infra.addon': 'tailscale-web',
       'mini-infra.synthetic': 'true',
       'mini-infra.addon-target': ctx.service.name,
     },

--- a/server/src/services/stack-addons/tailscale-web/build-service-definition.ts
+++ b/server/src/services/stack-addons/tailscale-web/build-service-definition.ts
@@ -4,22 +4,28 @@ import type {
   StackServiceDefinition,
 } from '@mini-infra/types';
 import { buildTailscaleSidecarDefinition } from '../shared/tailscale-sidecar';
+import type { TailscaleSidecarMount } from './serve-config';
 
 /**
  * Materialise the synthetic sidecar `StackServiceDefinition` for the
  * `tailscale-web` addon. The image, state volume, capabilities, and
  * control-plane egress all come from the shared helper; this function only
  * varies the env (incl. `TS_SERVE_CONFIG`), the rendered `serve.json` config
- * file, and the addon-id labels.
+ * file, the matching mount the sidecar reads it from, and the addon-id
+ * labels.
  */
 export function buildTailscaleWebServiceDefinition(
   ctx: ProvisionContext,
   provisioned: ProvisionedValues,
 ): StackServiceDefinition {
+  const serveConfigMount = provisioned.templateVars.serveConfigMount as
+    | TailscaleSidecarMount
+    | undefined;
   return buildTailscaleSidecarDefinition({
     ctx,
     env: { ...(provisioned.envForSidecar ?? {}) },
     files: provisioned.files ?? [],
+    extraMounts: serveConfigMount ? [serveConfigMount] : [],
     labels: {
       'mini-infra.addon': 'tailscale-web',
       'mini-infra.synthetic': 'true',

--- a/server/src/services/stack-addons/tailscale-web/index.ts
+++ b/server/src/services/stack-addons/tailscale-web/index.ts
@@ -1,0 +1,32 @@
+import type { AddonDefinition } from '@mini-infra/types';
+import { productionAddonRegistry, type RegisteredAddon } from '../registry';
+import {
+  tailscaleWebConfigSchema,
+  tailscaleWebManifest,
+  tailscaleWebTargetIntegration,
+} from './manifest';
+import { provisionTailscaleWeb } from './provision';
+import { buildTailscaleWebServiceDefinition } from './build-service-definition';
+
+/**
+ * `tailscale-web` addon — Phase 4 sibling to `tailscale-ssh`. Materialises a
+ * tailscaled sidecar running `tailscale serve` so the target service is
+ * reachable at `https://<service>-<env>.<tailnet>.ts.net` with auto-issued
+ * Let's Encrypt certs and no port forwarding. Shares `kind: tailscale` with
+ * `tailscale-ssh` — when both are declared on the same service the merge
+ * strategy collapses them into one sidecar.
+ */
+export const tailscaleWebDefinition: AddonDefinition = {
+  manifest: tailscaleWebManifest,
+  targetIntegration: tailscaleWebTargetIntegration,
+  provision: provisionTailscaleWeb,
+  buildServiceDefinition: buildTailscaleWebServiceDefinition,
+};
+
+export const tailscaleWebAddon: RegisteredAddon = {
+  manifest: tailscaleWebManifest,
+  configSchema: tailscaleWebConfigSchema,
+  definition: tailscaleWebDefinition,
+};
+
+productionAddonRegistry.register(tailscaleWebAddon);

--- a/server/src/services/stack-addons/tailscale-web/manifest.ts
+++ b/server/src/services/stack-addons/tailscale-web/manifest.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+import type { AddonManifest, TargetIntegration } from '@mini-infra/types';
+
+/**
+ * User-supplied config for the `tailscale-web` addon.
+ *
+ * `port` is required — it's the local port on the target service the sidecar
+ * proxies to over the shared Docker network (the addon's
+ * `targetIntegration.network` is `peer-on-target-network`, so the sidecar
+ * reaches the target by service-name DNS).
+ *
+ * `path` defaults to `/`; an addon-config that wants to expose a sub-path
+ * (`{ path: "/api" }`) is supported but the common case is `/`.
+ *
+ * `extraTags` mirrors the `tailscale-ssh` addon — operator-supplied tags must
+ * already be declared in the tailnet's `tagOwners` ACL. The static
+ * `tag:mini-infra-managed` is always added by the authkey minter.
+ */
+export const tailscaleWebConfigSchema = z
+  .object({
+    port: z
+      .number()
+      .int()
+      .min(1)
+      .max(65535),
+    path: z
+      .string()
+      .regex(/^\//, 'path must begin with "/"')
+      .optional(),
+    extraTags: z
+      .array(
+        z
+          .string()
+          .regex(
+            /^tag:[a-z0-9-]+$/,
+            'tag must match tag:[a-z0-9-]+ (e.g. tag:dev-team)',
+          ),
+      )
+      .optional(),
+  })
+  .strict();
+
+export type TailscaleWebConfig = z.infer<typeof tailscaleWebConfigSchema>;
+
+export const tailscaleWebManifest: AddonManifest = {
+  id: 'tailscale-web',
+  kind: 'tailscale',
+  description:
+    'Expose the target service over HTTPS on the tailnet with auto-provisioned TLS. Materialises a tailscaled sidecar running `tailscale serve` against ${TS_CERT_DOMAIN}:443 → http://<target>:<port>.',
+  appliesTo: ['Stateful', 'StatelessWeb', 'Pool'],
+  requiresConnectedService: 'tailscale',
+};
+
+export const tailscaleWebTargetIntegration: TargetIntegration = {
+  // Sidecar joins the same Docker network as the target. `tailscale serve`
+  // proxies traffic from the tailnet to `http://<target>:<port>` resolved by
+  // service-name DNS on the shared bridge network. The target itself is
+  // unmodified — no `network_mode` rewrite, no port reclamation.
+  network: 'peer-on-target-network',
+};

--- a/server/src/services/stack-addons/tailscale-web/provision.ts
+++ b/server/src/services/stack-addons/tailscale-web/provision.ts
@@ -8,11 +8,10 @@ import {
 import { TailscaleAuthkeyMinter } from '../../tailscale/tailscale-authkey-minter';
 import { TailscaleService } from '../../tailscale/tailscale-service';
 import { getLogger } from '../../../lib/logger-factory';
-import { tailscaleSidecarServiceName } from '../shared/sidecar-naming';
 import {
   TAILSCALE_SERVE_CONFIG_PATH,
+  buildServeConfigArtifacts,
   renderServeJson,
-  tailscaleConfigVolumeName,
 } from './serve-config';
 import type { TailscaleWebConfig } from './manifest';
 
@@ -80,13 +79,15 @@ export async function provisionTailscaleWeb(
     );
   }
 
-  const sidecarServiceName = tailscaleSidecarServiceName(ctx.service.name);
-  const configVolume = tailscaleConfigVolumeName(sidecarServiceName);
   const serveJson = renderServeJson({
     targetService: ctx.service.name,
     targetPort: config.port,
     path: config.path,
   });
+  const { configFile, configMount } = buildServeConfigArtifacts(
+    ctx.service.name,
+    serveJson,
+  );
 
   return {
     envForSidecar: {
@@ -96,14 +97,7 @@ export async function provisionTailscaleWeb(
       TS_USERSPACE: 'false',
       TS_SERVE_CONFIG: TAILSCALE_SERVE_CONFIG_PATH,
     },
-    files: [
-      {
-        volumeName: configVolume,
-        path: TAILSCALE_SERVE_CONFIG_PATH,
-        content: serveJson,
-        permissions: '0644',
-      },
-    ],
+    files: [configFile],
     templateVars: {
       tailscaleHostname: hostname,
       tailscaleTags: tagSet,
@@ -111,6 +105,10 @@ export async function provisionTailscaleWeb(
       tailnetDomain,
       targetPort: config.port,
       targetPath: config.path ?? '/',
+      // Carried into buildServiceDefinition so the sidecar mounts the same
+      // volume the configFile gets written into. Without this, tailscaled
+      // boots with TS_SERVE_CONFIG pointing at a non-existent path.
+      serveConfigMount: configMount,
     },
   };
 }

--- a/server/src/services/stack-addons/tailscale-web/provision.ts
+++ b/server/src/services/stack-addons/tailscale-web/provision.ts
@@ -1,0 +1,116 @@
+import {
+  TAILSCALE_DEFAULT_TAG,
+  buildTailscaleTagSet,
+  sanitizeTailscaleHostname,
+  type ProvisionContext,
+  type ProvisionedValues,
+} from '@mini-infra/types';
+import { TailscaleAuthkeyMinter } from '../../tailscale/tailscale-authkey-minter';
+import { TailscaleService } from '../../tailscale/tailscale-service';
+import { getLogger } from '../../../lib/logger-factory';
+import { tailscaleSidecarServiceName } from '../shared/sidecar-naming';
+import {
+  TAILSCALE_SERVE_CONFIG_PATH,
+  renderServeJson,
+  tailscaleConfigVolumeName,
+} from './serve-config';
+import type { TailscaleWebConfig } from './manifest';
+
+interface AddonConnectedServicesLookup {
+  tailscale?: TailscaleService;
+}
+
+function asLookup(input: unknown): AddonConnectedServicesLookup {
+  if (input && typeof input === 'object') {
+    return input as AddonConnectedServicesLookup;
+  }
+  return {};
+}
+
+/**
+ * Mint the authkey, render `serve.json`, and resolve the tailnet domain for
+ * the `tailscale-web` sidecar.
+ *
+ * The rendered `serve.json` uses the runtime-substituted `${TS_CERT_DOMAIN}`
+ * so the file is invariant across tailnets — tailscaled fills the host in
+ * when it boots. The tailnet domain we resolve here is best-effort and lands
+ * in `templateVars.tailnetDomain` for downstream UI (Phase 5 Connect panel)
+ * to compose a clickable URL without a separate API roundtrip; if the lookup
+ * fails (e.g. MagicDNS disabled on the tailnet), we still ship the sidecar —
+ * the runtime substitution carries the data plane.
+ */
+export async function provisionTailscaleWeb(
+  ctx: ProvisionContext,
+): Promise<ProvisionedValues> {
+  const config = ctx.addonConfig as TailscaleWebConfig;
+  const lookup = asLookup(ctx.connectedServices);
+  const tailscale = lookup.tailscale;
+  if (!tailscale) {
+    throw new Error(
+      'tailscale-web addon requires the Tailscale connected service to be configured',
+    );
+  }
+
+  const envSlug =
+    ctx.environment.name && ctx.environment.name.length > 0
+      ? ctx.environment.name
+      : 'host';
+  const hostname = sanitizeTailscaleHostname(ctx.service.name, envSlug);
+
+  const minter = new TailscaleAuthkeyMinter(tailscale);
+  const tagSet = buildTailscaleTagSet(config.extraTags ?? []);
+  const authkey = await minter.mintAuthkey({
+    tags: tagSet,
+    ephemeral: true,
+    preauthorized: true,
+    reusable: false,
+  });
+
+  let tailnetDomain: string | null = null;
+  try {
+    tailnetDomain = await tailscale.getTailnetDomain();
+  } catch (err) {
+    // Best-effort — falling back to null leaves Phase 5 to either re-resolve
+    // or surface a "domain unknown" placeholder. The data path is unaffected
+    // because the rendered serve.json uses runtime-substituted
+    // `${TS_CERT_DOMAIN}`.
+    getLogger('integrations', 'tailscale-web-provision').warn(
+      { error: err instanceof Error ? err.message : String(err) },
+      'Failed to resolve tailnet MagicDNS suffix',
+    );
+  }
+
+  const sidecarServiceName = tailscaleSidecarServiceName(ctx.service.name);
+  const configVolume = tailscaleConfigVolumeName(sidecarServiceName);
+  const serveJson = renderServeJson({
+    targetService: ctx.service.name,
+    targetPort: config.port,
+    path: config.path,
+  });
+
+  return {
+    envForSidecar: {
+      TS_AUTHKEY: authkey.key,
+      TS_HOSTNAME: hostname,
+      TS_STATE_DIR: '/var/lib/tailscale',
+      TS_USERSPACE: 'false',
+      TS_SERVE_CONFIG: TAILSCALE_SERVE_CONFIG_PATH,
+    },
+    files: [
+      {
+        volumeName: configVolume,
+        path: TAILSCALE_SERVE_CONFIG_PATH,
+        content: serveJson,
+        permissions: '0644',
+      },
+    ],
+    templateVars: {
+      tailscaleHostname: hostname,
+      tailscaleTags: tagSet,
+      tailscaleDefaultTag: TAILSCALE_DEFAULT_TAG,
+      tailnetDomain,
+      targetPort: config.port,
+      targetPath: config.path ?? '/',
+    },
+  };
+}

--- a/server/src/services/stack-addons/tailscale-web/serve-config.ts
+++ b/server/src/services/stack-addons/tailscale-web/serve-config.ts
@@ -1,3 +1,6 @@
+import type { StackConfigFile, StackContainerConfig } from '@mini-infra/types';
+import { tailscaleSidecarServiceName } from '../shared/sidecar-naming';
+
 /**
  * `serve.json` template for `tailscale serve`. The tailscaled container reads
  * this file when `TS_SERVE_CONFIG` is set and substitutes `${TS_CERT_DOMAIN}`
@@ -40,8 +43,32 @@ export function renderServeJson(input: ServeConfigInput): string {
   return JSON.stringify(config, null, 2);
 }
 
-/** Path inside the sidecar where the rendered `serve.json` is mounted. */
-export const TAILSCALE_SERVE_CONFIG_PATH = '/etc/tailscale/serve.json';
+const SERVE_CONFIG_FILENAME = 'serve.json';
+
+/**
+ * Directory the config volume is mounted at inside the sidecar container —
+ * also the dir component of `TS_SERVE_CONFIG`.
+ */
+export const TAILSCALE_SERVE_CONFIG_DIR = '/etc/tailscale';
+
+/**
+ * Absolute path inside the sidecar container where tailscaled finds
+ * `serve.json` — the value of the `TS_SERVE_CONFIG` env var. Equal to
+ * `<TAILSCALE_SERVE_CONFIG_DIR>/<filename>`.
+ */
+export const TAILSCALE_SERVE_CONFIG_PATH = `${TAILSCALE_SERVE_CONFIG_DIR}/${SERVE_CONFIG_FILENAME}`;
+
+/**
+ * Path *inside the named volume* where `StackContainerManager.writeConfigFiles`
+ * writes the rendered `serve.json`. The volume is mounted at
+ * {@link TAILSCALE_SERVE_CONFIG_DIR} on the sidecar, so a file at this
+ * in-volume path appears at {@link TAILSCALE_SERVE_CONFIG_PATH} inside the
+ * container. The split mirrors the `haproxy_config` convention in
+ * `server/templates/haproxy/template.json` — file path is *inside* the volume,
+ * mount target is the absolute container path, the file appears at
+ * `<mount-target><file-path>` at runtime.
+ */
+const TAILSCALE_SERVE_CONFIG_VOLUME_PATH = `/${SERVE_CONFIG_FILENAME}`;
 
 /**
  * Volume name that holds the rendered `serve.json` for a given sidecar
@@ -50,4 +77,43 @@ export const TAILSCALE_SERVE_CONFIG_PATH = '/etc/tailscale/serve.json';
  */
 export function tailscaleConfigVolumeName(sidecarServiceName: string): string {
   return `${sidecarServiceName}-config`;
+}
+
+export type TailscaleSidecarMount = NonNullable<
+  StackContainerConfig['mounts']
+>[number];
+
+export interface ServeConfigArtifacts {
+  /** Goes into `provisioned.files`; written into the named volume. */
+  configFile: StackConfigFile;
+  /** Goes into the sidecar's `containerConfig.mounts` so the file is readable. */
+  configMount: TailscaleSidecarMount;
+}
+
+/**
+ * Compose the (file, mount) pair the tailscale-web sidecar needs to read its
+ * `serve.json`. Without the matching mount on the consumer sidecar, the file
+ * is written into a volume nothing reads — `TS_SERVE_CONFIG` would point at a
+ * non-existent path. Returning the pair from one helper keeps the two halves
+ * impossible to wire up out of sync.
+ */
+export function buildServeConfigArtifacts(
+  targetServiceName: string,
+  serveJsonContent: string,
+): ServeConfigArtifacts {
+  const sidecarServiceName = tailscaleSidecarServiceName(targetServiceName);
+  const volumeName = tailscaleConfigVolumeName(sidecarServiceName);
+  return {
+    configFile: {
+      volumeName,
+      path: TAILSCALE_SERVE_CONFIG_VOLUME_PATH,
+      content: serveJsonContent,
+      permissions: '0644',
+    },
+    configMount: {
+      source: volumeName,
+      target: TAILSCALE_SERVE_CONFIG_DIR,
+      type: 'volume',
+    },
+  };
 }

--- a/server/src/services/stack-addons/tailscale-web/serve-config.ts
+++ b/server/src/services/stack-addons/tailscale-web/serve-config.ts
@@ -1,0 +1,53 @@
+/**
+ * `serve.json` template for `tailscale serve`. The tailscaled container reads
+ * this file when `TS_SERVE_CONFIG` is set and substitutes `${TS_CERT_DOMAIN}`
+ * at runtime with the device's MagicDNS hostname (e.g.
+ * `<service>-<env>.<tailnet>.ts.net`). Keeping the host literal in the file
+ * means the sidecar works identically across tailnets without re-rendering
+ * the file at apply time.
+ *
+ * Shared between the solo `tailscale-web` provision step and the
+ * `kind: tailscale` merge strategy so they emit byte-identical config when
+ * the (target, port, path) tuple matches.
+ */
+export interface ServeConfigInput {
+  /** Service name of the target on the shared Docker network. */
+  targetService: string;
+  /** Port on the target service the sidecar proxies to. */
+  targetPort: number;
+  /** URL path prefix exposed on the tailnet host; defaults to `/`. */
+  path?: string;
+}
+
+export function renderServeJson(input: ServeConfigInput): string {
+  const path = input.path && input.path.length > 0 ? input.path : '/';
+  const proxy = `http://${input.targetService}:${input.targetPort}`;
+  const config = {
+    TCP: {
+      '443': { HTTPS: true },
+    },
+    Web: {
+      '${TS_CERT_DOMAIN}:443': {
+        Handlers: {
+          [path]: { Proxy: proxy },
+        },
+      },
+    },
+    AllowFunnel: {
+      '${TS_CERT_DOMAIN}:443': false,
+    },
+  };
+  return JSON.stringify(config, null, 2);
+}
+
+/** Path inside the sidecar where the rendered `serve.json` is mounted. */
+export const TAILSCALE_SERVE_CONFIG_PATH = '/etc/tailscale/serve.json';
+
+/**
+ * Volume name that holds the rendered `serve.json` for a given sidecar
+ * service. Aligning with the state-volume convention (`<sidecar>-state`)
+ * keeps per-application volumes grouped by the sidecar they belong to.
+ */
+export function tailscaleConfigVolumeName(sidecarServiceName: string): string {
+  return `${sidecarServiceName}-config`;
+}

--- a/server/src/services/tailscale/tailscale-service.ts
+++ b/server/src/services/tailscale/tailscale-service.ts
@@ -317,6 +317,71 @@ export class TailscaleService extends ConfigurationService {
     }
   }
 
+  /**
+   * Resolve the tailnet's MagicDNS suffix (e.g. `tail-abc.ts.net`) so callers
+   * can compose `https://<host>.<tailnet>.ts.net` URLs without hardcoding the
+   * domain. Tailscale exposes the suffix via the DNS search paths on the
+   * tailnet — `searchPaths[0]` is the MagicDNS suffix when MagicDNS is on.
+   *
+   * Used by the `tailscale-web` addon to populate `templateVars.tailnetDomain`
+   * for downstream UI (Phase 5 Connect panel). The `serve.json` itself uses
+   * the runtime-substituted `${TS_CERT_DOMAIN}` so this lookup is not
+   * load-bearing for traffic — it's a UI ergonomic.
+   */
+  async getTailnetDomain(): Promise<string | null> {
+    const accessToken = await this.getAccessToken();
+    const controller = new AbortController();
+    const timer = setTimeout(
+      () => controller.abort(),
+      DEFAULT_REQUEST_TIMEOUT_MS,
+    );
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(
+        `${TAILSCALE_API_BASE}/tailnet/-/dns/searchpaths`,
+        {
+          method: "GET",
+          headers: { Authorization: `Bearer ${accessToken}` },
+          signal: controller.signal,
+        },
+      );
+    } catch (err) {
+      const name = err instanceof Error ? err.name : "";
+      if (name === "AbortError") {
+        throw new TailscaleAuthError(
+          "Tailscale DNS searchpaths request timed out",
+          TAILSCALE_ERROR_CODES.NETWORK_ERROR,
+        );
+      }
+      throw new TailscaleAuthError(
+        `Failed to reach Tailscale DNS endpoint: ${
+          err instanceof Error ? err.message : "unknown"
+        }`,
+        TAILSCALE_ERROR_CODES.NETWORK_ERROR,
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!response.ok) {
+      const text = await safeReadText(response);
+      throw new TailscaleAuthError(
+        `Tailscale DNS searchpaths request failed (HTTP ${response.status}): ${text}`,
+        TAILSCALE_ERROR_CODES.TAILSCALE_API_ERROR,
+      );
+    }
+
+    const data = (await response.json()) as { searchPaths?: string[] };
+    const first = data.searchPaths?.find(
+      (p): p is string => typeof p === "string" && p.length > 0,
+    );
+    if (!first) return null;
+    // The endpoint returns paths with a trailing dot (FQDN form) on some
+    // tailnets; normalise to the bare suffix.
+    return first.replace(/\.$/, "");
+  }
+
   async getHealthStatus(): Promise<ServiceHealthStatus> {
     const latestStatus = await this.getLatestConnectivityStatus();
 


### PR DESCRIPTION
## Summary
- New `tailscale-web` addon: tailscaled sidecar running `tailscale serve` against `${TS_CERT_DOMAIN}:443` proxying to `http://<target>:<port>`. Required `port`, optional `path` (defaults to `/`).
- New `kind: tailscale` merge strategy: when both Tailscale addons target one service, render one merged sidecar — one authkey, one hostname, one tailnet device, one state volume — composing both `--ssh` and `TS_SERVE_CONFIG` under one tailscaled.
- `TailscaleService.getTailnetDomain()` resolves the MagicDNS suffix via `GET /api/v2/tailnet/-/dns/searchpaths`; best-effort, surfaced through `templateVars.tailnetDomain` for the Phase 5 Connect panel.
- Image, caps, state-volume mount, restart policy, control-plane `requiredEgress`, dependsOn, and order extracted into `stack-addons/shared/tailscale-sidecar.ts` so the two solo addons and the merge strategy share one source of truth.

## Test plan
- [x] `pnpm build:lib`
- [x] `pnpm --filter mini-infra-server build`
- [x] `pnpm --filter mini-infra-server lint`
- [x] `pnpm --filter mini-infra-server test` — 2148 tests, all green
- [x] `pnpm --filter mini-infra-client build`
- [x] Merge-strategy unit tests: both addons → one sidecar with `--ssh` + `TS_SERVE_CONFIG` + `serve.json`; each addon alone → unchanged solo shape; idempotency; tailnet-domain lookup failure tolerated; `extraTags` unioned & deduped; missing connected service rejected.
- [ ] Live smoke against a tailnet-joined laptop (`ssh root@<host>` + `curl https://<host>.<tailnet>.ts.net`) — deferred to Phase 5 verification once a Tailscale connected service is wired into a real env; the docker-state / live-tailnet smoke from the ticket's "Smoke tests" section is operator-driven and not feasible in CI.

Closes MINI-3