### PR TITLE
feat(addons): Connect panel + Tailscale device-status poller (Phase 5, MINI-4)

### DIFF
--- a/client/src/app/applications/[id]/_components/connect-card.tsx
+++ b/client/src/app/applications/[id]/_components/connect-card.tsx
@@ -1,0 +1,249 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { IconAlertTriangle } from "@tabler/icons-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { useStackAddonEndpoints } from "@/hooks/use-stack-addon-endpoints";
+import {
+  useTailscaleDevices,
+  indexDevicesByHostname,
+} from "@/hooks/use-tailscale-devices";
+import { useServiceConnectivity } from "@/hooks/use-settings-validation";
+import { EndpointRow } from "./endpoint-row";
+import { AddonBadge } from "@/components/stacks/addon-badge";
+import type {
+  TailscaleAddonEndpoint,
+  TailscaleDeviceStatus,
+} from "@mini-infra/types";
+import type { DeviceStatus } from "@/components/stacks/device-status-badge";
+
+const VISIBLE_LIMIT = 5;
+
+interface ConnectCardProps {
+  stackId: string | undefined;
+}
+
+/**
+ * Connect card on the Application Overview tab.
+ *
+ * Renders one compact row per addon-derived tailnet endpoint, grouped by
+ * the authored target service. Omits itself entirely when the stack has
+ * no addon endpoints — non-Tailscale apps see no Connect surface.
+ */
+export function ConnectCard({ stackId }: ConnectCardProps) {
+  const endpointsQuery = useStackAddonEndpoints(stackId, !!stackId);
+  const devicesQuery = useTailscaleDevices();
+
+  const { data: tailscaleConnectivity } = useServiceConnectivity("tailscale");
+  const tailscaleStatus = tailscaleConnectivity?.data?.[0]?.status;
+  const tailscaleDown =
+    tailscaleStatus === "failed" ||
+    tailscaleStatus === "timeout" ||
+    tailscaleStatus === "unreachable";
+
+  const endpoints = useMemo(
+    () => endpointsQuery.data?.endpoints ?? [],
+    [endpointsQuery.data?.endpoints],
+  );
+
+  // Grouped by target service for the section headers; preserves the
+  // server-side ordering within each group.
+  const grouped = useMemo(() => groupByTargetService(endpoints), [endpoints]);
+
+  const [expanded, setExpanded] = useState(false);
+  const allRows = endpoints.length;
+  const visibleGroups = useMemo(() => {
+    if (expanded || allRows <= VISIBLE_LIMIT) return grouped;
+    return clampGroupedRows(grouped, VISIBLE_LIMIT);
+  }, [expanded, allRows, grouped]);
+
+  // Loading state — render the card with skeletons so the operator gets
+  // immediate feedback that *something* is loading.
+  if (endpointsQuery.isLoading) {
+    return (
+      <Card data-tour="connect-card">
+        <CardHeader>
+          <CardTitle>Connect</CardTitle>
+          <CardDescription>Reach this application over your tailnet.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            <Skeleton className="h-7 w-full" />
+            <Skeleton className="h-7 w-full" />
+            <Skeleton className="h-7 w-full" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Empty — application has no addon endpoints. Omit the card entirely so
+  // non-Tailscale apps' Overview pages stay focused.
+  if (allRows === 0) {
+    return null;
+  }
+
+  // Tailscale connectivity broken — keep the card so the operator sees the
+  // empty rows aren't a bug; replace the body with an actionable alert.
+  if (tailscaleDown) {
+    return (
+      <Card data-tour="connect-card">
+        <CardHeader>
+          <CardTitle>Connect</CardTitle>
+          <CardDescription>Reach this application over your tailnet.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Alert variant="destructive">
+            <IconAlertTriangle className="h-4 w-4" />
+            <AlertTitle>Tailscale isn&apos;t connected</AlertTitle>
+            <AlertDescription>
+              Configure it in{" "}
+              <Link
+                to="/connectivity-tailscale"
+                className="underline underline-offset-2 hover:text-destructive-foreground"
+              >
+                Connectivity settings
+              </Link>
+              .
+            </AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const devicesByHostname = indexDevicesByHostname(devicesQuery.data?.devices);
+  const lastUpdatedAt = devicesQuery.data?.lastUpdatedAt ?? null;
+  const showStaleFootnote = !lastUpdatedAt && !devicesQuery.isLoading;
+
+  return (
+    <Card data-tour="connect-card">
+      <CardHeader>
+        <CardTitle>Connect</CardTitle>
+        <CardDescription>Reach this application over your tailnet.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {visibleGroups.map((group) => (
+            <ServiceGroup
+              key={group.targetService}
+              group={group}
+              devicesByHostname={devicesByHostname}
+              lastUpdatedAt={lastUpdatedAt}
+            />
+          ))}
+
+          {!expanded && allRows > VISIBLE_LIMIT && (
+            <div className="pt-1">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setExpanded(true)}
+              >
+                Show all {allRows} endpoints
+              </Button>
+            </div>
+          )}
+
+          {showStaleFootnote && (
+            <p className="text-xs text-muted-foreground pt-1">
+              Devices have not reported yet — last apply may still be in flight.
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ServiceGroup({
+  group,
+  devicesByHostname,
+  lastUpdatedAt,
+}: {
+  group: { targetService: string; endpoints: TailscaleAddonEndpoint[] };
+  devicesByHostname: Map<string, TailscaleDeviceStatus>;
+  lastUpdatedAt: string | null;
+}) {
+  return (
+    <div>
+      <div className="flex items-center gap-2 pb-1">
+        <span className="text-xs font-medium text-muted-foreground">
+          {group.targetService}
+        </span>
+        <AddonBadge addonName="tailscale" />
+      </div>
+      <ul className="divide-y">
+        {group.endpoints.map((endpoint) => {
+          const device = devicesByHostname.get(endpoint.hostname);
+          const status = resolveStatus(device, lastUpdatedAt);
+          return (
+            <EndpointRow
+              key={`${endpoint.syntheticServiceName}-${endpoint.kind}`}
+              endpoint={endpoint}
+              status={status}
+              lastSeenAt={device?.lastSeen ?? null}
+            />
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function groupByTargetService(
+  endpoints: TailscaleAddonEndpoint[],
+): Array<{ targetService: string; endpoints: TailscaleAddonEndpoint[] }> {
+  const groups = new Map<string, TailscaleAddonEndpoint[]>();
+  for (const endpoint of endpoints) {
+    const current = groups.get(endpoint.targetService) ?? [];
+    current.push(endpoint);
+    groups.set(endpoint.targetService, current);
+  }
+  return Array.from(groups.entries()).map(([targetService, items]) => ({
+    targetService,
+    endpoints: items,
+  }));
+}
+
+function clampGroupedRows(
+  groups: Array<{ targetService: string; endpoints: TailscaleAddonEndpoint[] }>,
+  limit: number,
+): typeof groups {
+  const out: typeof groups = [];
+  let remaining = limit;
+  for (const group of groups) {
+    if (remaining <= 0) break;
+    if (group.endpoints.length <= remaining) {
+      out.push(group);
+      remaining -= group.endpoints.length;
+    } else {
+      out.push({
+        targetService: group.targetService,
+        endpoints: group.endpoints.slice(0, remaining),
+      });
+      remaining = 0;
+    }
+  }
+  return out;
+}
+
+function resolveStatus(
+  device: TailscaleDeviceStatus | undefined,
+  lastUpdatedAt: string | null,
+): DeviceStatus {
+  if (!device) {
+    // No device record yet — `unknown` until the poller reports.
+    return lastUpdatedAt ? "offline" : "unknown";
+  }
+  return device.online ? "online" : "offline";
+}

--- a/client/src/app/applications/[id]/_components/endpoint-row.tsx
+++ b/client/src/app/applications/[id]/_components/endpoint-row.tsx
@@ -1,0 +1,165 @@
+import * as React from "react";
+import {
+  IconCheck,
+  IconCopy,
+  IconExternalLink,
+  IconTerminal2,
+  IconWorld,
+} from "@tabler/icons-react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  DeviceStatusBadge,
+  type DeviceStatus,
+} from "@/components/stacks/device-status-badge";
+import type { TailscaleAddonEndpoint } from "@mini-infra/types";
+
+interface EndpointRowProps {
+  endpoint: TailscaleAddonEndpoint;
+  status: DeviceStatus;
+  lastSeenAt?: string | null;
+}
+
+/**
+ * One row on the Connect card — addon-kind icon, the action affordance
+ * (`ssh root@…` for SSH endpoints, `https://…` link for HTTPS), an inline
+ * copy button, and the device-status badge. Compact flex layout (not a
+ * `<TableRow>`) to keep the card visually quieter than a full table.
+ */
+export function EndpointRow({ endpoint, status, lastSeenAt }: EndpointRowProps) {
+  const Icon = endpoint.kind === "ssh" ? IconTerminal2 : IconWorld;
+  const offline = status === "offline";
+
+  const offlineTooltip = "Device offline — connection will time out";
+
+  return (
+    <li
+      className="flex items-center gap-3 py-2"
+      data-tour={`connect-endpoint-${endpoint.targetService}-${endpoint.kind}`}
+    >
+      <Icon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+
+      <div className="min-w-0 flex-1">
+        <ActionAffordance endpoint={endpoint} disabled={offline} disabledTooltip={offlineTooltip} />
+        <p className="text-xs text-muted-foreground truncate">
+          {endpoint.targetService}
+        </p>
+      </div>
+
+      <CopyButton value={endpoint.url ?? endpoint.hostname} disabled={!endpoint.url} />
+      <DeviceStatusBadge status={status} lastSeenAt={lastSeenAt} />
+    </li>
+  );
+}
+
+function ActionAffordance({
+  endpoint,
+  disabled,
+  disabledTooltip,
+}: {
+  endpoint: TailscaleAddonEndpoint;
+  disabled: boolean;
+  disabledTooltip: string;
+}) {
+  // No URL yet (tailnet domain hasn't resolved) — render the hostname so the
+  // operator sees the addon attached without rendering a broken link.
+  if (!endpoint.url) {
+    return (
+      <code className="font-mono text-sm text-muted-foreground truncate block">
+        {endpoint.hostname}
+      </code>
+    );
+  }
+
+  if (endpoint.kind === "ssh") {
+    return (
+      <code
+        className={cn(
+          "font-mono text-sm truncate block",
+          disabled && "text-muted-foreground",
+        )}
+      >
+        {endpoint.url}
+      </code>
+    );
+  }
+
+  // HTTPS — render the URL as an actual anchor.
+  const link = (
+    <a
+      href={endpoint.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-disabled={disabled || undefined}
+      onClick={(e) => {
+        // We deliberately do not block the click — operators sometimes want
+        // to copy the URL regardless of online status — but we want the
+        // visual cue to land first.
+        if (disabled) {
+          e.stopPropagation();
+        }
+      }}
+      className={cn(
+        "font-mono text-sm truncate inline-flex items-center gap-1 hover:underline",
+        disabled
+          ? "text-muted-foreground"
+          : "text-primary",
+      )}
+    >
+      <span className="truncate">{endpoint.url}</span>
+      <IconExternalLink className="size-3.5 shrink-0" aria-hidden="true" />
+    </a>
+  );
+
+  if (!disabled) return link;
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>{link}</TooltipTrigger>
+        <TooltipContent>{disabledTooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function CopyButton({ value, disabled }: { value: string; disabled?: boolean }) {
+  const [copied, setCopied] = React.useState(false);
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      toast.error(
+        "Couldn't copy — your browser blocked clipboard access.",
+      );
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      onClick={onCopy}
+      disabled={disabled}
+      className="h-7 px-2"
+      aria-label={copied ? "Copied" : "Copy to clipboard"}
+    >
+      {copied ? (
+        <IconCheck className="size-3.5" />
+      ) : (
+        <IconCopy className="size-3.5" />
+      )}
+    </Button>
+  );
+}

--- a/client/src/app/applications/[id]/overview/page.tsx
+++ b/client/src/app/applications/[id]/overview/page.tsx
@@ -38,6 +38,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import type { StackDeploymentRecord } from "@mini-infra/types";
 import { StatusStrip } from "../_components/status-strip";
+import { ConnectCard } from "../_components/connect-card";
 import type { ApplicationDetailContext } from "../layout";
 
 function formatDateTime(value: string | null): string {
@@ -160,6 +161,8 @@ export default function ApplicationOverviewTab() {
           </AlertDescription>
         </Alert>
       )}
+
+      {hasStacks && <ConnectCard stackId={primaryStack?.id} />}
 
       {!hasStacks && (
         <Card>

--- a/client/src/components/site-header.tsx
+++ b/client/src/components/site-header.tsx
@@ -11,6 +11,7 @@ import {
   IconDatabase,
   IconHelp,
   IconRobot,
+  IconWorld,
   IconX,
 } from "@tabler/icons-react";
 import {
@@ -350,6 +351,12 @@ export function SiteHeader() {
                 icon={IconBrandGithub}
                 label="GitHub"
                 tourId="header-github"
+              />
+              <ConnectivityIndicator
+                service="tailscale"
+                icon={IconWorld}
+                label="Tailscale"
+                tourId="header-tailscale"
               />
             </div>
             <BackupHealthIndicator />

--- a/client/src/components/stacks/device-status-badge.tsx
+++ b/client/src/components/stacks/device-status-badge.tsx
@@ -1,0 +1,88 @@
+import { formatDistanceToNow } from "date-fns";
+import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+export type DeviceStatus = "online" | "offline" | "unknown";
+
+interface DeviceStatusBadgeProps {
+  status: DeviceStatus;
+  lastSeenAt?: string | null;
+  size?: "sm" | "md";
+}
+
+const dotColor: Record<DeviceStatus, string> = {
+  online: "bg-emerald-500",
+  offline: "bg-zinc-400",
+  unknown: "bg-amber-500",
+};
+
+const labelText: Record<DeviceStatus, string> = {
+  online: "Online",
+  offline: "Offline",
+  unknown: "Checking…",
+};
+
+/**
+ * Compact dot+label indicator for one tailnet device. Mirrors the
+ * dot-and-label vocabulary of [connectivity-status.tsx](../../components/connectivity-status.tsx)
+ * so the per-row Connect badges read consistently with the global
+ * connectivity strip in the header.
+ */
+export function DeviceStatusBadge({
+  status,
+  lastSeenAt,
+  size = "sm",
+}: DeviceStatusBadgeProps) {
+  const dotSize = size === "sm" ? "h-2.5 w-2.5" : "h-3 w-3";
+  const textSize = size === "sm" ? "text-xs" : "text-sm";
+
+  const lastSeen = formatLastSeen(lastSeenAt);
+  const tooltipText =
+    status === "unknown"
+      ? "Status not reported yet"
+      : lastSeen
+        ? `Last seen ${lastSeen}`
+        : labelText[status];
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className={cn(
+              "inline-flex items-center gap-1.5 transition-colors",
+              textSize,
+            )}
+            aria-label={`Device status: ${labelText[status]}`}
+          >
+            <span
+              className={cn(
+                "rounded-full",
+                dotSize,
+                dotColor[status],
+                status === "unknown" && "animate-pulse",
+              )}
+              aria-hidden="true"
+            />
+            <span className="text-muted-foreground">{labelText[status]}</span>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>{tooltipText}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function formatLastSeen(value: string | null | undefined): string | null {
+  if (!value) return null;
+  try {
+    return formatDistanceToNow(new Date(value), { addSuffix: true });
+  } catch {
+    return null;
+  }
+}

--- a/client/src/hooks/use-stack-addon-endpoints.ts
+++ b/client/src/hooks/use-stack-addon-endpoints.ts
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+import type { TailscaleAddonEndpointsResponse } from "@mini-infra/types";
+
+async function fetchAddonEndpoints(
+  stackId: string,
+): Promise<TailscaleAddonEndpointsResponse> {
+  const response = await fetch(`/api/stacks/${stackId}/addon-endpoints`, {
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch addon endpoints: ${response.statusText}`,
+    );
+  }
+  return (await response.json()) as TailscaleAddonEndpointsResponse;
+}
+
+/**
+ * Server-derived addon endpoint list for a stack. Server-side derivation
+ * keeps the `<host>.<tailnet>.ts.net` URL formatting in one place and
+ * means the panel doesn't have to know about the addon registry shape.
+ *
+ * Refetches when the stack snapshot changes (caller passes the version)
+ * — there's no socket event for "stack snapshot updated" because the
+ * stack-apply pipeline already invalidates the parent stack queries the
+ * caller depends on.
+ */
+export function useStackAddonEndpoints(
+  stackId: string | undefined,
+  enabled: boolean = true,
+) {
+  return useQuery({
+    queryKey: ["stack-addon-endpoints", stackId],
+    queryFn: () => fetchAddonEndpoints(stackId as string),
+    enabled: enabled && !!stackId,
+  });
+}

--- a/client/src/hooks/use-tailscale-devices.ts
+++ b/client/src/hooks/use-tailscale-devices.ts
@@ -1,0 +1,93 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import {
+  Channel,
+  ServerEvent,
+  type TailscaleDeviceStatus,
+  type TailscaleDeviceStatusEvent,
+  type TailscaleDevicesResponse,
+} from "@mini-infra/types";
+import { useSocket, useSocketChannel, useSocketEvent } from "./use-socket";
+
+const TAILSCALE_DEVICES_KEY = ["tailscale", "devices"] as const;
+const POLL_INTERVAL_DISCONNECTED = 30_000;
+
+async function fetchTailscaleDevices(): Promise<TailscaleDevicesResponse> {
+  const response = await fetch("/api/tailscale/devices", {
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch Tailscale devices: ${response.statusText}`,
+    );
+  }
+  return (await response.json()) as TailscaleDevicesResponse;
+}
+
+/**
+ * Live device-status hook for the Connect panel.
+ *
+ * Subscribes to the `tailscale` Socket.IO channel and patches the device
+ * map in place when `tailscale:device:online` / `tailscale:device:offline`
+ * events arrive — no full re-fetch per event. Polling falls back to 30s
+ * only when the socket is disconnected (per `client/CLAUDE.md`'s
+ * data-fetching rules); `refetchOnReconnect: true` covers events missed
+ * during a brief disconnection.
+ */
+export function useTailscaleDevices() {
+  const { connected } = useSocket();
+  const queryClient = useQueryClient();
+
+  useSocketChannel(Channel.TAILSCALE);
+
+  const patchDevice = useCallback(
+    (incoming: TailscaleDeviceStatus) => {
+      queryClient.setQueryData<TailscaleDevicesResponse>(
+        TAILSCALE_DEVICES_KEY,
+        (prev) => {
+          if (!prev) return prev;
+          const others = prev.devices.filter((d) => d.id !== incoming.id);
+          return {
+            ...prev,
+            devices: [...others, incoming],
+          };
+        },
+      );
+    },
+    [queryClient],
+  );
+
+  useSocketEvent(
+    ServerEvent.TAILSCALE_DEVICE_ONLINE,
+    (data: TailscaleDeviceStatusEvent) => patchDevice(data.device),
+  );
+  useSocketEvent(
+    ServerEvent.TAILSCALE_DEVICE_OFFLINE,
+    (data: TailscaleDeviceStatusEvent) => patchDevice(data.device),
+  );
+
+  const query = useQuery({
+    queryKey: TAILSCALE_DEVICES_KEY,
+    queryFn: fetchTailscaleDevices,
+    refetchInterval: connected ? false : POLL_INTERVAL_DISCONNECTED,
+    refetchOnReconnect: true,
+  });
+
+  return query;
+}
+
+/**
+ * Convenience selector — turn the device array into a hostname → status map
+ * for O(1) lookups from per-row components.
+ */
+export function indexDevicesByHostname(
+  devices: TailscaleDeviceStatus[] | undefined,
+): Map<string, TailscaleDeviceStatus> {
+  const map = new Map<string, TailscaleDeviceStatus>();
+  if (!devices) return map;
+  for (const device of devices) {
+    map.set(device.hostname, device);
+  }
+  return map;
+}

--- a/lib/types/socket-events.ts
+++ b/lib/types/socket-events.ts
@@ -28,6 +28,7 @@ import type {
   VaultAppRoleAppliedEvent,
 } from "./vault";
 import type { NatsAppliedEvent } from "./nats";
+import type { TailscaleDeviceStatusEvent } from "./tailscale";
 import type {
   EgressEventBroadcast,
   EgressPolicyUpdatedEvent,
@@ -60,6 +61,7 @@ export const STATIC_SOCKET_CHANNELS = [
   "pools",
   "egress",
   "egress-fw-agent",
+  "tailscale",
 ] as const;
 
 /** Static (non-parameterized) channels */
@@ -98,6 +100,7 @@ export const Channel = {
   POOLS: "pools",
   EGRESS: "egress",
   EGRESS_FW_AGENT: "egress-fw-agent",
+  TAILSCALE: "tailscale",
 } as const satisfies Record<string, StaticSocketChannel>;
 
 /** Helpers to build parameterized channel names */
@@ -241,6 +244,9 @@ export const ServerEvent = {
   EGRESS_FW_AGENT_STARTUP_STARTED: "egress-fw-agent:startup:started",
   EGRESS_FW_AGENT_STARTUP_STEP: "egress-fw-agent:startup:step",
   EGRESS_FW_AGENT_STARTUP_COMPLETED: "egress-fw-agent:startup:completed",
+  // Tailscale device-status poller (Phase 5 of Service Addons)
+  TAILSCALE_DEVICE_ONLINE: "tailscale:device:online",
+  TAILSCALE_DEVICE_OFFLINE: "tailscale:device:offline",
 } as const;
 
 /** Client → Server event names */
@@ -577,6 +583,12 @@ export interface ServerToClientEvents {
     steps: OperationStep[];
     errors: string[];
   }) => void;
+
+  // ── Tailscale Device Status (Phase 5 of Service Addons) ──
+  /** A tailnet device transitioned from offline → online (or first-seen as online). */
+  "tailscale:device:online": (data: TailscaleDeviceStatusEvent) => void;
+  /** A tailnet device transitioned from online → offline (or stopped reporting). */
+  "tailscale:device:offline": (data: TailscaleDeviceStatusEvent) => void;
 }
 
 // ====================

--- a/lib/types/tailscale.ts
+++ b/lib/types/tailscale.ts
@@ -77,6 +77,84 @@ export interface TailscaleAuthkeyResponse {
   capabilities: TailscaleAuthkeyRequest["capabilities"];
 }
 
+/**
+ * One tailnet device as the Phase 5 device-status poller cares about it.
+ * Subset of the full `GET /api/v2/tailnet/-/devices` payload — only the
+ * fields the Connect panel and connection-status indicator consume. The
+ * scheduler trims the upstream response to this shape so the rest of the
+ * server (and the API surface) doesn't have to know about Tailscale's
+ * full device JSON.
+ *
+ * `online` is derived from `lastSeen` ≤ 5 minutes ago (Tailscale's own
+ * heuristic — `online: true` from the API can lag a heartbeat). The
+ * scheduler is the single source of truth for that derivation.
+ */
+export interface TailscaleDeviceStatus {
+  /** Tailnet device ID (`nodeId`). Stable across restarts of the same node. */
+  id: string;
+  /** Hostname the sidecar registered under (e.g. `web-app-prod`). */
+  hostname: string;
+  /** Full tailnet name (e.g. `web-app-prod.tail-abc.ts.net`). */
+  name: string;
+  /** Whether the device is currently online per the lastSeen heuristic. */
+  online: boolean;
+  /** ISO-8601 timestamp of the device's last keepalive. Null when never seen. */
+  lastSeen: string | null;
+  /** Tags applied to the device (lowercased, includes `tag:mini-infra-managed`). */
+  tags: string[];
+}
+
+/** GET /api/tailscale/devices — current device set + the resolved tailnet domain. */
+export interface TailscaleDevicesResponse {
+  /** Tailnet MagicDNS suffix (e.g. `tail-abc.ts.net`); null when unresolved. */
+  tailnet: string | null;
+  /** All devices Mini Infra owns under `tag:mini-infra-managed`. */
+  devices: TailscaleDeviceStatus[];
+  /** ISO-8601 timestamp of the most recent successful poller tick. */
+  lastUpdatedAt: string | null;
+}
+
+/**
+ * Payload for the Socket.IO `tailscale:device:online` / `tailscale:device:offline`
+ * events. The Connect panel uses this to flip the per-row status badge
+ * without re-fetching the full device list.
+ */
+export interface TailscaleDeviceStatusEvent {
+  device: TailscaleDeviceStatus;
+}
+
+/**
+ * One addon-derived endpoint surfaced on the stack-detail Connect panel.
+ * Endpoint *URLs* are derived server-side so the host/tailnet formatting
+ * lives in one place — the panel renders these strings as-is.
+ */
+export interface TailscaleAddonEndpoint {
+  /** Authored service this sidecar wraps. */
+  targetService: string;
+  /** Synthetic sidecar service name (e.g. `web-app-tailscale`). */
+  syntheticServiceName: string;
+  /** `tailscale-ssh` and/or `tailscale-web` ids that produced this endpoint. */
+  addonIds: string[];
+  /** SSH or HTTPS — drives the action affordance on the row. */
+  kind: "ssh" | "https";
+  /** Sanitised `<service>-<env>` hostname. Stable join key against device status. */
+  hostname: string;
+  /**
+   * The full reachable URL.
+   * - `kind: 'ssh'` → `ssh root@<hostname>.<tailnet>.ts.net`
+   * - `kind: 'https'` → `https://<hostname>.<tailnet>.ts.net[<path>]`
+   *
+   * Null when the tailnet domain hasn't been resolved yet — the panel still
+   * renders the row with `<hostname>` so the operator sees the addon attached.
+   */
+  url: string | null;
+}
+
+/** GET /api/stacks/:id/addon-endpoints — derived endpoint list for the Connect panel. */
+export interface TailscaleAddonEndpointsResponse {
+  endpoints: TailscaleAddonEndpoint[];
+}
+
 /** Validation error categories surfaced to the form. */
 export const TAILSCALE_ERROR_CODES = {
   MISSING_CREDENTIALS: "MISSING_CREDENTIALS",

--- a/server/src/app-factory.ts
+++ b/server/src/app-factory.ts
@@ -36,6 +36,7 @@ import cloudflareSettingsRoutes from "./routes/cloudflare-settings";
 import cloudflareConnectivityRoutes from "./routes/cloudflare-connectivity";
 import tailscaleSettingsRoutes from "./routes/tailscale-settings";
 import tailscaleConnectivityRoutes from "./routes/tailscale-connectivity";
+import tailscaleDevicesRoutes from "./routes/tailscale-devices";
 import githubSettingsRoutes from "./routes/github-settings";
 import githubBugReportRoutes from "./routes/github-bug-report";
 import postgresDatabasesRoutes from "./routes/postgres-databases";
@@ -158,6 +159,7 @@ function getRouteDefinitions(): RouteDefinition[] {
     { id: "storageConnectivity", path: "/api/connectivity/storage", name: "storageConnectivityRoutes", getRouter: () => storageConnectivityRoutes },
     { id: "cloudflareConnectivity", path: "/api/connectivity", name: "cloudflareConnectivityRoutes", getRouter: () => cloudflareConnectivityRoutes },
     { id: "tailscaleConnectivity", path: "/api/connectivity", name: "tailscaleConnectivityRoutes", getRouter: () => tailscaleConnectivityRoutes },
+    { id: "tailscaleDevices", path: "/api/tailscale", name: "tailscaleDevicesRoutes", getRouter: () => tailscaleDevicesRoutes },
     { id: "postgresDatabases", path: "/api/postgres/databases", name: "postgresDatabasesRoutes", getRouter: () => postgresDatabasesRoutes },
     { id: "postgresBackupConfigs", path: "/api/postgres/backup-configs", name: "postgresBackupConfigsRoutes", getRouter: () => postgresBackupConfigsRoutes },
     { id: "postgresBackups", path: "/api/postgres", name: "postgresBackupsRoutes", getRouter: () => postgresBackupsRoutes },

--- a/server/src/routes/stacks/index.ts
+++ b/server/src/routes/stacks/index.ts
@@ -7,6 +7,7 @@ import updateRoutes from './stacks-update-route';
 import destroyRoutes from './stacks-destroy-route';
 import historyRoutes from './stacks-history-routes';
 import poolRoutes from './stacks-pool-routes';
+import addonEndpointsRoutes from './stacks-addon-endpoints-route';
 import { stacksErrorHandler } from './stacks-error-handler';
 
 const router = Router();
@@ -23,6 +24,7 @@ router.use(updateRoutes);
 router.use(destroyRoutes);
 router.use(historyRoutes);
 router.use(poolRoutes);
+router.use(addonEndpointsRoutes);
 
 router.use(stacksErrorHandler);
 

--- a/server/src/routes/stacks/stacks-addon-endpoints-route.ts
+++ b/server/src/routes/stacks/stacks-addon-endpoints-route.ts
@@ -1,0 +1,190 @@
+import { Router } from "express";
+import prisma from "../../lib/prisma";
+import { asyncHandler } from "../../lib/async-handler";
+import { requirePermission } from "../../middleware/auth";
+import { TailscaleDeviceStatusScheduler } from "../../services/tailscale";
+import { getLogger } from "../../lib/logger-factory";
+import {
+  sanitizeTailscaleHostname,
+  type StackDefinition,
+  type StackServiceDefinition,
+  type TailscaleAddonEndpoint,
+  type TailscaleAddonEndpointsResponse,
+} from "@mini-infra/types";
+
+const logger = getLogger("integrations", "stacks-addon-endpoints-route");
+
+const router = Router();
+
+interface TailscaleWebAddonConfig {
+  port?: number;
+  path?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Resolve the operator-authored target service for a synthetic Tailscale
+ * sidecar. The sidecar's `synthetic.targetService` is the canonical link;
+ * fall back to the labels emitted by the addon framework
+ * (`mini-infra.addon-target`) when the snapshot was written by a build
+ * that didn't yet stamp `synthetic`.
+ */
+function findTargetService(
+  service: StackServiceDefinition,
+): string | null {
+  if (service.synthetic?.targetService) return service.synthetic.targetService;
+  const labels = service.containerConfig?.labels;
+  if (labels && typeof labels === "object") {
+    const raw = (labels as Record<string, unknown>)["mini-infra.addon-target"];
+    if (typeof raw === "string" && raw.length > 0) return raw;
+  }
+  return null;
+}
+
+/**
+ * Pull the `tailscale-web` addon config off the *target* service so the
+ * Connect panel can render the right URL path. The sidecar's container
+ * config doesn't carry `port`/`path` directly — those live on the user's
+ * authored `addons['tailscale-web']` block on the target.
+ */
+function readWebConfig(
+  snapshot: StackDefinition,
+  targetServiceName: string,
+): TailscaleWebAddonConfig | null {
+  const target = snapshot.services.find(
+    (s) => s.serviceName === targetServiceName,
+  );
+  if (!target?.addons) return null;
+  const raw = (target.addons as Record<string, unknown>)["tailscale-web"];
+  if (!isRecord(raw)) return null;
+  return {
+    port: typeof raw.port === "number" ? raw.port : undefined,
+    path: typeof raw.path === "string" ? raw.path : undefined,
+  };
+}
+
+function deriveEndpoints(
+  snapshot: StackDefinition,
+  envName: string,
+  tailnet: string | null,
+): TailscaleAddonEndpoint[] {
+  const endpoints: TailscaleAddonEndpoint[] = [];
+  const envSlug = envName.length > 0 ? envName : "host";
+
+  for (const service of snapshot.services) {
+    const synth = service.synthetic;
+    if (!synth) continue;
+
+    // Pre-`synthetic` stamping branches (and any other addon kinds) get
+    // skipped — Phase 5 only surfaces tailnet endpoints.
+    const isTailscale =
+      synth.kind === "tailscale" ||
+      synth.addonIds.some((id) => id === "tailscale-ssh" || id === "tailscale-web");
+    if (!isTailscale) continue;
+
+    const targetService = findTargetService(service);
+    if (!targetService) continue;
+
+    const hostname = sanitizeTailscaleHostname(targetService, envSlug);
+    const fqdn = tailnet ? `${hostname}.${tailnet}` : null;
+
+    if (synth.addonIds.includes("tailscale-ssh")) {
+      endpoints.push({
+        targetService,
+        syntheticServiceName: service.serviceName,
+        addonIds: synth.addonIds,
+        kind: "ssh",
+        hostname,
+        url: fqdn ? `ssh root@${fqdn}` : null,
+      });
+    }
+
+    if (synth.addonIds.includes("tailscale-web")) {
+      const cfg = readWebConfig(snapshot, targetService);
+      const path = cfg?.path && cfg.path !== "/" ? cfg.path : "";
+      endpoints.push({
+        targetService,
+        syntheticServiceName: service.serviceName,
+        addonIds: synth.addonIds,
+        kind: "https",
+        hostname,
+        url: fqdn ? `https://${fqdn}${path}` : null,
+      });
+    }
+  }
+
+  // Stable sort: target service alphabetical, ssh before https within a target.
+  endpoints.sort((a, b) => {
+    if (a.targetService !== b.targetService) {
+      return a.targetService.localeCompare(b.targetService);
+    }
+    return a.kind === b.kind ? 0 : a.kind === "ssh" ? -1 : 1;
+  });
+
+  return endpoints;
+}
+
+/**
+ * GET /:stackId/addon-endpoints
+ *
+ * Returns the list of addon-derived endpoints (currently SSH + HTTPS via
+ * Tailscale) for a stack. URLs are formatted server-side so the
+ * `<host>.<tailnet>.ts.net` pattern lives in one place.
+ *
+ * Returns `endpoints: []` when:
+ *   - the stack has no Tailscale addons attached,
+ *   - the stack has not been applied yet (no `lastAppliedSnapshot`), or
+ *   - Tailscale is not configured (no scheduler running).
+ */
+router.get(
+  "/:stackId/addon-endpoints",
+  requirePermission("stacks:read"),
+  asyncHandler(async (req, res) => {
+    const stackId = String(req.params.stackId);
+
+    const stack = await prisma.stack.findUnique({
+      where: { id: stackId },
+      include: {
+        environment: { select: { name: true } },
+      },
+    });
+
+    if (!stack) {
+      return res
+        .status(404)
+        .json({ success: false, message: "Stack not found" });
+    }
+
+    const snapshot = stack.lastAppliedSnapshot as StackDefinition | null;
+    if (!snapshot) {
+      const empty: TailscaleAddonEndpointsResponse = { endpoints: [] };
+      return res.json(empty);
+    }
+
+    const scheduler = TailscaleDeviceStatusScheduler.getInstance();
+    const tailnet = scheduler?.getSnapshot().tailnet ?? null;
+
+    let endpoints: TailscaleAddonEndpoint[];
+    try {
+      endpoints = deriveEndpoints(
+        snapshot,
+        stack.environment?.name ?? "",
+        tailnet,
+      );
+    } catch (err) {
+      logger.warn(
+        { err, stackId },
+        "Failed to derive Tailscale addon endpoints (returning empty list)",
+      );
+      endpoints = [];
+    }
+
+    const response: TailscaleAddonEndpointsResponse = { endpoints };
+    res.json(response);
+  }),
+);
+
+export default router;

--- a/server/src/routes/tailscale-devices.ts
+++ b/server/src/routes/tailscale-devices.ts
@@ -1,0 +1,50 @@
+import { Router } from "express";
+import { asyncHandler } from "../lib/async-handler";
+import { requirePermission } from "../middleware/auth";
+import {
+  TailscaleDeviceStatusScheduler,
+} from "../services/tailscale";
+import type {
+  TailscaleDevicesResponse,
+} from "@mini-infra/types";
+
+const router = Router();
+
+/**
+ * GET /api/tailscale/devices
+ *
+ * Returns the in-process device-status snapshot maintained by the scheduler.
+ * The snapshot refreshes on the scheduler's poll interval (default 30s); the
+ * Connect panel relies on Socket.IO `tailscale:device:online` /
+ * `tailscale:device:offline` events for sub-poll latency, this route is for
+ * the initial query + reconnect re-fetch.
+ *
+ * Returns an empty payload when the scheduler is not yet running (Tailscale
+ * not configured) — the panel renders the empty state in that case rather
+ * than 404'ing.
+ */
+router.get(
+  "/devices",
+  requirePermission("settings:read"),
+  asyncHandler(async (_req, res) => {
+    const scheduler = TailscaleDeviceStatusScheduler.getInstance();
+    if (!scheduler) {
+      const empty: TailscaleDevicesResponse = {
+        tailnet: null,
+        devices: [],
+        lastUpdatedAt: null,
+      };
+      return res.json(empty);
+    }
+
+    const snapshot = scheduler.getSnapshot();
+    const response: TailscaleDevicesResponse = {
+      tailnet: snapshot.tailnet,
+      devices: Array.from(snapshot.devicesByHostname.values()),
+      lastUpdatedAt: snapshot.lastUpdatedAt,
+    };
+    res.json(response);
+  }),
+);
+
+export default router;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -42,6 +42,10 @@ import serverHealthScheduler from "./services/postgres-server/health-scheduler";
 import { UserEventCleanupScheduler } from "./services/user-events";
 import prisma from "./lib/prisma";
 import { DnsCacheService, DnsCacheScheduler } from "./services/dns";
+import {
+  TailscaleService,
+  TailscaleDeviceStatusScheduler,
+} from "./services/tailscale";
 import { CertificateRenewalScheduler } from "./services/tls/certificate-renewal-scheduler";
 import { PoolInstanceReaper } from "./services/stacks/pool-instance-reaper";
 import { TlsConfigService } from "./services/tls/tls-config";
@@ -84,6 +88,7 @@ let selfBackupScheduler: SelfBackupScheduler | null = null;
 let tlsRenewalScheduler: CertificateRenewalScheduler | null = null;
 let userEventCleanupScheduler: UserEventCleanupScheduler | null = null;
 let dnsCacheScheduler: DnsCacheScheduler | null = null;
+let tailscaleDeviceStatusScheduler: TailscaleDeviceStatusScheduler | null = null;
 let poolInstanceReaper: PoolInstanceReaper | null = null;
 
 /**
@@ -569,6 +574,40 @@ const initializeServices = async () => {
       console.log("[STARTUP] ⚠ DNS cache scheduler initialization failed (non-fatal)");
     }
 
+    // Initialize Tailscale device-status scheduler. Only start it when the
+    // OAuth credentials are configured — without them every poll tick would
+    // log a credential error and never produce useful events.
+    try {
+      console.log("[STARTUP] Initializing Tailscale device-status scheduler...");
+      const tailscaleService = new TailscaleService(prisma);
+      const clientId = await tailscaleService.getClientId();
+      const clientSecret = await tailscaleService.getClientSecret();
+      if (clientId && clientSecret) {
+        tailscaleDeviceStatusScheduler = new TailscaleDeviceStatusScheduler(
+          tailscaleService,
+        );
+        TailscaleDeviceStatusScheduler.setInstance(tailscaleDeviceStatusScheduler);
+        await tailscaleDeviceStatusScheduler.start();
+        logger.info("Tailscale device-status scheduler initialized successfully");
+        console.log("[STARTUP] ✓ Tailscale device-status scheduler initialized");
+      } else {
+        logger.info(
+          "Tailscale not configured, skipping device-status scheduler initialization",
+        );
+        console.log(
+          "[STARTUP] Tailscale not configured, skipping device-status scheduler",
+        );
+      }
+    } catch (error) {
+      logger.warn(
+        { error },
+        "Failed to initialize Tailscale device-status scheduler (non-fatal)",
+      );
+      console.log(
+        "[STARTUP] ⚠ Tailscale device-status scheduler initialization failed (non-fatal)",
+      );
+    }
+
     // Seed default permission presets if not already present
     console.log("[STARTUP] Seeding default permission presets...");
     await seedDefaultPresets();
@@ -741,6 +780,13 @@ startServer()
       if (dnsCacheScheduler) {
         dnsCacheScheduler.stop();
         logger.info("DNS cache scheduler stopped");
+      }
+
+      // Stop Tailscale device-status scheduler
+      if (tailscaleDeviceStatusScheduler) {
+        tailscaleDeviceStatusScheduler.stop();
+        TailscaleDeviceStatusScheduler.setInstance(null);
+        logger.info("Tailscale device-status scheduler stopped");
       }
 
       // Stop pool instance reaper

--- a/server/src/services/tailscale/index.ts
+++ b/server/src/services/tailscale/index.ts
@@ -3,3 +3,4 @@ export {
   TailscaleAuthkeyMinter,
   type MintAuthkeyOptions,
 } from "./tailscale-authkey-minter";
+export { TailscaleDeviceStatusScheduler } from "./tailscale-device-status-scheduler";

--- a/server/src/services/tailscale/tailscale-device-status-scheduler.ts
+++ b/server/src/services/tailscale/tailscale-device-status-scheduler.ts
@@ -1,0 +1,190 @@
+import {
+  Channel,
+  ServerEvent,
+  type TailscaleDeviceStatus,
+} from "@mini-infra/types";
+import { getLogger } from "../../lib/logger-factory";
+import { withOperation } from "../../lib/logging-context";
+import { emitToChannel } from "../../lib/socket";
+import { TailscaleService } from "./tailscale-service";
+
+const DEFAULT_INTERVAL_MS = 30_000;
+const logger = getLogger("integrations", "tailscale-device-status-scheduler");
+
+interface SchedulerSnapshot {
+  /** Most recent device map, keyed by hostname (the join key the panel uses). */
+  devicesByHostname: Map<string, TailscaleDeviceStatus>;
+  /** Tailnet MagicDNS suffix; null until the first successful resolution. */
+  tailnet: string | null;
+  /** Wall-clock of the most recent successful tick, ISO-8601. */
+  lastUpdatedAt: string | null;
+}
+
+/**
+ * Polls Tailscale's device-list API on a fixed interval, compares the
+ * result against the previous tick, and emits per-device transition events
+ * onto the `tailscale` Socket.IO channel. Maintains an in-process snapshot
+ * the `GET /api/tailscale/devices` route reads — no DB persistence; live
+ * tailnet state is the source of truth and the snapshot is the cache.
+ *
+ * Emit semantics:
+ * - first time a device is seen: emit `TAILSCALE_DEVICE_ONLINE` if online,
+ *   `TAILSCALE_DEVICE_OFFLINE` otherwise. The Connect panel needs an
+ *   initial event per device so its TanStack Query cache picks up the
+ *   right status without forcing a re-fetch.
+ * - subsequent ticks emit only on transition (online ↔ offline).
+ *
+ * The scheduler is best-effort — a failed tick logs and skips, leaving the
+ * previous snapshot intact. The badges in the UI fall back to the cached
+ * status; that's the intended degraded state, not a panic condition.
+ */
+export class TailscaleDeviceStatusScheduler {
+  private readonly tailscale: TailscaleService;
+  private readonly intervalMs: number;
+  private timer: NodeJS.Timeout | null = null;
+  private snapshot: SchedulerSnapshot = {
+    devicesByHostname: new Map(),
+    tailnet: null,
+    lastUpdatedAt: null,
+  };
+
+  private static instance: TailscaleDeviceStatusScheduler | null = null;
+
+  static getInstance(): TailscaleDeviceStatusScheduler | null {
+    return TailscaleDeviceStatusScheduler.instance;
+  }
+
+  static setInstance(instance: TailscaleDeviceStatusScheduler | null): void {
+    TailscaleDeviceStatusScheduler.instance = instance;
+  }
+
+  constructor(
+    tailscale: TailscaleService,
+    options: { intervalMs?: number } = {},
+  ) {
+    this.tailscale = tailscale;
+    this.intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  }
+
+  async start(): Promise<void> {
+    if (this.timer) {
+      logger.warn(
+        "Tailscale device-status scheduler already running, restarting",
+      );
+      this.stop();
+    }
+    logger.info(
+      { intervalMs: this.intervalMs },
+      "Starting Tailscale device-status scheduler",
+    );
+
+    // Run an initial tick immediately so the first request to the GET route
+    // returns a populated snapshot rather than an empty list.
+    await this.runOnce();
+
+    this.timer = setInterval(() => {
+      void withOperation("tailscale-device-status-tick", () => this.runOnce());
+    }, this.intervalMs);
+    // Don't keep the event loop alive on shutdown — the explicit stop()
+    // path runs on SIGTERM.
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+      logger.info("Tailscale device-status scheduler stopped");
+    }
+  }
+
+  /**
+   * Read the most recent successful snapshot. Returns the live in-process
+   * map — callers should not mutate it.
+   */
+  getSnapshot(): SchedulerSnapshot {
+    return this.snapshot;
+  }
+
+  private async runOnce(): Promise<void> {
+    const startedAt = Date.now();
+
+    let devices: TailscaleDeviceStatus[];
+    try {
+      devices = await this.tailscale.listDevices();
+    } catch (err) {
+      logger.warn(
+        { err, durationMs: Date.now() - startedAt },
+        "Tailscale device-list poll failed (non-fatal)",
+      );
+      return;
+    }
+
+    // Tailnet domain is needed by the Connect panel for URL formatting.
+    // Best-effort — if the lookup fails we keep the previous value.
+    let tailnet = this.snapshot.tailnet;
+    try {
+      const resolved = await this.tailscale.getTailnetDomain();
+      if (resolved) tailnet = resolved;
+    } catch (err) {
+      logger.debug(
+        { err },
+        "Tailnet domain lookup failed (non-fatal, reusing cached value)",
+      );
+    }
+
+    const previous = this.snapshot.devicesByHostname;
+    const next = new Map<string, TailscaleDeviceStatus>();
+    for (const device of devices) {
+      next.set(device.hostname, device);
+      const wasKnown = previous.get(device.hostname);
+      const transitioned =
+        !wasKnown || wasKnown.online !== device.online;
+      if (transitioned) {
+        const event = device.online
+          ? ServerEvent.TAILSCALE_DEVICE_ONLINE
+          : ServerEvent.TAILSCALE_DEVICE_OFFLINE;
+        try {
+          emitToChannel(Channel.TAILSCALE, event, { device });
+        } catch (err) {
+          logger.warn(
+            { err, hostname: device.hostname },
+            "Failed to emit tailscale device-status event (non-fatal)",
+          );
+        }
+      }
+    }
+
+    // Devices that disappeared between ticks — likely deregistered (ephemeral
+    // node). Emit one final OFFLINE so any UI listener can clear its row.
+    for (const [hostname, prev] of previous.entries()) {
+      if (!next.has(hostname) && prev.online) {
+        try {
+          emitToChannel(Channel.TAILSCALE, ServerEvent.TAILSCALE_DEVICE_OFFLINE, {
+            device: { ...prev, online: false },
+          });
+        } catch (err) {
+          logger.warn(
+            { err, hostname },
+            "Failed to emit deregistration OFFLINE (non-fatal)",
+          );
+        }
+      }
+    }
+
+    this.snapshot = {
+      devicesByHostname: next,
+      tailnet,
+      lastUpdatedAt: new Date().toISOString(),
+    };
+
+    logger.debug(
+      {
+        deviceCount: next.size,
+        tailnet,
+        durationMs: Date.now() - startedAt,
+      },
+      "Tailscale device-status tick completed",
+    );
+  }
+}

--- a/server/src/services/tailscale/tailscale-service.ts
+++ b/server/src/services/tailscale/tailscale-service.ts
@@ -3,6 +3,7 @@ import {
   ValidationResult,
   ServiceHealthStatus,
   ConnectivityStatusType,
+  TailscaleDeviceStatus,
   TailscaleOAuthTokenResponse,
   TAILSCALE_SETTING_KEYS,
   TAILSCALE_DEFAULT_TAG,
@@ -380,6 +381,91 @@ export class TailscaleService extends ConfigurationService {
     // The endpoint returns paths with a trailing dot (FQDN form) on some
     // tailnets; normalise to the bare suffix.
     return first.replace(/\.$/, "");
+  }
+
+  /**
+   * List every tailnet device Mini Infra owns under `tag:mini-infra-managed`.
+   * Trims the upstream `GET /api/v2/tailnet/-/devices` payload down to the
+   * fields the device-status poller and Connect panel consume.
+   *
+   * `online` is derived locally rather than read from the API: Tailscale's
+   * `online` flag can lag a heartbeat, and the design contract is "badges
+   * flip within ~5s of a deliberate device-down test" — recomputing from
+   * `lastSeen` keeps the poller and the API consistent.
+   */
+  async listDevices(): Promise<TailscaleDeviceStatus[]> {
+    const accessToken = await this.getAccessToken();
+    const controller = new AbortController();
+    const timer = setTimeout(
+      () => controller.abort(),
+      DEFAULT_REQUEST_TIMEOUT_MS,
+    );
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(
+        `${TAILSCALE_API_BASE}/tailnet/-/devices`,
+        {
+          method: "GET",
+          headers: { Authorization: `Bearer ${accessToken}` },
+          signal: controller.signal,
+        },
+      );
+    } catch (err) {
+      const name = err instanceof Error ? err.name : "";
+      if (name === "AbortError") {
+        throw new TailscaleAuthError(
+          "Tailscale device-list request timed out",
+          TAILSCALE_ERROR_CODES.NETWORK_ERROR,
+        );
+      }
+      throw new TailscaleAuthError(
+        `Failed to reach Tailscale device-list endpoint: ${
+          err instanceof Error ? err.message : "unknown"
+        }`,
+        TAILSCALE_ERROR_CODES.NETWORK_ERROR,
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!response.ok) {
+      const text = await safeReadText(response);
+      throw new TailscaleAuthError(
+        `Tailscale device-list request failed (HTTP ${response.status}): ${text}`,
+        TAILSCALE_ERROR_CODES.TAILSCALE_API_ERROR,
+      );
+    }
+
+    const data = (await response.json()) as { devices?: unknown };
+    if (!Array.isArray(data.devices)) return [];
+
+    const ONLINE_THRESHOLD_MS = 5 * 60 * 1000;
+    const now = Date.now();
+    const managedTags = await this.getAllManagedTags();
+    const managedTagSet = new Set(managedTags);
+
+    return data.devices
+      .filter((d): d is Record<string, unknown> => !!d && typeof d === "object")
+      .map((d) => {
+        const tags = Array.isArray(d.tags)
+          ? d.tags.filter((t): t is string => typeof t === "string")
+          : [];
+        const lastSeenRaw = typeof d.lastSeen === "string" ? d.lastSeen : null;
+        const lastSeenMs = lastSeenRaw ? Date.parse(lastSeenRaw) : NaN;
+        const online =
+          !Number.isNaN(lastSeenMs) && now - lastSeenMs <= ONLINE_THRESHOLD_MS;
+        return {
+          id: typeof d.nodeId === "string" ? d.nodeId : String(d.id ?? ""),
+          hostname: typeof d.hostname === "string" ? d.hostname : "",
+          name: typeof d.name === "string" ? d.name : "",
+          online,
+          lastSeen: lastSeenRaw,
+          tags,
+        } satisfies TailscaleDeviceStatus & { id: string };
+      })
+      .filter((d) => d.id && d.hostname)
+      .filter((d) => d.tags.some((t) => managedTagSet.has(t)));
   }
 
   async getHealthStatus(): Promise<ServiceHealthStatus> {


### PR DESCRIPTION
## Summary
- Adds the Connect card on the application Overview tab — one row per Tailscale-addon-attached endpoint with one-click `ssh` / `https://…` actions and a live online/offline badge (Option B from the [MINI-24 design](docs/designs/mini-24-connect-panel.md)).
- Server-side Tailscale device-status scheduler (30 s poll) on a new `tailscale` Socket.IO channel emitting `TAILSCALE_DEVICE_ONLINE` / `TAILSCALE_DEVICE_OFFLINE` events; safely skipped when Tailscale isn't configured.
- New REST surfaces: `GET /api/tailscale/devices` (cached snapshot) and `GET /api/stacks/:id/addon-endpoints` (URLs derived server-side so `<host>.<tailnet>.ts.net` formatting lives in one place). Tailscale also joins the site-header connectivity strip.

## Test plan
- [x] `pnpm build:lib`, `pnpm --filter mini-infra-server build`, `pnpm --filter mini-infra-client build` — all green.
- [x] `pnpm --filter mini-infra-server lint`, `pnpm --filter mini-infra-client lint` — clean.
- [x] `pnpm --filter mini-infra-server test` — 2147 unit/integration tests pass; `nats-prerequisites.integration.test.ts` is failing on `main` too (pre-existing).
- [x] `pnpm --filter mini-infra-client test` — 69 pass.
- [x] Live smoke: `GET /api/tailscale/devices` returns the empty payload (Tailscale not configured), `GET /api/stacks/<id>/addon-endpoints` returns `{"endpoints":[]}`, server logs show `Tailscale not configured, skipping device-status scheduler`.
- [x] Browser smoke (test-dev): new Tailscale indicator visible in the header strip alongside Docker / Cloudflare / Storage / GitHub.
- [ ] **Verify in prod**: device-flip latency ~5 s after a deliberate tailnet-side device-down — needs a tailnet-joined laptop and a real `tailscale-ssh` / `tailscale-web` deployment.

Closes MINI-4