### PR TITLE
chore(skills): refresh mk skill via install-skill

### DIFF
--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -23,7 +23,7 @@ mk status -o json
 
 This should print the current repo, prefix (expected `MINI`), and counts. If `mk` errors with "not inside a git repository", `cd` to the repo root and retry. If the binary isn't installed, stop and tell the user — without `mk` we can't read the review or post the response.
 
-All `mk` reads in this skill use `-o json` for stable parsing. All mutations pass `--user Claude` so the audit log attributes the change correctly, and every `mk comment add` also passes `--as Claude` (the comment author).
+All `mk` reads in this skill use `-o json` for stable parsing. All mutations go through the `--json` payload form (the agent-preferred surface — strict-decoded, dry-runnable, schema discoverable via `mk schema show <command>`) and pass `--user Claude` so the audit log attributes the change correctly. The JSON payload's `author` field replaces the flag-form `--as Claude` on `mk comment add`.
 
 ---
 
@@ -49,10 +49,13 @@ State the resolved triple before proceeding:
 The issue should currently be in **in_review** (that's the state `execute-next-task` left it in). The fixes are real work, so flip it back to in_progress before touching code — symmetric with the rest of the project's flow:
 
 ```bash
-mk issue state MINI-NN in_progress --user Claude
+mk issue state --user Claude --json '{"key":"MINI-NN","state":"in_progress"}'
 
-printf 'Addressing review findings. Validating each item before applying — full summary will follow once the fixup commit lands.\n' \
-  | mk comment add MINI-NN --as Claude --user Claude --body -
+mk comment add --user Claude --json '{
+  "issue_key":"MINI-NN",
+  "author":"Claude",
+  "body":"Addressing review findings. Validating each item before applying — full summary will follow once the fixup commit lands."
+}'
 ```
 
 Don't move past Phase 2 until both succeeded. If `mk issue state` errors (state name drift, issue doesn't exist), surface and stop — fixing in the wrong board state defeats the audit trail.
