### PR TITLE
feat(deployment): seed Tailscale OAuth credentials from dev.env

### DIFF
--- a/deployment/development/dev.env.example
+++ b/deployment/development/dev.env.example
@@ -41,3 +41,13 @@ ADMIN_PASSWORD=changeme123
 # ---- GitHub (optional; seeder skips if blank) -----------------------------
 # Classic PAT or fine-grained token with repo read access for your use case.
 # GITHUB_TOKEN=
+
+# ---- Tailscale (optional; seeder skips if either id/secret is blank) ------
+# OAuth client credentials from https://login.tailscale.com/admin/settings/oauth.
+# The client must own the tags listed below; the default tag:mini-infra-managed
+# is always included by the server — only add EXTRA tags here if you need ACL
+# segmentation between Mini-Infra-managed devices.
+# TAILSCALE_OAUTH_CLIENT_ID=
+# TAILSCALE_OAUTH_CLIENT_SECRET=
+# Comma-separated list of extra tags. Each must match tag:[a-z0-9-]+ (max 20).
+# TAILSCALE_EXTRA_TAGS=tag:mini-infra-dev,tag:mini-infra-test

--- a/deployment/development/lib/dev-env.ts
+++ b/deployment/development/lib/dev-env.ts
@@ -21,6 +21,9 @@ export interface DevEnv {
   CLOUDFLARE_ACCOUNT_ID?: string;
   DOCKER_HOST_IP?: string;
   GITHUB_TOKEN?: string;
+  TAILSCALE_OAUTH_CLIENT_ID?: string;
+  TAILSCALE_OAUTH_CLIENT_SECRET?: string;
+  TAILSCALE_EXTRA_TAGS?: string[];
 }
 
 function stripQuotes(raw: string): string {
@@ -60,6 +63,12 @@ export function loadDevEnv(filePath: string): DevEnv {
   if (!adminEmail) throw new Error('ADMIN_EMAIL must be set in dev.env');
   if (!adminPassword) throw new Error('ADMIN_PASSWORD must be set in dev.env');
 
+  const extraTagsRaw = map.TAILSCALE_EXTRA_TAGS || '';
+  const extraTags = extraTagsRaw
+    .split(',')
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+
   return {
     ADMIN_EMAIL: adminEmail,
     ADMIN_PASSWORD: adminPassword,
@@ -70,5 +79,8 @@ export function loadDevEnv(filePath: string): DevEnv {
     CLOUDFLARE_ACCOUNT_ID: map.CLOUDFLARE_ACCOUNT_ID || undefined,
     DOCKER_HOST_IP: map.DOCKER_HOST_IP || undefined,
     GITHUB_TOKEN: map.GITHUB_TOKEN || undefined,
+    TAILSCALE_OAUTH_CLIENT_ID: map.TAILSCALE_OAUTH_CLIENT_ID || undefined,
+    TAILSCALE_OAUTH_CLIENT_SECRET: map.TAILSCALE_OAUTH_CLIENT_SECRET || undefined,
+    TAILSCALE_EXTRA_TAGS: extraTags.length > 0 ? extraTags : undefined,
   };
 }

--- a/deployment/development/lib/env-details.ts
+++ b/deployment/development/lib/env-details.ts
@@ -168,6 +168,7 @@ export interface FullEnvironmentDetailsInput {
   azureConfigured: boolean;
   cloudflareConfigured: boolean;
   githubConfigured: boolean;
+  tailscaleConfigured: boolean;
   localEnvironment: LocalEnvironmentSummary | null;
   stacks: StackSummary[];
   shortDescription?: string;
@@ -238,6 +239,7 @@ ${descBlock}${profileLine}  <seeded>true</seeded>
     <azure configured="${input.azureConfigured}"/>
     <cloudflare configured="${input.cloudflareConfigured}"/>
     <github configured="${input.githubConfigured}"/>
+    <tailscale configured="${input.tailscaleConfigured}"/>
   </connectedServices>
 ${localEnvBlock}
   <stacks>

--- a/deployment/development/lib/seeder.ts
+++ b/deployment/development/lib/seeder.ts
@@ -6,7 +6,7 @@
 //      POST /api/dev/issue-api-key (requires ENABLE_DEV_API_KEY_ENDPOINT=true)
 //   3. Complete the setup wizard (docker host) via POST /auth/setup/complete
 //   3b. Upsert docker_host_ip system setting (needed for application DNS)
-//   4. Upsert Azure / Cloudflare / GitHub credentials
+//   4. Upsert Azure / Tailscale / Cloudflare / GitHub credentials
 //   5. Instantiate + apply the built-in Vault host stack template
 //   6. Bootstrap/unlock Vault and publish system policies
 //      (cross-stack `requires` predicate `vault-bootstrapped` gates everything
@@ -328,6 +328,41 @@ async function configureAzure(api: ApiClient, connectionString: string): Promise
   }
 }
 
+interface TailscaleSettingsData {
+  isValid?: boolean;
+  validationMessage?: string;
+}
+
+async function configureTailscale(
+  api: ApiClient,
+  clientId: string,
+  clientSecret: string,
+  extraTags: string[],
+): Promise<void> {
+  logInfo('Configuring Tailscale');
+  const post = await api.post<unknown>('/api/settings/tailscale', {
+    client_id: clientId,
+    client_secret: clientSecret,
+    extra_tags: extraTags,
+  });
+  if (post.status !== 200 && post.status !== 201) {
+    logError(`Tailscale POST returned ${post.status}: ${post.bodyText}`);
+    return;
+  }
+  logOk('Tailscale configured');
+  // POST runs validation inline and returns isValid in the body, so we don't
+  // need a second round-trip to /api/settings/tailscale/test. pickObject
+  // unwraps the `data` envelope from `{ success, data: { ... } }`.
+  const data = pickObject<TailscaleSettingsData>(post.body);
+  if (data?.isValid) {
+    logOk('Tailscale connectivity verified');
+  } else {
+    logError(
+      `Tailscale validation failed: ${data?.validationMessage || 'no message'}`,
+    );
+  }
+}
+
 async function configureCloudflare(
   api: ApiClient,
   apiToken: string,
@@ -377,6 +412,16 @@ async function configureServices(api: ApiClient, env: DevEnv): Promise<void> {
     await configureAzure(api, env.AZURE_STORAGE_CONNECTION_STRING);
   } else {
     logSkip('AZURE_STORAGE_CONNECTION_STRING not set — skipping');
+  }
+  if (env.TAILSCALE_OAUTH_CLIENT_ID && env.TAILSCALE_OAUTH_CLIENT_SECRET) {
+    await configureTailscale(
+      api,
+      env.TAILSCALE_OAUTH_CLIENT_ID,
+      env.TAILSCALE_OAUTH_CLIENT_SECRET,
+      env.TAILSCALE_EXTRA_TAGS ?? [],
+    );
+  } else {
+    logSkip('TAILSCALE_OAUTH_CLIENT_ID / TAILSCALE_OAUTH_CLIENT_SECRET not set — skipping');
   }
   if (env.CLOUDFLARE_API_TOKEN && env.CLOUDFLARE_ACCOUNT_ID) {
     await configureCloudflare(api, env.CLOUDFLARE_API_TOKEN, env.CLOUDFLARE_ACCOUNT_ID);
@@ -967,6 +1012,9 @@ export async function seed(input: SeederInput): Promise<SeederOutput> {
     azureConfigured: Boolean(env.AZURE_STORAGE_CONNECTION_STRING),
     cloudflareConfigured: Boolean(env.CLOUDFLARE_API_TOKEN && env.CLOUDFLARE_ACCOUNT_ID),
     githubConfigured: Boolean(env.GITHUB_TOKEN),
+    tailscaleConfigured: Boolean(
+      env.TAILSCALE_OAUTH_CLIENT_ID && env.TAILSCALE_OAUTH_CLIENT_SECRET,
+    ),
     localEnvironment,
     stacks,
     shortDescription: input.shortDescription,


### PR DESCRIPTION
## Summary

- Add a Tailscale step to the worktree seeder (`deployment/development/lib/seeder.ts`) so OAuth `client_id` / `client_secret` / optional `extra_tags` from `~/.mini-infra/dev.env` are upserted via `POST /api/settings/tailscale` during first-run setup, alongside Azure / Cloudflare / GitHub.
- Extend `dev-env.ts` to load `TAILSCALE_OAUTH_CLIENT_ID`, `TAILSCALE_OAUTH_CLIENT_SECRET`, and `TAILSCALE_EXTRA_TAGS` (parsed from a comma-separated string into `string[]`, trimmed, empties dropped).
- Surface a `tailscaleConfigured` flag in `environment-details.xml` next to the existing `<azure|cloudflare|github>` entries so downstream skills (`test-dev`, `diagnose-dev`) can see whether Tailscale was wired up.
- Mirror the new commented-out Tailscale block into the committed `dev.env.example` template so future devs see the slots.

## Test plan

- [x] `pnpm build` passes locally
- [x] `pnpm worktree-env start --seed` runs end-to-end against real Tailscale OAuth credentials and logs `Tailscale configured` → `Tailscale connectivity verified`
- [x] `environment-details.xml` includes `<tailscale configured="true"/>` after the seed
- [x] `loadDevEnv()` correctly parses comma-separated `TAILSCALE_EXTRA_TAGS` (whitespace trimmed, empty entries dropped)
- [x] Seeder skips the step with a `[skip]` log line when `TAILSCALE_OAUTH_CLIENT_ID` or `TAILSCALE_OAUTH_CLIENT_SECRET` is blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)
