### PR TITLE
fix(addons + egress): plumb synthetic services through plan, apply, and the egress data plane

### DIFF
--- a/docs/planning/not-shipped/addons-egress-followups.md
+++ b/docs/planning/not-shipped/addons-egress-followups.md
@@ -1,0 +1,239 @@
+# Addons + Egress Integration — Deferred Follow-Ups
+
+**Status:** Tracking doc for work intentionally not in PR #398.
+**Companion to:** [`docs/planning/not-shipped/service-addons-plan.md`](./service-addons-plan.md)
+
+PR #398 landed nine commits that took the Service Addons framework from
+"applies cleanly in unit tests" to "an end-to-end nginx + tailscale-web
+stack joins the tailnet, traverses the egress firewall, and is no-op on
+re-apply." Every commit was driven by a real failure surfaced while
+smoke-testing the addon end-to-end against a worktree dev env, so the
+PR's scope grew beyond the original "make the addon framework work in
+plan + apply" into the egress data plane that addon-derived sidecars
+depend on.
+
+The items below were surfaced during that smoke and are explicitly out
+of scope for #398. Each is sized so it can be picked up independently —
+none is load-bearing on another.
+
+---
+
+## Synthetic services in `reconciler.update` and `pool-spawner`
+
+**Symptom.** PR #398 made `reconciler.plan` and `reconciler.apply`
+synthetic-aware (dryRun expansion, planStub, plan-computer iterates
+rendered defs, Stateful handler tolerates `svc: null`). Two siblings still
+call `resolveServiceConfigs` without `connectedServices` and without
+`dryRun: true`:
+
+- `server/src/services/stacks/stack-reconciler.ts:497` — inside `updateInner`,
+  the body of `reconciler.update()` (force-pull update flow).
+- `server/src/services/stacks/pool-spawner.ts:115` — pool-instance spawn.
+
+Either path will reproduce the original "Addon expansion failed on
+service X (addons: tailscale-*): requires connected service tailscale but
+it is not configured" error if used against an addon-using stack.
+
+**Tasks.**
+- Build the same `addonExpansion = { connectedServices: { tailscale: new TailscaleService(prisma) }, progress: ... }` value that the apply route already constructs, and pass it through both call paths.
+- For `pool-spawner` specifically: pool services may want addon expansion to run with a per-instance synthetic service-name suffix; the existing addon framework supports that via `ExpansionContext.instance` (already plumbed for spawner callers).
+- Add a regression test covering each path with the noop test addon registry, mirroring the existing `definition-hash-addons.test.ts` pattern.
+
+**Verification.** A stack with `addons: { tailscale-web: {...} }`
+applied through `POST /api/stacks/:id/update` (the route that drives
+`reconciler.update`) succeeds and the synthetic sidecar is recreated with
+a fresh authkey. A pool-service stack with addons spawned via the
+existing pool-spawn API materializes per-instance synthetics.
+
+---
+
+## Apply-route setup-failure path doesn't write `lastFailureReason`
+
+**Symptom.** When `reconciler.plan(stackId)` throws inside
+`runApplyInBackground` — which is the failure surface for "addon
+expansion failed" plus any other pre-reconciler error — the catch at
+`server/src/routes/stacks/stacks-apply-route.ts:343-352` logs an `error`,
+calls `userEvent.fail(error)`, and emits `STACK_APPLY_FAILED` on the
+socket channel. It does **not** write `lastFailureReason` to the `Stack`
+row, and the row's `status` stays at whatever it was before the apply
+(typically `undeployed` for a fresh stack).
+
+To an operator polling `GET /api/stacks/:id` or watching the UI without
+the task tracker open, the apply looks like a silent stall — the route
+returned `{started: true}`, the row never moves off `undeployed`, and
+the failure is only visible in server logs or as an ephemeral socket
+event that's gone the next time the page loads.
+
+**Tasks.**
+- In the outer catch block (`stacks-apply-route.ts:353-366`), before
+  calling `emitStackApplyFailed`, write `lastFailureReason` and possibly
+  flip `status` to `error` so the row reflects the failure.
+- Decide whether the inner reconciler-failure catch (line 342-352) should
+  do the same writeback, or leave that to the reconciler itself.
+- Match whatever convention `reconciler.apply`'s success path uses for
+  clearing `lastFailureReason` on a subsequent successful apply — the
+  fix shouldn't leave an old failure reason lingering after recovery.
+- Add a regression test that POSTs an apply against a stack designed to
+  fail in the setup phase (e.g. an unregistered addon id) and asserts
+  `GET /api/stacks/:id` shows `status: "error"` and a populated
+  `lastFailureReason` afterwards.
+
+**Verification.** After an addon-expansion failure or any other
+pre-reconciler throw, `GET /api/stacks/:id` reflects the failure for
+operators who don't have the task tracker open.
+
+---
+
+## Dev-startup Vault auto-unlock
+
+**Symptom.** Every `pnpm worktree-env start` (and every `docker restart
+mini-infra-bold-lynx-mini-infra-1` in dev) leaves Vault sealed. Until
+the operator manually `POST`s `/api/vault/passphrase/unlock`, the
+server's NATS bus can't fetch its own creds, every NATS-dependent
+subsystem times out (egress rule push, container map push, jetstream
+bootstrap), and downstream features fail in confusing ways. PR #398's
+`fix(nats): wait up to 5 min for bus before giving up on system
+bootstrap` papered over the worst symptom (the EgressFwEvents stream
+silently never seeding) but the root ergonomic issue remains.
+
+The dev seeder writes `~/.mini-infra/dev.env` containing a Vault
+passphrase, and `vaultServices.passphrase.tryAutoUnlockFromEnv()` is
+already called at server start
+(`server/src/server.ts:353`). Either the env var isn't being seeded into
+the container, the auto-unlock logic isn't reading the right key, or
+there's a race where the unlock runs before the env var is loaded.
+
+**Tasks.**
+- Audit `tryAutoUnlockFromEnv` against the dev seeder's env-var output:
+  is the passphrase exposed under the expected key
+  (`MINI_INFRA_VAULT_PASSPHRASE` or similar)?
+- Confirm the env var actually lands in the running app container — check
+  `docker inspect` against the dev compose file and the worktree-env's
+  env-injection path.
+- If everything is wired correctly but the unlock simply hasn't been
+  attempted yet at the right moment, retry on the bus's first connect
+  attempt or wire it into the same `bootstrapNatsSystemResources` retry
+  loop that PR #398 added.
+
+**Verification.** `pnpm worktree-env start` followed by hitting the API
+without a manual unlock call shows: bus connects within ~5s, the system
+bootstrap fires within its existing 5-min budget, every NATS-dependent
+subsystem comes up cleanly. No manual `curl POST /api/vault/passphrase/unlock`
+needed for the smoke loop.
+
+---
+
+## `forcePull` should recreate the container when only role permissions change
+
+**Symptom.** While verifying the fw-agent role-perms fix (commit
+`1debc9a`), `forcePull: true` on `POST /api/stacks/:id/apply` ran the
+image pull, found the image SHA unchanged (the role-perm fix was
+server-side TS, not in the agent's Go binary), saw no other definition
+delta, and emitted `noOps:1`. The fw-agent container kept running with
+its old JWT — the new role permissions in NATS were materialized but the
+container's `dynamicEnv.NATS_CREDS` was still the JWT minted at the
+last container-create. The fix was to manually
+`docker rm -f mini-infra-egress-fw-agent-egress-fw-agent` and trigger a
+re-apply, which the plan computer correctly saw as `service not deployed`
+→ `create`.
+
+The architectural gap: the role-permission delta affects only the
+service's `dynamicEnv` resolution, which is intentionally not part of
+the definition hash (so transient secrets don't trigger spurious
+recreates). But that exclusion catches BOTH "secret rotated"
+(legitimately should not recreate) AND "role permissions changed"
+(should recreate so the service picks up the new JWT).
+
+**Tasks.**
+- Distinguish "permission delta" from "secret-content delta" on the
+  role-credential path. One option: hash the role's `publishAllow` /
+  `subscribeAllow` (which IS part of the materialized
+  `NatsCredentialProfile` row, not the per-mint JWT) into the service
+  definition hash so the plan picks up perm changes as `recreate`.
+- Or: make the apply path detect that the materialized role profile's
+  permissions changed since the last applied state and promote the
+  no-op to recreate — analogous to the existing `promoteStalePullActions`
+  helper that handles the image-SHA case.
+- Add a regression test against the noop addon registry: change the
+  role's permission set, verify the next apply emits `recreate` for the
+  bound service.
+
+**Verification.** Bumping a role's `publish`/`subscribe` list in a
+template re-applies the stack as `recreate`, the container comes up with
+a freshly-minted JWT carrying the new permissions, and operators don't
+have to remember to `docker rm -f` to pick up the change.
+
+---
+
+## `reconcileTemplateRules`-on-apply may double-up on hot-path latency
+
+**Symptom (theoretical).** PR #398 added
+`egressLifecycle.reconcileTemplateRules(stackId, ...)` to the apply
+route's hot path
+(`server/src/routes/stacks/stacks-apply-route.ts`). The reconciler is
+cheap when nothing changed — just a few SELECTs and a no-op compare —
+but on every apply it ALSO triggers a gateway push if there's any delta.
+On a busy env where many stacks apply together (e.g. a stack-template
+update that touches dozens of stacks), every apply will fire its own
+push. The gateway already coalesces by debouncing, but the server-side
+push code path runs unconditionally per apply.
+
+**Tasks.**
+- Measure: how often does `reconcileTemplateRules` actually find a delta
+  on apply? In steady state (no addon code changes) it should be zero.
+- If the cost is real, debounce or coalesce server-side per env (the
+  container-map pusher already does this — see
+  `egress-container-map-pusher.ts:135-147`). Otherwise leave as-is.
+
+**Verification.** Apply latency p50/p99 in steady state is unchanged
+after the apply-time reconciliation lands.
+
+---
+
+## Addon-expansion warnings on the apply path are not surfaced to operators
+
+**Symptom.** When dryRun expansion fails inside
+`reconcileTemplateRules` (e.g. an addon implementation throws during
+`planStub`), the catch block logs a `warn` and falls back to authored-
+services-only rule promotion. The apply itself succeeds. But the operator
+has no way of knowing their addon's `requiredEgress` was silently
+dropped from the rule set — `enforce_would_deny` would suddenly start
+firing on production traffic if the env was in enforce mode.
+
+**Tasks.**
+- Plumb a non-fatal warning back through the apply pipeline so the
+  task tracker / event log shows "addon expansion partial — N synthetic
+  patterns dropped" with the underlying error.
+- Or: emit a dedicated socket event the UI can render as a banner on the
+  stack detail page.
+
+**Verification.** A planStub-throwing test addon registered alongside a
+real addon results in: apply still succeeds with the real addon's rules
+in place, but the failure is visible in the task tracker / event log.
+
+---
+
+## Test seam for the `enforce_would_deny` regression
+
+**Symptom.** The `enforce_would_deny` symptom from PR #398's
+investigation was a real architectural defect (apply didn't trigger
+`reconcileTemplateRules`, so existing stacks frozen with empty
+allowlists), but there's no automated test that would have caught it.
+The existing addon tests exercise expansion in isolation; the existing
+egress tests exercise the rule reconciler with mocked stacks. Nothing
+hits the apply → reconcile → push → gateway-decision pipeline together.
+
+**Tasks.**
+- Stand up an integration-style test against `testcontainers`
+  `nats:2.12.8-alpine` + a stub HTTP "smokescreen" — apply a stack with
+  a synthetic-service requiredEgress, assert the gateway sees a CONNECT
+  for the right hostname with `decision_reason: "host matched allowed
+  domain in rule"` and `enforce_would_deny: false`.
+- Or, lighter-weight: an integration test against the apply route that
+  inspects `prisma.egressRule.findMany` after an apply against a
+  noop-addon stack and asserts the rules exist with the right patterns
+  and targets.
+
+**Verification.** A regression where `reconcileTemplateRules` stops
+running on apply (or stops harvesting synthetic services) is caught in
+CI rather than at smoke-test time.

--- a/docs/user/stack-definition-reference.md
+++ b/docs/user/stack-definition-reference.md
@@ -229,6 +229,7 @@ Runtime meaning:
 | `order` | Yes | Apply order for the service. | Integer `>= 0`. |
 | `routing` | No | HTTP routing configuration. | Required when `serviceType` is `StatelessWeb` or `AdoptedWeb`. |
 | `adoptedContainer` | No | Existing external container to route to. | Required when `serviceType` is `AdoptedWeb`. |
+| `addons` | No | Named capability declarations expanded into synthetic sidecars at apply time. | Map of registered `<addon-id>` to addon-specific config. See `services[].addons` below. |
 
 Runtime meaning of `serviceType`:
 
@@ -430,6 +431,60 @@ Reference note:
 | --- | --- | --- | --- |
 | `containerName` | Yes | Name of the already-running Docker container to route to. | 1-253 chars. |
 | `listeningPort` | Yes | Port Mini Infra should target on that container. | Integer `1-65535`. |
+
+## `services[].addons`
+
+A map of `<addon-id>` to addon-specific config. Each entry opts the service into a named capability — typically a sidecar container that attaches to the target at apply time. The expanded sidecar is rendered as a synthetic service (carrying `mini-infra.synthetic=true` and `mini-infra.addon-target=<service>` labels) and flows through the existing reconciler; the stack template author never declares the sidecar directly.
+
+Validation runs in two passes:
+
+1. The addon id must be registered. Unknown ids are rejected at draft / template-load time with `Addon "<id>" is not registered`.
+2. The entry value is parsed by the addon's `configSchema`. Per-addon required-field errors surface with a path of `addons.<id>.<field>`.
+
+Per-addon applicability is gated by two manifest fields, both checked at render time:
+
+- **`appliesTo`** — the addon declares which `serviceType`s it supports. Applying an addon to an unsupported service type is rejected.
+- **`requiresConnectedService`** — when set, the named connected service (e.g. `tailscale`) must be configured in the environment, otherwise expansion fails.
+
+When two addons declared on the same service share a `kind` (declared on each addon's manifest), they **merge** into a single synthetic sidecar via the registered merge strategy for that kind. The merged sidecar inherits each member's env, files, and labels and carries `mini-infra.addon-kind=<kind>` plus `mini-infra.addon-members=<comma-separated-ids>`. Addons without a `kind`, or with distinct `kind`s, expand independently.
+
+### Registered addons
+
+| ID | `kind` | Required connected service | Applies to | Config fields |
+| --- | --- | --- | --- | --- |
+| `tailscale-ssh` | `tailscale` | `tailscale` | `Stateful`, `StatelessWeb`, `Pool` | `extraTags?: string[]` |
+| `tailscale-web` | `tailscale` | `tailscale` | `Stateful`, `StatelessWeb`, `Pool` | `port: integer 1-65535` (required); `path?: string` (must start with `/`, default `/`); `extraTags?: string[]` |
+
+`tailscale-ssh` exposes operator SSH into the target service via Tailscale identity (gated by the tailnet ACL `ssh` policy). `tailscale-web` exposes the target over HTTPS on the tailnet at `${TS_CERT_DOMAIN}:443` using `tailscale serve` against `http://<target>:<port>`.
+
+Both share the `tailscale` kind: declaring both on one service produces a **single** tailscaled sidecar — one authkey, one tailnet device, one state volume — running `--ssh` and `tailscale serve` together.
+
+`extraTags` entries must match `tag:[a-z0-9-]+` and must already be declared in the operator's tailnet `tagOwners` ACL. The static `tag:mini-infra-managed` is always added by the authkey minter, so omitting `extraTags` is the common case.
+
+### Worked example — both Tailscale addons on one web service
+
+```yaml
+services:
+  - serviceName: web
+    serviceType: StatelessWeb
+    dockerImage: nginx
+    dockerTag: "1.27"
+    containerConfig:
+      ports:
+        - { containerPort: 80, hostPort: 8080, protocol: tcp }
+    dependsOn: []
+    order: 0
+    routing:
+      hostname: web.local
+      listeningPort: 80
+    addons:
+      tailscale-ssh: {}
+      tailscale-web:
+        port: 80
+        path: "/"
+```
+
+At apply time the render pipeline expands the two entries into one synthetic sidecar joined to the same Docker network as `web`. The target service itself is unchanged — no `network_mode` rewrite, no port reclamation; the sidecar reaches the target by service-name DNS on the shared bridge network.
 
 ## `nats` — app-author surface (roles, signers, imports/exports)
 

--- a/egress-gateway/internal/proxy/logadapter.go
+++ b/egress-gateway/internal/proxy/logadapter.go
@@ -133,9 +133,19 @@ func (h *NDJSONLogHook) Fire(entry *logrus.Entry) error {
 // falling back to stdout if (somehow) none was wired. The default
 // constructor always sets one — this branch only fires for tests that
 // pass a nil emitter explicitly.
+//
+// Defensive `Ts` default mirrors the per-handler stamp: the JetStream
+// publisher path doesn't pass through `EmitToStdout`'s default, and the
+// server-side Zod schema rejects payloads with an empty `ts` (min(1)),
+// so an unstamped event would be NAK'd repeatedly until the stream's
+// max-deliveries count kicks in. Stamping here covers any handler that
+// forgets to set it explicitly.
 func (h *NDJSONLogHook) emitOrFallback(evt EgressEvent) {
 	if h.environmentId != "" {
 		evt.EnvironmentId = h.environmentId
+	}
+	if evt.Ts == "" {
+		evt.Ts = time.Now().UTC().Format(time.RFC3339Nano)
 	}
 	if h.emit != nil {
 		h.emit(evt)
@@ -150,6 +160,7 @@ func (h *NDJSONLogHook) emitOrFallback(evt EgressEvent) {
 func (h *NDJSONLogHook) handleDecision(entry *logrus.Entry) {
 	evt := EgressEvent{
 		Evt:        "tcp",
+		Ts:         entry.Time.UTC().Format(time.RFC3339Nano),
 		MergedHits: 1,
 	}
 
@@ -207,6 +218,7 @@ func (h *NDJSONLogHook) handleConnClose(entry *logrus.Entry) {
 	evt := EgressEvent{
 		Evt:        "tcp",
 		Protocol:   "connect",
+		Ts:         entry.Time.UTC().Format(time.RFC3339Nano),
 		MergedHits: 1,
 	}
 

--- a/egress-gateway/internal/proxy/logadapter_test.go
+++ b/egress-gateway/internal/proxy/logadapter_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -195,6 +196,56 @@ func TestToInt64_NumericTypes(t *testing.T) {
 				t.Errorf("value: want %d, got %d", tc.want, got)
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Ts is always set on emitted events
+// ---------------------------------------------------------------------------
+
+// Regression for the JetStream-publish path: server-side Zod schema requires
+// `ts: string min(1)`, but only `EmitToStdout` was defaulting `Ts`. The
+// JetStream emitter wasn't, so every CANONICAL-PROXY-DECISION published from
+// the gateway hit the server's nats-bus payload validator with
+// `ts: Too small` and was NAK'd until max-deliveries.
+func TestNDJSONLogHook_Decision_StampsTsForCustomEmitter(t *testing.T) {
+	var captured EgressEvent
+	hook := NewNDJSONLogHookWithEmitter("env-1", func(evt EgressEvent) {
+		captured = evt
+	})
+	entry := makeEntry("CANONICAL-PROXY-DECISION", logrus.Fields{
+		"proxy_type":          "connect",
+		"inbound_remote_addr": "172.30.0.6:33342",
+		"requested_host":      "controlplane.tailscale.com:443",
+		"allow":               true,
+	})
+	entry.Time = time.Date(2026, 5, 10, 0, 23, 22, 379256180, time.UTC)
+
+	_ = hook.Fire(entry)
+
+	if captured.Ts == "" {
+		t.Fatal("Ts: expected non-empty, got empty")
+	}
+	if captured.Ts != "2026-05-10T00:23:22.37925618Z" {
+		t.Errorf("Ts: expected logrus entry time stamped (RFC3339Nano), got %q", captured.Ts)
+	}
+}
+
+func TestNDJSONLogHook_ConnClose_StampsTsForCustomEmitter(t *testing.T) {
+	var captured EgressEvent
+	hook := NewNDJSONLogHookWithEmitter("env-1", func(evt EgressEvent) {
+		captured = evt
+	})
+	entry := makeEntry("CANONICAL-PROXY-CN-CLOSE", logrus.Fields{
+		"inbound_remote_addr": "172.30.0.6:33342",
+		"requested_host":      "controlplane.tailscale.com:443",
+	})
+	entry.Time = time.Date(2026, 5, 10, 0, 23, 33, 0, time.UTC)
+
+	_ = hook.Fire(entry)
+
+	if captured.Ts == "" {
+		t.Fatal("Ts: expected non-empty, got empty")
 	}
 }
 

--- a/egress-shared/natsbus/bus.go
+++ b/egress-shared/natsbus/bus.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"sync"
 	"time"
 
@@ -304,29 +305,39 @@ func splitCredsBody(body string) (string, string, error) {
 	return jwt, seed, nil
 }
 
+// extractArmored pulls the body out of a `-----BEGIN <label>-----` /
+// `-----END <label>-----` block.
+//
+// The dash-count on either side is tolerated as 3-or-more, anchored to a
+// line boundary, because the upstream `nats-jwt` formatter (and assorted
+// `.creds` files in the wild) emit asymmetric markers: 5 dashes on BEGIN
+// but 6 on END. An exact substring match would absorb the extra dash into
+// the body and yield e.g. a 59-char nkey seed (legit 58 chars + 1 stray
+// `-`), which fails base32 decode at byte 58 — exactly the failure the
+// egress-gateway / egress-fw-agent containers were hitting on boot.
+//
+// Mirrors the regex used by `nats-jwt`'s own `parseCreds`
+// (`/[-]{3,}[^\n]*[-]{3,}\n/`).
 func extractArmored(body, label string) (string, error) {
-	beginMarker := "-----BEGIN " + label + "-----"
-	endMarker := "-----END " + label + "-----"
-	start := indexOf(body, beginMarker)
-	if start < 0 {
-		return "", fmt.Errorf("natsbus: missing %q in creds body", beginMarker)
+	beginRe := regexp.MustCompile(`(?m)^-{3,}\s*BEGIN ` + regexp.QuoteMeta(label) + `\s*-{3,}\s*$`)
+	endRe := regexp.MustCompile(`(?m)^-{3,}\s*END ` + regexp.QuoteMeta(label) + `\s*-{3,}\s*$`)
+	beginLoc := beginRe.FindStringIndex(body)
+	if beginLoc == nil {
+		return "", fmt.Errorf("natsbus: missing BEGIN %s marker in creds body", label)
 	}
-	rest := body[start+len(beginMarker):]
-	end := indexOf(rest, endMarker)
-	if end < 0 {
-		return "", fmt.Errorf("natsbus: missing %q in creds body", endMarker)
+	endLoc := endRe.FindStringIndex(body[beginLoc[1]:])
+	if endLoc == nil {
+		return "", fmt.Errorf("natsbus: missing END %s marker in creds body", label)
 	}
-	inner := rest[:end]
-	// Trim leading/trailing whitespace and skip the "***" padding lines the
-	// nats-jwt encoder inserts around the actual content.
+	inner := body[beginLoc[1] : beginLoc[1]+endLoc[0]]
+	// Trim per-line whitespace and skip the "***" padding lines the nats-jwt
+	// encoder inserts between the JWT block and the seed block.
 	out := ""
 	for _, line := range splitLines(inner) {
 		line = trimSpace(line)
 		if line == "" {
 			continue
 		}
-		// `.creds` blobs sometimes carry a single line of asterisks as a
-		// visual separator. Skip those — they're never part of the payload.
 		if isAllAsterisks(line) {
 			continue
 		}

--- a/egress-shared/natsbus/payloads_test.go
+++ b/egress-shared/natsbus/payloads_test.go
@@ -177,17 +177,6 @@ func TestExtractArmored_RoundTrip(t *testing.T) {
 	body := "" +
 		"-----BEGIN NATS USER JWT-----\n" +
 		"abc.def.ghi\n" +
-		"------END NATS USER JWT------\n" +
-		"************************************************************\n" +
-		"-----BEGIN USER NKEY SEED-----\n" +
-		"SUACSEED\n" +
-		"------END USER NKEY SEED------\n"
-	// Note: tolerate the `------` 6-dash variant by including both ends in
-	// real `.creds` blobs; our extractor matches the canonical 5-dash form.
-	// Switch the body to canonical for the test.
-	body = "" +
-		"-----BEGIN NATS USER JWT-----\n" +
-		"abc.def.ghi\n" +
 		"-----END NATS USER JWT-----\n" +
 		"-----BEGIN USER NKEY SEED-----\n" +
 		"SUACSEED\n" +
@@ -202,6 +191,42 @@ func TestExtractArmored_RoundTrip(t *testing.T) {
 	}
 	if seed != "SUACSEED" {
 		t.Errorf("seed = %q, want %q", seed, "SUACSEED")
+	}
+}
+
+// nats-jwt's `fmtCreds` emits 5-dash BEGIN markers and 6-dash END markers.
+// Real .creds blobs hitting both egress-gateway and egress-fw-agent in dev
+// look like this. The parser must accept the asymmetry — earlier substring
+// matching absorbed the extra dash into the seed body, producing a 59-char
+// "seed" that failed base32 decode at byte 58 and crashed both binaries on
+// every boot with `error signing nonce: unable to extract key pair from
+// seed: illegal base32 data at input byte 58`.
+func TestExtractArmored_AsymmetricEndMarkers(t *testing.T) {
+	body := "" +
+		"-----BEGIN NATS USER JWT-----\n" +
+		"abc.def.ghi\n" +
+		"------END NATS USER JWT------\n" +
+		"\n" +
+		"************************* IMPORTANT *************************\n" +
+		"\n" +
+		"-----BEGIN USER NKEY SEED-----\n" +
+		"SUAD3HZCAIX43R4AAIE7SNKC5UXBB3X4C2XT4TXQZIM4VLIRLBL4TWLF34\n" +
+		"------END USER NKEY SEED------\n"
+
+	jwt, seed, err := splitCredsBody(body)
+	if err != nil {
+		t.Fatalf("splitCredsBody: %v", err)
+	}
+	if jwt != "abc.def.ghi" {
+		t.Errorf("jwt = %q, want %q", jwt, "abc.def.ghi")
+	}
+	wantSeed := "SUAD3HZCAIX43R4AAIE7SNKC5UXBB3X4C2XT4TXQZIM4VLIRLBL4TWLF34"
+	if seed != wantSeed {
+		t.Errorf("seed = %q (len %d), want %q (len %d)", seed, len(seed), wantSeed, len(wantSeed))
+	}
+	// Specifically guard against the absorbed-trailing-dash regression.
+	if len(seed) != 58 {
+		t.Errorf("seed length = %d, want 58 (NATS NKey seeds are exactly 58 chars)", len(seed))
 	}
 }
 

--- a/lib/types/addons.ts
+++ b/lib/types/addons.ts
@@ -172,6 +172,19 @@ export interface AddonDefinition {
   ): StackServiceDefinition;
   cleanup?(ctx: ProvisionContext, provisioned: ProvisionedValues): Promise<void>;
   status?(ctx: StatusContext): Promise<AddonStatus>;
+  /**
+   * Read-only synthetic-service skeleton used at plan time. Must be
+   * deterministic — the same `(stack, service, addonConfig)` triple produces
+   * byte-identical output. Returned definition stands in for what
+   * `buildServiceDefinition()` would produce after `provision()` ran, but
+   * with non-deterministic per-mint values (authkeys, hostnames derived from
+   * runtime state) excluded so plan-time hashes don't drift between runs.
+   *
+   * When omitted, the framework substitutes a generic placeholder
+   * (`dockerImage: 'addon-pending'`); addons that want plan-time identity to
+   * reflect their real image / mounts / requiredEgress should implement this.
+   */
+  planStub?(ctx: ProvisionContext): StackServiceDefinition;
 }
 
 /**
@@ -190,6 +203,16 @@ export interface AddonMergeStrategy {
   buildServiceDefinition(
     ctx: ProvisionContext,
     provisioned: ProvisionedValues,
+    members: Array<{ addonId: string; config: unknown }>,
+  ): StackServiceDefinition;
+  /**
+   * Plan-time deterministic skeleton for the merged sidecar. See
+   * `AddonDefinition.planStub` for the contract — the merge variant takes
+   * the resolved member list so it can label the synthetic with the right
+   * `addon-members` set without running provision().
+   */
+  planStub?(
+    ctx: ProvisionContext,
     members: Array<{ addonId: string; config: unknown }>,
   ): StackServiceDefinition;
 }

--- a/server/src/__tests__/egress-fw-agent-template.test.ts
+++ b/server/src/__tests__/egress-fw-agent-template.test.ts
@@ -23,7 +23,7 @@ describe("egress-fw-agent template", () => {
     expect(json.name).toBe("egress-fw-agent");
     expect(json.scope).toBe("host");
     expect(json.category).toBe("infrastructure");
-    expect(json.builtinVersion).toBe(3);
+    expect(json.builtinVersion).toBe(4);
 
     // The agent role declares the KV bucket Phase 2 needs.
     expect(json.nats.subjectPrefix).toBe("mini-infra.egress.fw");
@@ -34,6 +34,14 @@ describe("egress-fw-agent template", () => {
     // not via a subject publish on `mini-infra.egress.fw.health`.
     expect(role.publish).toEqual(["rules.applied", "events"]);
     expect(role.subscribe).toEqual(["rules.apply"]);
+    // `inboxAuto: 'both'` is required because every JetStream operation
+    // (KV Put, JS Publish to `rules.applied` / `events`) is a request/reply
+    // under the hood — nats.go awaits the JS API ack on a synthetic
+    // `_INBOX.<id>.<seq>` subject. With the previous `'reply'` setting the
+    // role got PUB on `_INBOX.>` (for replying to inbound `rules.apply`
+    // requests) but no SUB, so KV Puts hit a Permissions Violation on the
+    // ack-subscribe and timed out as `context deadline exceeded`.
+    expect(role.inboxAuto).toBe("both");
 
     // Host networking + privileged caps are the whole reason this template
     // exists (vs being a regular bridge-mode stack).
@@ -55,7 +63,7 @@ describe("egress-fw-agent template", () => {
       publish: ["rules.applied", "events"],
       subscribe: ["rules.apply"],
       kvBuckets: ["egress-fw-health"],
-      inboxAuto: "reply",
+      inboxAuto: "both",
     };
     expect(() => templateNatsRoleSchema.parse(role)).not.toThrow();
   });

--- a/server/src/routes/stacks/stacks-apply-route.ts
+++ b/server/src/routes/stacks/stacks-apply-route.ts
@@ -14,6 +14,7 @@ import { findEmptyStackParameters } from '../../services/stacks/parameter-valida
 import { evaluatePrerequisites } from '../../services/stacks/template-prerequisites';
 import { runStackVaultApplyPhase } from '../../services/stacks/stack-vault-apply-orchestrator';
 import { runStackNatsApplyPhase } from '../../services/stacks/stack-nats-apply-orchestrator';
+import { EgressPolicyLifecycleService } from '../../services/egress/egress-policy-lifecycle';
 import { pruneOrphanedInputValues as doPruneOrphanedInputValues } from '../../services/stacks/orphan-input-pruner';
 import {
   emitStackApplyStarted,
@@ -256,6 +257,19 @@ async function runApplyInBackground(args: RunApplyArgs): Promise<void> {
       if (natsPhase.status === 'error') {
         throw new Error(natsPhase.error ?? 'NATS reconciliation phase failed');
       }
+
+      // Re-promote `requiredEgress` declarations into template-source
+      // EgressRules so addon-derived patterns (e.g. Tailscale's control-plane
+      // hostnames from the synthetic sidecar) propagate to existing stacks
+      // when the apply pipeline is the trigger — not just when the stack is
+      // first created or PUT'd. Without this, a code-level change to which
+      // hostnames an addon emits never updates the rules of stacks that
+      // were instantiated before the change.
+      //
+      // Failures are logged inside `reconcileTemplateRules` and do not throw,
+      // so an egress-side reconciliation issue can't block the stack apply.
+      const egressLifecycle = new EgressPolicyLifecycleService(prisma);
+      await egressLifecycle.reconcileTemplateRules(stackId, triggeredBy ?? null);
 
       // Service Addons render-pass plumbing — fan addon-provisioning
       // events out on the stacks channel (Phase 3) and hand the addon

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -413,28 +413,47 @@ const initializeServices = async () => {
       // avoids a slow-NATS cold boot leaving the watcher permanently
       // unstarted (review finding H1).
       startFwAgentHealthWatcher();
+      // Probe whether the bus is up *now* so the operator gets a
+      // confidence-building startup banner. The 3s budget is short on
+      // purpose — Vault unlock + creds fetch typically takes longer than
+      // that on a fresh worktree, and we don't want boot to wait on it.
       try {
         await NatsBus.getInstance().ready({ timeoutMs: 3_000 });
         console.log("[STARTUP] ✓ NATS bus connected");
-        // ALT-27: ensure JetStream streams + KV buckets system-internal
-        // subjects depend on. Fire-and-forget — the helper logs its own
-        // errors and the next boot retries. Doing it here (rather than
-        // inside `applyConfig`) keeps the messaging-namespace boot
-        // separate from the NATS control-plane boot.
-        const { bootstrapNatsSystemResources } = await import(
-          "./services/nats/nats-system-bootstrap"
-        );
-        void bootstrapNatsSystemResources();
-        // ALT-29: start the backup NATS bridge (progress → Socket.IO fan-out
-        // + BackupHistory JetStream consumer for cold-boot replay).
-        const { startBackupNatsBridge } = await import("./services/backup");
-        startBackupNatsBridge(prisma);
       } catch (busErr) {
         logger.info(
           { err: busErr instanceof Error ? busErr.message : String(busErr) },
           "NATS bus not connected at boot — will keep retrying in the background",
         );
         console.log("[STARTUP] NATS bus retrying in background (non-fatal)");
+      }
+
+      // The dependent fire-and-forget helpers below MUST run regardless of
+      // whether the 3s ready-probe above succeeded — both helpers handle a
+      // not-yet-ready bus internally (bootstrap waits up to 10s on its own;
+      // bus.subscribe / bus.jetstream.consume are durable across reconnects
+      // and queue subscriptions when the bus comes up later). Gating them on
+      // the probe meant fresh-worktree boots — where NATS reliably takes
+      // ~10-15s to come up while Vault unlocks — silently skipped them and
+      // the EgressFwEvents stream + backup bridge were never bootstrapped.
+      try {
+        // ALT-27: ensure JetStream streams + KV buckets system-internal
+        // subjects depend on (EgressFwEvents stream, egress-fw-health KV).
+        // Fire-and-forget — the helper logs its own errors and the next
+        // boot retries.
+        const { bootstrapNatsSystemResources } = await import(
+          "./services/nats/nats-system-bootstrap"
+        );
+        void bootstrapNatsSystemResources();
+        // ALT-29: start the backup NATS bridge (progress → Socket.IO
+        // fan-out + BackupHistory JetStream consumer for cold-boot replay).
+        const { startBackupNatsBridge } = await import("./services/backup");
+        startBackupNatsBridge(prisma);
+      } catch (err) {
+        logger.warn(
+          { err: err instanceof Error ? err.message : String(err) },
+          "NATS dependent helper start failed (non-fatal)",
+        );
       }
     } catch (err) {
       logger.warn(

--- a/server/src/services/egress/egress-container-map-pusher.ts
+++ b/server/src/services/egress/egress-container-map-pusher.ts
@@ -318,6 +318,15 @@ export class EgressContainerMapPusher {
 
     const entries: ContainerMapEntry[] = [];
 
+    // Synthetic sidecars produced by the addon render pipeline don't have a
+    // StackService DB row, so they're absent from `serviceConfigByKey`. They
+    // do carry `mini-infra.synthetic=true` plus the parent's `mini-infra.stack-id`
+    // — both labels set by the reconciler, not the user — so we accept them
+    // when the parent stack is known to this env. Without this, the sidecar's
+    // IP is missing from the gateway's container map and tailscaled (or any
+    // other addon outbound traffic) is 403'd by UnknownIPDenyHandler.
+    const knownStackIds = new Set(stacks.map((s) => s.id));
+
     for (const c of rawContainers) {
       const ip = c.NetworkSettings?.Networks?.[egressNetwork]?.IPAddress;
       if (!ip) continue;
@@ -327,12 +336,26 @@ export class EgressContainerMapPusher {
       const serviceName = labels['mini-infra.service'];
       if (!stackId || !serviceName) continue;
 
+      const isSynthetic = labels['mini-infra.synthetic'] === 'true';
       const key = `${stackId}:${serviceName}`;
+
       if (!serviceConfigByKey.has(key)) {
-        // Container is on this egress network but the stack/service is
-        // unknown to this env (foreign stack, deleted service, or a stale
-        // container that survived a stack rebuild). Skip — don't trust
-        // labels alone for membership.
+        if (!isSynthetic || !knownStackIds.has(stackId)) {
+          // Container is on this egress network but the stack/service is
+          // unknown to this env (foreign stack, deleted service, or a stale
+          // container that survived a stack rebuild). Skip — don't trust
+          // labels alone for non-synthetic membership.
+          continue;
+        }
+        // Synthetic with a known parent stack — trust the labels and admit.
+        // Synthetic sidecars never declare egressBypass; the only legitimate
+        // bypass is for infra containers like the egress gateway itself.
+        entries.push({
+          ip,
+          stackId,
+          serviceName,
+          containerId: c.Id,
+        });
         continue;
       }
 

--- a/server/src/services/egress/egress-policy-lifecycle.ts
+++ b/server/src/services/egress/egress-policy-lifecycle.ts
@@ -1,8 +1,18 @@
 import type { PrismaClient } from '../../generated/prisma/client';
 import type * as runtime from '@prisma/client/runtime/client';
 import { getLogger } from '../../lib/logger-factory';
-import type { EgressArchivedReason, StackContainerConfig } from '@mini-infra/types';
+import type {
+  EgressArchivedReason,
+  StackContainerConfig,
+  StackParameterDefinition,
+  StackParameterValue,
+} from '@mini-infra/types';
 import { emitEgressPolicyUpdated, emitEgressRuleMutation } from './egress-socket-emitter';
+import {
+  buildStackTemplateContext,
+  mergeParameterValues,
+  resolveServiceConfigs,
+} from '../stacks/utils';
 
 const log = getLogger('stacks', 'egress-policy-lifecycle');
 
@@ -331,17 +341,18 @@ export class EgressPolicyLifecycleService {
    */
   async reconcileTemplateRules(stackId: string, userId: string | null): Promise<void> {
     try {
-      // 1. Load the stack's services and their requiredEgress declarations.
+      // 1. Load the stack with everything needed to render the addon expansion.
+      // Authored services give us their `requiredEgress` directly; addon-derived
+      // synthetic sidecars (e.g. tailscaled with its control-plane allowlist)
+      // are produced by `resolveServiceConfigs` in dryRun mode and need to be
+      // included so the addon's required hostnames auto-promote into
+      // template-source rules. Without this, every addon stack hits 403 at the
+      // gateway because its required egress is invisible to the rule reconciler.
       const stack = await this.prisma.stack.findUnique({
         where: { id: stackId },
-        select: {
-          environmentId: true,
-          services: {
-            select: {
-              serviceName: true,
-              containerConfig: true,
-            },
-          },
+        include: {
+          services: { orderBy: { order: 'asc' } },
+          environment: true,
         },
       });
 
@@ -356,7 +367,15 @@ export class EgressPolicyLifecycleService {
         return;
       }
 
-      // 2. Build Map<pattern, Set<serviceName>> from requiredEgress declarations.
+      // 2. Build Map<pattern, Set<serviceName>> from requiredEgress
+      // declarations. Two passes: (a) authored services straight from the DB
+      // rows — this is the long-standing behaviour and the source of truth
+      // for hand-authored stack definitions; (b) addon-derived synthetic
+      // sidecars via dryRun expansion — these don't have DB rows but their
+      // planStub carries `requiredEgress` (e.g. Tailscale's control-plane
+      // hostnames). Without (b), addon stacks like nginx + tailscale-web get
+      // 403'd at the gateway because the synthetic's required hostnames
+      // never auto-promote into template-source rules.
       const desiredPatterns = new Map<string, Set<string>>();
       for (const svc of stack.services) {
         const config = svc.containerConfig as unknown as StackContainerConfig;
@@ -366,6 +385,37 @@ export class EgressPolicyLifecycleService {
           targets.add(svc.serviceName);
           desiredPatterns.set(pattern, targets);
         }
+      }
+
+      const authoredNames = new Set(stack.services.map((s) => s.serviceName));
+      try {
+        const params = mergeParameterValues(
+          (stack.parameters as unknown as StackParameterDefinition[]) ?? [],
+          (stack.parameterValues as unknown as Record<string, StackParameterValue>) ?? {},
+        );
+        const templateContext = buildStackTemplateContext(stack, params);
+        const { resolvedDefinitions } = await resolveServiceConfigs(
+          stack.services,
+          templateContext,
+          { dryRun: true },
+        );
+        for (const [serviceName, def] of resolvedDefinitions) {
+          if (authoredNames.has(serviceName)) continue; // already covered by pass (a)
+          const required = def.containerConfig?.requiredEgress;
+          if (!required || required.length === 0) continue;
+          for (const pattern of required) {
+            const targets = desiredPatterns.get(pattern) ?? new Set<string>();
+            targets.add(serviceName);
+            desiredPatterns.set(pattern, targets);
+          }
+        }
+      } catch (err) {
+        // Addon expansion failure here must not break the rule reconciler —
+        // pass (a) above already produced a baseline from authored services.
+        log.warn(
+          { err, stackId },
+          'reconcileTemplateRules: synthetic expansion failed; rules limited to authored services',
+        );
       }
 
       // 3. Load the stack's active EgressPolicy.

--- a/server/src/services/nats/nats-system-bootstrap.ts
+++ b/server/src/services/nats/nats-system-bootstrap.ts
@@ -51,16 +51,21 @@ const BACKUP_HISTORY_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 export async function bootstrapNatsSystemResources(): Promise<void> {
   const bus = NatsBus.getInstance();
 
-  // Wait briefly for the bus — caller already kicked it off, but a fresh-
-  // worktree boot can have NATS still coming up. The bus's reconnect loop
-  // continues in the background regardless; if we time out here we just
-  // surface the error and rely on the next boot to retry.
+  // Wait for the bus to be ready. Generous timeout because this fire-and-
+  // forget call runs concurrently with Vault unlock + creds rotation on
+  // fresh-worktree / dev-env boots, and "no retry until next server boot"
+  // is too coarse — `pnpm worktree-env start` runs the seeded server
+  // directly, and an EgressFwEvents stream missing for that boot's whole
+  // lifetime means the egress-log-ingester never attaches and the
+  // fw-agent's NFLOG stream piles up unconsumed. 5 minutes is well past
+  // any realistic Vault-unlock window, including the manual-unlock path
+  // where the operator types the passphrase after seeing the boot banner.
   try {
-    await bus.ready({ timeoutMs: 10_000 });
+    await bus.ready({ timeoutMs: 5 * 60 * 1000 });
   } catch (err) {
     log.warn(
       { err: err instanceof Error ? err.message : String(err) },
-      "nats system bootstrap: bus not ready in 10s — skipping (will retry on next boot)",
+      "nats system bootstrap: bus not ready in 5 min — giving up (next server boot will retry)",
     );
     return;
   }

--- a/server/src/services/stack-addons/__tests__/expand-addons.test.ts
+++ b/server/src/services/stack-addons/__tests__/expand-addons.test.ts
@@ -174,3 +174,78 @@ describe('expandAddons (Phase 1)', () => {
     expect(provisioned).toEqual([{ serviceName: 'web', addonIds: ['noop'] }]);
   });
 });
+
+describe('expandAddons (dryRun)', () => {
+  it('falls back to a generic stub when the addon does not implement planStub', async () => {
+    const registry = createAddonRegistry();
+    registry.register(noopAddon);
+
+    const target = makeStateful('web', { addons: { noop: { label: 'plan' } } });
+    const rendered = await expandAddons([target], {
+      ...baseContext,
+      registry,
+      dryRun: true,
+    });
+
+    expect(rendered).toHaveLength(2);
+    const sidecar = rendered.find((s) => s.serviceName === 'web-noop')!;
+    expect(sidecar).toBeDefined();
+    // Generic stub uses sentinel image so accidental apply use would be obvious.
+    expect(sidecar.dockerImage).toBe('addon-pending');
+    expect(sidecar.dockerTag).toBe('plan');
+    expect(sidecar.synthetic).toEqual({
+      addonIds: ['noop'],
+      targetService: 'web',
+    });
+    // No env from provision() — the noop addon would normally inject NOOP_TARGET / NOOP_LABEL.
+    expect(sidecar.containerConfig.env).toBeUndefined();
+  });
+
+  it('skips the requiresConnectedService check when no lookup is provided', async () => {
+    // Synthetic addon that requires a connected service. Without dryRun this
+    // would fail with "is not configured"; with dryRun + no lookup, expansion
+    // succeeds (the apply path re-checks before any side-effects fire).
+    const registry = createAddonRegistry();
+    registry.register({
+      manifest: {
+        ...noopAddon.manifest,
+        id: 'requires-svc',
+        requiresConnectedService: 'imaginary',
+      },
+      configSchema: noopAddon.configSchema,
+      definition: { ...noopAddon.definition, manifest: { ...noopAddon.manifest, id: 'requires-svc', requiresConnectedService: 'imaginary' } },
+    });
+
+    const target = makeStateful('web', { addons: { 'requires-svc': {} } });
+    const rendered = await expandAddons([target], {
+      ...baseContext,
+      registry,
+      dryRun: true,
+    });
+    expect(rendered).toHaveLength(2);
+    expect(rendered.find((s) => s.serviceName === 'web-requires-svc')).toBeDefined();
+  });
+
+  it('still enforces requiresConnectedService when the lookup is provided but missing the service', async () => {
+    const registry = createAddonRegistry();
+    registry.register({
+      manifest: {
+        ...noopAddon.manifest,
+        id: 'requires-svc',
+        requiresConnectedService: 'imaginary',
+      },
+      configSchema: noopAddon.configSchema,
+      definition: { ...noopAddon.definition, manifest: { ...noopAddon.manifest, id: 'requires-svc', requiresConnectedService: 'imaginary' } },
+    });
+
+    const target = makeStateful('web', { addons: { 'requires-svc': {} } });
+    await expect(
+      expandAddons([target], {
+        ...baseContext,
+        registry,
+        dryRun: true,
+        connectedServices: { other: true },
+      }),
+    ).rejects.toThrow(/requires connected service "imaginary"/);
+  });
+});

--- a/server/src/services/stack-addons/__tests__/tailscale-web.test.ts
+++ b/server/src/services/stack-addons/__tests__/tailscale-web.test.ts
@@ -199,4 +199,50 @@ describe('tailscale-web addon', () => {
       expandAddons([target], { ...baseContext, registry }),
     ).rejects.toThrow(/connected service/);
   });
+
+  it('dryRun renders the deterministic sidecar skeleton without minting an authkey', async () => {
+    const registry = createAddonRegistry();
+    registry.register(tailscaleWebAddon);
+
+    const target = makeStateful('web', {
+      addons: { 'tailscale-web': { port: 8080 } },
+    });
+
+    // Stub fetch with a sentinel that would throw if any provision-time HTTP
+    // call slipped through — the assertion below is "expansion completes
+    // without calling fetch", not just "expansion completes".
+    const originalFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls++;
+      throw new Error('fetch must not be called in dryRun');
+    }) as typeof fetch;
+    let rendered;
+    try {
+      rendered = await expandAddons([target], {
+        ...baseContext,
+        registry,
+        dryRun: true,
+        // No connectedServices lookup — plan path doesn't have one.
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(fetchCalls).toBe(0);
+    expect(rendered).toHaveLength(2);
+    const sidecar = rendered.find((s) => s.serviceName === 'web-tailscale')!;
+    expect(sidecar).toBeDefined();
+    // Real image / requiredEgress (from buildTailscaleSidecarDefinition).
+    expect(sidecar.dockerImage).toBe('tailscale/tailscale');
+    expect(sidecar.containerConfig.requiredEgress).toBeDefined();
+    // Per-mint env is absent — TS_AUTHKEY only lands at apply time.
+    expect(sidecar.containerConfig.env?.TS_AUTHKEY).toBeUndefined();
+    expect(sidecar.containerConfig.env?.TS_HOSTNAME).toBeUndefined();
+    expect(sidecar.synthetic).toEqual({
+      addonIds: ['tailscale-web'],
+      kind: undefined,
+      targetService: 'web',
+    });
+  });
 });

--- a/server/src/services/stack-addons/expand-addons.ts
+++ b/server/src/services/stack-addons/expand-addons.ts
@@ -26,6 +26,14 @@ export interface ExpansionContext {
   instance?: { instanceId: string };
   vault?: unknown;
   connectedServices?: unknown;
+  /**
+   * When true, expansion runs from a read-only plan path: `provision()` and
+   * `buildServiceDefinition()` are skipped in favour of `planStub()` (or a
+   * generic placeholder), and the `requiresConnectedService` check is
+   * tolerant of an absent `connectedServices` lookup. Apply paths leave this
+   * unset so real provisioning runs.
+   */
+  dryRun?: boolean;
 }
 
 /**
@@ -231,8 +239,15 @@ async function resolveGroups(
         `Addon "${addonId}" does not apply to service type "${target.serviceType}" (allowed: ${registered.manifest.appliesTo.join(', ')})`,
       );
     }
+    // Connected-service presence is enforced at apply time (when the caller
+    // supplies a real lookup). Plan-time callers run with `dryRun: true` and
+    // no lookup — the synthetic sidecar still appears in the plan diff, and
+    // the eventual apply re-checks before any provisioning runs. Skipping
+    // here keeps standalone plan UIs (validation-routes, update-route)
+    // working for stacks that declare addons.
     if (
       registered.manifest.requiresConnectedService &&
+      context.connectedServices !== undefined &&
       !connectedServiceConfigured(
         registered.manifest.requiresConnectedService,
         context.connectedServices,
@@ -242,6 +257,17 @@ async function resolveGroups(
         target.serviceName,
         [addonId],
         `Addon "${addonId}" requires connected service "${registered.manifest.requiresConnectedService}" but it is not configured`,
+      );
+    }
+    if (
+      registered.manifest.requiresConnectedService &&
+      context.connectedServices === undefined &&
+      !context.dryRun
+    ) {
+      throw new AddonExpansionError(
+        target.serviceName,
+        [addonId],
+        `Addon "${addonId}" requires connected service "${registered.manifest.requiresConnectedService}" but no connected-services lookup was provided to apply-time expansion`,
       );
     }
 
@@ -293,7 +319,12 @@ async function applyGroup(
   rendered: Map<string, StackServiceDefinition>,
   progress: ExpansionProgress,
 ): Promise<void> {
-  // Step 4–5 — provision and materialise.
+  // Step 4–5 — provision and materialise. In `dryRun` mode the side-effecting
+  // `provision()` (e.g. authkey minting) is skipped; the addon's `planStub()`
+  // (or a generic placeholder) supplies a deterministic synthetic-service
+  // skeleton so the plan diff still shows the sidecar. `applyTargetIntegration`
+  // also degrades to a no-op in dryRun because `provisioned` carries nothing
+  // for it to thread through.
   let provisioned: ProvisionedValues;
   let sidecar: StackServiceDefinition;
   let integration: TargetIntegration;
@@ -307,8 +338,15 @@ async function applyGroup(
       group.application.config,
       context,
     );
-    provisioned = await def.provision(provisionCtx);
-    sidecar = def.buildServiceDefinition(provisionCtx, provisioned);
+    if (context.dryRun) {
+      provisioned = { templateVars: {} };
+      sidecar = def.planStub
+        ? def.planStub(provisionCtx)
+        : genericPlanStub(group.target.serviceName, [group.application.addonId]);
+    } else {
+      provisioned = await def.provision(provisionCtx);
+      sidecar = def.buildServiceDefinition(provisionCtx, provisioned);
+    }
     integration = def.targetIntegration;
     memberIds = [group.application.addonId];
     synthetic = {
@@ -329,14 +367,21 @@ async function applyGroup(
       addonId: m.addonId,
       config: m.config,
     }));
-    provisioned = await group.strategy.provision(provisionCtx, memberPairs);
-    sidecar = group.strategy.buildServiceDefinition(
-      provisionCtx,
-      provisioned,
-      memberPairs,
-    );
-    integration = group.strategy.targetIntegration;
     memberIds = group.members.map((m) => m.addonId);
+    if (context.dryRun) {
+      provisioned = { templateVars: {} };
+      sidecar = group.strategy.planStub
+        ? group.strategy.planStub(provisionCtx, memberPairs)
+        : genericPlanStub(group.target.serviceName, memberIds, group.kindLabel);
+    } else {
+      provisioned = await group.strategy.provision(provisionCtx, memberPairs);
+      sidecar = group.strategy.buildServiceDefinition(
+        provisionCtx,
+        provisioned,
+        memberPairs,
+      );
+    }
+    integration = group.strategy.targetIntegration;
     synthetic = {
       addonIds: memberIds,
       kind: group.kindLabel,
@@ -375,6 +420,31 @@ async function applyGroup(
     kind: group.kind === 'merged' ? group.kindLabel : undefined,
     syntheticServiceName: renderedSidecar.serviceName,
   });
+}
+
+/**
+ * Fallback synthetic-service skeleton when an addon (or merge strategy)
+ * doesn't supply its own `planStub`. The shape is deliberately minimal —
+ * just enough that the plan diff can include the synthetic by name without
+ * leaking apply-time provisioned state. Image / tag use a sentinel that
+ * makes plan-time misuse obvious if it ever leaks past plan into the
+ * reconciler.
+ */
+function genericPlanStub(
+  targetServiceName: string,
+  addonIds: string[],
+  kind?: string,
+): StackServiceDefinition {
+  const suffix = kind ?? addonIds[0] ?? 'addon';
+  return {
+    serviceName: `${targetServiceName}-${suffix}`,
+    serviceType: 'Stateful',
+    dockerImage: 'addon-pending',
+    dockerTag: 'plan',
+    containerConfig: {},
+    dependsOn: [targetServiceName],
+    order: 1000,
+  };
 }
 
 function buildProvisionContext(

--- a/server/src/services/stack-addons/merge-strategies/tailscale.ts
+++ b/server/src/services/stack-addons/merge-strategies/tailscale.ts
@@ -199,6 +199,29 @@ const tailscaleMergedTargetIntegration: TargetIntegration = {
   network: 'peer-on-target-network',
 };
 
+function planStubMergedServiceDefinition(
+  ctx: ProvisionContext,
+  members: ReadonlyArray<{ addonId: string; config: unknown }>,
+): StackServiceDefinition {
+  // Mirror buildMergedServiceDefinition's labels exactly (sorted member ids)
+  // so the plan-time synthetic identity matches the apply-time one. Per-mint
+  // env (TS_AUTHKEY, TS_HOSTNAME, TS_EXTRA_ARGS, TS_SERVE_CONFIG) is omitted —
+  // those values come from `provision()` and would change the synthetic's
+  // hash on every plan run if included.
+  const memberIds = members.map((m) => m.addonId).sort();
+  return buildTailscaleSidecarDefinition({
+    ctx,
+    env: {},
+    labels: {
+      'mini-infra.addon': TAILSCALE_KIND,
+      'mini-infra.addon-kind': TAILSCALE_KIND,
+      'mini-infra.addon-members': memberIds.join(','),
+      'mini-infra.synthetic': 'true',
+      'mini-infra.addon-target': ctx.service.name,
+    },
+  });
+}
+
 /**
  * Merge strategy for `kind: "tailscale"`. Collapses any combination of
  * `tailscale-ssh` and `tailscale-web` declared on the same target service
@@ -211,4 +234,5 @@ export const tailscaleMergeStrategy: AddonMergeStrategy = {
   targetIntegration: tailscaleMergedTargetIntegration,
   provision: provisionTailscaleMerged,
   buildServiceDefinition: buildMergedServiceDefinition,
+  planStub: planStubMergedServiceDefinition,
 };

--- a/server/src/services/stack-addons/tailscale-ssh/index.ts
+++ b/server/src/services/stack-addons/tailscale-ssh/index.ts
@@ -1,4 +1,4 @@
-import type { AddonDefinition } from '@mini-infra/types';
+import type { AddonDefinition, ProvisionContext } from '@mini-infra/types';
 import { productionAddonRegistry, type RegisteredAddon } from '../registry';
 import {
   tailscaleSshConfigSchema,
@@ -7,6 +7,7 @@ import {
 } from './manifest';
 import { provisionTailscaleSsh } from './provision';
 import { buildTailscaleSshServiceDefinition } from './build-service-definition';
+import { buildTailscaleSidecarDefinition } from '../shared/tailscale-sidecar';
 
 /**
  * `tailscale-ssh` addon — the first production addon in the framework
@@ -19,6 +20,19 @@ export const tailscaleSshDefinition: AddonDefinition = {
   targetIntegration: tailscaleSshTargetIntegration,
   provision: provisionTailscaleSsh,
   buildServiceDefinition: buildTailscaleSshServiceDefinition,
+  // Plan-time skeleton: the deterministic shape of the sidecar (image, capAdd,
+  // state-volume mount, requiredEgress) without the per-mint env (TS_AUTHKEY,
+  // TS_HOSTNAME, TS_EXTRA_ARGS — these land at apply time via `provision`).
+  planStub: (ctx: ProvisionContext) =>
+    buildTailscaleSidecarDefinition({
+      ctx,
+      env: {},
+      labels: {
+        'mini-infra.addon': 'tailscale-ssh',
+        'mini-infra.synthetic': 'true',
+        'mini-infra.addon-target': ctx.service.name,
+      },
+    }),
 };
 
 export const tailscaleSshAddon: RegisteredAddon = {

--- a/server/src/services/stack-addons/tailscale-web/index.ts
+++ b/server/src/services/stack-addons/tailscale-web/index.ts
@@ -1,4 +1,4 @@
-import type { AddonDefinition } from '@mini-infra/types';
+import type { AddonDefinition, ProvisionContext } from '@mini-infra/types';
 import { productionAddonRegistry, type RegisteredAddon } from '../registry';
 import {
   tailscaleWebConfigSchema,
@@ -7,6 +7,7 @@ import {
 } from './manifest';
 import { provisionTailscaleWeb } from './provision';
 import { buildTailscaleWebServiceDefinition } from './build-service-definition';
+import { buildTailscaleSidecarDefinition } from '../shared/tailscale-sidecar';
 
 /**
  * `tailscale-web` addon — Phase 4 sibling to `tailscale-ssh`. Materialises a
@@ -21,6 +22,19 @@ export const tailscaleWebDefinition: AddonDefinition = {
   targetIntegration: tailscaleWebTargetIntegration,
   provision: provisionTailscaleWeb,
   buildServiceDefinition: buildTailscaleWebServiceDefinition,
+  // Plan-time skeleton — see tailscale-ssh's planStub for rationale. The
+  // serve-config file mount and TS_SERVE_CONFIG env land at apply time;
+  // the plan-time stub just carries the deterministic sidecar identity.
+  planStub: (ctx: ProvisionContext) =>
+    buildTailscaleSidecarDefinition({
+      ctx,
+      env: {},
+      labels: {
+        'mini-infra.addon': 'tailscale-web',
+        'mini-infra.synthetic': 'true',
+        'mini-infra.addon-target': ctx.service.name,
+      },
+    }),
 };
 
 export const tailscaleWebAddon: RegisteredAddon = {

--- a/server/src/services/stacks/__tests__/definition-hash-addons.test.ts
+++ b/server/src/services/stacks/__tests__/definition-hash-addons.test.ts
@@ -115,4 +115,59 @@ describe('resolveServiceConfigs — §7 hash invariant pinned end-to-end', () =>
     expect(targetHashB).toBeDefined();
     expect(targetHashA).not.toBe(targetHashB);
   });
+
+  it('synthetic sidecar hash is stable across plan/apply when authored addon-config is unchanged', async () => {
+    const registry = createAddonRegistry();
+    registry.register(noopAddon);
+
+    const ctx = buildTemplateContext(
+      { name: 'demo', networks: [], volumes: [] },
+      [{ serviceName: 'web', dockerImage: 'nginx', dockerTag: 'latest', containerConfig: { restartPolicy: 'unless-stopped' } }],
+    );
+
+    // Apply path: full provisioning (no dryRun) — synthetic ends up with the
+    // noop addon's per-call provisioned env (NOOP_TARGET, NOOP_LABEL).
+    const { serviceHashes: applyHashes } = await resolveServiceConfigs(
+      [makeServiceRow({ noop: { label: 'x' } })],
+      ctx,
+      { addonRegistry: registry },
+    );
+    // Plan path: dryRun stub — synthetic uses the generic placeholder def,
+    // which has a different shape than the apply-time def. The synthetic
+    // hash must agree with apply-time despite that difference.
+    const { serviceHashes: planHashes } = await resolveServiceConfigs(
+      [makeServiceRow({ noop: { label: 'x' } })],
+      ctx,
+      { addonRegistry: registry, dryRun: true },
+    );
+
+    const applyHash = applyHashes.get('web-noop');
+    const planHash = planHashes.get('web-noop');
+    expect(applyHash).toBeDefined();
+    expect(planHash).toBeDefined();
+    expect(planHash).toBe(applyHash);
+  });
+
+  it('synthetic sidecar hash changes when authored addon-config changes', async () => {
+    const registry = createAddonRegistry();
+    registry.register(noopAddon);
+
+    const ctx = buildTemplateContext(
+      { name: 'demo', networks: [], volumes: [] },
+      [{ serviceName: 'web', dockerImage: 'nginx', dockerTag: 'latest', containerConfig: { restartPolicy: 'unless-stopped' } }],
+    );
+
+    const { serviceHashes: hashA } = await resolveServiceConfigs(
+      [makeServiceRow({ noop: { label: 'a' } })],
+      ctx,
+      { addonRegistry: registry, dryRun: true },
+    );
+    const { serviceHashes: hashB } = await resolveServiceConfigs(
+      [makeServiceRow({ noop: { label: 'b' } })],
+      ctx,
+      { addonRegistry: registry, dryRun: true },
+    );
+
+    expect(hashA.get('web-noop')).not.toBe(hashB.get('web-noop'));
+  });
 });

--- a/server/src/services/stacks/definition-hash.ts
+++ b/server/src/services/stacks/definition-hash.ts
@@ -1,5 +1,10 @@
 import { createHash } from 'crypto';
-import { StackServiceDefinition, StackConfigFile, StackContainerConfig } from '@mini-infra/types';
+import {
+  StackServiceDefinition,
+  StackConfigFile,
+  StackContainerConfig,
+  SyntheticServiceInfo,
+} from '@mini-infra/types';
 
 /**
  * Strip apply-time dynamic-env metadata from containerConfig before hashing.
@@ -73,5 +78,42 @@ export function computeDefinitionHash(
     .update(stableStringify(canonical))
     .digest('hex');
 
+  return `sha256:${hash}`;
+}
+
+/**
+ * Stable hash for an addon-derived synthetic sidecar.
+ *
+ * Synthetic services live outside the authored DB rows — their rendered shape
+ * (image, env, mounts) is computed at apply time by the addon's `provision()`
+ * and `buildServiceDefinition()`. Some of that shape is deterministic
+ * (image, capAdd, state-volume mount) and some is per-mint (TS_AUTHKEY,
+ * hostnames derived from runtime state). Hashing the rendered definition
+ * directly would change the hash on every apply, marking the sidecar as
+ * permanently drifted.
+ *
+ * Instead we hash the *authoring intent* — the synthetic's identity (addon
+ * ids, kind, target service) plus the target's authored addon-config block.
+ * Two applies with the same authored input yield the same hash regardless
+ * of when provisioning ran or what authkey was minted.
+ */
+export function computeSyntheticDefinitionHash(
+  synthetic: SyntheticServiceInfo,
+  targetAuthoredAddons: Record<string, unknown> | undefined,
+): string {
+  const sortedAddonIds = [...synthetic.addonIds].sort();
+  const relevantConfigs: Record<string, unknown> = {};
+  for (const id of sortedAddonIds) {
+    relevantConfigs[id] = targetAuthoredAddons?.[id] ?? null;
+  }
+  const canonical = {
+    syntheticAddonIds: sortedAddonIds,
+    syntheticKind: synthetic.kind ?? null,
+    syntheticTarget: synthetic.targetService,
+    addonConfigs: relevantConfigs,
+  };
+  const hash = createHash('sha256')
+    .update(stableStringify(canonical))
+    .digest('hex');
   return `sha256:${hash}`;
 }

--- a/server/src/services/stacks/stack-plan-computer.ts
+++ b/server/src/services/stacks/stack-plan-computer.ts
@@ -52,7 +52,14 @@ export class StackPlanComputer {
     );
     const templateContext = buildStackTemplateContext(stack, params);
 
-    const { resolvedDefinitions, serviceHashes } = await resolveServiceConfigs(stack.services, templateContext);
+    // Plan-time addon expansion runs in `dryRun` mode: synthetic sidecars
+    // appear in the plan diff but no `provision()` side-effects fire. See
+    // ExpansionContext.dryRun on the addon framework for the full contract.
+    const { resolvedDefinitions, serviceHashes } = await resolveServiceConfigs(
+      stack.services,
+      templateContext,
+      { dryRun: true },
+    );
 
     const docker = this.dockerExecutor.getDockerClient();
     const rawContainers = await docker.listContainers({
@@ -200,7 +207,71 @@ export class StackPlanComputer {
       });
     }
 
-    const definedServiceNames = new Set(stack.services.map((s) => s.serviceName));
+    // Synthetic sidecars produced by the addon render pipeline live in
+    // `resolvedDefinitions` but have no DB row in `stack.services` — the loop
+    // above skipped them. Iterate the rendered map for any names not handled
+    // yet and emit Stateful-shaped actions so the apply path actually creates
+    // them. Synthetics are always Stateful per the addon framework contract.
+    const authoredServiceNames = new Set(stack.services.map((s) => s.serviceName));
+    for (const [serviceName, def] of resolvedDefinitions) {
+      if (authoredServiceNames.has(serviceName)) continue;
+      const desiredHash = serviceHashes.get(serviceName);
+      if (!desiredHash) continue;
+      const desiredImage = `${def.dockerImage}:${def.dockerTag}`;
+      const container = containerMap.get(serviceName);
+
+      if (!container) {
+        actions.push({
+          serviceName,
+          action: 'create',
+          reason: 'addon-derived sidecar not deployed',
+          desiredImage,
+        });
+        continue;
+      }
+
+      const currentHash = container.Labels['mini-infra.definition-hash'];
+      const currentImage = container.Image;
+
+      if (container.State !== 'running') {
+        actions.push({
+          serviceName,
+          action: 'recreate',
+          reason: 'sidecar container not running',
+          currentImage,
+          desiredImage,
+        });
+        continue;
+      }
+
+      if (currentHash === desiredHash) {
+        actions.push({
+          serviceName,
+          action: 'no-op',
+          currentImage,
+          desiredImage,
+        });
+        continue;
+      }
+
+      actions.push({
+        serviceName,
+        action: 'recreate',
+        reason: 'addon configuration changed',
+        currentImage,
+        desiredImage,
+      });
+    }
+
+    // Orphan-removal: any container labelled with this stack's id whose
+    // service name no longer maps to either an authored service OR a
+    // currently-rendered synthetic sidecar. The earlier behaviour omitted
+    // synthetics from the defined set, so a correctly-applied sidecar was
+    // flagged for removal on every subsequent plan.
+    const definedServiceNames = new Set([
+      ...authoredServiceNames,
+      ...resolvedDefinitions.keys(),
+    ]);
     for (const [serviceName, container] of containerMap) {
       if (!definedServiceNames.has(serviceName)) {
         actions.push({

--- a/server/src/services/stacks/stack-reconciler.ts
+++ b/server/src/services/stacks/stack-reconciler.ts
@@ -309,7 +309,7 @@ export class StackReconciler {
         }
 
         const handlerCtx: ServiceHandlerContext = {
-          action, svc: svc!, serviceDef, projectName, stackId, stack,
+          action, svc: svc ?? null, serviceDef, projectName, stackId, stack,
           networkNames, serviceHashes, resolvedConfigsMap, containerByService,
           infraNetworkMap, resolvedEnvOverrides, actionStart, log,
         };
@@ -567,7 +567,7 @@ export class StackReconciler {
         const actionStart = Date.now();
 
         const handlerCtx: ServiceHandlerContext = {
-          action, svc: svc!, serviceDef, projectName, stackId, stack,
+          action, svc: svc ?? null, serviceDef, projectName, stackId, stack,
           networkNames, serviceHashes, resolvedConfigsMap, containerByService,
           infraNetworkMap, resolvedEnvOverrides, actionStart, log,
         };

--- a/server/src/services/stacks/stack-service-handlers.ts
+++ b/server/src/services/stacks/stack-service-handlers.ts
@@ -29,10 +29,17 @@ import {
 /**
  * Shared context passed to every service handler invocation. Contains
  * everything the handler needs beyond the per-call action and service defs.
+ *
+ * `svc` is the authored DB row when this action targets a user-declared
+ * service. It is `null` for synthetic sidecars produced by the addon render
+ * pipeline (e.g. a `tailscale-web` sidecar attached to a target service) —
+ * synthetics have no dedicated DB row, only a `serviceDef` derived from the
+ * addon's `buildServiceDefinition()` output. Handlers that need
+ * authored-service metadata (vault refs, pool config) must guard on `svc`.
  */
 export interface ServiceHandlerContext {
   action: ServiceAction;
-  svc: Prisma.StackServiceGetPayload<true>;
+  svc: Prisma.StackServiceGetPayload<true> | null;
   serviceDef: StackServiceDefinition | null;
   projectName: string;
   stackId: string;
@@ -87,7 +94,7 @@ export class StackServiceHandlers {
   ) {}
 
   async applyStateful(ctx: ServiceHandlerContext): Promise<ServiceApplyResult> {
-    const { action, svc, serviceDef, projectName, stackId, stack, networkNames, serviceHashes,
+    const { action, serviceDef, projectName, stackId, stack, networkNames, serviceHashes,
       resolvedConfigsMap, containerByService, infraNetworkMap, resolvedEnvOverrides, actionStart, log } = ctx;
 
     const overridesForService = resolvedEnvOverrides?.get(action.serviceName);
@@ -95,7 +102,7 @@ export class StackServiceHandlers {
 
     switch (action.action) {
       case 'create': {
-        if (!effectiveServiceDef || !svc) throw new Error(`Service ${action.serviceName} not found`);
+        if (!effectiveServiceDef) throw new Error(`Service ${action.serviceName} not found`);
         log.info({ service: action.serviceName }, 'Creating service');
 
         await removeConflictingContainer(
@@ -151,7 +158,7 @@ export class StackServiceHandlers {
       }
 
       case 'recreate': {
-        if (!effectiveServiceDef || !svc) throw new Error(`Service ${action.serviceName} not found`);
+        if (!effectiveServiceDef) throw new Error(`Service ${action.serviceName} not found`);
         log.info({ service: action.serviceName }, 'Recreating service');
 
         const oldContainer = containerByService.get(action.serviceName);

--- a/server/src/services/stacks/utils.ts
+++ b/server/src/services/stacks/utils.ts
@@ -12,7 +12,7 @@ import type {
   StackServiceInfo,
 } from '@mini-infra/types';
 import { buildTemplateContext, resolveStackConfigFiles, resolveServiceDefinition } from './template-engine';
-import { computeDefinitionHash } from './definition-hash';
+import { computeDefinitionHash, computeSyntheticDefinitionHash } from './definition-hash';
 import { StackContainerManager } from './stack-container-manager';
 import { decryptInputValues } from './stack-input-values-service';
 import {
@@ -287,6 +287,15 @@ export interface ResolveServiceConfigsOptions {
    * Omitted in `plan()` flows where no provisioning runs.
    */
   connectedServices?: unknown;
+  /**
+   * When true, addon expansion runs as a read-only plan pass: `provision()`
+   * and `buildServiceDefinition()` are skipped in favour of the addon's
+   * `planStub()` (or a generic placeholder), so plan invocations don't mint
+   * authkeys, hit external APIs, or produce synthetic-service hashes that
+   * drift between runs. The apply path leaves this unset (defaults to false)
+   * so real provisioning runs.
+   */
+  dryRun?: boolean;
 }
 
 /**
@@ -382,6 +391,7 @@ export async function resolveServiceConfigs(
         : { id: '', name: '', networkType: 'local' },
       instance: options.instance,
       connectedServices: options.connectedServices,
+      dryRun: options.dryRun,
     },
     options.expansionProgress,
   );
@@ -399,19 +409,34 @@ export async function resolveServiceConfigs(
     const resolvedDef = resolveServiceDefinition(def, templateContext);
     resolvedDefinitions.set(def.serviceName, resolvedDef);
     // Hash the resolved definition so parameter value changes trigger
-    // recreates. For authored services we re-attach the original `addons:`
-    // block (stripped on the render output) so the hash includes the
-    // authoring intent — definition-hash.ts §7 invariant. Synthetic
-    // sidecars don't carry an addons block of their own.
+    // recreates. Three cases:
+    //
+    // 1. Authored services: re-attach the authored `addons:` block (stripped
+    //    on the render output) so addon-config changes recreate the target,
+    //    without leaking provisioned values into the hash. Definition-hash.ts
+    //    §7 invariant.
+    // 2. Synthetic sidecars: hash the *authoring intent* (synthetic info +
+    //    target's authored addon configs). Hashing the rendered sidecar
+    //    directly would include per-mint env (TS_AUTHKEY etc.) and drift
+    //    every apply, so plan would always say "recreate".
+    // 3. Pre-existing services with neither: hash the resolved def as-is.
     const authoredAddons = authoredAddonsByName.get(def.serviceName);
-    const defForHash =
-      authoredAddons !== undefined
-        ? { ...resolvedDef, addons: authoredAddons }
-        : resolvedDef;
-    serviceHashes.set(
-      def.serviceName,
-      computeDefinitionHash(defForHash, resolvedConfigs),
-    );
+    if (def.synthetic) {
+      const targetAuthoredAddons = authoredAddonsByName.get(def.synthetic.targetService);
+      serviceHashes.set(
+        def.serviceName,
+        computeSyntheticDefinitionHash(def.synthetic, targetAuthoredAddons),
+      );
+    } else {
+      const defForHash =
+        authoredAddons !== undefined
+          ? { ...resolvedDef, addons: authoredAddons }
+          : resolvedDef;
+      serviceHashes.set(
+        def.serviceName,
+        computeDefinitionHash(defForHash, resolvedConfigs),
+      );
+    }
   }
 
   return { resolvedConfigsMap, resolvedDefinitions, serviceHashes };

--- a/server/templates/egress-fw-agent/template.json
+++ b/server/templates/egress-fw-agent/template.json
@@ -1,7 +1,7 @@
 {
   "name": "egress-fw-agent",
   "displayName": "Egress Firewall Agent",
-  "builtinVersion": 3,
+  "builtinVersion": 4,
   "scope": "host",
   "category": "infrastructure",
   "description": "Blocks outbound network traffic that breaks your environment's egress rules. Runs once per host. Logs every blocked connection so you can see what was denied and why. Requires a synced NATS host stack (which transitively requires Vault to be bootstrapped).",
@@ -33,7 +33,7 @@
         "kvBuckets": [
           "egress-fw-health"
         ],
-        "inboxAuto": "reply"
+        "inboxAuto": "both"
       }
     ]
   },


### PR DESCRIPTION
## Summary
This started as the addon-framework end-to-end fix and grew, while smoke-testing it, into the four egress integration bugs that all blocked the same goal: an addon stack that actually works end-to-end. Each commit is independently reviewable.

### Commits
1. **docs(stack-definition-reference)** — document the `services[].addons` block (registry-validated config, applies-to / requires-connected-service gates, kind-merge semantics, worked example with both Tailscale addons on one nginx service).
2. **fix(addons): plumb synthetic services through plan and apply end-to-end** — The original target. Adds `dryRun` to `ExpansionContext` + optional `planStub()` per addon and per merge strategy so plan callers don't trigger `provision()` side-effects (no authkey minting at plan time). Plan computer walks rendered defs for synthetics; Stateful handler tolerates synthetic actions (no DB row); `computeSyntheticDefinitionHash` keeps plan/apply hashes in agreement so re-apply is a true no-op.
3. **fix(egress): tolerate asymmetric BEGIN/END marker dash counts in creds parser** — `nats-jwt`'s `fmtCreds` emits 5-dash BEGIN markers but 6-dash END markers; our exact-substring matcher absorbed the extra dash into the body, producing a 59-char "seed" that base32-decoded with `illegal base32 data at input byte 58` and crashed both `egress-gateway` and `egress-fw-agent` on every boot. Switch `extractArmored` to a regex anchored to line boundaries (`-{3,}` either side), mirroring nats-jwt's own `parseCreds`.
4. **fix(egress): include synthetic sidecars in container map and rule reconciler** — Two parallel iterate-only-of-authored-rows bugs. `_buildContainerMap` dropped synthetic IPs from the gateway map, so `UnknownIPDenyHandler` 403'd every CONNECT before the ACL ran; `reconcileTemplateRules` never auto-promoted addon-derived `requiredEgress` (the Tailscale control-plane allowlist) into template-source rules. Both now recognise synthetics — the map trusts `mini-infra.synthetic=true` + parent `mini-infra.stack-id` (both reconciler-set, not user-controlled), and the rule reconciler runs a second pass via dryRun expansion to pick up synthetic `requiredEgress`.
5. **fix(egress): stamp ts on every CANONICAL-PROXY-DECISION emit path** — Server's nats-bus Zod validator requires `ts: string min(1)`, but only `EmitToStdout` defaulted it. The production JetStream emitter (`bridge.DecisionEmitter`) and per-handler builders left `Ts` empty, so every published decision was rejected with `ts: Too small` and NAK'd until max-deliveries. Stamp `Ts` from `entry.Time` in the handlers (accurate timing) plus a defensive default in `emitOrFallback` (safety net).

### End-to-end smoke
nginx + `tailscale-web` addon → instantiate → apply → synthetic sidecar (`local-nginx-ts-test-web-tailscale`) comes up labelled `mini-infra.synthetic=true` `mini-infra.addon=tailscale-web` `mini-infra.addon-target=web` → tailscaled reaches `controlplane.tailscale.com:443` (200 OK) → joins the tailnet (DERP-5 connected, netmap received with suggested exit node) → uploads logs to `log.tailscale.com:443`. Re-apply emits `noOps:2` (synthetic hash deterministic). Validation failures on `EgressGwDecisions`: 0 in the last 500 server log lines (was ~60 before the rebuild).

## Test plan
- [x] `pnpm build:lib && pnpm --filter mini-infra-server build` clean
- [x] `pnpm --filter mini-infra-server lint` clean
- [x] `pnpm --filter mini-infra-server test` — 156 files / 2154 tests pass (8 new across addon framework + hash determinism + egress-gateway logadapter)
- [x] `cd egress-shared && go test ./...` — natsbus parser tests pass including new `TestExtractArmored_AsymmetricEndMarkers`
- [x] `cd egress-gateway && go test ./...` — logadapter tests pass including new ts-stamping regressions
- [x] Live smoke against the dev env: stack syncs, sidecar joins tailnet, no `ts: Too small` errors after the rebuild
- [ ] Operator smoke after merge: any stack with `tailscale-ssh`/`tailscale-web` now applies cleanly through the API and joins the tailnet, and JetStream's egress-decisions stream stops accumulating NAK'd messages.

## Known follow-ups (not in this PR)
- `reconciler.update` (`stack-reconciler.ts:497`) and `pool-spawner.ts:115` still call `resolveServiceConfigs` without `connectedServices`; same bug shape, would still fail for addon stacks on update or pool spawn.
- `stacks-apply-route.ts:343-352` "Stack apply setup failed" only emits a socket event; the stack row keeps `lastFailureReason: null`, so setup failures look like silent stalls in the UI.
- `enforce_would_deny:true` shows up in gateway CANONICAL-PROXY-DECISION lines despite matching addon-derived rules — Smokescreen's `Report` mode allows + logs but seems not to count the addon hostnames as in-allowlist for the "enforce would" simulation; worth a look once a stack is moved to enforce mode.
- `EgressFwEvents` stream not seeded by the dev env — egress-fw-agent's heartbeat KV puts time out and the ingester logs `stream not found` warnings on a loop.
- Vault re-seals after a server restart in dev; needs `POST /api/vault/passphrase/unlock` (env-details has the passphrase). Possibly worth a dev-startup auto-unlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)