@@ -305,11 +308,15 @@ If the push fails (someone else has pushed to the branch in the meantime, or you
 
 ## Phase 10 — Post the response comment and transition back to in_review
 
-Single response comment on the mk issue, structured to mirror the original review's structure so reviewers can scan diff against finding. Write the body to a temp file, then:
+Single response comment on the mk issue, structured to mirror the original review's structure so reviewers can scan diff against finding. Write the body to a temp file, then bridge it into the JSON payload via `jq -n --rawfile` so the markdown stays out of inline-JSON escape soup:
 
 ```bash
-mk comment add MINI-NN --as Claude --user Claude --body-file /tmp/address-review-MINI-NN.md
-mk issue state MINI-NN in_review --user Claude
+jq -n \
+  --rawfile body /tmp/address-review-MINI-NN.md \
+  '{issue_key:"MINI-NN", author:"Claude", body:$body}' \
+  | mk comment add --user Claude --json -
+
+mk issue state --user Claude --json '{"key":"MINI-NN","state":"in_review"}'
 ```
 
 Template — omit a section that's empty rather than write "None.":
@@ -379,8 +386,9 @@ That's the run.
 - **Never open a new PR.** The fixup belongs on the existing PR. The diff updates automatically when the branch updates.
 - **Symmetric state flow.** The issue moves todo → in_progress → in_review → in_progress (this skill, Phase 2.1) → in_review (Phase 10). Don't skip either transition. The board has to reflect what's actually happening.
 - **Don't accidentally over-scope.** Cleanups you spot but `/review` didn't flag belong in a separate ticket. Note them in the final report; don't bundle them into this fixup commit.
-- **Always pass `--user Claude` on `mk` mutations and `--as Claude` on `mk comment add`.** Without `--user`, the audit log silently attributes the change to whichever OS user the agent runs under — useless history.
+- **Always pass `--user Claude` on `mk` mutations.** Without it the audit log silently attributes the change to whichever OS user the agent runs under — useless history. On `mk comment add` JSON payloads the comment author is the `author` field (replaces the flag-form `--as Claude`).
 - **Always pass `-o json` when parsing `mk` output.** Text mode is for humans only.
+- **Prefer `--json` payloads on mutations** over per-field flags. Strict-decoded (typos surface as `unknown field` errors), schema discoverable via `mk schema show <command>`, dry-runnable.
 - **Never run `mk` outside a git repo** — it hard-errors. `cd` to the repo first.
 - **Stop on missing inputs.** No review comment found, ambiguous PR resolution, no mk key resolvable from the input → stop and ask.
 - **Never produce an ExitPlanMode block.** This is an action skill; the fixup commit + mk comment are the deliverables.
@@ -393,11 +401,11 @@ That's the run.
 >
 > *Skill runs `mk status -o json` to confirm the binary is wired up and the repo prefix is `MINI`. Resolves: MINI-32 ("Phase 4: pg-az-backup progress + result events"), PR #412, branch `claude/mini-32`. Confirms: "Addressing review on MINI-32 — PR #412, branch `claude/mini-32`."*
 >
-> *Phase 2.1: `mk issue state MINI-32 in_progress --user Claude` + claim comment via `mk comment add MINI-32 --as Claude --user Claude --body -`.*
+> *Phase 2.1: `mk issue state --user Claude --json '{"key":"MINI-32","state":"in_progress"}'` + claim comment via `mk comment add --user Claude --json '{"issue_key":"MINI-32","author":"Claude","body":"Addressing review findings..."}'`.*
 >
-> *Phase 3: `mk comment list MINI-32 -o json`. Most recent `**Review of …**` comment shows 4 findings: 1 high (error swallowing in `backup-progress-emitter.ts:47`), 1 medium (duplicated step-name normalisation in `backup-executor.ts:208`), 1 low (`console.log` leftover), 1 medium ("missing `userId` on the new metric-emit row"). Drops the low. Three to validate.*
+> *Phase 3: `mk issue brief MINI-32 > /tmp/brief-MINI-32.json` (one read for the issue + comments + linked docs). Most recent `**Review of …**` comment in `.comments[]` shows 4 findings: 1 high (error swallowing in `backup-progress-emitter.ts:47`), 1 medium (duplicated step-name normalisation in `backup-executor.ts:208`), 1 low (`console.log` leftover), 1 medium ("missing `userId` on the new metric-emit row"). Drops the low. Three to validate.*
 >
-> *Phase 4: re-reads MINI-32 ticket body via `mk issue show`, server/CLAUDE.md (server-side findings), root CLAUDE.md (audit-trail rule for the `userId` finding). No design comment on this ticket — backend-only work.*
+> *Phase 4: reuses the brief from Phase 3 — pulls Goal / Deliverables / Done when from `.issue.description`, server/CLAUDE.md (server-side findings), root CLAUDE.md (audit-trail rule for the `userId` finding). No design comment on this ticket — backend-only work.*
 >
 > *Phase 5: `.claude/worktrees/mini-32` was torn down by `/finish-worktree` after the original PR shipped. Skill recreates: `git fetch origin claude/mini-32`, `git worktree add ...`, `pnpm install`, backgrounded `pnpm worktree-env start`.*
 >
@@ -412,6 +420,6 @@ That's the run.
 >
 > *Phase 9: commits `fix(backup): address review findings (MINI-32)` with the two fixed bullets, pushes.*
 >
-> *Phase 10: posts the response comment on MINI-32 via `mk comment add` with three sections (Fixed: 2; Dismissed: 1 with the user-vs-job rationale; Skipped (low): 1). `mk issue state MINI-32 in_review --user Claude`.*
+> *Phase 10: posts the response comment on MINI-32 via `jq -n --rawfile body /tmp/address-review-MINI-32.md '{issue_key:"MINI-32",author:"Claude",body:$body}' | mk comment add --user Claude --json -` with three sections (Fixed: 2; Dismissed: 1 with the user-vs-job rationale; Skipped (low): 1). `mk issue state --user Claude --json '{"key":"MINI-32","state":"in_review"}'`.*
 >
 > Skill: "Addressed review on MINI-32: <commit URL>. Fixed: 2. Dismissed: 1. Couldn't verify: 0. Skipped (low): 1. The high finding (error swallowing) and one medium (duplication) are now fixed. The other medium turned out to be a false positive — the audit-trail rule applies to user-initiated mutations, not the background job in question."

--- a/.claude/skills/design-task/SKILL.md
+++ b/.claude/skills/design-task/SKILL.md
@@ -43,9 +43,9 @@ You should see a JSON blob with the repo's prefix (`MINI`) and per-state issue c
 **Critical agent-mode rules** (these apply to every `mk` call you make in this run):
 
 - **Always pass `--user Claude` on every mutating command.**
-- **Always pass `--as Claude` on `mk comment add`.**
 - **Always pass `-o json` when parsing output.**
-- **Always pass long text via `--description-file` / `--body-file` / `--body -` (stdin).**
+- **Prefer `--json` payloads on mutations** over per-field flags. Strict-decoded (typos surface as `unknown field` errors), schema discoverable via `mk schema show <command>`, dry-runnable. The JSON payload's `author` field replaces the flag-form `--as Claude` on `mk comment add`.
+- **For multi-line text bodies** (long descriptions, comment bodies, doc content), bridge a temp file into the JSON payload via `jq -n --rawfile body /tmp/foo.md '{...}' | mk ... --json -` — keeps the markdown out of inline-JSON escape soup. The exception is `mk doc upsert --from-path <path>`, which derives filename + reads content from disk in one shot and uses flag form (the JSON path doesn't have a path-derivation equivalent).
 
 Note: this skill calls `mk issue state` exactly once, near the end (Phase 8), to move the issue to **`in_review`**. No other state transitions. The terminal `done` transition is left to the human reviewer flipping it after the PR merges (the `Closes MINI-NN` line in the commit is for the audit trail; `mk` does not parse it).
 
@@ -485,7 +485,7 @@ EOF
 Once the PR URL is back, attach it to the design ticket so `mk issue show MINI-NN` and `mk pr list MINI-NN` both link to it:
 
 ```bash
-mk pr attach MINI-NN <PR_URL> --user Claude
+mk pr attach --user Claude --json '{"issue_key":"MINI-NN","url":"<PR_URL>"}'
 ```
 
 If `gh pr create` fails (no `gh` auth, repo settings, branch-protection rules), surface the error and stop. Don't retry silently. The user can authenticate `gh` and re-run the skill, or open the PR manually and paste the URL into Phase 7's comments — but don't try to half-ship by posting mk comments without a PR.
@@ -494,7 +494,7 @@ If `gh pr create` fails (no `gh` auth, repo settings, branch-protection rules), 
 
 Why: downstream skills (`execute-next-task`, `address-review`, `review`) fetch the design doc as supplemental context for the impl ticket. Linking via `mk doc link` gives them a single uniform fetch — they pull every linked doc's content out of the `documents[]` array of `mk issue brief` in one bulk read — instead of having to know which branch the doc lives on. SVG wireframes go in too (they're just XML — mk's `doc` subsystem stores arbitrary text content), so the executor can materialise them on demand even when the design PR hasn't merged yet.
 
-`mk doc upsert --from-path` derives the mk filename (path with `/` → `-`) and reads the file content in one shot. Pass `--type designs` because `--from-path` only auto-derives type for plan-doc paths; design paths need an explicit type.
+`mk doc upsert --from-path` derives the mk filename (path with `/` → `-`) and reads the file content in one shot — keep flag form for it (the JSON path has no path-derivation equivalent; you'd otherwise have to compute the filename and `cat` the content yourself). Pass `--type designs` because `--from-path` only auto-derives type for plan-doc paths; design paths need an explicit type. The link calls go through `--json` for strict decoding:
 
 ```bash
 register_and_link() {
@@ -502,11 +502,15 @@ register_and_link() {
   [ -f "$path" ] || return 0                            # skip artefacts not produced
   local name="${path//\//-}"                            # docs/designs/foo.md → docs-designs-foo.md
   mk doc upsert --from-path "$path" --type designs --user Claude
-  mk doc link "$name" MINI-NN \
-    --why "Design exploration artefacts for this design ticket" --user Claude
+  jq -nc --arg filename "$name" --arg key MINI-NN \
+       --arg why "Design exploration artefacts for this design ticket" \
+       '{filename:$filename, issue_key:$key, description:$why}' \
+    | mk doc link --user Claude --json -
   if [ -n "<impl-MINI-NN>" ]; then
-    mk doc link "$name" <impl-MINI-NN> \
-      --why "Design recommendation + wireframes for this implementation" --user Claude
+    jq -nc --arg filename "$name" --arg key "<impl-MINI-NN>" \
+         --arg why "Design recommendation + wireframes for this implementation" \
+         '{filename:$filename, issue_key:$key, description:$why}' \
+      | mk doc link --user Claude --json -
   fi
 }
 
@@ -515,7 +519,7 @@ register_and_link "docs/designs/<filename>-option-a.svg"
 register_and_link "docs/designs/<filename>-option-b.svg"
 ```
 
-`mk doc upsert` and `mk doc link` are both upserts — re-running the whole block on a re-design pass is safe (content refreshes, `--why` refreshes, no duplicate rows). The mk docs are the authoritative copies for downstream skills; the `.md` + `.svg` files on disk and the merged design PR are the source of truth for humans browsing the repo.
+`mk doc upsert` and `mk doc link` are both upserts — re-running the whole block on a re-design pass is safe (content refreshes, `description` refreshes, no duplicate rows). The mk docs are the authoritative copies for downstream skills; the `.md` + `.svg` files on disk and the merged design PR are the source of truth for humans browsing the repo.
 
 ---
 
@@ -540,7 +544,10 @@ Two options explored:
 Moving this design ticket to `in_review` and tearing down the local worktree — once the PR merges, the human reviewer flips it to `done`, which unblocks `/execute-next-task <impl-MINI-NN>`. If you disagree with the pick, comment on the PR or reopen the ticket. (Re-edits: `git worktree add .claude/worktrees/mini-NN claude/mini-NN` recreates the worktree against the same branch.)
 EOF
 
-mk comment add MINI-NN --as Claude --user Claude --body-file /tmp/design-comment.md
+jq -n \
+  --rawfile body /tmp/design-comment.md \
+  '{issue_key:"MINI-NN", author:"Claude", body:$body}' \
+  | mk comment add --user Claude --json -
 ```
 
 If the parent ticket lists an impl ticket it blocks (look at the issue's relations in the JSON from `mk issue show` — specifically outgoing `blocks`-typed edges), name that ticket explicitly so the user has a one-click follow-up. If there's no blocked impl ticket, drop the impl-ticket clause.
@@ -560,7 +567,11 @@ cat <<'EOF' > /tmp/impl-comment.md
 Read this before starting implementation — it includes Key abstractions, File / component sketch, and Implementation outline that the design doc commits to. Open questions in the doc are unresolved choices that may matter at implementation time. Wait for the design PR to merge before kicking off `/execute-next-task` so the doc + SVGs land on `main`; the executor can technically run sooner because the design artefacts are also linked as mk docs, but the design hasn't been reviewed by a human yet.
 EOF
 
-mk comment add <impl-MINI-NN> --as Claude --user Claude --body-file /tmp/impl-comment.md
+jq -n \
+  --arg key "<impl-MINI-NN>" \
+  --rawfile body /tmp/impl-comment.md \
+  '{issue_key:$key, author:"Claude", body:$body}' \
+  | mk comment add --user Claude --json -
 ```
 
 If there's no outgoing `blocks` edge (standalone design, no impl ticket), skip 7.2. If there's more than one (rare — usually a planning mistake), post the comment on each one and surface the multi-target case to the user in the final report.
@@ -572,7 +583,7 @@ If there's no outgoing `blocks` edge (standalone design, no impl ticket), skip 7
 The PR is open, the comments are posted. Move the design ticket from `todo` to `in_review` so the mk board reflects the actual state of play:
 
 ```bash
-mk issue state MINI-NN in_review --user Claude
+mk issue state --user Claude --json '{"key":"MINI-NN","state":"in_review"}'
 ```
 
 That single call is all this phase does. The terminal `done` transition is **not** this skill's job — when the PR merges, the human reviewer flips the design ticket to `done` (or runs `mk issue state MINI-NN done --user Geoff`), at which point any impl ticket that had this design ticket as a `blocks` edge becomes pickable by `execute-next-task`.
@@ -644,7 +655,7 @@ That's the whole skill. Keep the output short — the design PR is the substanti
 - **Always commit + push + open a PR before posting mk comments.** Phase 6 must complete before Phase 7. The mk comments link to the PR URL — without a PR, the comments would point at a blob URL on a feature branch that may never reach `main`. If `gh pr create` fails, stop the whole run; don't half-ship.
 - **Commit only the design artefacts.** `git add` the design `.md` and any sibling `.svg` files explicitly. Never `git add .` — a stale `pnpm-lock.yaml` change or other in-flight worktree noise must not land in the design commit.
 - **Always include `Closes <MINI-NN>` in the commit message.** It's the audit-trail reference back to the ticket. `mk` does not parse it, but human reviewers and the commit history rely on it. Keep it in.
-- **Never call `mk` without `--user Claude` on a mutating command, or without `--as Claude` on `mk comment add`.** The audit log silently falls back to `geoff` otherwise — useless attribution for agent-driven runs.
+- **Never call `mk` without `--user Claude` on a mutating command.** The audit log silently falls back to `geoff` otherwise — useless attribution for agent-driven runs. On `mk comment add` JSON payloads the comment author is the `author` field (replaces the flag-form `--as Claude`).
 - **Never collapse two options into one.** If you genuinely can't think of two distinct approaches, surface that and ask the user whether to write one with a "rejected alternatives" appendix instead. Forcing a weak second option produces noise.
 - **Never punt the recommendation back to the user.** The §Recommendation section must commit to one option. "No strong preference" / "either works" / "user picks" are invalid outputs — pick one and name what would flip the call. The PR body and mk comments depend on the recommendation; the skill cannot ship them if it hasn't picked.
 - **Never skip the prior-art search (Phase 4.4).** Designs that ignore the existing codebase are usually wrong about what's expensive vs. cheap. Even if you find nothing reusable, the search itself should inform your options.
@@ -658,7 +669,7 @@ That's the whole skill. Keep the output short — the design PR is the substanti
 
 > User: "design MINI-38"
 >
-> *Skill runs `mk status -o json` to confirm `mk` is available and the prefix is `MINI`. Fetches MINI-38 with `mk issue show MINI-38 -o json`: "Phase 2: container-level egress firewall toggle", part of the `egress-firewall-per-container` feature. Runs `mk feature show egress-firewall-per-container -o json` and finds `Plan: docs/planning/not-shipped/egress-per-container-plan.md` in the description. Skill reads the ticket body (Goal: per-container override of the egress firewall policy; Deliverables: API field, UI control, applied at apply-time, audit-logged; Done when: integration test shows the override flips behaviour). Reads the plan doc's Phase 2 section as supplemental context. Skims prior comments via `mk comment list MINI-38 -o json` — none from this skill — so no overwrite risk.*
+> *Skill runs `mk status -o json` to confirm `mk` is available and the prefix is `MINI`. Fetches MINI-38 with `mk issue brief MINI-38 > /tmp/brief-MINI-38.json` — one read covers the issue + parent feature + linked docs + comments + relations + PRs. From `.issue.description`: "Phase 2: container-level egress firewall toggle"; from `.feature.description`: `Plan: docs/planning/not-shipped/egress-per-container-plan.md`. Skill reads the ticket body (Goal: per-container override of the egress firewall policy; Deliverables: API field, UI control, applied at apply-time, audit-logged; Done when: integration test shows the override flips behaviour). Reads the plan doc's Phase 2 section as supplemental context. Skims `.comments[]` from the brief — none from this skill — so no overwrite risk.*
 >
 > *Phase 4: identifies the dominant pattern axis as "where does the override live and how does it propagate to apply-time" — i.e. a state-placement + propagation question. Surveys two candidate shapes: (i) override stored on the StackService row, propagated through the existing apply pipeline; (ii) override stored on a new `EgressOverride` table keyed by service, looked up at apply-time. Searches the codebase for similar override patterns: finds `server/src/services/networking/haproxy-frontend-overrides.ts` (per-frontend overrides on the frontend row, similar to option (i)) and `server/src/services/registry/registry-credential-resolver.ts` (separate-table indirection lookup, similar to option (ii)). Cites both.*
 >
@@ -666,13 +677,13 @@ That's the whole skill. Keep the output short — the design PR is the substanti
 >
 > *Phase 5: writes `docs/designs/mini-38-egress-per-container-override.md` inside the worktree. Option A is the row-extension shape (cheap, follows the haproxy pattern, but couples the override to the service row's lifecycle). Option B is the separate-table shape (heavier, needs a new migration and model, but cleaner audit trail and easier to extend with override types later). Each option has Key abstractions / File sketch / Implementation outline / Pros / Cons. **Recommendation: Option A** — the team has no plans for other override types and the cheaper change is the right call for the ticket as scoped; flip to B if a second override type lands on the roadmap. One Open question: "do we want overrides to survive a service rename?" — answer changes which option wins. Two items in Out-of-scope: bulk override import (different ticket), override expiry (no Deliverable for it).*
 >
-> *Phase 6: stages the design `.md`, commits with `docs(designs): egress per-container override (MINI-38)` and a `Closes MINI-38` line, pushes `claude/mini-38`, opens PR #371 via `gh pr create`. Captures the PR URL and runs `mk pr attach MINI-38 <PR URL> --user Claude` so future `mk issue show MINI-38` calls surface the link.*
+> *Phase 6: stages the design `.md`, commits with `docs(designs): egress per-container override (MINI-38)` and a `Closes MINI-38` line, pushes `claude/mini-38`, opens PR #371 via `gh pr create`. Captures the PR URL and runs `mk pr attach --user Claude --json '{"issue_key":"MINI-38","url":"<PR URL>"}'` so future `mk issue show MINI-38` calls surface the link.*
 >
-> *Phase 7.1: writes the design-ticket comment to a temp file, then `mk comment add MINI-38 --as Claude --user Claude --body-file /tmp/design-comment.md`: "Designs drafted (PR open): #371. A — Service-row column; B — Separate EgressOverride table. **Picked: Option A** — cheap, leans on the haproxy override pattern; flip to B only if a second override type lands. Moving this design ticket to in_review and tearing down the local worktree — once the PR merges, the human reviewer flips it to done, which unblocks `/execute-next-task MINI-39`."*
+> *Phase 7.1: writes the design-ticket comment to a temp file, then bridges it via `jq -n --rawfile body /tmp/design-comment.md '{issue_key:"MINI-38",author:"Claude",body:$body}' | mk comment add --user Claude --json -`: "Designs drafted (PR open): #371. A — Service-row column; B — Separate EgressOverride table. **Picked: Option A** — cheap, leans on the haproxy override pattern; flip to B only if a second override type lands. Moving this design ticket to in_review and tearing down the local worktree — once the PR merges, the human reviewer flips it to done, which unblocks `/execute-next-task MINI-39`."*
 >
-> *Phase 7.2: MINI-38's relations include an outgoing `blocks` edge to MINI-39 (the impl ticket). Writes the impl-ticket comment to a temp file and `mk comment add MINI-39 --as Claude --user Claude --body-file /tmp/impl-comment.md`: "**Design ready (PR open):** #371 — design doc at `docs/designs/mini-38-egress-per-container-override.md` once merged. Picked: Option A — Service-row column. Read this before starting implementation … Wait for the design PR to merge before kicking off `/execute-next-task` — the doc lands on `main` at that point, and once the human flips the design ticket to `done` the impl ticket becomes pickable." A future `/execute-next-task MINI-39` skim of comments via `mk comment list` will see this immediately.*
+> *Phase 7.2: MINI-38's relations include an outgoing `blocks` edge to MINI-39 (the impl ticket). Writes the impl-ticket comment to a temp file and `jq -n --arg key MINI-39 --rawfile body /tmp/impl-comment.md '{issue_key:$key,author:"Claude",body:$body}' | mk comment add --user Claude --json -`: "**Design ready (PR open):** #371 — design doc at `docs/designs/mini-38-egress-per-container-override.md` once merged. Picked: Option A — Service-row column. Read this before starting implementation … Wait for the design PR to merge before kicking off `/execute-next-task` — the doc lands on `main` at that point, and once the human flips the design ticket to `done` the impl ticket becomes pickable." A future `/execute-next-task MINI-39` will pick this comment up via `mk issue brief MINI-39` (one read covers issue + comments + linked docs).*
 >
-> *Phase 8: `mk issue state MINI-38 in_review --user Claude`. The single state transition. MINI-38 will be flipped to `done` by the human after PR #371 merges; MINI-39 becomes picker-eligible at that point.*
+> *Phase 8: `mk issue state --user Claude --json '{"key":"MINI-38","state":"in_review"}'`. The single state transition. MINI-38 will be flipped to `done` by the human after PR #371 merges; MINI-39 becomes picker-eligible at that point.*
 >
 > *Phase 9: `Skill(skill: "finish-worktree", args: "mini-38")`. The finish-worktree skill checks the working tree (clean), unpushed commits (none), and PR state (open) — all green — then `cd`s back to the repo root, runs `pnpm worktree-env delete mini-38 --force` (or skips if no env was started — design-task always passes `--no-env` to `setup-worktree`), and `git worktree remove .claude/worktrees/mini-38`. The remote branch `claude/mini-38` is left intact for the PR.*
 >

--- a/.claude/skills/execute-next-task/SKILL.md
+++ b/.claude/skills/execute-next-task/SKILL.md
@@ -56,9 +56,8 @@ You should see a JSON blob with the repo's prefix (`MINI`) and per-state issue c
 **Critical agent-mode rules** (these apply to every `mk` call you make in this run):
 
 - **Always pass `--user Claude` on every mutating command** (`mk issue add`, `mk issue state`, `mk issue edit`, `mk comment add`, `mk tag add`, `mk link`, `mk pr attach`). Without it the audit log silently attributes the change to the current user.
-- **Always pass `--as Claude` on `mk comment add`** — required by the binary.
 - **Always pass `-o json` when parsing output.** Text mode is for humans only.
-- **Always pass long text via `--description-file <path>` / `--body-file <path>` / `--body -` (stdin).** There is no inline editor; inline `\n` is not interpreted.
+- **Drive mutations via `--json` payloads** (the agent-preferred surface — strict-decoded, dry-runnable, schema discoverable via `mk schema show <command>`). The JSON payload's `author` field replaces the flag-form `--as Claude` on `mk comment add`. For multi-line text bodies (handoff comments, claim comments, worktree details), bridge a temp file into the JSON payload via `jq -n --rawfile body /tmp/foo.md '{...}' | mk ... --json -` so the markdown stays out of inline-JSON escape soup.
 
 ---
 
@@ -109,11 +108,14 @@ The preferred picker is **`mk issue next`** — a single atomic call that combin
 
 ```bash
 # Explicit-ID path only — auto-pick path skips this; `mk issue next` already transitioned.
-mk issue state MINI-NN in_progress --user Claude
+mk issue state --user Claude --json '{"key":"MINI-NN","state":"in_progress"}'
 
 # Both paths:
-printf 'Claimed by Claude. Reading ticket and preparing the worktree — full setup details will follow once the worktree is up.\n' \
-  | mk comment add MINI-NN --as Claude --user Claude --body -
+mk comment add --user Claude --json '{
+  "issue_key":"MINI-NN",
+  "author":"Claude",
+  "body":"Claimed by Claude. Reading ticket and preparing the worktree — full setup details will follow once the worktree is up."
+}'
 ```
 
 If, in any later phase, the skill stops with a hard-fail (malformed ticket, dirty tree, worktree collision, etc.), **leave the issue `in_progress`** and surface the failure to the user. Don't auto-roll-back to `todo` — the user decides whether to retry, hand off, or revert state manually.
@@ -263,7 +265,10 @@ Worktree ready.
 - Env startup: backgrounded (`pnpm worktree-env start`)
 EOF
 
-mk comment add MINI-NN --as Claude --user Claude --body-file /tmp/worktree-comment.md
+jq -n \
+  --rawfile body /tmp/worktree-comment.md \
+  '{issue_key:"MINI-NN", author:"Claude", body:$body}' \
+  | mk comment add --user Claude --json -
 ```
 
 If the phase is **docs-only** and the dev-env spin-up was skipped (you passed `--no-env` to `setup-worktree`), drop the env-startup line.
@@ -397,7 +402,7 @@ PR title matches the implementation commit's subject. PR body must:
 Once the PR URL is back from `gh pr create`, attach it to the issue:
 
 ```bash
-mk pr attach MINI-NN <PR_URL> --user Claude
+mk pr attach --user Claude --json '{"issue_key":"MINI-NN","url":"<PR_URL>"}'
 ```
 
 This gives `mk issue show` and `mk pr list MINI-NN` a clickable link back to the work — useful for the human reviewer and for any future agent that picks up follow-up work on this ticket.
@@ -409,9 +414,9 @@ This gives `mk issue show` and `mk pr list MINI-NN` a clickable link back to the
 Move the issue to `in_review` and post a single structured comment summarising the run. The comment is the handoff to the human reviewer — and, when a plan doc was loaded, to the future re-integration agent that will fold drift back into it — so it captures everything the PR diff doesn't show. **The plan doc itself is read-only for this skill** (see hard rules); drift goes here.
 
 ```bash
-mk issue state MINI-NN in_review --user Claude
+mk issue state --user Claude --json '{"key":"MINI-NN","state":"in_review"}'
 
-# Write the handoff to a temp file (long text must come from --body-file or stdin)
+# Write the handoff to a temp file, then bridge it into the JSON payload
 cat <<'EOF' > /tmp/handoff.md
 **PR:** <PR_URL>
 
@@ -428,7 +433,10 @@ cat <<'EOF' > /tmp/handoff.md
 <…>
 EOF
 
-mk comment add MINI-NN --as Claude --user Claude --body-file /tmp/handoff.md
+jq -n \
+  --rawfile body /tmp/handoff.md \
+  '{issue_key:"MINI-NN", author:"Claude", body:$body}' \
+  | mk comment add --user Claude --json -
 ```
 
 Use this template. Omit any section that genuinely has nothing to report — don't pad with "N/A" or "none". If every section is empty, the comment is just the PR link.
@@ -490,11 +498,12 @@ The skill will:
   2. Analyze it and generate retrospective markdown per the skill's Output Format.
   3. Create a NEW mk issue in the current repo's `backlog` state, tagged "retro",
      titled "Retro: <MINI-NN> — <original-issue-title>", with a reference back to
-     <MINI-NN> at the top of the description. Use:
-       mk issue add "<title>" --description-file <path> --state backlog \
-         --tag retro --user Claude
+     <MINI-NN> at the top of the description. Use the JSON payload form:
+       jq -n --arg title "<title>" --rawfile description <path> \
+         '{title:$title, state:"backlog", description:$description, tags:["retro"]}' \
+         | mk issue add --user Claude --json - -o json
   4. After the retro issue is created, link it to <MINI-NN> using `mk link`:
-       mk link <new-retro-key> relates-to <MINI-NN> --user Claude
+       mk link --user Claude --json '{"from":"<new-retro-key>","type":"relates-to","to":"<MINI-NN>"}'
      This creates a first-class `relates-to` edge between the two issues so
      anyone viewing <MINI-NN> via `mk issue show` sees the retro under
      Relations, not just buried in the description body. The in-body reference
@@ -559,7 +568,7 @@ These are non-negotiable. If you find yourself wanting to break one, stop and as
 - **Never `git checkout main`, `git stash`, or create a new branch outside the delegated worktree flow.** Worktree creation is owned by `setup-worktree` (Phase 4) and cleanup by `finish-worktree` (Phase 14); this skill does no other branch manipulation. Once inside the worktree, you stay on `claude/<slug>` until cleanup.
 - **Never skip pre-flight checks** by running on `main` or with a dirty tree. `setup-worktree` enforces this — if it stops, surface the failure.
 - **Never use `--no-verify` or skip hooks.** If a hook fails, investigate.
-- **Never call `mk` without `--user Claude` on a mutating command, or without `--as Claude` on `mk comment add`.** The audit log silently falls back to `geoff` otherwise — useless attribution for agent-driven runs.
+- **Never call `mk` without `--user Claude` on a mutating command.** The audit log silently falls back to `geoff` otherwise — useless attribution for agent-driven runs. On `mk comment add` JSON payloads the comment author is the `author` field (replaces the flag-form `--as Claude`).
 - **Never guess at the contract.** If the ticket has no Goal/Deliverables/Done-when sections, **stop and report** — the ticket wasn't populated correctly. (A missing `Plan:` line on the feature, or a missing `### Phase N` section in the plan doc, is *not* a stop condition under the looser flow — see Phase 3 for the rules.)
 
 ---
@@ -578,11 +587,11 @@ These are non-negotiable. If you find yourself wanting to break one, stop and as
 >
 > User: "internal-nats-messaging"
 >
-> *Skill runs `mk issue next --feature internal-nats-messaging --user Claude -o json` — this atomically picks the lowest-numbered ready issue (MINI-29 — Phase 4: pg-az-backup progress + result events; Phase 3 already shipped, so blockers clear), flips it to `in_progress`, and stamps Claude as the assignee in one call. Phase 2.1 collapses to just the claim comment via `mk comment add MINI-29 --as Claude --user Claude --body -` so the mk board reflects who's working on it before any setup runs.*
+> *Skill runs `mk issue next --feature internal-nats-messaging --user Claude -o json` — this atomically picks the lowest-numbered ready issue (MINI-29 — Phase 4: pg-az-backup progress + result events; Phase 3 already shipped, so blockers clear), flips it to `in_progress`, and stamps Claude as the assignee in one call. Phase 2.1 collapses to just the claim comment via `mk comment add --user Claude --json '{"issue_key":"MINI-29","author":"Claude","body":"Claimed by Claude. Reading ticket and preparing the worktree…"}'` so the mk board reflects who's working on it before any setup runs.*
 >
 > *Skill bulk-fetches context with `mk issue brief MINI-29 > /tmp/brief-MINI-29.json` — one call returning the issue + feature + linked docs (with content) + comments + relations + PRs. Reads `.feature.description` and finds `Plan: [docs/planning/not-shipped/internal-nats-messaging-plan.md](https://github.com/...)`. Reads the ticket body (Goal, Deliverables, Done when, Relevant docs, Smoke tests). The feature has one linked mk doc in `.documents[]` — `docs-planning-not-shipped-internal-nats-messaging-plan.md` (type `project_in_planning`, `linked_via: ["feature/internal-nats-messaging"]`); the skill reads its `### Phase 4` section as supplemental context. The issue itself has no linked docs (no design phase for this ticket). Reads each linked CLAUDE.md / ARCHITECTURE.md from disk. Iterates `.comments[]` from the brief — no designer hand-off. Reads `git log` for `Phase 1`/`Phase 2`/`Phase 3` shipped commits to learn the area tag (`nats`) and PR title shape.*
 >
-> *Phase 4: invokes `Skill(setup-worktree, args: "MINI-29")`. The setup-worktree skill pre-flights main, runs `git pull --ff-only origin main`, creates the worktree at `.claude/worktrees/mini-29` on `claude/mini-29`, runs `pnpm install` synchronously, then backgrounds `pnpm worktree-env start --description "Phase 4 — pg-az-backup progress + result events"` (description derived from the mk title). Returns control with cwd = the worktree. Skill posts the worktree-details follow-up comment on MINI-29 via `mk comment add … --body-file`.*
+> *Phase 4: invokes `Skill(setup-worktree, args: "MINI-29")`. The setup-worktree skill pre-flights main, runs `git pull --ff-only origin main`, creates the worktree at `.claude/worktrees/mini-29` on `claude/mini-29`, runs `pnpm install` synchronously, then backgrounds `pnpm worktree-env start --description "Phase 4 — pg-az-backup progress + result events"` (description derived from the mk title). Returns control with cwd = the worktree. Skill posts the worktree-details follow-up comment on MINI-29 via `jq -n --rawfile body /tmp/worktree-comment.md '{issue_key:"MINI-29",author:"Claude",body:$body}' | mk comment add --user Claude --json -`.*
 >
 > Skill: "Implementing Phase 4 — adding `mini-infra.backup.run` request handler and JetStream `BackupHistory` stream. Touching `server/src/services/backup/backup-executor.ts` first, then `server/src/services/nats/payload-schemas.ts`, then the boot sequence."
 >
@@ -590,10 +599,10 @@ These are non-negotiable. If you find yourself wanting to break one, stop and as
 >
 > *Phase 10: commits with `feat(nats): pg-az-backup progress + result events (Phase 4, MINI-29)`, pushes the branch with `-u`. Code review is left to a separate `/review` run that the user kicks off after the PR is open.*
 >
-> *Phase 11: opens PR with the implementation commit's title and `Closes MINI-29` in the body. Then runs `mk pr attach MINI-29 <PR_URL> --user Claude`.*
+> *Phase 11: opens PR with the implementation commit's title and `Closes MINI-29` in the body. Then runs `mk pr attach --user Claude --json '{"issue_key":"MINI-29","url":"<PR_URL>"}'`.*
 >
-> *Phase 12: runs `mk issue state MINI-29 in_review --user Claude`. Posts the handoff comment via `mk comment add MINI-29 --as Claude --user Claude --body-file /tmp/handoff.md`: PR URL, plus a Deviations section noting that the optional retry-on-transient-failure deliverable was deferred to a follow-up issue per the plan doc's wording. The plan doc itself is left untouched; the re-integration agent will fold the Deviations back later. Reports the PR URL.*
+> *Phase 12: runs `mk issue state --user Claude --json '{"key":"MINI-29","state":"in_review"}'`. Posts the handoff comment via `jq -n --rawfile body /tmp/handoff.md '{issue_key:"MINI-29",author:"Claude",body:$body}' | mk comment add --user Claude --json -`: PR URL, plus a Deviations section noting that the optional retry-on-transient-failure deliverable was deferred to a follow-up issue per the plan doc's wording. The plan doc itself is left untouched; the re-integration agent will fold the Deviations back later. Reports the PR URL.*
 >
-> *Phase 13: captures `$CLAUDE_SESSION_ID` (the parent session), spawns a `general-purpose` subagent on Sonnet, and tells it to invoke the `session-retrospective` skill with `--session-id <parent-id> --issue MINI-29`. The skill verifies `mk` works in the current repo, runs `scripts/get-session.sh` against the parent JSONL, generates retrospective markdown, and creates a new issue via `mk issue add "Retro: MINI-29 — Phase 4: pg-az-backup progress + result events" --description-file /tmp/retro.md --state backlog --tag retro --user Claude`. Then `mk link MINI-42 relates-to MINI-29 --user Claude` so both issues show the link in their Relations section. Subagent returns `MINI-42`; skill appends it to the run report.*
+> *Phase 13: captures `$CLAUDE_SESSION_ID` (the parent session), spawns a `general-purpose` subagent on Sonnet, and tells it to invoke the `session-retrospective` skill with `--session-id <parent-id> --issue MINI-29`. The skill verifies `mk` works in the current repo, runs `scripts/get-session.sh` against the parent JSONL, generates retrospective markdown, and creates a new issue via `jq -n --arg title "Retro: MINI-29 — Phase 4: pg-az-backup progress + result events" --rawfile description /tmp/retro.md '{title:$title,state:"backlog",description:$description,tags:["retro"]}' | mk issue add --user Claude --json - -o json`. Then `mk link --user Claude --json '{"from":"MINI-42","type":"relates-to","to":"MINI-29"}'` so both issues show the link in their Relations section. Subagent returns `MINI-42`; skill appends it to the run report.*
 >
 > *Phase 14: every prior phase succeeded, so the skill invokes `Skill(finish-worktree, args: "mini-29")`. The finish-worktree skill verifies the tree is clean, the branch is fully pushed, and the PR exists; then `cd`s back to the repo root, runs `pnpm worktree-env delete mini-29 --force` and `git worktree remove .claude/worktrees/mini-29`. Reports cleanup done. The `claude/mini-29` branch stays on the remote (the PR points at it).*

--- a/.claude/skills/mk/SKILL.md
+++ b/.claude/skills/mk/SKILL.md
@@ -283,23 +283,7 @@ mk issue brief MINI-42 | tee /tmp/ctx.json
 
 `mk issue brief` returns a single object: `{issue, feature?, relations, pull_requests, documents, comments, warnings}`. Each entry in `documents` carries `filename`, `type`, `description` (the link's `--why`), `linked_via` (one or both of `"issue"` and `"feature/<slug>"`), `source_path`, and `content`. Docs reachable from both the issue and its parent feature are deduped to a single entry whose `linked_via` lists both paths. If the issue and feature link rows have differing `--why` descriptions, the issue's wins and a string is appended to `warnings`.
 
-**Driving an agent through a feature in dependency order.** Use `mk feature plan <slug>` to inspect the topo order, then loop on `mk issue next --feature <slug> --user <agent>` to claim issues one at a time:
-
-```bash
-# Read the plan once to understand what's ahead
-mk feature plan service-addons-framework
-
-# Agent loop: claim → work → mark done → repeat
-while :; do
-  next=$(mk issue next --feature service-addons-framework --user agent-1 -o json)
-  key=$(jq -r '.issue.key // empty' <<<"$next")
-  if [ -z "$key" ]; then sleep 30; continue; fi
-  # ... agent does the work ...
-  mk issue state "$key" done --user agent-1
-done
-```
-
-Two agents can call `mk issue next` against the same feature in parallel; the SQLite writer lock plus a conditional UPDATE serialise claims, so each issue is handed to exactly one agent. When the DAG is currently serial (everything else blocked) the second agent simply gets `{"issue": null}` and should retry later. Crashed agents leave a stale `in_progress`/assigned issue — clear with `mk issue state <KEY> todo --user <human>` and `mk issue unassign <KEY>` to release it.
+**Driving an agent through a feature in dependency order.** Inspect the topo order with `mk feature plan <slug>`, then loop on `mk issue next --feature <slug> --user <agent> -o json`, treating `{"issue": null}` as "retry later". Multiple agents can call `next` in parallel — SQLite serialises the claim. Crashed agents leave a stale `in_progress`/assigned issue; clear with `mk issue state <KEY> todo` + `mk issue unassign <KEY>`.
 
 ### Comments
 
@@ -422,15 +406,7 @@ mk doc unlink <filename> <ISSUE-KEY|feature-slug>
 **`--from-path` filename derivation:** replaces `/` with `-`, so
 `docs/planning/not-shipped/foo-plan.md` → `docs-planning-not-shipped-foo-plan.md`.
 
-**`--from-path` type derivation** (skip `--type` when one of these matches):
-
-| path prefix                       | derived type           |
-| --------------------------------- | ---------------------- |
-| `docs/planning/not-shipped/`      | `project_in_planning`  |
-| `docs/planning/in-progress/`      | `project_in_progress`  |
-| `docs/planning/shipped/`          | `project_complete`     |
-
-For any other path, pass `--type` explicitly. Explicit `--type` / `--content-file` always wins over derivation. When `--from-path` is given without `--content`/`--content-file`, the path itself is used as the content file.
+**`--from-path` type derivation:** `docs/planning/{not-shipped,in-progress,shipped}/` → `project_in_{planning,progress,complete}`. For any other path, pass `--type` explicitly. Explicit `--type` / `--content-file` always wins over derivation. When `--from-path` is given without `--content`/`--content-file`, the path itself is used as the content file.
 
 **Example:**
 ```bash
@@ -492,369 +468,74 @@ mk pr list <KEY>                     One URL per line (or JSON)
 mk pr attach MINI-42 https://github.com/owner/repo/pull/7
 ```
 
-## Common workflows (JSON path — agent-preferred)
-
-**File a bug with repro steps:**
-```bash
-mk issue add --user agent-claude --json '{
-  "title": "Login returns 500",
-  "state": "todo",
-  "description": "## Repro\n1. POST /login with valid creds\n2. Server returns 500\n\n## Logs\nNullPointerException at AuthFilter.java:42"
-}'
-```
-
-**Pick up an issue and link the PR:**
-```bash
-mk issue state   --user agent-claude --json '{"key":"MINI-42","state":"in_progress"}'
-mk comment add   --user agent-claude --json '{"issue_key":"MINI-42","author":"Claude","body":"Picking this up."}'
-mk pr attach     --user agent-claude --json '{"issue_key":"MINI-42","url":"https://github.com/owner/repo/pull/123"}'
-```
-
-**Mark blocked work:**
-```bash
-mk link --user agent-claude --json '{"from":"MINI-42","type":"blocks","to":"MINI-43"}'
-mk issue show MINI-43          # MINI-43 will show "blocked by MINI-42" in relations
-```
-
-**Find what's in flight across all repos:**
-```bash
-mk issue list --all-repos --state in_progress,in_review -o json
-```
-
-**Preview a destructive change before committing:**
-```bash
-mk issue rm --user agent-claude --dry-run --json '{"key":"MINI-99"}' -o json
-# Inspect cascade counts in the output, then re-run without --dry-run.
-```
-
-The same workflows are available via the older flag/positional surface for human use (`mk issue add "Login returns 500" --state todo --description-file /tmp/repro.md`). Agents should prefer the JSON path because it's strict, schema-published, and dry-runnable.
-
 ## HTTP API
 
-`mk api` exposes every CLI mutation and read over HTTP, backed by the same SQLite database, the same `inputs.*Input` JSON shapes, the same store-side validators, and the same audit log. Use this surface when you can't be a child process of `mk` — web UIs, IDE plugins, long-running agents that already speak HTTP. The CLI stays available for shell-driven flows; the API is byte-for-byte equivalent for what overlaps.
-
-Start it with:
+`mk api` exposes every CLI mutation and read over HTTP, backed by the same SQLite database, JSON shapes, validators, and audit log. **The CLI conventions above all apply** — discover schemas, compose JSON, dry-run, then commit. The only differences are HTTP plumbing.
 
 ```bash
-mk api                                # bind 127.0.0.1:5320 (default), no auth
-mk api --port 8080                    # same host, different port
+mk api                                # bind 127.0.0.1:5320, no auth
 mk api --addr 127.0.0.1:7777 --token T   # require Authorization: Bearer T
-MK_API_TOKEN=T mk api                 # token via env (same effect as --token)
+MK_API_TOKEN=T mk api                 # token via env
 ```
 
-The same five conventions apply, in the same order:
+### Discovery
 
-1. **Discover the shape:** `GET /schema` (every command, one JSON object) or `GET /schema/{name}` (one command's schema with `examples[0]`). Both mirror `mk schema all` / `mk schema show` byte-for-byte.
-2. **Compose the JSON body** to match the schema. Bodies are strict-decoded — unknown fields get a `400 invalid_input`.
-3. **Rehearse with `?dry_run=true`** (or `X-Dry-Run: 1`). The response carries `X-Dry-Run: applied`, the body shape matches the real call, no row is written, no history entry is recorded.
-4. **Execute** by dropping the dry-run flag and sending `X-Actor: <agent-name>` so audit rows attribute correctly.
-5. **Query lean** by default. Issue / feature lists drop `description`; doc lists drop `content`. Opt-in to inflation with `?with_description=true` or `?with_content=true`.
+- `GET /schema/list` — every command name + one-line summary (mirrors `mk schema list`).
+- `GET /schema/{name}` — full JSON Schema for one command with `examples[0]` (mirrors `mk schema show`).
+- `GET /schema` — every schema in one object.
 
-Worked example, end to end:
+Schemas describe payload shapes, not routes. Routes follow REST conventions under `/repos/{prefix}/...` — list/create on the collection, show/patch/delete on the item, plus sub-resources for state changes (`/state`, `/assignee`), batch ops (`/tags`, `/pull-requests`), graph edges (`/relations`, `/links`), bulk reads (`/brief`, `/plan`), and claim/peek (`/next`). Use `GET /schema/list` to enumerate every operation. Issue keys in URLs and bodies must be canonical (`MINI-42`); the bare-number CLI shortcut isn't accepted.
 
-```bash
-# 1. Discover.
-curl -s http://127.0.0.1:5320/schema/issue.add | jq .examples[0]
+A few non-obvious mappings:
 
-# 2. Compose & rehearse.
-#    WHY ?dry_run=true: prove the payload validates and the projected
-#    issue looks right before we touch the DB.
-curl -s -X POST 'http://127.0.0.1:5320/repos/MINI/issues?dry_run=true' \
-  -H 'Content-Type: application/json' \
-  -H 'X-Actor: agent-claude' \
-  -d '{
-    "title": "Pin tab strip",
-    "feature_slug": "tui-polish",
-    "description": "Body height should clip the tab strip.",
-    "tags": ["ui","tui"]
-  }'
+- **Tags:** `POST/DELETE /repos/{prefix}/issues/{key}/tags` with `{"tags":[...]}` (batch, not per-tag URLs).
+- **Relations:** `POST /repos/{prefix}/relations` with `{"from","type","to"}`; `DELETE` with `{"a","b"}` (bidirectional).
+- **PR detach:** `DELETE /repos/{prefix}/issues/{key}/pull-requests` with `{"url"}` or `?url=`.
+- **Documents:** link/unlink at `POST/DELETE /documents/{filename}/links`; rename at `POST /documents/{filename}/rename`.
+- **State / assignee:** `PUT /issues/{key}/state`, `PUT/DELETE /issues/{key}/assignee`.
 
-# 3. Commit (drop dry_run).
-curl -s -X POST http://127.0.0.1:5320/repos/MINI/issues \
-  -H 'Content-Type: application/json' \
-  -H 'X-Actor: agent-claude' \
-  -d '{ ...same payload... }'
-```
+### Headers, query params, dry-run
 
-### Endpoints
-
-`{prefix}` is the 4-char repo prefix uppercased (`MINI`). `{key}` is the canonical `PREFIX-N` issue key (`MINI-42`) — the bare-number CLI shortcut is not accepted here. `{slug}` is the kebab-case feature slug. `{filename}` is the document filename. All bodies and responses are `application/json` except `GET /documents/{filename}/download`. Mutating endpoints accept `?dry_run=true|1` or `X-Dry-Run: 1|true`.
-
-#### Meta
-
-| Method | Path | Body | Success | Audit op |
-|---|---|---|---|---|
-| `GET` | `/healthz` | — | 200 `{ok,version}` | — |
-| `GET` | `/schema` | — | 200 — every schema, keyed by name | — |
-| `GET` | `/schema/list` | — | 200 — name + one-line summary | — |
-| `GET` | `/schema/{name}` | — | 200 — single schema with `examples[0]` | — |
-
-#### Repos
-
-| Method | Path | Body | Success | Audit op |
-|---|---|---|---|---|
-| `GET` | `/repos` | — | 200 array | — |
-| `POST` | `/repos` | `{prefix?, name, path, remote_url?}` | 201 repo | `repo.create` |
-| `GET` | `/repos/{prefix}` | — | 200 repo | — |
-
-`POST /repos` is the explicit equivalent of `mk init`. The CLI's auto-create-on-first-use only works because it can read CWD; over HTTP you have to spell out `name` and `path`. `prefix` is optional — the server allocates from `name` if omitted, same as the CLI.
-
-#### Features
-
-| Method | Path | Body | Success | Audit op |
-|---|---|---|---|---|
-| `GET` | `/repos/{prefix}/features` | — (`?with_description`) | 200 array | — |
-| `POST` | `/repos/{prefix}/features` | `FeatureAddInput` | 201 feature | `feature.create` |
-| `GET` | `/repos/{prefix}/features/{slug}` | — | 200 view (issues + linked docs) | — |
-| `PATCH` | `/repos/{prefix}/features/{slug}` | `FeatureEditInput` | 200 feature | `feature.update` |
-| `DELETE` | `/repos/{prefix}/features/{slug}` | — | 204 (200 dry-run preview) | `feature.delete` |
-| `GET` | `/repos/{prefix}/features/{slug}/plan` | — | 200 plan | — |
-| `GET` | `/repos/{prefix}/features/{slug}/next` | — | 200 `{issue}` (peek) | — |
-| `POST` | `/repos/{prefix}/features/{slug}/next` | — (requires `X-Actor`) | 200 `{issue}` (claim) | `issue.claim` |
-
-#### Issues
-
-| Method | Path | Body | Success | Audit op |
-|---|---|---|---|---|
-| `GET` | `/repos/{prefix}/issues` | — (`?state`,`?feature`,`?tag`,`?with_description`) | 200 array | — |
-| `POST` | `/repos/{prefix}/issues` | `IssueAddInput` | 201 issue | `issue.create` |
-| `GET` | `/repos/{prefix}/issues/{key}` | — | 200 view (comments + relations + PRs + docs) | — |
-| `GET` | `/repos/{prefix}/issues/{key}/brief` | — (`?no_feature_docs`,`?no_comments`,`?no_doc_content`) | 200 brief | — |
-| `PATCH` | `/repos/{prefix}/issues/{key}` | `IssueEditInput` | 200 issue | `issue.update` |
-| `DELETE` | `/repos/{prefix}/issues/{key}` | — | 204 (200 dry-run preview) | `issue.delete` |
-| `PUT` | `/repos/{prefix}/issues/{key}/state` | `{state}` | 200 issue | `issue.state` |
-| `PUT` | `/repos/{prefix}/issues/{key}/assignee` | `{assignee}` | 200 issue | `issue.assign` |
-| `DELETE` | `/repos/{prefix}/issues/{key}/assignee` | — | 200 issue (no-op when already clear) | `issue.assign` |
-
-#### Comments
-
-| Method | Path | Body | Success | Audit op |
-|---|---|---|---|---|
-| `GET` | `/repos/{prefix}/issues/{key}/comments` | — | 200 array | — |
-| `POST` | `/repos/{prefix}/issues/{key}/comments` | `CommentAddInput` (`{author, body}`) | 201 comment | `comment.add` |
-
-#### Relations
-
-| Method | Path | Body | Success | Audit op |
-|---|---|---|---|---|
-| `POST` | `/repos/{prefix}/relations` | `{from, type, to}` (canonical keys) | 201 relation | `relation.create` |
-| `DELETE` | `/repos/{prefix}/relations` | `{a, b}` | 204 (200 dry-run preview) | `relation.delete` |
-
-`type` is one of `blocks`, `relates-to` (alias `relates`), `duplicate-of` (alias `duplicates`).
-
-#### Pull requests
-
-| Method | Path | Body | Success | Audit op |
-|---|---|---|---|---|
-| `GET` | `/repos/{prefix}/issues/{key}/pull-requests` | — | 200 array | — |
-| `POST` | `/repos/{prefix}/issues/{key}/pull-requests` | `{url}` | 201 pr | `pr.attach` |
-| `DELETE` | `/repos/{prefix}/issues/{key}/pull-requests` | `{url}` or `?url=` | 204 (200 dry-run preview) | `pr.detach` |
-
-#### Tags
-
-| Method | Path | Body | Success | Audit op |
-|---|---|---|---|---|
-| `POST` | `/repos/{prefix}/issues/{key}/tags` | `{tags:[...]}` | 200 issue | `tag.add` |
-| `DELETE` | `/repos/{prefix}/issues/{key}/tags` | `{tags:[...]}` | 200 issue | `tag.remove` |
-
-#### Documents
-
-| Method | Path | Body | Success | Audit op |
-|---|---|---|---|---|
-| `GET` | `/repos/{prefix}/documents` | — (`?type`, `?with_content`) | 200 array | — |
-| `POST` | `/repos/{prefix}/documents` | `DocAddInput` | 201 document | `document.create` |
-| `GET` | `/repos/{prefix}/documents/{filename}` | — (`?with_content=false` to drop body) | 200 view (doc + links) | — |
-| `PUT` | `/repos/{prefix}/documents/{filename}` | `DocAddInput` (filename in URL wins) | 200 document | `document.create` or `document.update` |
-| `PATCH` | `/repos/{prefix}/documents/{filename}` | `DocEditInput` | 200 document | `document.update` |
-| `DELETE` | `/repos/{prefix}/documents/{filename}` | — | 204 (200 dry-run preview with cascade) | `document.delete` |
-| `GET` | `/repos/{prefix}/documents/{filename}/download` | — | 200 `text/markdown` body, `Content-Disposition: attachment` | — |
-| `POST` | `/repos/{prefix}/documents/{filename}/rename` | `{new_filename, type?}` | 200 document | `document.rename` |
-| `POST` | `/repos/{prefix}/documents/{filename}/links` | `{issue_key OR feature_slug, description?}` | 201 link | `document.link` |
-| `DELETE` | `/repos/{prefix}/documents/{filename}/links` | `{issue_key OR feature_slug}` | 204 (200 dry-run preview) | `document.unlink` |
-
-#### History
-
-| Method | Path | Body | Success | Audit op |
-|---|---|---|---|---|
-| `GET` | `/history` | — | 200 array (every repo) | — |
-| `GET` | `/repos/{prefix}/history` | — | 200 array (single repo) | — |
-
-Filters mirror the CLI: `?limit=` (default 50, 0 = no cap), `?offset=`, `?op=`, `?kind=`, `?actor=` (alias `?user_filter=`), `?since=`, `?from=`, `?to=`, `?oldest_first=true`. `since` and `from` are mutually exclusive. Bare-date stamps are local-timezone; RFC 3339 stamps are honoured as written. Reads are not audited.
-
-### Authentication
-
-When the server is started with `--token T` (or `MK_API_TOKEN=T`), every request except `GET /healthz` MUST send `Authorization: Bearer T`. Missing or wrong token → `401 unauthorized`. The token is compared with `subtle.ConstantTimeCompare`.
-
-When no token is configured, requests are accepted without an `Authorization` header — the loopback default address (`127.0.0.1:5320`) is the trust boundary. There is no per-user auth; one token serves every caller.
-
-### Actor identity
-
-```
-X-Actor: agent-claude
-```
-
-Every mutating endpoint stamps the audit row with the value from `X-Actor`. When the header is absent, the actor falls back to the literal string `"api"` (NOT the OS user the server runs as). The header is validated by `store.ValidateActor` once per request — control characters or overlength values fail with `400 invalid_input`.
-
-`POST /repos/{prefix}/features/{slug}/next` is the one endpoint where `X-Actor` is **required**: claiming work demands a real assignee, so the server returns `400 invalid_input` with `details.field=X-Actor` if it's missing.
-
-### Dry-run
-
-```
-?dry_run=true        # query parameter
-?dry_run=1           # also accepted
-X-Dry-Run: true      # header form (use whichever your client makes easier)
-X-Dry-Run: 1
-```
-
-Every mutating endpoint accepts dry-run. The response status matches what a real call would return (e.g. `201 Created` on `POST /issues?dry_run=true`), the body is the projected entity in the same shape, the response carries `X-Dry-Run: applied`, no row is written, no history entry is recorded. Server-time fields (`id`, `created_at`, `updated_at`) come back zero, same as the CLI's `--dry-run`. Destructive endpoints (`DELETE`) return a `*DeletePreview` carrying cascade counts.
+- **Auth.** When `--token` / `MK_API_TOKEN` is set, every request except `GET /healthz` needs `Authorization: Bearer <token>` (constant-time compare). The loopback default with no token is the trust boundary.
+- **Actor.** `X-Actor: <agent-name>` stamps the audit log. Absent → falls back to the literal `"api"` (NOT the OS user). **Required** on `POST /repos/{prefix}/features/{slug}/next` — claiming work demands a real assignee.
+- **Dry-run.** `?dry_run=true` (or `=1`) or `X-Dry-Run: 1`. Response status matches a real call, body is the projected entity, response carries `X-Dry-Run: applied`. No row written, no audit row recorded. Server-time fields (`id`, `created_at`, `updated_at`) come back zero. `DELETE` returns a `*DeletePreview` with cascade counts.
+- **Lean lists.** Issue/feature lists drop `description`; doc list drops `content`. Inflate with `?with_description=true` or `?with_content=true`. For a single doc, `?with_content=false` strips the body the other way.
+- **Brief opt-outs.** `?no_feature_docs=1`, `?no_comments=1`, `?no_doc_content=1` on `GET /issues/{key}/brief`.
+- **History filters.** `?limit`, `?offset`, `?op`, `?kind`, `?actor` (alias `?user_filter`), `?since`, `?from`, `?to`, `?oldest_first` on `GET /history` and `GET /repos/{prefix}/history`. `since` and `from` are mutually exclusive.
 
 ### Errors
 
-Every error response is a single envelope:
-
 ```json
-{
-  "error": "title is required",
-  "code": "invalid_input",
-  "details": {"field": "title"}
-}
+{ "error": "title is required", "code": "invalid_input", "details": {"field": "title"} }
 ```
 
 | Status | Code | When |
 |---|---|---|
-| 400 | `invalid_input` | malformed JSON, unknown fields (strict decode), validator failure, missing required `X-Actor` on claim |
-| 401 | `unauthorized` | `--token` configured and bearer is missing/wrong |
-| 404 | `not_found` | path resolves no such repo / feature / issue / document |
-| 409 | `conflict` | duplicate slug, duplicate prefix, duplicate PR attachment, document already exists |
-| 413 | `payload_too_large` | request body exceeds the 4 MiB cap |
-| 500 | `internal` | bug — server-side panic was caught by the recovery middleware |
+| 400 | `invalid_input` | malformed JSON, unknown fields, validator failure, missing required `X-Actor` on claim |
+| 401 | `unauthorized` | token configured and bearer is missing/wrong |
+| 404 | `not_found` | path resolves no such entity |
+| 409 | `conflict` | duplicate slug/prefix/PR URL/document filename |
+| 413 | `payload_too_large` | body > 4 MiB |
+| 500 | `internal` | server-side panic (caught by recovery middleware) |
 
-`details` is optional and field-specific. Most validation errors include `details.field` pointing at the offending payload key.
+### API-only quirks
 
-### Lean lists
+- **`POST /repos`** is the equivalent of `mk init`, but the server can't see your CWD — supply `{"name":"...", "path":"..."}` (plus optional `prefix`) explicitly.
+- **`GET /repos/{prefix}/documents/{filename}/download`** is the only non-JSON endpoint. Streams the body as `text/markdown` with `Content-Disposition: attachment`. No audit row, no dry-run, no `with_content`. The API never reads or writes the server filesystem, so callers materialise on disk by piping the response (`curl -O`).
+- **CLI verbs with no API equivalent** (touch the local filesystem or terminal): `mk init` (use `POST /repos`), `mk install-skill`, `mk doc add --from-path` / `--content-file` (inline `content` in the body), `mk doc export` (use `/download`), `mk tui`.
 
-Same defaults as the CLI. List endpoints strip heavy fields by default; use these flags to inflate when you really need bodies:
-
-- `GET /repos/{prefix}/issues?with_description=true|1` — inline `description` per row.
-- `GET /repos/{prefix}/features?with_description=true|1` — same.
-- `GET /repos/{prefix}/documents?with_content=true|1` — inline `content` per row.
-- `GET /repos/{prefix}/documents/{filename}?with_content=false|0` — opposite direction: skip the body when fetching one doc by name.
-
-`GET /repos/{prefix}/issues/{key}/brief` is the one bulk-context endpoint that *does* inline doc bodies on purpose. Use the three opt-out filters when the full payload is too large:
-
-- `?no_feature_docs=1` — skip docs linked to the parent feature.
-- `?no_comments=1` — skip the comments section.
-- `?no_doc_content=1` — keep linked-doc metadata but drop the bodies.
-
-### Special endpoints
-
-- `GET /repos/{prefix}/issues/{key}/brief` — the agent's bulk-context single-fetch. Returns `{issue, feature?, relations, pull_requests, documents, comments, warnings}` in one call, with linked-doc bodies inlined. Replaces the `show` + per-doc-fetch dance. Always JSON.
-- `POST /repos/{prefix}/features/{slug}/next` — atomic claim. **Requires `X-Actor`.** Picks the lowest-numbered todo issue in the feature with all blockers resolved and no existing assignee, flips it to `in_progress`, and stamps the assignee with the actor. Returns `{"issue": null}` (status 200) when nothing is currently claimable — poll/retry rather than treating that as an error. Records `issue.claim`.
-- `GET /repos/{prefix}/features/{slug}/next` — read-only peek. Same response shape as the claim, no mutation, no audit row. Use this to inspect what the next claim *would* return before committing.
-- `GET /repos/{prefix}/documents/{filename}/download` — the only non-JSON endpoint. Streams the doc body as `text/markdown; charset=utf-8` with `Content-Disposition: attachment; filename="<name>"`. No audit row, no `?dry_run`, no `with_content`. This replaces the CLI's `mk doc export --to-path`: the API never reads or writes the server filesystem, so callers materialise on disk by piping the response body themselves (e.g. `curl -O`).
-
-### CLI verbs that have no API equivalent
-
-Some CLI verbs touch the developer's local filesystem or terminal. They stay local-only and have no HTTP analogue:
-
-- **`mk init`** — auto-detects the repo from CWD by walking up to a `.git` toplevel. The API can't see your working tree; use `POST /repos` with explicit `{name, path}`.
-- **`mk install-skill`** — writes `.claude/skills/mk/SKILL.md` into the local repo. No remote sense.
-- **`mk doc add --from-path` / `--content-file`** — read a file off the server's disk. Over HTTP, put the body in the request `content` field directly (it's just a JSON string, multi-line is fine).
-- **`mk doc export --to-path` / `--to`** — write a file onto the server's disk. Over HTTP, use `GET /documents/{filename}/download` and let the client save the response stream.
-- **`mk tui`** — full-screen terminal UI. Same DB; no point exposing it over HTTP.
-
-The `mk schema*` commands have HTTP equivalents (`GET /schema*`) but the registry is identical, so a CLI agent can keep using either.
-
-### Worked examples
-
-**1. Create a repo and a first issue.**
-
-```bash
-# WHY: the API can't auto-detect a repo from CWD, so we register it explicitly.
-curl -s -X POST http://127.0.0.1:5320/repos \
-  -H 'Content-Type: application/json' \
-  -H 'X-Actor: agent-claude' \
-  -d '{"prefix":"MINI","name":"mini-kanban","path":"/home/me/Repos/mini-kanban"}'
-
-# WHY: file the first ticket. Strict decode means a typo in `tilte` returns 400.
-curl -s -X POST http://127.0.0.1:5320/repos/MINI/issues \
-  -H 'Content-Type: application/json' \
-  -H 'X-Actor: agent-claude' \
-  -d '{"title":"First ticket","state":"todo","tags":["bootstrap"]}'
-```
-
-**2. Agent claim loop.**
-
-```bash
-# WHY: claim → work → mark done. Each iteration writes an audit row stamped
-#      with X-Actor=agent-x, so the audit log shows exactly which agent did
-#      what. Returns {"issue": null} when nothing is claimable; sleep+retry.
-while :; do
-  resp=$(curl -s -X POST \
-    "http://127.0.0.1:5320/repos/MINI/features/auth-rewrite/next" \
-    -H 'X-Actor: agent-x')
-  key=$(jq -r '.issue.key // empty' <<<"$resp")
-  if [ -z "$key" ]; then sleep 30; continue; fi
-
-  # ... agent does the work, opens a PR, etc ...
-
-  # WHY: PUT /issues/{key}/state replaces the state. Body shape published at
-  #      /schema/issue.state — strict decode rejects extras.
-  curl -s -X PUT "http://127.0.0.1:5320/repos/MINI/issues/$key/state" \
-    -H 'Content-Type: application/json' \
-    -H 'X-Actor: agent-x' \
-    -d '{"state":"done"}'
-done
-```
-
-**3. Bulk-context fetch for an LLM prompt.**
-
-```bash
-# WHY: one read returns the issue, parent feature, all linked docs (with
-#      bodies inlined), comments, relations, and PRs. Drop --no-doc-content
-#      if the docs themselves are too large for context.
-curl -s "http://127.0.0.1:5320/repos/MINI/issues/MINI-42/brief?no_doc_content=1" \
-  -H 'X-Actor: reader' \
-  | jq .
-```
-
-### What the API deliberately doesn't do
-
-Same posture as the CLI's "what we deliberately don't do" — these came up during design and were rejected for v1. New consumers shouldn't expect them.
-
-- **No NDJSON / streaming / WebSockets.** Largest realistic response is one `issue brief`. Streaming complexity isn't justified.
-- **No per-user auth or sessions.** One shared bearer token. This is a local helper, not a SaaS.
-- **No remote `from-path` / `to-path` doc commands.** The API never reads or writes the server filesystem. Inline content in the body; pipe `/download` to disk.
-- **No metrics / Prometheus endpoint.** `/healthz` is the only non-resource endpoint.
-- **No CORS, no TLS termination, no rate limiting.** Designed for loopback and trusted LAN.
-- **No cursor pagination.** History uses `?limit=` + `?offset=`; nothing else paginates yet.
-
-For the full design rationale, the threat model, and the forward-looking "Phase 6: CLI client mode" sketch, see `docs/rest-api-design.md`.
+For the full design rationale, threat model, and what the API deliberately doesn't do (NDJSON, per-user auth, CORS, cursor pagination, …), see `docs/rest-api-design.md`.
 
 ## CLI client mode (`--remote` / `MK_REMOTE`)
 
-The same `mk` binary can drive a remote `mk api` server instead of the local SQLite database, so an agent can use the familiar CLI surface against a shared kanban without changing flags or output format. Set one of:
-
-- `--remote http://host:5320` (per-invocation flag), or
-- `MK_REMOTE=http://host:5320` (env, persists across the shell), and
-- `--token <secret>` / `MK_API_TOKEN=<secret>` if the server enforces auth.
+`mk` can drive a remote `mk api` server instead of the local DB. Set `--remote http://host:5320` (or `MK_REMOTE=...`) and, if the server enforces auth, `--token` / `MK_API_TOKEN`. Every read and mutating verb behaves identically — same flags, same JSON output, same `--dry-run`, same `--user`. The client translates each verb into the matching HTTP route; audit rows are written by the server.
 
 ```bash
 MK_REMOTE=http://team-mk:5320 MK_API_TOKEN=$T mk issue list -o json
 mk --remote http://team-mk:5320 issue add "Login broken" --feature auth
 ```
 
-In remote mode every read and mutating verb above behaves exactly as it does locally — same flags, same JSON output, same `--dry-run` semantics, same `--user` actor. The client transparently translates each verb into the corresponding HTTP route from the table above. Audit rows are written by the API server, not the client.
-
-Verbs that touch the developer's local filesystem stay local-only and error clearly when `MK_REMOTE` is set:
-
-- `mk init` — auto-detects CWD; use `POST /repos` (or run `mk init` against the local DB) instead.
-- `mk install-skill` — writes `.claude/skills/mk/SKILL.md` locally.
-- `mk doc add --from-path` / `mk doc upsert --from-path` — read from the client filesystem; pass `--content`/`--content-file` instead.
-- `mk doc export` (`--to-path` and `--to`) — writes to the client filesystem; use `mk doc download <filename>` (writes to stdout, or `--to <path>`) to get the body locally over HTTP.
-- `mk tui` — opens the local DB directly.
-
-`mk schema *` and `mk status` also stay local-direct (no remote endpoint exists in v1; the registry / stats are local concerns).
+Verbs that touch the local filesystem or terminal error clearly in remote mode and stay local-direct: `mk init`, `mk install-skill`, `mk doc add --from-path` / `--content-file` (use `--content` inline instead), `mk doc export` (use `mk doc download <filename>` — writes to stdout or `--to <path>`), `mk tui`, `mk schema *`, `mk status`.
 
 ## Gotchas
 

--- a/.claude/skills/mk/SKILL.md
+++ b/.claude/skills/mk/SKILL.md
@@ -5,7 +5,35 @@ description: Use this skill whenever you need to create, read, update, or organi
 
 # Working with `mk` (mini-kanban)
 
-`mk` is a local CLI issue tracker. Everything lives in a single SQLite db at `~/.mini-kanban/db.sqlite`. It's designed to be driven non-interactively by AI agents — every read command supports JSON output, and every long-text input is supplied via a file or stdin.
+`mk` is a local CLI issue tracker. Everything lives in a single SQLite db at `~/.mini-kanban/db.sqlite`. It's designed to be driven non-interactively by AI agents — every read command supports JSON output, every mutation accepts a JSON payload via `--json`, and every payload shape is published at runtime via `mk schema`.
+
+## Agent quick start
+
+The five conventions below combine into one straightforward flow. Each is documented in detail further down; this section is the cheat-sheet:
+
+1. **Discover the shape:** `mk schema show <command>` (or `mk schema all` for one-shot ingestion). Worked examples are in every schema's `examples[0]`.
+2. **Compose the payload as JSON.** Every mutating command accepts `--json '<payload>'`, `--json -` (stdin), or `--json @path/to.json`. Long text (descriptions, comment bodies, doc content) goes inline as a string.
+3. **Rehearse with `--dry-run`** if the call is destructive or non-trivial. Stdout has the same shape as a real call; stderr emits `[dry-run] no changes were written`. Especially useful before `mk issue rm` / `feature rm` / `doc rm`, where the dry-run reports cascade counts.
+4. **Run for real** without `--dry-run`. **Always pass `--user <agent-name>`** so the audit log attributes work correctly.
+5. **Query lean by default.** `mk issue list -o json` and `mk feature list -o json` strip the heavy `description` field; pass `--with-description` if you actually need bodies. `mk doc show --metadata` skips the body. `mk issue brief --no-doc-content` gives you the structure without inlining linked-doc bodies.
+
+A worked example, end to end:
+
+```bash
+# 1. Discover.
+mk schema show issue.add | jq .examples[0]
+
+# 2. Compose & rehearse.
+mk issue add --user agent-claude --dry-run --json '{
+  "title": "Pin tab strip",
+  "feature_slug": "tui-polish",
+  "description": "Body height should clip the tab strip.",
+  "tags": ["ui", "tui"]
+}' -o json
+
+# 3. Commit (drop --dry-run).
+mk issue add --user agent-claude --json '{ ...same payload... }' -o json
+```
 
 ## Mental model
 
@@ -35,6 +63,91 @@ description: Use this skill whenever you need to create, read, update, or organi
 - **Comment author.** `--as <name>` is required on every comment. There is no auth — use a sensible identity (e.g. `Claude`, `Geoff`).
 - **`--user` is REQUIRED for AI agents.** Every mutation is recorded in an audit log alongside the actor that performed it. The CLI will silently fall back to the OS username if `--user` is omitted, but for agents that produces useless `<your-os-user> did everything` history. **Always pass `--user <your-agent-name>` (e.g. `--user Claude`) on every mutating command.** Treat it as mandatory in any agent-driven invocation, even though the binary tolerates its absence for human users.
 - **Database override.** `--db <path>` is a global flag, useful for tests. In production agents, leave it at the default.
+
+### Recommended: drive `mk` via `--json` (JSON)
+
+Every mutating command accepts `--json` (alias `-j`) — a JSON payload that fully describes the operation. **Prefer this over typed flags when driving `mk` from an agent.** It's strict (typos surface as `unknown field` errors instead of silent no-ops), it removes the `--description-file` / stdin dance for long text, and the schema is published at runtime so you don't have to memorise field names.
+
+- `--json '<json>'` — inline JSON.
+- `--json -` — read JSON from stdin.
+- `--json @path/to.json` — read JSON from a file.
+
+`--json` is **mutually exclusive** with positionals and per-field flags (`--title`, `--state`, etc.). Mixing them is rejected with a clear error.
+
+**Discover shapes at runtime, don't guess:**
+
+```bash
+mk schema list                # every command name with --json + one-line description
+mk schema show issue.add      # full JSON Schema (draft 2020-12) for one command
+mk schema all                 # every schema, keyed by command name (one ingest pass)
+```
+
+Each schema includes a worked `examples[0]` you can copy and adapt:
+
+```bash
+$ mk schema show issue.add | jq .examples[0]
+{
+  "title": "Pin tab strip in place",
+  "feature_slug": "tui-polish",
+  "description": "Body height should clip the tab strip so it doesn't drift on overflow.",
+  "state": "todo",
+  "tags": ["ui", "tui"]
+}
+
+$ mk schema show issue.add | jq .examples[0] | mk issue add --user agent-claude --json -
+```
+
+**Conventions baked into the JSON path:**
+
+- **Issue keys must be canonical** (`MINI-42`, not `42`). The bare-number shortcut is for humans on the CLI flag path only.
+- **Long-text fields are inline strings.** No JSON-side `--description-file`; just put the markdown directly in the `description` / `body` / `content` field.
+- **Edit semantics on `*string` fields:** field absent = no change; empty string = clear (where the model allows). Required fields like `title` reject empty strings — omit the field to leave the value alone.
+- **Globals stay as flags.** `--user`, `--db`, and `-o text|json` are passed as flags alongside `--json`, not inside the JSON.
+- **Strict decoding.** Unknown fields fail the call. If you get `unknown field "..."` errors, run `mk schema show <command>` to see the exact accepted shape.
+
+### `--dry-run` for safe rehearsals
+
+Every mutating command accepts a global `--dry-run` flag. When set, the command runs everything up to the SQL write — input validation, entity resolution, slug/key derivation, cascade lookups — and emits the projected result without touching the database or the audit log. A `[dry-run] no changes were written` line is written to stderr; stdout has the same shape as a real call's output, so the same parsing code works.
+
+Worth using when:
+
+- You want to rehearse an `--json` payload before committing it, especially after composing it from `mk schema show`.
+- You're about to delete something and want the cascade counts first. `mk issue rm --dry-run` returns the issue plus how many comments / relations / PR attachments / doc links would be removed alongside it; same shape on `mk feature rm --dry-run` (issues unlinked, doc links removed) and `mk doc rm --dry-run` (links removed).
+- You want to confirm a complicated `mk issue edit` patch would resolve to the right object (especially for `feature_slug: null` clears).
+
+Notes:
+
+- `mk issue next --dry-run` is equivalent to `mk issue peek` — it reports what would be claimed without flipping state.
+- `mk doc export --dry-run` reports the absolute destination path it would write to and the byte count, but doesn't create directories or files.
+- Server-time fields (`id`, `created_at`, `updated_at`) come back as zero values in dry-run output; everything else is faithful to the real call.
+
+### Output is lean by default
+
+To keep agent context windows small, list-style commands strip heavy fields by default:
+
+- `mk issue list -o json` — no `description`. Pass `--with-description` to inline bodies.
+- `mk feature list -o json` — no `description`. Pass `--with-description` to inline bodies.
+- `mk doc list -o json` — already metadata-only (emits `size_bytes`, never `content`).
+
+When you need just the metadata of a single document, pass `--metadata` to `mk doc show <name>` and the body is skipped. Pair it with `--raw` (mutually exclusive) only if you wanted the body and nothing else.
+
+`mk issue brief <KEY>` is the one bulk-context call that *does* inline doc bodies on purpose — it exists so a skill can read everything in one shot. Three opt-outs trim it when the full payload is too much:
+
+- `--no-feature-docs` — skip docs linked to the parent feature.
+- `--no-comments` — skip the comments section.
+- `--no-doc-content` — keep linked-doc metadata (filename, type, source_path, linked_via, description) but drop the bodies. Fetch specific bodies later via `mk doc show <name>`.
+
+### Input validation contract
+
+Every mutation runs through validators in the store layer, so malformed input fails fast with a clear error rather than being silently normalised or stored as garbage. Rules an agent should know:
+
+- **No control characters** anywhere. Single-line fields (titles, slugs, names, filenames, URLs, tags) reject all C0 controls and DEL (`\x00–\x1F`, `\x7F`). Multi-line fields (descriptions, comment bodies, document content) allow `\t \n \r` but reject the rest.
+- **No silent trimming on identifiers.** Leading or trailing whitespace in a `filename`, `slug`, or URL is rejected — if you fat-finger a payload you'll see it instead of having it normalised away.
+- **Length caps:** title 200 chars, name/assignee/`--user` 80, slug 60, filename 200, tag 80, PR URL 2 KiB, body fields 1 MiB. Generous for legitimate content, tight enough to fail loud on a runaway paste.
+- **Slugs must be kebab-case** matching `^[a-z0-9][a-z0-9-]*$`. Auto-derived slugs (when you omit `slug` on `feature.add`) always satisfy this; explicit slugs in JSON must too.
+- **PR URLs** must use `http` or `https` and have a host. `javascript:` and similar exotic schemes are rejected.
+- **`--user` is validated once per command.** A `--user` that contains a newline or a control character is rejected at the start of the command before any work happens.
+- **Strict JSON decode.** Unknown fields fail (covered by principle #1). Combined with the above, an agent that sends garbage gets a useful error pointing at the bad field rather than a successful write of corrupted data.
 
 ## Command reference
 
@@ -145,6 +258,10 @@ mk issue next --feature <slug>       Atomically claim the next ready issue
                                      nothing is currently claimable —
                                      callers should poll/retry rather
                                      than treat that as an error.
+mk issue peek --feature <slug>       Read-only counterpart to `next`:
+                                     shows what `next` would claim
+                                     without mutating state. Same empty
+                                     result shape when nothing is ready.
 mk issue rm <KEY>                    Delete an issue (cascades to comments,
                                      relations, PRs, tags, doc links)
 ```
@@ -375,32 +492,28 @@ mk pr list <KEY>                     One URL per line (or JSON)
 mk pr attach MINI-42 https://github.com/owner/repo/pull/7
 ```
 
-## Common workflows
+## Common workflows (JSON path — agent-preferred)
 
 **File a bug with repro steps:**
 ```bash
-cat <<'EOF' > /tmp/repro.md
-## Repro
-1. POST /login with valid creds
-2. Server returns 500
-
-## Logs
-NullPointerException at AuthFilter.java:42
-EOF
-mk issue add "Login returns 500" --description-file /tmp/repro.md --state todo
+mk issue add --user agent-claude --json '{
+  "title": "Login returns 500",
+  "state": "todo",
+  "description": "## Repro\n1. POST /login with valid creds\n2. Server returns 500\n\n## Logs\nNullPointerException at AuthFilter.java:42"
+}'
 ```
 
 **Pick up an issue and link the PR:**
 ```bash
-mk issue state MINI-42 in_progress
-mk comment add MINI-42 --as Claude --body "Picking this up."
-mk pr attach MINI-42 https://github.com/owner/repo/pull/123
+mk issue state   --user agent-claude --json '{"key":"MINI-42","state":"in_progress"}'
+mk comment add   --user agent-claude --json '{"issue_key":"MINI-42","author":"Claude","body":"Picking this up."}'
+mk pr attach     --user agent-claude --json '{"issue_key":"MINI-42","url":"https://github.com/owner/repo/pull/123"}'
 ```
 
 **Mark blocked work:**
 ```bash
-mk link MINI-42 blocks MINI-43
-mk issue show MINI-43          # MINI-43 will show "blocks by MINI-42" in relations
+mk link --user agent-claude --json '{"from":"MINI-42","type":"blocks","to":"MINI-43"}'
+mk issue show MINI-43          # MINI-43 will show "blocked by MINI-42" in relations
 ```
 
 **Find what's in flight across all repos:**
@@ -408,12 +521,350 @@ mk issue show MINI-43          # MINI-43 will show "blocks by MINI-42" in relati
 mk issue list --all-repos --state in_progress,in_review -o json
 ```
 
+**Preview a destructive change before committing:**
+```bash
+mk issue rm --user agent-claude --dry-run --json '{"key":"MINI-99"}' -o json
+# Inspect cascade counts in the output, then re-run without --dry-run.
+```
+
+The same workflows are available via the older flag/positional surface for human use (`mk issue add "Login returns 500" --state todo --description-file /tmp/repro.md`). Agents should prefer the JSON path because it's strict, schema-published, and dry-runnable.
+
+## HTTP API
+
+`mk api` exposes every CLI mutation and read over HTTP, backed by the same SQLite database, the same `inputs.*Input` JSON shapes, the same store-side validators, and the same audit log. Use this surface when you can't be a child process of `mk` — web UIs, IDE plugins, long-running agents that already speak HTTP. The CLI stays available for shell-driven flows; the API is byte-for-byte equivalent for what overlaps.
+
+Start it with:
+
+```bash
+mk api                                # bind 127.0.0.1:5320 (default), no auth
+mk api --port 8080                    # same host, different port
+mk api --addr 127.0.0.1:7777 --token T   # require Authorization: Bearer T
+MK_API_TOKEN=T mk api                 # token via env (same effect as --token)
+```
+
+The same five conventions apply, in the same order:
+
+1. **Discover the shape:** `GET /schema` (every command, one JSON object) or `GET /schema/{name}` (one command's schema with `examples[0]`). Both mirror `mk schema all` / `mk schema show` byte-for-byte.
+2. **Compose the JSON body** to match the schema. Bodies are strict-decoded — unknown fields get a `400 invalid_input`.
+3. **Rehearse with `?dry_run=true`** (or `X-Dry-Run: 1`). The response carries `X-Dry-Run: applied`, the body shape matches the real call, no row is written, no history entry is recorded.
+4. **Execute** by dropping the dry-run flag and sending `X-Actor: <agent-name>` so audit rows attribute correctly.
+5. **Query lean** by default. Issue / feature lists drop `description`; doc lists drop `content`. Opt-in to inflation with `?with_description=true` or `?with_content=true`.
+
+Worked example, end to end:
+
+```bash
+# 1. Discover.
+curl -s http://127.0.0.1:5320/schema/issue.add | jq .examples[0]
+
+# 2. Compose & rehearse.
+#    WHY ?dry_run=true: prove the payload validates and the projected
+#    issue looks right before we touch the DB.
+curl -s -X POST 'http://127.0.0.1:5320/repos/MINI/issues?dry_run=true' \
+  -H 'Content-Type: application/json' \
+  -H 'X-Actor: agent-claude' \
+  -d '{
+    "title": "Pin tab strip",
+    "feature_slug": "tui-polish",
+    "description": "Body height should clip the tab strip.",
+    "tags": ["ui","tui"]
+  }'
+
+# 3. Commit (drop dry_run).
+curl -s -X POST http://127.0.0.1:5320/repos/MINI/issues \
+  -H 'Content-Type: application/json' \
+  -H 'X-Actor: agent-claude' \
+  -d '{ ...same payload... }'
+```
+
+### Endpoints
+
+`{prefix}` is the 4-char repo prefix uppercased (`MINI`). `{key}` is the canonical `PREFIX-N` issue key (`MINI-42`) — the bare-number CLI shortcut is not accepted here. `{slug}` is the kebab-case feature slug. `{filename}` is the document filename. All bodies and responses are `application/json` except `GET /documents/{filename}/download`. Mutating endpoints accept `?dry_run=true|1` or `X-Dry-Run: 1|true`.
+
+#### Meta
+
+| Method | Path | Body | Success | Audit op |
+|---|---|---|---|---|
+| `GET` | `/healthz` | — | 200 `{ok,version}` | — |
+| `GET` | `/schema` | — | 200 — every schema, keyed by name | — |
+| `GET` | `/schema/list` | — | 200 — name + one-line summary | — |
+| `GET` | `/schema/{name}` | — | 200 — single schema with `examples[0]` | — |
+
+#### Repos
+
+| Method | Path | Body | Success | Audit op |
+|---|---|---|---|---|
+| `GET` | `/repos` | — | 200 array | — |
+| `POST` | `/repos` | `{prefix?, name, path, remote_url?}` | 201 repo | `repo.create` |
+| `GET` | `/repos/{prefix}` | — | 200 repo | — |
+
+`POST /repos` is the explicit equivalent of `mk init`. The CLI's auto-create-on-first-use only works because it can read CWD; over HTTP you have to spell out `name` and `path`. `prefix` is optional — the server allocates from `name` if omitted, same as the CLI.
+
+#### Features
+
+| Method | Path | Body | Success | Audit op |
+|---|---|---|---|---|
+| `GET` | `/repos/{prefix}/features` | — (`?with_description`) | 200 array | — |
+| `POST` | `/repos/{prefix}/features` | `FeatureAddInput` | 201 feature | `feature.create` |
+| `GET` | `/repos/{prefix}/features/{slug}` | — | 200 view (issues + linked docs) | — |
+| `PATCH` | `/repos/{prefix}/features/{slug}` | `FeatureEditInput` | 200 feature | `feature.update` |
+| `DELETE` | `/repos/{prefix}/features/{slug}` | — | 204 (200 dry-run preview) | `feature.delete` |
+| `GET` | `/repos/{prefix}/features/{slug}/plan` | — | 200 plan | — |
+| `GET` | `/repos/{prefix}/features/{slug}/next` | — | 200 `{issue}` (peek) | — |
+| `POST` | `/repos/{prefix}/features/{slug}/next` | — (requires `X-Actor`) | 200 `{issue}` (claim) | `issue.claim` |
+
+#### Issues
+
+| Method | Path | Body | Success | Audit op |
+|---|---|---|---|---|
+| `GET` | `/repos/{prefix}/issues` | — (`?state`,`?feature`,`?tag`,`?with_description`) | 200 array | — |
+| `POST` | `/repos/{prefix}/issues` | `IssueAddInput` | 201 issue | `issue.create` |
+| `GET` | `/repos/{prefix}/issues/{key}` | — | 200 view (comments + relations + PRs + docs) | — |
+| `GET` | `/repos/{prefix}/issues/{key}/brief` | — (`?no_feature_docs`,`?no_comments`,`?no_doc_content`) | 200 brief | — |
+| `PATCH` | `/repos/{prefix}/issues/{key}` | `IssueEditInput` | 200 issue | `issue.update` |
+| `DELETE` | `/repos/{prefix}/issues/{key}` | — | 204 (200 dry-run preview) | `issue.delete` |
+| `PUT` | `/repos/{prefix}/issues/{key}/state` | `{state}` | 200 issue | `issue.state` |
+| `PUT` | `/repos/{prefix}/issues/{key}/assignee` | `{assignee}` | 200 issue | `issue.assign` |
+| `DELETE` | `/repos/{prefix}/issues/{key}/assignee` | — | 200 issue (no-op when already clear) | `issue.assign` |
+
+#### Comments
+
+| Method | Path | Body | Success | Audit op |
+|---|---|---|---|---|
+| `GET` | `/repos/{prefix}/issues/{key}/comments` | — | 200 array | — |
+| `POST` | `/repos/{prefix}/issues/{key}/comments` | `CommentAddInput` (`{author, body}`) | 201 comment | `comment.add` |
+
+#### Relations
+
+| Method | Path | Body | Success | Audit op |
+|---|---|---|---|---|
+| `POST` | `/repos/{prefix}/relations` | `{from, type, to}` (canonical keys) | 201 relation | `relation.create` |
+| `DELETE` | `/repos/{prefix}/relations` | `{a, b}` | 204 (200 dry-run preview) | `relation.delete` |
+
+`type` is one of `blocks`, `relates-to` (alias `relates`), `duplicate-of` (alias `duplicates`).
+
+#### Pull requests
+
+| Method | Path | Body | Success | Audit op |
+|---|---|---|---|---|
+| `GET` | `/repos/{prefix}/issues/{key}/pull-requests` | — | 200 array | — |
+| `POST` | `/repos/{prefix}/issues/{key}/pull-requests` | `{url}` | 201 pr | `pr.attach` |
+| `DELETE` | `/repos/{prefix}/issues/{key}/pull-requests` | `{url}` or `?url=` | 204 (200 dry-run preview) | `pr.detach` |
+
+#### Tags
+
+| Method | Path | Body | Success | Audit op |
+|---|---|---|---|---|
+| `POST` | `/repos/{prefix}/issues/{key}/tags` | `{tags:[...]}` | 200 issue | `tag.add` |
+| `DELETE` | `/repos/{prefix}/issues/{key}/tags` | `{tags:[...]}` | 200 issue | `tag.remove` |
+
+#### Documents
+
+| Method | Path | Body | Success | Audit op |
+|---|---|---|---|---|
+| `GET` | `/repos/{prefix}/documents` | — (`?type`, `?with_content`) | 200 array | — |
+| `POST` | `/repos/{prefix}/documents` | `DocAddInput` | 201 document | `document.create` |
+| `GET` | `/repos/{prefix}/documents/{filename}` | — (`?with_content=false` to drop body) | 200 view (doc + links) | — |
+| `PUT` | `/repos/{prefix}/documents/{filename}` | `DocAddInput` (filename in URL wins) | 200 document | `document.create` or `document.update` |
+| `PATCH` | `/repos/{prefix}/documents/{filename}` | `DocEditInput` | 200 document | `document.update` |
+| `DELETE` | `/repos/{prefix}/documents/{filename}` | — | 204 (200 dry-run preview with cascade) | `document.delete` |
+| `GET` | `/repos/{prefix}/documents/{filename}/download` | — | 200 `text/markdown` body, `Content-Disposition: attachment` | — |
+| `POST` | `/repos/{prefix}/documents/{filename}/rename` | `{new_filename, type?}` | 200 document | `document.rename` |
+| `POST` | `/repos/{prefix}/documents/{filename}/links` | `{issue_key OR feature_slug, description?}` | 201 link | `document.link` |
+| `DELETE` | `/repos/{prefix}/documents/{filename}/links` | `{issue_key OR feature_slug}` | 204 (200 dry-run preview) | `document.unlink` |
+
+#### History
+
+| Method | Path | Body | Success | Audit op |
+|---|---|---|---|---|
+| `GET` | `/history` | — | 200 array (every repo) | — |
+| `GET` | `/repos/{prefix}/history` | — | 200 array (single repo) | — |
+
+Filters mirror the CLI: `?limit=` (default 50, 0 = no cap), `?offset=`, `?op=`, `?kind=`, `?actor=` (alias `?user_filter=`), `?since=`, `?from=`, `?to=`, `?oldest_first=true`. `since` and `from` are mutually exclusive. Bare-date stamps are local-timezone; RFC 3339 stamps are honoured as written. Reads are not audited.
+
+### Authentication
+
+When the server is started with `--token T` (or `MK_API_TOKEN=T`), every request except `GET /healthz` MUST send `Authorization: Bearer T`. Missing or wrong token → `401 unauthorized`. The token is compared with `subtle.ConstantTimeCompare`.
+
+When no token is configured, requests are accepted without an `Authorization` header — the loopback default address (`127.0.0.1:5320`) is the trust boundary. There is no per-user auth; one token serves every caller.
+
+### Actor identity
+
+```
+X-Actor: agent-claude
+```
+
+Every mutating endpoint stamps the audit row with the value from `X-Actor`. When the header is absent, the actor falls back to the literal string `"api"` (NOT the OS user the server runs as). The header is validated by `store.ValidateActor` once per request — control characters or overlength values fail with `400 invalid_input`.
+
+`POST /repos/{prefix}/features/{slug}/next` is the one endpoint where `X-Actor` is **required**: claiming work demands a real assignee, so the server returns `400 invalid_input` with `details.field=X-Actor` if it's missing.
+
+### Dry-run
+
+```
+?dry_run=true        # query parameter
+?dry_run=1           # also accepted
+X-Dry-Run: true      # header form (use whichever your client makes easier)
+X-Dry-Run: 1
+```
+
+Every mutating endpoint accepts dry-run. The response status matches what a real call would return (e.g. `201 Created` on `POST /issues?dry_run=true`), the body is the projected entity in the same shape, the response carries `X-Dry-Run: applied`, no row is written, no history entry is recorded. Server-time fields (`id`, `created_at`, `updated_at`) come back zero, same as the CLI's `--dry-run`. Destructive endpoints (`DELETE`) return a `*DeletePreview` carrying cascade counts.
+
+### Errors
+
+Every error response is a single envelope:
+
+```json
+{
+  "error": "title is required",
+  "code": "invalid_input",
+  "details": {"field": "title"}
+}
+```
+
+| Status | Code | When |
+|---|---|---|
+| 400 | `invalid_input` | malformed JSON, unknown fields (strict decode), validator failure, missing required `X-Actor` on claim |
+| 401 | `unauthorized` | `--token` configured and bearer is missing/wrong |
+| 404 | `not_found` | path resolves no such repo / feature / issue / document |
+| 409 | `conflict` | duplicate slug, duplicate prefix, duplicate PR attachment, document already exists |
+| 413 | `payload_too_large` | request body exceeds the 4 MiB cap |
+| 500 | `internal` | bug — server-side panic was caught by the recovery middleware |
+
+`details` is optional and field-specific. Most validation errors include `details.field` pointing at the offending payload key.
+
+### Lean lists
+
+Same defaults as the CLI. List endpoints strip heavy fields by default; use these flags to inflate when you really need bodies:
+
+- `GET /repos/{prefix}/issues?with_description=true|1` — inline `description` per row.
+- `GET /repos/{prefix}/features?with_description=true|1` — same.
+- `GET /repos/{prefix}/documents?with_content=true|1` — inline `content` per row.
+- `GET /repos/{prefix}/documents/{filename}?with_content=false|0` — opposite direction: skip the body when fetching one doc by name.
+
+`GET /repos/{prefix}/issues/{key}/brief` is the one bulk-context endpoint that *does* inline doc bodies on purpose. Use the three opt-out filters when the full payload is too large:
+
+- `?no_feature_docs=1` — skip docs linked to the parent feature.
+- `?no_comments=1` — skip the comments section.
+- `?no_doc_content=1` — keep linked-doc metadata but drop the bodies.
+
+### Special endpoints
+
+- `GET /repos/{prefix}/issues/{key}/brief` — the agent's bulk-context single-fetch. Returns `{issue, feature?, relations, pull_requests, documents, comments, warnings}` in one call, with linked-doc bodies inlined. Replaces the `show` + per-doc-fetch dance. Always JSON.
+- `POST /repos/{prefix}/features/{slug}/next` — atomic claim. **Requires `X-Actor`.** Picks the lowest-numbered todo issue in the feature with all blockers resolved and no existing assignee, flips it to `in_progress`, and stamps the assignee with the actor. Returns `{"issue": null}` (status 200) when nothing is currently claimable — poll/retry rather than treating that as an error. Records `issue.claim`.
+- `GET /repos/{prefix}/features/{slug}/next` — read-only peek. Same response shape as the claim, no mutation, no audit row. Use this to inspect what the next claim *would* return before committing.
+- `GET /repos/{prefix}/documents/{filename}/download` — the only non-JSON endpoint. Streams the doc body as `text/markdown; charset=utf-8` with `Content-Disposition: attachment; filename="<name>"`. No audit row, no `?dry_run`, no `with_content`. This replaces the CLI's `mk doc export --to-path`: the API never reads or writes the server filesystem, so callers materialise on disk by piping the response body themselves (e.g. `curl -O`).
+
+### CLI verbs that have no API equivalent
+
+Some CLI verbs touch the developer's local filesystem or terminal. They stay local-only and have no HTTP analogue:
+
+- **`mk init`** — auto-detects the repo from CWD by walking up to a `.git` toplevel. The API can't see your working tree; use `POST /repos` with explicit `{name, path}`.
+- **`mk install-skill`** — writes `.claude/skills/mk/SKILL.md` into the local repo. No remote sense.
+- **`mk doc add --from-path` / `--content-file`** — read a file off the server's disk. Over HTTP, put the body in the request `content` field directly (it's just a JSON string, multi-line is fine).
+- **`mk doc export --to-path` / `--to`** — write a file onto the server's disk. Over HTTP, use `GET /documents/{filename}/download` and let the client save the response stream.
+- **`mk tui`** — full-screen terminal UI. Same DB; no point exposing it over HTTP.
+
+The `mk schema*` commands have HTTP equivalents (`GET /schema*`) but the registry is identical, so a CLI agent can keep using either.
+
+### Worked examples
+
+**1. Create a repo and a first issue.**
+
+```bash
+# WHY: the API can't auto-detect a repo from CWD, so we register it explicitly.
+curl -s -X POST http://127.0.0.1:5320/repos \
+  -H 'Content-Type: application/json' \
+  -H 'X-Actor: agent-claude' \
+  -d '{"prefix":"MINI","name":"mini-kanban","path":"/home/me/Repos/mini-kanban"}'
+
+# WHY: file the first ticket. Strict decode means a typo in `tilte` returns 400.
+curl -s -X POST http://127.0.0.1:5320/repos/MINI/issues \
+  -H 'Content-Type: application/json' \
+  -H 'X-Actor: agent-claude' \
+  -d '{"title":"First ticket","state":"todo","tags":["bootstrap"]}'
+```
+
+**2. Agent claim loop.**
+
+```bash
+# WHY: claim → work → mark done. Each iteration writes an audit row stamped
+#      with X-Actor=agent-x, so the audit log shows exactly which agent did
+#      what. Returns {"issue": null} when nothing is claimable; sleep+retry.
+while :; do
+  resp=$(curl -s -X POST \
+    "http://127.0.0.1:5320/repos/MINI/features/auth-rewrite/next" \
+    -H 'X-Actor: agent-x')
+  key=$(jq -r '.issue.key // empty' <<<"$resp")
+  if [ -z "$key" ]; then sleep 30; continue; fi
+
+  # ... agent does the work, opens a PR, etc ...
+
+  # WHY: PUT /issues/{key}/state replaces the state. Body shape published at
+  #      /schema/issue.state — strict decode rejects extras.
+  curl -s -X PUT "http://127.0.0.1:5320/repos/MINI/issues/$key/state" \
+    -H 'Content-Type: application/json' \
+    -H 'X-Actor: agent-x' \
+    -d '{"state":"done"}'
+done
+```
+
+**3. Bulk-context fetch for an LLM prompt.**
+
+```bash
+# WHY: one read returns the issue, parent feature, all linked docs (with
+#      bodies inlined), comments, relations, and PRs. Drop --no-doc-content
+#      if the docs themselves are too large for context.
+curl -s "http://127.0.0.1:5320/repos/MINI/issues/MINI-42/brief?no_doc_content=1" \
+  -H 'X-Actor: reader' \
+  | jq .
+```
+
+### What the API deliberately doesn't do
+
+Same posture as the CLI's "what we deliberately don't do" — these came up during design and were rejected for v1. New consumers shouldn't expect them.
+
+- **No NDJSON / streaming / WebSockets.** Largest realistic response is one `issue brief`. Streaming complexity isn't justified.
+- **No per-user auth or sessions.** One shared bearer token. This is a local helper, not a SaaS.
+- **No remote `from-path` / `to-path` doc commands.** The API never reads or writes the server filesystem. Inline content in the body; pipe `/download` to disk.
+- **No metrics / Prometheus endpoint.** `/healthz` is the only non-resource endpoint.
+- **No CORS, no TLS termination, no rate limiting.** Designed for loopback and trusted LAN.
+- **No cursor pagination.** History uses `?limit=` + `?offset=`; nothing else paginates yet.
+
+For the full design rationale, the threat model, and the forward-looking "Phase 6: CLI client mode" sketch, see `docs/rest-api-design.md`.
+
+## CLI client mode (`--remote` / `MK_REMOTE`)
+
+The same `mk` binary can drive a remote `mk api` server instead of the local SQLite database, so an agent can use the familiar CLI surface against a shared kanban without changing flags or output format. Set one of:
+
+- `--remote http://host:5320` (per-invocation flag), or
+- `MK_REMOTE=http://host:5320` (env, persists across the shell), and
+- `--token <secret>` / `MK_API_TOKEN=<secret>` if the server enforces auth.
+
+```bash
+MK_REMOTE=http://team-mk:5320 MK_API_TOKEN=$T mk issue list -o json
+mk --remote http://team-mk:5320 issue add "Login broken" --feature auth
+```
+
+In remote mode every read and mutating verb above behaves exactly as it does locally — same flags, same JSON output, same `--dry-run` semantics, same `--user` actor. The client transparently translates each verb into the corresponding HTTP route from the table above. Audit rows are written by the API server, not the client.
+
+Verbs that touch the developer's local filesystem stay local-only and error clearly when `MK_REMOTE` is set:
+
+- `mk init` — auto-detects CWD; use `POST /repos` (or run `mk init` against the local DB) instead.
+- `mk install-skill` — writes `.claude/skills/mk/SKILL.md` locally.
+- `mk doc add --from-path` / `mk doc upsert --from-path` — read from the client filesystem; pass `--content`/`--content-file` instead.
+- `mk doc export` (`--to-path` and `--to`) — writes to the client filesystem; use `mk doc download <filename>` (writes to stdout, or `--to <path>`) to get the body locally over HTTP.
+- `mk tui` — opens the local DB directly.
+
+`mk schema *` and `mk status` also stay local-direct (no remote endpoint exists in v1; the registry / stats are local concerns).
+
 ## Gotchas
 
 - **Never run `mk` outside a git repo** when a command needs the current repo — it hard-errors with "not inside a git repository". `cd` first.
-- **Comment author is required.** Forgetting `--as <name>` is the most common mistake.
-- **Long text via files only.** `mk issue add "Fix" --description "two\nlines"` does not interpret `\n`. Use `--description -` with a heredoc, or `--description-file`.
-- **State values** can be written as `in-progress`, `in progress`, or `in_progress` — but parsing is case-sensitive on the lowercase form.
+- **Comment author is required.** On the JSON path the field is `author`; on the flag path it's `--as <name>`. Forgetting it is the most common mistake.
+- **`--user` is required for agents.** It controls the actor field in the audit log; without it every action looks like the OS user. The flag is permissive (no rejection if omitted) so this is on you to pass consistently.
+- **Long text in JSON is just a string.** `description`, `body`, `content` etc. take inline strings — no `\n` translation magic, JSON's own `\n` escapes work as expected. The flag path's `--description-file` is unnecessary here.
+- **Issue keys in JSON must be canonical** (`MINI-42`). The bare-number shortcut (`42`) is for humans on the flag path; agents driving JSON should always pass the prefix.
+- **Mixing `--json` with positionals/flags is rejected.** Choose one mode per call.
+- **State values** accept `in-progress`, `in progress`, or `in_progress` — but parsing is case-sensitive on the lowercase form.
 - **Auto-created prefix can collide.** If two repos share a basename, `mk init` allocates `XXX2`, `XXX3`, etc. Use `mk repo list` to confirm what was assigned.
 - **Issue numbers never repeat.** Deleting `MINI-3` does not free up the number — the next issue is still `MINI-4`.
 - **JSON output is the contract.** When parsing programmatically, always pass `-o json`. Text output is for humans and may shift.

--- a/.claude/skills/plan-to-mk/SKILL.md
+++ b/.claude/skills/plan-to-mk/SKILL.md
@@ -478,7 +478,7 @@ When the final phase ships and the user moves the file from `docs/planning/not-s
 ```bash
 jq -nc --arg from "docs-planning-not-shipped-<slug>-plan.md" \
        --arg to "docs-planning-shipped-<slug>-plan.md" \
-       '{filename:$from, new_filename:$to, type:"project_complete"}' \
+       '{old_filename:$from, new_filename:$to, type:"project_complete"}' \
   | mk doc rename --user <them> --json -
 ```
 

--- a/.claude/skills/plan-to-mk/SKILL.md
+++ b/.claude/skills/plan-to-mk/SKILL.md
@@ -63,9 +63,10 @@ The repo prefix should be `MINI`. If it's anything else, stop and tell the user 
 
 Bake these into every `mk` invocation throughout the rest of this skill:
 
-- Pass `--user Claude` on every mutating command (`feature add`, `feature edit`, `issue add`, `issue edit`, `issue state`, `comment add`, `link`, `unlink`, `tag add`, `tag rm`, `pr attach`). The audit log uses this attribution; without it everything attributes to the OS user.
+- Pass `--user Claude` on every mutating command (`feature add`, `feature edit`, `issue add`, `issue edit`, `issue state`, `comment add`, `link`, `unlink`, `tag add`, `tag rm`, `pr attach`, `doc upsert`, `doc link`, `doc rename`). The audit log uses this attribution; without it everything attributes to the OS user.
 - Pass `-o json` on every read you parse (`feature list`, `feature show`, `issue list`, `issue show`, `comment list`, `pr list`).
-- Pass `--as Claude` on every `mk comment add` (it's required by the CLI and identifies the comment author).
+- **Drive mutations via `--json` payloads** (the agent-preferred surface — strict-decoded, dry-runnable, schema discoverable via `mk schema show <command>`). The JSON payload's `author` field replaces the flag-form `--as Claude` on `mk comment add`. For multi-line text bodies (issue descriptions, comment bodies, design ticket bodies), bridge a temp file into the JSON payload via `jq -n --rawfile body /tmp/foo.md '{...}' | mk ... --json -` so the markdown stays out of inline-JSON escape soup. The exception is `mk doc upsert --from-path <path>`, which derives filename + reads content from disk in one shot and uses flag form (the JSON path doesn't have a path-derivation equivalent).
+- **Rehearse destructive ops with `--dry-run`.** Every mutating command accepts a global `--dry-run` flag — input validation runs, the projected result prints, but no row is written and no audit entry is recorded. Especially useful in Phase 9 update mode before `mk unlink` (which removes *every* relation between two issues, not just the one you wanted) and before any update-mode pass that overwrites a large issue body.
 
 State names are fixed — `backlog | todo | in_progress | in_review | done | cancelled | duplicate`. There is no per-project status vocabulary to fetch.
 
@@ -421,7 +422,7 @@ Don't proceed without an explicit yes. Never guess "looks good, going" — the s
 
 Create the mk feature with the title from H1 and a description that **starts** with the `Plan:` line. This serves as a machine-readable anchor for `execute-next-task` and a clickable link for humans browsing `mk feature show <slug>`.
 
-Write the feature description to a temp file:
+Write the feature description to a temp file, then bridge into the JSON payload:
 
 ```bash
 cat <<'EOF' > /tmp/mini-feature.md
@@ -430,11 +431,12 @@ Plan: [<relative-path-to-plan-doc.md>](<full-https-url-to-plan-doc-on-main>)
 <§1 Background paragraph 1, copied verbatim>
 EOF
 
-mk feature add "<feature title>" \
-  --slug <kebab-slug> \
-  --description-file /tmp/mini-feature.md \
-  --user Claude \
-  -o json
+jq -n \
+  --arg title "<feature title>" \
+  --arg slug "<kebab-slug>" \
+  --rawfile description /tmp/mini-feature.md \
+  '{title:$title, slug:$slug, description:$description}' \
+  | mk feature add --user Claude --json - -o json
 ```
 
 Examples:
@@ -452,7 +454,7 @@ Capture the feature's slug from the response — you'll need it for Phase 8 (eve
 
 *Runs in **both** modes.* The on-disk plan markdown is the source of truth for humans. mk's `doc` subsystem stores a synchronised copy that downstream skills (`execute-next-task`, `address-review`, `review`) can fetch with a single `mk doc show <name> --raw` call instead of having to know which branch the file lives on or where on disk to look. Re-running `plan-to-mk` re-syncs the content.
 
-Use `mk doc upsert --from-path` — it derives the filename and the type from the path in one shot:
+Use `mk doc upsert --from-path` — it derives the filename and the type from the path in one shot. Keep flag form for the upsert (the JSON path has no path-derivation equivalent); the link call goes through `--json` for strict decoding:
 
 | On-disk path | mk doc filename | derived type |
 |---|---|---|
@@ -461,21 +463,23 @@ Use `mk doc upsert --from-path` — it derives the filename and the type from th
 
 ```bash
 mk doc upsert --from-path docs/planning/not-shipped/<slug>-plan.md --user Claude
-mk doc link  docs-planning-not-shipped-<slug>-plan.md <feature-slug> \
-  --why "Plan doc — phased rollout reference for this feature" \
-  --user Claude
+
+jq -nc --arg filename "docs-planning-not-shipped-<slug>-plan.md" \
+       --arg slug "<feature-slug>" \
+       --arg why "Plan doc — phased rollout reference for this feature" \
+       '{filename:$filename, feature_slug:$slug, description:$why}' \
+  | mk doc link --user Claude --json -
 ```
 
-`upsert` creates on first run, edits on every subsequent run — no probe-then-branch shell dance. `mk doc link` is an upsert too — calling it on an already-linked pair just refreshes `--why`, so it's safe to run on every re-sync.
+`upsert` creates on first run, edits on every subsequent run — no probe-then-branch shell dance. `mk doc link` is an upsert too — calling it on an already-linked pair just refreshes the description, so it's safe to run on every re-sync.
 
 When the final phase ships and the user moves the file from `docs/planning/not-shipped/` to `docs/planning/shipped/`, that's a single `mk doc rename` outside this skill — links survive:
 
 ```bash
-mk doc rename \
-  docs-planning-not-shipped-<slug>-plan.md \
-  docs-planning-shipped-<slug>-plan.md \
-  --type project_complete \
-  --user <them>
+jq -nc --arg from "docs-planning-not-shipped-<slug>-plan.md" \
+       --arg to "docs-planning-shipped-<slug>-plan.md" \
+       '{filename:$from, new_filename:$to, type:"project_complete"}' \
+  | mk doc rename --user <them> --json -
 ```
 
 This skill doesn't try to detect the move — re-running `plan-to-mk` after the file has moved would `upsert` the new-named doc against the existing feature, which is the same outcome.
@@ -628,12 +632,13 @@ If none of the recipes match, the populator emits `<no recipe — confirm with u
 Then create the issue:
 
 ```bash
-mk issue add "Phase N: <title>" \
-  --feature <slug> \
-  --state <todo|backlog> \
-  --description-file /tmp/mini-issue-phase-N.md \
-  --user Claude \
-  -o json
+jq -n \
+  --arg title "Phase N: <title>" \
+  --arg slug "<slug>" \
+  --arg state "<todo|backlog>" \
+  --rawfile description /tmp/mini-issue-phase-N.md \
+  '{title:$title, feature_slug:$slug, state:$state, description:$description}' \
+  | mk issue add --user Claude --json - -o json
 ```
 
 Capture each issue's key (`MINI-NN`) from the JSON response.
@@ -681,13 +686,12 @@ and any new design tokens merged into the design system.
 Create the design ticket:
 
 ```bash
-mk issue add "Design: Phase N: <title>" \
-  --feature <slug> \
-  --state backlog \
-  --tag design \
-  --description-file /tmp/mini-design-phase-N.md \
-  --user Claude \
-  -o json
+jq -n \
+  --arg title "Design: Phase N: <title>" \
+  --arg slug "<slug>" \
+  --rawfile description /tmp/mini-design-phase-N.md \
+  '{title:$title, feature_slug:$slug, state:"backlog", description:$description, tags:["design"]}' \
+  | mk issue add --user Claude --json - -o json
 ```
 
 Capture the design ticket's MINI-NN — Phase 9 uses it as a `blocks` and `relates-to` edge against the impl ticket.
@@ -704,14 +708,22 @@ For each matched issue:
 
 1. **Render the new body** using exactly the same template shape as create mode above (Source / Goal / Deliverables / Reversibility / UI changes / Done when / Verify in prod / extra subsections / Relevant docs / **Source-code touchpoints** / **Shared-library opportunities** / Workflow / Smoke tests / Conventions / Prior art). Re-derive doc pointers from Phase 3 against the current plan and current repo state — touched paths may have shifted. Re-derive touchpoints + shared-lib opportunities from Phase 3.5 against the current repo state — files renamed since seeding will not be reflected in the old body, and new shared-lib precedents may have appeared.
 2. **Compare titles.** If the plan's `### Phase N — <title>` (minus em-dash) differs from the existing issue title, update the title too. Match shape: `Phase N: <title>`.
-3. **Edit the issue.** Write the body to a temp file and run:
+3. **Edit the issue.** Write the body to a temp file, then bridge it through `--json`. Build the payload with the title only when it actually changed (omitting a field on edit means "no change"; an empty string would clear it where the model allows):
    ```bash
-   mk issue edit <KEY> \
-     [--title "Phase N: <new title>"] \
-     --description-file /tmp/mini-issue-phase-N.md \
-     --user Claude
+   # Title unchanged — omit the field; only refresh the body:
+   jq -n --arg key "<KEY>" \
+        --rawfile description /tmp/mini-issue-phase-N.md \
+        '{key:$key, description:$description}' \
+     | mk issue edit --user Claude --json -
+
+   # Title changed — include it:
+   jq -n --arg key "<KEY>" \
+        --arg title "Phase N: <new title>" \
+        --rawfile description /tmp/mini-issue-phase-N.md \
+        '{key:$key, title:$title, description:$description}' \
+     | mk issue edit --user Claude --json -
    ```
-   The `mk issue edit` command only touches the fields you pass — state, tags, comments, and PR attachments are preserved automatically. Don't pass `--state`. Don't touch tags here.
+   `mk issue edit` only touches the fields you pass — state, tags, comments, and PR attachments are preserved automatically. Don't include `state`. Don't touch tags here. Strict-decode means a typo (e.g. `decsription`) returns `unknown field "decsription"` instead of silently no-op-ing the edit.
 4. **Do not delete or alter existing comments.** All retros, handoff notes, and manual comments survive untouched.
 
 For phases newly added to the plan since seeding (detected in Phase 5 update-mode pre-flight, step 3 case "Plan has more phases than feature"), create the issue using the create-mode template above with state `todo` (or `backlog` if optional/deferred). Append the new MINI-NN line to §8 in Phase 10.
@@ -727,12 +739,12 @@ After refreshing each impl ticket, reconcile its paired design ticket against th
 2. **Reconcile against current `[design needed]` items:**
    | Plan has items? | Design ticket exists? | Action |
    |---|---|---|
-   | yes | yes | Refresh design body (regenerate `## Design needed` from the current verbatim items; preserve `## Source` and `## Done when`). Use `mk issue edit <KEY> --description-file <path> --user Claude`. |
+   | yes | yes | Refresh design body (regenerate `## Design needed` from the current verbatim items; preserve `## Source` and `## Done when`). Use the same `mk issue edit … --json -` shape from the impl-ticket refresh above (build the payload with `jq -n --arg key … --rawfile description …`). |
    | yes | no | Create the design ticket fresh (same template as Phase 8.1 create mode); add the design→impl `blocks` edge and the design↔impl `relates-to` edge in Phase 9. |
    | no | yes | **Leave alone.** Surface as orphan in the Phase 11 report. Designers may still be working on it; auto-delete is never the right call. |
    | no | no | No-op. |
 
-3. **State preservation** — same rules as impl tickets. Pass only `--description-file` and (if changed) `--title` to `mk issue edit`. State, tags, and comments survive untouched.
+3. **State preservation** — same rules as impl tickets. The JSON payload includes only `description` and (if changed) `title`; do not include `state`, do not include `tags`. `mk issue edit` only touches the fields you pass — state, tags, comments, and PR attachments are preserved automatically.
 
 Capture, for the Phase 11 report:
 
@@ -750,8 +762,8 @@ Capture, for the Phase 11 report:
 
 Use the dependency graph you parsed in Phase 2, plus the design pairings from Phase 8.1, to compute the **desired** set of relationship edges. There are two relation types in play, and they answer different questions:
 
-- **`blocks`** — hard ordering constraint. The impl ticket cannot start until its blockers are `done`. This is what the `execute-next-task` picker reads (via the inverse `blocked_by` view that `mk issue show` surfaces). Created with `mk link <FROM> blocks <TO> --user Claude`.
-- **`relates-to`** — soft "these belong together" link. Doesn't gate work; just makes the connection visible in both issues. Designers viewing a design ticket immediately see *which impl ticket consumes this design*, even after the design has shipped (and the `blocks` edge has resolved because the design is `done`). Created with `mk link <FROM> relates-to <TO> --user Claude`.
+- **`blocks`** — hard ordering constraint. The impl ticket cannot start until its blockers are `done`. This is what the `execute-next-task` picker reads (via the inverse `blocked_by` view that `mk issue show` surfaces). Created with `mk link --user Claude --json '{"from":"<FROM>","type":"blocks","to":"<TO>"}'`.
+- **`relates-to`** — soft "these belong together" link. Doesn't gate work; just makes the connection visible in both issues. Designers viewing a design ticket immediately see *which impl ticket consumes this design*, even after the design has shipped (and the `blocks` edge has resolved because the design is `done`). Created with `mk link --user Claude --json '{"from":"<FROM>","type":"relates-to","to":"<TO>"}'`.
 
 (`mk` also supports `duplicate-of`, but this skill never produces those — that's a manual reconciliation tool.)
 
@@ -768,7 +780,7 @@ Design tickets themselves have **no incoming `blocks` edges** — designers can 
 
 ### Create mode
 
-Add the desired edges in order via `mk link <FROM> <type> <TO> --user Claude`. There's nothing to compare against — the issues were just created and have no relationships yet. The design→impl `blocks` edges and the design→impl `relates-to` edges are added in the same pass alongside the inter-phase edges.
+Add the desired edges in order via `mk link --user Claude --json '{"from":"<FROM>","type":"<type>","to":"<TO>"}'`. There's nothing to compare against — the issues were just created and have no relationships yet. The design→impl `blocks` edges and the design→impl `relates-to` edges are added in the same pass alongside the inter-phase edges.
 
 ### Update mode
 
@@ -779,8 +791,8 @@ Existing edges may not match the desired graph — §8 brackets may have changed
    - desired `blocks` set per impl ticket (inter-phase from §8 ∪ design pairing)
    - desired `relates-to` set per design↔impl pair from Phase 8.1
 3. **Apply the delta** independently per relation type:
-   - **Add** edges that are desired but missing (`mk link <FROM> <type> <TO> --user Claude`).
-   - **Remove** `blocks` edges that exist but are no longer desired (e.g. §8 brackets changed). Use `mk unlink <A> <B> --user Claude` — note that `mk unlink` removes *every* relation between the two issues, so if there's also a `relates-to` edge between the same pair you want to keep, re-add it after unlinking.
+   - **Add** edges that are desired but missing: `mk link --user Claude --json '{"from":"<FROM>","type":"<type>","to":"<TO>"}'`.
+   - **Remove** `blocks` edges that exist but are no longer desired (e.g. §8 brackets changed). Use `mk unlink --user Claude --json '{"a":"<A>","b":"<B>"}'` — note that `mk unlink` removes *every* relation between the two issues, so if there's also a `relates-to` edge between the same pair you want to keep, re-add it after unlinking. **Rehearse with `--dry-run` first** when the §8 bracket diff is non-trivial: `... --dry-run --json '{"a":"<A>","b":"<B>"}'` prints the projected removals (and counts) without writing, so a misread of the desired graph doesn't quietly drop edges you still wanted.
    - For `relates-to` edges: **add** when missing, **never remove**. The `relates-to` link is cheap to keep around even if the impl ticket gets repurposed; deleting it costs context for designers, and the user can manually `mk unlink` if they truly want to.
    - **Leave alone** edges that are correct.
 4. **Cross-feature edges** (issues in this feature blocked by issues in *other* features) are out of scope for this skill — leave them untouched even if §8 makes no mention of them. They were added deliberately; we won't second-guess. Same rule for cross-feature `relates-to` edges — humans add those; the skill doesn't touch them.
@@ -875,8 +887,9 @@ Next step: <if §8 changed, "review and commit the plan-doc diff"; if orphans fl
 
 ### Both modes
 
-- **Always pass `--user Claude`** on every mutating `mk` command (`feature add`, `feature edit`, `issue add`, `issue edit`, `issue state`, `comment add`, `link`, `unlink`, `tag add`, `tag rm`, `pr attach`). The audit log requires it; without it actions attribute to the OS user.
+- **Always pass `--user Claude`** on every mutating `mk` command (`feature add`, `feature edit`, `issue add`, `issue edit`, `issue state`, `comment add`, `link`, `unlink`, `tag add`, `tag rm`, `pr attach`, `doc upsert`, `doc link`, `doc rename`). The audit log requires it; without it actions attribute to the OS user. On `mk comment add` JSON payloads the comment author is the `author` field (replaces the flag-form `--as Claude`).
 - **Always pass `-o json`** on reads you parse (`feature show`, `issue list`, `issue show`, etc.).
+- **Prefer `--json` payloads on mutations** over per-field flags. Strict-decoded (typos like `decsription` surface as `unknown field` errors instead of silent no-ops on edits — important when this skill is bulk-overwriting bodies in update mode), schema discoverable via `mk schema show <command>`, dry-runnable. Carve out one exception: `mk doc upsert --from-path <path>` keeps flag form because it derives the filename + reads file content in one shot, which the JSON path can't replicate.
 - **Always `cd` to the repo root before running `mk`.** mk auto-scopes by cwd's git toplevel and hard-errors outside any git repo.
 - **Never write a pre-baked implementation plan into the issue description.** Issue descriptions carry *context* — Goal, Deliverables, Reversibility, UI changes, Done when, Verify in prod, doc pointers, source-code touchpoints, shared-library opportunities — not file-by-file change lists. The executor produces its concrete implementation against current code at execution time. The line: **paths + ≤12-word what-for phrases are fine**; concrete edits ("change line 42 to…", "wrap this call in a try/catch") are not.
 - **Touchpoints are best-guess at seed time, not a contract.** The Phase 3.5 explorer produces its best guess from the deliverables; files may have been renamed since seeding, the explorer may have missed something, and the deliverables may evolve. The rendered ticket section explicitly tells the executor to verify each path and add what's missing. Never present touchpoints as exhaustive.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -23,7 +23,7 @@ mk status -o json
 
 This should print the current repo, prefix (expected `MINI`), and counts. If `mk` errors with "not inside a git repository", `cd` to the repo root and retry. If the binary isn't installed, stop and tell the user — without `mk` we can't read the contract or post the deliverable.
 
-All `mk` reads in this skill use `-o json` for stable parsing. All mutations pass `--user Claude` so the audit log attributes the change correctly.
+All `mk` reads in this skill use `-o json` for stable parsing. All mutations go through the `--json` payload form (the agent-preferred surface — strict-decoded, dry-runnable, schema discoverable via `mk schema show <command>`) and pass `--user Claude` so the audit log attributes the change correctly. The JSON payload's `author` field replaces the flag-form `--as Claude` on `mk comment add`.
 
 ---
 
@@ -175,13 +175,16 @@ If you have to debate `medium` vs `low`, default to `low`.
 
 The comment is the deliverable. One comment per review run, posted on the mk issue.
 
-Write the body to a temp file, then post:
+Write the body to a temp file, then bridge it into the JSON payload via `jq -n --rawfile` so the markdown stays out of inline-JSON escape soup:
 
 ```bash
-mk comment add MINI-NN --as Claude --user Claude --body-file /tmp/review-MINI-NN.md
+jq -n \
+  --rawfile body /tmp/review-MINI-NN.md \
+  '{issue_key:"MINI-NN", author:"Claude", body:$body}' \
+  | mk comment add --user Claude --json -
 ```
 
-`--as Claude` is the comment author (mandatory on every `mk comment add`). `--user Claude` is the audit-log actor (mandatory for every agent-driven mutation). `mk comment add` requires the body via `--body-file <path>` or `--body -` from stdin — there's no inline editor, and `--body "two\nlines"` does not interpret `\n`.
+The payload's `author` field is the comment author (replaces flag-form `--as Claude`). `--user Claude` is the audit-log actor (mandatory for every agent-driven mutation). Schema discoverable via `mk schema show comment.add`; rehearse with `--dry-run` if the body is unusually large or contains tricky characters.
 
 Template — omit a section that's empty rather than write "None.":
 
@@ -260,8 +263,9 @@ That's the run.
 - **Don't flag what you didn't read.** If a hunk is too noisy to follow without reading the whole file, read the whole file. Findings based on incomplete reading are worse than findings on a smaller set you actually understood.
 - **Cite file + line, always.** `<file>:<line>` notation; the user copies it straight into their editor. A finding without a path is not actionable.
 - **One comment per run.** Don't post multiple comments for one review. If you re-run after fixes, post a fresh comment — don't edit the previous one.
-- **Always pass `--user Claude` on `mk` mutations and `--as Claude` on `mk comment add`.** Without `--user`, the audit log silently attributes the change to whichever OS user the agent runs under — useless history.
+- **Always pass `--user Claude` on `mk` mutations.** Without it the audit log silently attributes the change to whichever OS user the agent runs under — useless history. On `mk comment add` JSON payloads the comment author is the `author` field (replaces the flag-form `--as Claude`).
 - **Always pass `-o json` when parsing `mk` output.** Text mode is for humans only.
+- **Prefer `--json` payloads on mutations** over per-field flags. Strict-decoded (typos surface as `unknown field` errors), schema discoverable via `mk schema show <command>`, dry-runnable.
 - **Never run `mk` outside a git repo** — it hard-errors. `cd` to the repo first.
 - **Stop on missing inputs.** No mk key, no PR, ambiguous resolution → stop and ask. Don't guess past these.
 - **Never produce an ExitPlanMode block.** This is a review skill; the mk comment is the deliverable.
@@ -274,7 +278,7 @@ That's the run.
 >
 > *Skill runs `mk status -o json` to confirm the binary is wired up and the repo prefix is `MINI`. Resolves: MINI-32 ("Phase 4: pg-az-backup progress + result events"), PR #412, branch `claude/mini-32`. Confirms: "Reviewing MINI-32 — PR #412, branch `claude/mini-32`."*
 >
-> *Phase 3: `mk issue show MINI-32 -o json`. Goal: emit progress + result events for pg-az-backup. Deliverables: three new socket events, task-tracker registry entry, server emitter. `mk comment list MINI-32 -o json` shows no design comment on this ticket — backend-only work. One handoff comment from execute-next-task notes the optional retry-on-transient-failure deliverable was deferred to a follow-up.*
+> *Phase 3: reuses `/tmp/brief-MINI-32.json` from Phase 2 (`mk issue brief MINI-32` — single read covers issue + comments + linked docs). Goal: emit progress + result events for pg-az-backup. Deliverables: three new socket events, task-tracker registry entry, server emitter. `.documents[]` has no design-typed entry on this ticket — backend-only work. One handoff comment in `.comments[]` from execute-next-task notes the optional retry-on-transient-failure deliverable was deferred to a follow-up.*
 >
 > *Phase 4: `gh pr diff 412 > /tmp/review-412.diff`. 7 files changed, mostly under `server/src/services/backup/` plus one update to `client/src/lib/task-type-registry.ts`.*
 >
@@ -285,6 +289,6 @@ That's the run.
 > - **Medium** — `server/src/services/backup/backup-executor.ts:208` — duplicates the step-name normalisation already at `cert-issuance/cert-issuance-executor.ts:412`; should be extracted into `server/src/services/operation-step.ts`.
 > - **Low** — leftover `console.log("emitter wired up")` in `backup-progress-emitter.ts:12`.
 >
-> *Phase 7: writes the comment body to `/tmp/review-MINI-32.md`, then `mk comment add MINI-32 --as Claude --user Claude --body-file /tmp/review-MINI-32.md`. Three sections (High / Medium / Low), closing line "Looks ready to ship after the high finding is addressed."*
+> *Phase 7: writes the comment body to `/tmp/review-MINI-32.md`, then `jq -n --rawfile body /tmp/review-MINI-32.md '{issue_key:"MINI-32",author:"Claude",body:$body}' | mk comment add --user Claude --json -`. Three sections (High / Medium / Low), closing line "Looks ready to ship after the high finding is addressed."*
 >
 > Skill: "Review posted on MINI-32 (3 findings). Breakdown: 0 critical, 1 high, 1 medium, 1 low. Highest-severity: error swallowing in `backup-progress-emitter.ts:47`. Run /review again after fixes land to re-check."

--- a/.claude/skills/session-retrospective/SKILL.md
+++ b/.claude/skills/session-retrospective/SKILL.md
@@ -73,19 +73,22 @@ worthless retro.
 
 6. **Generate the retrospective markdown** per the Output Format below.
 
-7. **Create the retro issue** via `mk issue add`. Write the body to a temp file first
-   (long-text inputs in `mk` come from a file or stdin — there is no inline editor):
+7. **Create the retro issue** via `mk issue add` using the JSON payload form (the
+   agent-preferred surface — strict-decoded, dry-runnable, schema discoverable via
+   `mk schema show issue.add`). Write the body to a temp file first, then bridge it
+   into the JSON payload via `jq -n --rawfile` so the markdown stays out of inline-JSON
+   escape soup:
 
    ```bash
    cat > /tmp/retro-body.md <<'EOF'
    <retrospective markdown body, per Output Format below>
    EOF
 
-   mk issue add "Retro: MINI-NN — <original-issue-title>" \
-     --description-file /tmp/retro-body.md \
-     --state backlog \
-     --tag retro \
-     --user Claude
+   jq -n \
+     --arg title "Retro: MINI-NN — <original-issue-title>" \
+     --rawfile description /tmp/retro-body.md \
+     '{title:$title, state:"backlog", description:$description, tags:["retro"]}' \
+     | mk issue add --user Claude --json - -o json
    ```
 
    - **Title**: `Retro: MINI-NN — <original-issue-title>` (truncate the original title to
@@ -94,26 +97,25 @@ worthless retro.
    - **Tag**: `retro` (free-form; created on first use).
    - **`--user Claude`** is **mandatory** for AI-driven calls — without it the audit log
      silently attributes the change to the OS user.
-   - Capture the new issue key from the command output (use `-o json` if you need to
-     parse it programmatically).
+   - Capture the new issue key from the JSON output (`jq -r .key`).
 
 8. **Link the retro back to the original** so `mk issue show` on either side surfaces the
    relation:
 
    ```bash
-   mk link <NEW-RETRO-KEY> relates-to MINI-NN --user Claude
+   mk link --user Claude --json '{"from":"<NEW-RETRO-KEY>","type":"relates-to","to":"MINI-NN"}'
    ```
 
    Optionally, drop a one-line pointer comment on the original so a human reading just
    that issue can find the retro:
 
    ```bash
-   printf 'Retro filed: <NEW-RETRO-KEY>\n' \
-     | mk comment add MINI-NN --as Claude --body - --user Claude
+   mk comment add --user Claude --json \
+     '{"issue_key":"MINI-NN","author":"Claude","body":"Retro filed: <NEW-RETRO-KEY>"}'
    ```
 
-   `--as` is required on every `mk comment add`; `--user Claude` is the audit-log
-   attribution and is mandatory for agent-driven calls.
+   The `author` field on the JSON payload replaces the flag-form `--as Claude`.
+   `--user Claude` is the audit-log attribution and is mandatory for agent-driven calls.
 
 9. **Return only** the new retro issue's key (e.g. `MINI-83`). Do not echo the markdown
    body — the caller (typically a subagent in `execute-next-task`) just needs the key

--- a/.claude/skills/ship-it/SKILL.md
+++ b/.claude/skills/ship-it/SKILL.md
@@ -120,13 +120,13 @@ If the SHA comes back empty, fall back to whatever `gh pr merge` printed to stde
 
 ## Phase 4 — Transition the issue to `done` and record the merge
 
-Two `mk` calls. Order matters: state transition first (so the board reflects reality immediately), then the comment (so the audit log records the merge alongside the state change).
+Two `mk` calls. Order matters: state transition first (so the board reflects reality immediately), then the comment (so the audit log records the merge alongside the state change). Both use the JSON payload form (the agent-preferred surface — strict-decoded, dry-runnable; schemas at `mk schema show issue.state` and `mk schema show comment.add`):
 
 ```bash
-mk issue state MINI-NN done --user Claude
+mk issue state --user Claude --json '{"key":"MINI-NN","state":"done"}'
 ```
 
-Then write a brief merge-record comment to a temp file and post it. Keep it terse — the PR diff is the real record; this is just a pointer.
+Then write a brief merge-record comment to a temp file and post it via `jq -n --rawfile` so the markdown stays out of inline-JSON escape soup. Keep it terse — the PR diff is the real record; this is just a pointer.
 
 ```bash
 cat <<EOF > /tmp/merge-MINI-NN.md
@@ -137,14 +137,17 @@ Merged via squash to \`main\`.
 - Branch \`<headRefName>\` deleted on remote.
 EOF
 
-mk comment add MINI-NN --as Claude --user Claude --body-file /tmp/merge-MINI-NN.md
+jq -n \
+  --rawfile body /tmp/merge-MINI-NN.md \
+  '{issue_key:"MINI-NN", author:"Claude", body:$body}' \
+  | mk comment add --user Claude --json -
 rm /tmp/merge-MINI-NN.md
 ```
 
 If the PR was discovered via `gh pr list` (i.e. not previously attached to the mk issue), also attach it now so the issue's `pull_requests[]` reflects what shipped:
 
 ```bash
-mk pr attach MINI-NN <PR-URL> --user Claude
+mk pr attach --user Claude --json '{"issue_key":"MINI-NN","url":"<PR-URL>"}'
 ```
 
 If either `mk` call fails after the merge succeeded, **don't try to undo the merge** — that's not recoverable. Surface the failure to the user with the exact `mk` command that failed so they can re-run it manually. The merge is the source of truth; the mk state is the bookkeeping that has to catch up.
@@ -190,7 +193,7 @@ Mention the `/finish-worktree` hint only if a worktree actually exists (`git wor
 >
 > *Phase 3: `gh pr merge 412 --squash --delete-branch` succeeds. Merge SHA `a3f1b29`.*
 >
-> *Phase 4: `mk issue state MINI-29 done --user Claude`. Posts merge-record comment.*
+> *Phase 4: `mk issue state --user Claude --json '{"key":"MINI-29","state":"done"}'`. Posts merge-record comment via `jq -n --rawfile body /tmp/merge-MINI-29.md '{issue_key:"MINI-29",author:"Claude",body:$body}' | mk comment add --user Claude --json -`.*
 >
 > Skill: "✓ Shipped MINI-29 — "Add NATS app role allowlist enforcement". PR #412 squash-merged to main as `a3f1b29`. Branch `claude/mini-29` deleted on remote. mk issue MINI-29 moved in_review → done. Next: `/finish-worktree mini-29` to tear down the local worktree + dev-env VM."
 

--- a/.claude/skills/task-to-mk/SKILL.md
+++ b/.claude/skills/task-to-mk/SKILL.md
@@ -47,7 +47,7 @@ This phase is **idempotent** — on every run, after the first, it's a fast no-o
 mk feature show maintenance -o json
 ```
 
-**If it doesn't exist** (the call exits non-zero), create it. Build the feature description starting with the `Plan:` line, write it to a temp file, then create:
+**If it doesn't exist** (the call exits non-zero), create it. Build the feature description starting with the `Plan:` line, write it to a temp file, then create via the JSON payload form (the agent-preferred surface — strict-decoded, dry-runnable, schema discoverable via `mk schema show feature.add`):
 
 ```bash
 cat <<EOF > /tmp/maintenance-feature.md
@@ -58,9 +58,10 @@ Catch-all feature for one-off maintenance and follow-up tickets filed via the
 don't have to ship in numerical order.
 EOF
 
-mk feature add "Maintenance" --slug maintenance \
-  --description-file /tmp/maintenance-feature.md \
-  --user Claude
+jq -n \
+  --rawfile description /tmp/maintenance-feature.md \
+  '{title:"Maintenance", slug:"maintenance", description:$description}' \
+  | mk feature add --user Claude --json -
 ```
 
 Build the GitHub URL from `git remote get-url origin` + `/blob/main/docs/planning/maintenance.md`. Don't use absolute filesystem paths or `./`-prefixed relative paths — they break the link in renderers.
@@ -216,7 +217,7 @@ State: `todo`.
 
 Description body — same shape `plan-to-mk` writes, so `execute-next-task` reads it without special-casing. The first line points at the maintenance plan doc (the feature stub) — `execute-next-task` will tolerate the lack of a per-phase anchor under the loosened flow.
 
-Write the body to a temp file first (long markdown can't go inline through `--description`):
+Write the body to a temp file first, then send it via the JSON payload form (`jq -n --rawfile` keeps the markdown out of inline-JSON escape soup):
 
 ```bash
 cat <<'EOF' > /tmp/mini-task-body.md
@@ -280,13 +281,14 @@ This is an execution-agent ticket — no separate planning phase. Read the docs 
 (no prior commits matching the area tag yet)   <-- only if applicable
 EOF
 
-mk issue add "<title>" \
-  --feature maintenance \
-  --state todo \
-  --description-file /tmp/mini-task-body.md \
-  --user Claude \
-  -o json
+jq -n \
+  --arg title "<title>" \
+  --rawfile description /tmp/mini-task-body.md \
+  '{title:$title, feature_slug:"maintenance", state:"todo", description:$description}' \
+  | mk issue add --user Claude --json - -o json
 ```
+
+Schema discoverable via `mk schema show issue.add`. To rehearse the call without writing, prepend `--dry-run` — same payload, no audit row, useful when sanity-checking a tricky description.
 
 Capture the issue's `MINI-NN` ID and (if you want a clickable reference) the local key — there's no remote URL, since `mk` is a local tracker.
 
@@ -325,6 +327,7 @@ These are non-negotiable. If you find yourself wanting to break one, stop and as
 - **Never skip the Phase 6 confirmation.** mk writes are user-visible side effects (and audit-logged) — confirm before, not after.
 - **Always pass `--user Claude` on every mutating `mk` command.** The audit log records the actor; without it the entry attributes to the OS user.
 - **Always pass `-o json` on reads you parse.** Text output is for humans and can shift.
+- **Prefer `--json` payloads over per-field flags on mutations.** Strict-decoded (typos surface as `unknown field` errors), schema discoverable via `mk schema show <command>`, dry-runnable. Use `jq -n --rawfile body /tmp/foo.md '{...}'` to keep multi-line markdown out of inline-JSON escape soup.
 
 ---
 
@@ -363,7 +366,7 @@ These are non-negotiable. If you find yourself wanting to break one, stop and as
 >
 > User: "go"
 >
-> *Skill writes the body to a temp file and runs `mk issue add "Add retry-with-backoff to cert renewer on Cloudflare 429" --feature maintenance --state todo --description-file /tmp/mini-task-body.md --user Claude -o json`. Captures `MINI-47`. No plan-doc edits — the doc is a stub.*
+> *Skill writes the body to `/tmp/mini-task-body.md`, then composes the JSON payload via `jq -n --arg title "Add retry-with-backoff..." --rawfile description /tmp/mini-task-body.md '{title:$title, feature_slug:"maintenance", state:"todo", description:$description}' | mk issue add --user Claude --json - -o json`. Captures `MINI-47`. No plan-doc edits — the doc is a stub.*
 >
 > Skill: "✓ Created Add retry-with-backoff to cert renewer on Cloudflare 429
 >    MINI-47  (run `mk issue show MINI-47` to view)


### PR DESCRIPTION
## Summary
- **Commit 1** — re-run `mk install-skill` to refresh `.claude/skills/mk/SKILL.md` with the latest from the `mk` CLI (+470 / −19). Major shifts: `--json` payload path is now the agent-preferred surface, `mk schema show <cmd>` for runtime discovery, global `--dry-run` rehearsal flag, `mk issue brief` collapses 4 calls into 1, `mk feature plan`/`next`/`peek` for orchestrated execution, `mk doc upsert`/`rename`/`export` for doc lifecycle, `mk history` audit log, optional HTTP `mk api` server + `--remote` client mode, lean lists by default, `--user` is now explicitly mandatory for agents.
- **Commit 2** — roll the 8 consumer skills (`task-to-mk`, `session-retrospective`, `ship-it`, `address-review`, `review`, `design-task`, `plan-to-mk`, `execute-next-task`) onto the new surface:
  - Mutating calls converted to `--json` payloads (scalar args inline, multi-line markdown bodies bridged via `jq -n --rawfile body /tmp/foo.md '{...}' | mk ... --json -` so the markdown stays out of escape-soup territory).
  - `mk doc upsert --from-path` kept in flag form (path-derivation has no JSON equivalent).
  - Rules-of-the-road sections updated to point at `mk schema show` for discovery and `--dry-run` for safety; `--as Claude` migration to JSON `author` field documented.
  - Stale worked-example narrations referencing the legacy `mk issue show + mk comment list + per-doc mk doc show` dance updated to `mk issue brief` (which the prescriptive instructions already use).

## Test plan
- [ ] Skill loads in Claude Code without errors.
- [ ] Spot-check one consumer skill end-to-end on a real `mk` ticket (e.g. file a maintenance task via `task-to-mk`, check the audit log records the JSON-form mutation).
- [ ] Verify `mk schema show issue.add` / `mk schema show comment.add` / `mk schema show feature.add` field names match what the consumer-skill `jq` payloads send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)