### PR TITLE
feat(nats): app-author JetStream via roles[].streams + consumers

### DIFF
--- a/docs/planning/not-shipped/nats-app-roles-followups.md
+++ b/docs/planning/not-shipped/nats-app-roles-followups.md
@@ -112,15 +112,31 @@ connected with what JWT; the manager service is responsible for its own
 audit log if it needs one. Worth revisiting if a real compliance ask
 appears.
 
-### JetStream-for-apps (`roles[].streams`)
+### ~~JetStream-for-apps (`roles[].streams`)~~ — shipped
 
-V1 keeps `streams` as a legacy-only template field with absolute
-subjects, system-template-only path. Apps that want JetStream are blocked
-by the mixing rule. Slackbot doesn't need it, but the next NATS-using app
-might. Adding `roles[].streams` (relative subjects, auto-prefixed) is
-straightforward once a use case appears — the materialization path
-already exists, just needs prefix-prepending in
-`stack-nats-apply-orchestrator.ts` legacy-streams branch.
+Shipped: app-author roles can now declare `streams[]` and `consumers[]`
+nested on the role. Stream subjects + consumer `filterSubject` are written
+relative to the stack's `subjectPrefix` and the orchestrator prepends at
+apply time. The role's credentials gain the matching JetStream API grants
+(`$JS.API.STREAM.INFO.<stream>`, `$JS.API.CONSUMER.{INFO,CREATE,MSG.NEXT}.<stream>.<consumer>`,
+`$JS.ACK.<stream>.<consumer>.>`) so a service bound to the role can
+publish, bind the durable consumer, pull, and ACK without any extra
+plumbing. `NatsStream` rows now carry a `stackId` so cascade-delete +
+`pruneOrphanRoleStreams` clean up renames and removals. The mixing rule
+extends to streams/consumers — top-level `nats.streams[]` and
+`nats.consumers[]` cannot coexist with `nats.roles[]` in the same
+template; declare them via `nats.roles[].streams` instead. Real-NATS
+external coverage in
+[server/src/__tests__/nats-role-streams.external.test.ts](../../../server/src/__tests__/nats-role-streams.external.test.ts).
+
+Known follow-up: removing a role-stream from a template deletes the
+`NatsStream` DB row but does not delete the underlying JetStream stream
+in NATS itself (the orchestrator only adds/updates via
+`applyJetStreamResources`). Stale streams stop receiving traffic because
+nothing else publishes to the prefixed subjects, but they leak storage
+until manually pruned. A reconciliation step that lists JetStream
+streams and deletes any that aren't in the DB is the natural fix; punted
+out of this PR to keep the change focused.
 
 ### Drift detection in `lastAppliedNatsSnapshot`
 

--- a/docs/planning/not-shipped/nats-app-roles-followups.md
+++ b/docs/planning/not-shipped/nats-app-roles-followups.md
@@ -138,6 +138,20 @@ until manually pruned. A reconciliation step that lists JetStream
 streams and deletes any that aren't in the DB is the natural fix; punted
 out of this PR to keep the change focused.
 
+No system templates need to migrate to the new surface. The shared
+system JetStream streams (`EgressFwEvents`, `BackupHistory`, etc.) and KV
+buckets (`egress-fw-health`) are bootstrapped server-side at boot via
+`bus.jetstream.ensureStream(...)` in
+[server/src/services/nats/nats-system-bootstrap.ts](../../../server/src/services/nats/nats-system-bootstrap.ts) —
+not from any template. Their lifecycle is "server up", not "stack
+applied", which is the right shape for shared infra streams that
+multiple stack instances and the server itself consume from. The two
+NATS-using system templates that exist (`egress-fw-agent`,
+`egress-gateway`) already declare `roles[]` with allowlisted prefixes
+(`mini-infra.egress.fw` / `.gw`) and don't declare any streams in the
+template. `roles[].streams` is purely additive for future app
+templates that want their own per-stack JetStream.
+
 ### Drift detection in `lastAppliedNatsSnapshot`
 
 The snapshot writes accounts/credentials/streams/consumers/roles/exports/

--- a/lib/types/stack-templates.ts
+++ b/lib/types/stack-templates.ts
@@ -251,8 +251,64 @@ export interface TemplateNatsRole {
    * bucket. Future system templates use the same mechanism.
    */
   kvBuckets?: string[];
+  /**
+   * App-declared JetStream streams owned by this role. Stream subjects are
+   * written *relative* to the stack's subjectPrefix; the orchestrator
+   * prepends `<prefix>.` at apply time so every stream's subject filter
+   * lives inside the stack's namespace. The stream is created on the
+   * shared system account (same prefix-only isolation as roles), and
+   * the role's credentials automatically retain pub/sub on the role's
+   * own subject tree — so a service bound to this role can publish to
+   * the stream and subscribe through any consumer it declares without
+   * extra plumbing.
+   */
+  streams?: TemplateNatsRoleStream[];
+  /**
+   * Consumers attached to one of this role's `streams[]`. The `stream`
+   * field references the role-stream by its declared `name`; it is NOT
+   * prefixed (it's a logical reference within the role). `filterSubject`
+   * is relative to the stack's subjectPrefix and gets prepended at apply
+   * time.
+   */
+  consumers?: TemplateNatsRoleConsumer[];
   /** Credential JWT TTL. Defaults to NatsCredentialProfile system default (3600s). */
   ttlSeconds?: number;
+}
+
+/**
+ * App-author-facing JetStream stream declaration nested inside a role.
+ * Mirrors `TemplateNatsStream` but drops `account` (always the shared
+ * system account) and `scope` (always stack-scoped) — both implied by
+ * the prefix-only isolation model. Subjects are relative to the stack's
+ * subjectPrefix; the orchestrator builds the absolute form at apply.
+ */
+export interface TemplateNatsRoleStream {
+  name: string;
+  description?: string;
+  subjects: string[];
+  retention?: 'limits' | 'interest' | 'workqueue';
+  storage?: 'file' | 'memory';
+  maxMsgs?: number | null;
+  maxBytes?: number | null;
+  maxAgeSeconds?: number | null;
+}
+
+/**
+ * App-author-facing JetStream consumer attached to a role's stream.
+ * Mirrors `TemplateNatsConsumer` but `stream` references one of the
+ * containing role's `streams[]` by declared name (not the materialized
+ * concrete name) and `filterSubject` is relative to the subjectPrefix.
+ */
+export interface TemplateNatsRoleConsumer {
+  name: string;
+  stream: string;
+  durableName?: string;
+  description?: string;
+  filterSubject?: string;
+  deliverPolicy?: 'all' | 'last' | 'new' | 'by_start_sequence' | 'by_start_time' | 'last_per_subject';
+  ackPolicy?: 'none' | 'all' | 'explicit';
+  maxDeliver?: number | null;
+  ackWaitSeconds?: number | null;
 }
 
 /**

--- a/server/prisma/migrations/20260510000000_nats_stream_stack_id/migration.sql
+++ b/server/prisma/migrations/20260510000000_nats_stream_stack_id/migration.sql
@@ -1,0 +1,63 @@
+-- Add a stackId FK to nats_streams. Used by the apply orchestrator's
+-- diff-and-prune step (`pruneOrphanRoleStreams`) to clean up app-author
+-- role-derived streams when a template renames or removes a role's stream.
+-- Legacy top-level `nats.streams[]` rows (system-template-only) keep
+-- stackId = NULL — their lifecycle is owned by the system seeder, not a
+-- stack, so they must not be swept by the per-stack prune. Backfilled
+-- from the `<stackId>-<roleName>-<streamName>` naming convention.
+
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE "new_nats_streams" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "accountId" TEXT NOT NULL,
+    "stackId" TEXT,
+    "description" TEXT,
+    "subjects" JSONB NOT NULL,
+    "retention" TEXT NOT NULL DEFAULT 'limits',
+    "storage" TEXT NOT NULL DEFAULT 'file',
+    "maxMsgs" INTEGER,
+    "maxBytes" INTEGER,
+    "maxAgeSeconds" INTEGER,
+    "lastAppliedAt" DATETIME,
+    "createdById" TEXT,
+    "updatedById" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "nats_streams_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "nats_accounts" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "nats_streams_stackId_fkey" FOREIGN KEY ("stackId") REFERENCES "stacks" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+INSERT INTO "new_nats_streams" (
+    "accountId", "createdAt", "createdById", "description",
+    "id", "lastAppliedAt", "maxAgeSeconds", "maxBytes", "maxMsgs",
+    "name", "retention", "storage", "subjects", "updatedAt", "updatedById",
+    "stackId"
+)
+SELECT
+    s."accountId", s."createdAt", s."createdById", s."description",
+    s."id", s."lastAppliedAt", s."maxAgeSeconds", s."maxBytes", s."maxMsgs",
+    s."name", s."retention", s."storage", s."subjects", s."updatedAt",
+    s."updatedById",
+    -- Backfill: app-author stream names follow `<stackId>-<roleName>-<streamName>`.
+    -- Resolve only to a stack id that actually exists; legacy system streams
+    -- whose names don't match any stack id stay NULL.
+    (
+        SELECT st."id"
+        FROM "stacks" st
+        WHERE s."name" = st."id" || '-' || substr(s."name", length(st."id") + 2)
+        LIMIT 1
+    )
+FROM "nats_streams" s;
+
+DROP TABLE "nats_streams";
+ALTER TABLE "new_nats_streams" RENAME TO "nats_streams";
+
+CREATE UNIQUE INDEX "nats_streams_name_key" ON "nats_streams"("name");
+CREATE INDEX "nats_streams_accountId_idx" ON "nats_streams"("accountId");
+CREATE INDEX "nats_streams_stackId_idx" ON "nats_streams"("stackId");
+
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1129,6 +1129,7 @@ model Stack {
   natsResources        StackNatsResource[]
   natsSigningKeys      NatsSigningKey[]     @relation("StackNatsSigningKey")
   natsCredentialProfiles NatsCredentialProfile[] @relation("StackNatsCredentialProfile")
+  natsStreams          NatsStream[]            @relation("StackNatsStream")
   egressPolicies       EgressPolicy[]
 
   @@index([environmentId])
@@ -1329,6 +1330,12 @@ model NatsStream {
   name            String          @unique
   accountId       String
   account         NatsAccount     @relation(fields: [accountId], references: [id], onDelete: Restrict)
+  /// Set for streams materialized from `nats.roles[].streams` so the
+  /// cascade delete + orphan-prune path can find them by stackId. Legacy
+  /// system-template streams (declared at `nats.streams[]`) leave this
+  /// null — their lifecycle is owned by the system seeder, not a stack.
+  stackId         String?
+  stack           Stack?          @relation("StackNatsStream", fields: [stackId], references: [id], onDelete: Cascade)
   description     String?
   subjects        Json
   retention       String          @default("limits")
@@ -1345,6 +1352,7 @@ model NatsStream {
   consumers       NatsConsumer[]
 
   @@index([accountId])
+  @@index([stackId])
   @@map("nats_streams")
 }
 

--- a/server/src/__tests__/nats-app-roles-schema.test.ts
+++ b/server/src/__tests__/nats-app-roles-schema.test.ts
@@ -156,6 +156,153 @@ describe('NATS mixing rule (legacy credentials + new roles)', () => {
     const r = draftVersionSchema.safeParse(draftBody(mixed));
     expect(r.success).toBe(false);
   });
+
+  it('roles + legacy top-level streams is rejected — declare via roles[].streams instead', () => {
+    // Symmetry with the credentials-vs-roles rule: an app template using
+    // the new role surface must declare its JetStream resources nested on
+    // those roles (auto-prefixed, relative subjects). Top-level streams
+    // keep absolute subjects for system templates and must not coexist
+    // with roles in the same template.
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: {
+        roles: [{ name: 'gateway', publish: ['x'] }],
+        streams: [{ name: 'legacy', account: 'app', subjects: ['legacy.>'], scope: 'host' }],
+        // accounts is required so top-level streams pass shape validation
+        accounts: [{ name: 'app', scope: 'host' as const }],
+      },
+    }));
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const msg = r.error.issues.map((i) => i.message).join('|');
+      expect(msg).toContain('nats.streams (legacy');
+    }
+  });
+
+  it('roles + legacy top-level consumers is rejected — declare via roles[].consumers instead', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: {
+        roles: [{ name: 'gateway', publish: ['x'] }],
+        consumers: [{ name: 'leg', stream: 'legacy', scope: 'host' }],
+      },
+    }));
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const msg = r.error.issues.map((i) => i.message).join('|');
+      expect(msg).toContain('nats.consumers (legacy)');
+    }
+  });
+});
+
+// ─── roles[].streams + roles[].consumers — name uniqueness, refs, validation ─
+
+describe('NATS role-nested streams + consumers', () => {
+  it('a role with prefix-relative streams[] is accepted', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: {
+        roles: [
+          {
+            name: 'worker',
+            publish: ['work.>'],
+            streams: [
+              { name: 'jobs', subjects: ['work.in.>'], retention: 'workqueue' },
+            ],
+          },
+        ],
+      },
+    }));
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects a role-stream with a wildcard at root (would shadow the prefix)', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: {
+        roles: [{ name: 'worker', streams: [{ name: 'wide', subjects: ['>'] }] }],
+      },
+    }));
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const msg = r.error.issues.map((i) => i.message).join('|');
+      expect(msg).toContain('must not start with a wildcard');
+    }
+  });
+
+  it('rejects duplicate stream names within a role', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: {
+        roles: [
+          {
+            name: 'worker',
+            streams: [
+              { name: 'jobs', subjects: ['x.>'] },
+              { name: 'jobs', subjects: ['y.>'] },
+            ],
+          },
+        ],
+      },
+    }));
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const msg = r.error.issues.map((i) => i.message).join('|');
+      expect(msg).toContain("Duplicate stream name 'jobs'");
+    }
+  });
+
+  it("rejects a consumer whose `stream` doesn't reference one of the role's streams", () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: {
+        roles: [
+          {
+            name: 'worker',
+            streams: [{ name: 'jobs', subjects: ['x.>'] }],
+            consumers: [{ name: 'broken', stream: 'no-such-stream' }],
+          },
+        ],
+      },
+    }));
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const msg = r.error.issues.map((i) => i.message).join('|');
+      expect(msg).toContain("references unknown stream 'no-such-stream'");
+    }
+  });
+
+  it('accepts a consumer with a relative filterSubject', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: {
+        roles: [
+          {
+            name: 'worker',
+            streams: [{ name: 'jobs', subjects: ['work.>'] }],
+            consumers: [
+              { name: 'high', stream: 'jobs', filterSubject: 'work.priority.high' },
+            ],
+          },
+        ],
+      },
+    }));
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects a consumer filterSubject that targets _INBOX directly', () => {
+    const r = templateFileSchema.safeParse(fileBody({
+      nats: {
+        roles: [
+          {
+            name: 'worker',
+            streams: [{ name: 'jobs', subjects: ['x.>'] }],
+            consumers: [
+              { name: 'evil', stream: 'jobs', filterSubject: '_INBOX.intercept' },
+            ],
+          },
+        ],
+      },
+    }));
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const msg = r.error.issues.map((i) => i.message).join('|');
+      expect(msg).toContain('_INBOX');
+    }
+  });
 });
 
 // ─── Name uniqueness ─────────────────────────────────────────────────────────

--- a/server/src/__tests__/nats-role-streams.external.test.ts
+++ b/server/src/__tests__/nats-role-streams.external.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { connect, credsAuthenticator, AckPolicy } from "nats";
+import { startTestNats, type TestNatsEnv } from "./helpers/nats-test-server";
+import { generateAccount, loadKeyPair, mintUserCreds, reissueAccountJwt } from "../services/nats/nats-key-manager";
+
+/**
+ * Phase 6 — JetStream-for-apps end-to-end against a real `nats:2.12.8-alpine`.
+ *
+ * The integration tests pin DB-side materialization (NatsStream/NatsConsumer
+ * rows with prefixed subjects, and the JS API grants list on the role's
+ * NatsCredentialProfile). What only a real NATS can confirm is the
+ * compound guarantee:
+ *
+ *   - With the **exact** grant set the orchestrator's `materializeRole`
+ *     produces for a role with `streams[]` + `consumers[]`, a service
+ *     bound to that role can publish into the prefixed stream subjects,
+ *     bind the durable consumer, pull, and ACK — all without any system-
+ *     admin creds.
+ *
+ * If a future refactor drops one of the JS API grants (`STREAM.INFO`,
+ * `CONSUMER.INFO`, `CONSUMER.CREATE`, `CONSUMER.MSG.NEXT`, or `$JS.ACK.>`),
+ * this test will fail with a permissions-violation surfaced by the live
+ * server — exactly the regression we can't catch with mocks.
+ */
+describe("Phase 6 — JetStream-for-apps role pub/consume (external)", () => {
+  let env: TestNatsEnv;
+
+  beforeAll(async () => {
+    env = await startTestNats();
+  }, 60_000);
+
+  afterAll(async () => {
+    if (env) await env.stop();
+  });
+
+  it("a role-bound connection can publish to its stream and consume via its durable consumer", async () => {
+    // Stand up an app account with JetStream available — the test rig already
+    // boots `nats-server` with JS enabled on the system account, but each
+    // app account gets JS turned on via its own JWT claim. We push the
+    // account WITHOUT special claims (default JS quotas suffice for a tiny
+    // test stream) and rely on the unbounded test config.
+    const account = await generateAccount("rolejs-acct", env.operatorKp);
+    const reissued = await reissueAccountJwt(
+      "rolejs-acct",
+      account.seed,
+      env.operatorKp,
+    );
+    await env.pushAccountClaim(reissued.publicKey, reissued.jwt);
+    const accountKp = loadKeyPair(account.seed);
+
+    // Concrete materialized names, mirroring what the orchestrator produces
+    // for a stack with id "stk-rolejs", role "worker", stream "jobs",
+    // consumer "pull". The orchestrator's `concreteName` lower-cases and
+    // hyphen-collapses; the inputs here are already normalised to keep the
+    // expected names short and readable in assertions.
+    const subjectPrefix = "app.stk-rolejs";
+    const streamName = "stk-rolejs-worker-jobs";
+    const consumerName = "stk-rolejs-worker-jobs-pull";
+    const streamSubjectPattern = `${subjectPrefix}.work.>`;
+
+    // Use account-admin creds to create the JetStream stream + consumer up
+    // front. In production the control plane's `applyJetStreamResources()`
+    // does this; here we collapse it inline because the apply orchestrator
+    // isn't under test on this path.
+    const adminCreds = await mintUserCreds(
+      "admin",
+      accountKp,
+      { pub: [">"], sub: [">"] },
+      300,
+    );
+    const adminNc = await connect({
+      servers: env.url,
+      authenticator: credsAuthenticator(new TextEncoder().encode(adminCreds)),
+      timeout: 5_000,
+      reconnect: false,
+    });
+    try {
+      const jsm = await adminNc.jetstreamManager();
+      await jsm.streams.add({ name: streamName, subjects: [streamSubjectPattern] });
+      await jsm.consumers.add(streamName, {
+        durable_name: consumerName,
+        ack_policy: AckPolicy.Explicit,
+        filter_subject: `${subjectPrefix}.work.in.>`,
+      });
+    } finally {
+      await adminNc.drain();
+    }
+
+    // Mint role creds with the **exact** grant set materializeRole produces
+    // for `roles[].streams[]` + `roles[].consumers[]`. Anything missing
+    // here (e.g. dropping CONSUMER.MSG.NEXT) will surface as a real
+    // permissions violation when we try to pull below.
+    const roleCreds = await mintUserCreds(
+      "worker-role",
+      accountKp,
+      {
+        pub: [
+          streamSubjectPattern,
+          "_INBOX.>",
+          `$JS.API.STREAM.INFO.${streamName}`,
+          `$JS.API.CONSUMER.INFO.${streamName}.${consumerName}`,
+          `$JS.API.CONSUMER.CREATE.${streamName}.${consumerName}`,
+          `$JS.API.CONSUMER.MSG.NEXT.${streamName}.${consumerName}`,
+          `$JS.ACK.${streamName}.${consumerName}.>`,
+        ],
+        sub: [streamSubjectPattern, "_INBOX.>"],
+      },
+      300,
+    );
+
+    const nc = await connect({
+      servers: env.url,
+      authenticator: credsAuthenticator(new TextEncoder().encode(roleCreds)),
+      timeout: 5_000,
+      reconnect: false,
+    });
+    try {
+      const js = nc.jetstream();
+
+      // Publish into the stream as a role-bound producer. NATS routes the
+      // message into the stream because the subject matches the stream's
+      // declared filter pattern.
+      const ack = await js.publish(
+        `${subjectPrefix}.work.in.42`,
+        new TextEncoder().encode("hello-jetstream"),
+      );
+      expect(ack.stream).toBe(streamName);
+
+      // Pull-fetch from the durable consumer. The pull-bind exercises
+      // CONSUMER.INFO + CONSUMER.MSG.NEXT; the explicit ack exercises
+      // `$JS.ACK.>`. Any missing grant surfaces as a permissions error.
+      const c = await js.consumers.get(streamName, consumerName);
+      const messages = await c.fetch({ max_messages: 1, expires: 3_000 });
+
+      const received: string[] = [];
+      for await (const m of messages) {
+        received.push(new TextDecoder().decode(m.data));
+        m.ack();
+      }
+      expect(received).toEqual(["hello-jetstream"]);
+    } finally {
+      await nc.drain();
+    }
+  }, 60_000);
+});

--- a/server/src/__tests__/stack-nats-apply-orchestrator-roles.integration.test.ts
+++ b/server/src/__tests__/stack-nats-apply-orchestrator-roles.integration.test.ts
@@ -503,3 +503,236 @@ describe('runStackNatsApplyPhase — Phase 3 reviewer-flagged gaps', () => {
     expect(result.error).toMatch(/empty tokens/);
   });
 });
+
+describe('runStackNatsApplyPhase — role-nested JetStream streams + consumers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('materializes role-nested streams with prefix-prepended subjects and stackId set', async () => {
+    const { stackId } = await seedStack({
+      natsRoles: [
+        {
+          name: 'worker',
+          publish: ['work.>'],
+          streams: [
+            {
+              name: 'jobs',
+              subjects: ['work.in.>', 'work.retry.>'],
+              retention: 'workqueue',
+            },
+          ],
+        },
+      ],
+      serviceNatsRole: 'worker',
+    });
+
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: 'test-user' });
+    expect(result.status).toBe('applied');
+
+    const expectedPrefix = `app.${stackId}`;
+    const stream = await testPrisma.natsStream.findFirst({
+      where: { stackId, name: { contains: 'worker-jobs' } },
+    });
+    expect(stream).not.toBeNull();
+    // Subjects are prefix-prepended; retention/storage carry through.
+    expect(stream!.subjects).toEqual([
+      `${expectedPrefix}.work.in.>`,
+      `${expectedPrefix}.work.retry.>`,
+    ]);
+    expect(stream!.retention).toBe('workqueue');
+    expect(stream!.stackId).toBe(stackId);
+  });
+
+  it('materializes role-nested consumers with prefix-prepended filterSubject', async () => {
+    const { stackId } = await seedStack({
+      natsRoles: [
+        {
+          name: 'worker',
+          subscribe: ['work.>'],
+          streams: [{ name: 'jobs', subjects: ['work.>'] }],
+          consumers: [
+            {
+              name: 'high-priority',
+              stream: 'jobs',
+              filterSubject: 'work.priority.high',
+              ackPolicy: 'explicit',
+              maxDeliver: 5,
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('applied');
+
+    const expectedPrefix = `app.${stackId}`;
+    const stream = await testPrisma.natsStream.findFirst({
+      where: { stackId, name: { contains: 'worker-jobs' } },
+    });
+    expect(stream).not.toBeNull();
+    const consumer = await testPrisma.natsConsumer.findFirst({
+      where: { streamId: stream!.id, name: { contains: 'high-priority' } },
+    });
+    expect(consumer).not.toBeNull();
+    // filterSubject auto-prefixed; ack/maxDeliver carry through.
+    expect(consumer!.filterSubject).toBe(`${expectedPrefix}.work.priority.high`);
+    expect(consumer!.ackPolicy).toBe('explicit');
+    expect(consumer!.maxDeliver).toBe(5);
+  });
+
+  it('orphan-prune drops role-streams whose names disappear on re-apply', async () => {
+    // First apply: declare two streams. Second apply: remove the second one.
+    // The orchestrator's pruneOrphanRoleStreams must delete the now-orphan
+    // row by stackId — without it, every template edit leaks NatsStream rows.
+    const stackName = `stack-orphan-${Date.now()}`;
+    const { stackId, templateId } = await seedStack({
+      stackName,
+      natsRoles: [
+        {
+          name: 'worker',
+          publish: ['x'],
+          streams: [
+            { name: 'keep', subjects: ['k.>'] },
+            { name: 'drop', subjects: ['d.>'] },
+          ],
+        },
+      ],
+    });
+
+    const first = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(first.status).toBe('applied');
+
+    expect(
+      await testPrisma.natsStream.count({ where: { stackId } }),
+    ).toBe(2);
+
+    // Edit the template version in place — drop the second stream from the role.
+    await testPrisma.stackTemplateVersion.updateMany({
+      where: { templateId, version: 1 },
+      data: {
+        natsRoles: [
+          {
+            name: 'worker',
+            publish: ['x'],
+            streams: [{ name: 'keep', subjects: ['k.>'] }],
+          },
+        ],
+      },
+    });
+
+    const second = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(second.status).toBe('applied');
+
+    const remaining = await testPrisma.natsStream.findMany({ where: { stackId } });
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].name).toContain('worker-keep');
+  });
+
+  it('two stacks with the same role-stream name get distinct NatsStream rows scoped by stackId', async () => {
+    const a = await seedStack({
+      stackName: `stack-a-${Date.now()}`,
+      natsRoles: [
+        { name: 'worker', publish: ['x'], streams: [{ name: 'jobs', subjects: ['x.>'] }] },
+      ],
+    });
+    const b = await seedStack({
+      stackName: `stack-b-${Date.now()}`,
+      natsRoles: [
+        { name: 'worker', publish: ['x'], streams: [{ name: 'jobs', subjects: ['x.>'] }] },
+      ],
+    });
+
+    await runStackNatsApplyPhase(testPrisma, a.stackId, { triggeredBy: undefined });
+    await runStackNatsApplyPhase(testPrisma, b.stackId, { triggeredBy: undefined });
+
+    const streamA = await testPrisma.natsStream.findFirst({ where: { stackId: a.stackId } });
+    const streamB = await testPrisma.natsStream.findFirst({ where: { stackId: b.stackId } });
+    expect(streamA).not.toBeNull();
+    expect(streamB).not.toBeNull();
+    expect(streamA!.id).not.toBe(streamB!.id);
+    // Names disambiguated by stackId so the unique-name constraint never fires.
+    expect(streamA!.name).not.toBe(streamB!.name);
+    // Subjects scoped to each stack's own prefix — no overlap.
+    const subjA = streamA!.subjects as unknown as string[];
+    const subjB = streamB!.subjects as unknown as string[];
+    expect(subjA[0]).toBe(`app.${a.stackId}.x.>`);
+    expect(subjB[0]).toBe(`app.${b.stackId}.x.>`);
+  });
+
+  it('defense-in-depth: stream subject with `>` at root is rejected at apply', async () => {
+    // The static schema rejects this at publish time, but a corrupt JSON
+    // column could otherwise reach the materializer. The apply-time check
+    // refuses rather than emitting a NatsStream row whose filter shadows
+    // the entire prefix tree.
+    const { stackId } = await seedStack({
+      natsRoles: [
+        {
+          name: 'worker',
+          publish: ['x'],
+          streams: [{ name: 'wide', subjects: ['>'] }],
+        },
+      ],
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/escapes the prefix/);
+  });
+
+  it("role's credentials get the JetStream API grants for its own streams + consumers", async () => {
+    // Without these grants the role's connection can publish/subscribe on
+    // the stream's subjects but can't bind the JetStream view (STREAM.INFO),
+    // pull messages (CONSUMER.MSG.NEXT), or ack them ($JS.ACK.>). Pinning
+    // the exact grants so a future refactor can't accidentally drop one and
+    // silently break consumption.
+    const { stackId } = await seedStack({
+      natsRoles: [
+        {
+          name: 'worker',
+          publish: ['work.>'],
+          streams: [{ name: 'jobs', subjects: ['work.>'] }],
+          consumers: [{ name: 'pull', stream: 'jobs' }],
+        },
+      ],
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('applied');
+
+    const profile = await testPrisma.natsCredentialProfile.findFirst({
+      where: { stackId, name: { contains: 'worker' } },
+    });
+    const pub = profile!.publishAllow as unknown as string[];
+
+    const stream = await testPrisma.natsStream.findFirst({ where: { stackId } });
+    const consumer = await testPrisma.natsConsumer.findFirst({
+      where: { streamId: stream!.id },
+    });
+    expect(stream).not.toBeNull();
+    expect(consumer).not.toBeNull();
+
+    // Stream-level: bind the view.
+    expect(pub).toContain(`$JS.API.STREAM.INFO.${stream!.name}`);
+    // Consumer-level: info / create / pull-next / ack.
+    expect(pub).toContain(`$JS.API.CONSUMER.INFO.${stream!.name}.${consumer!.name}`);
+    expect(pub).toContain(`$JS.API.CONSUMER.CREATE.${stream!.name}.${consumer!.name}`);
+    expect(pub).toContain(`$JS.API.CONSUMER.MSG.NEXT.${stream!.name}.${consumer!.name}`);
+    expect(pub).toContain(`$JS.ACK.${stream!.name}.${consumer!.name}.>`);
+  });
+
+  it('consumer referencing an unknown role-stream fails apply with a clear error', async () => {
+    const { stackId } = await seedStack({
+      natsRoles: [
+        {
+          name: 'worker',
+          publish: ['x'],
+          streams: [{ name: 'jobs', subjects: ['x.>'] }],
+          consumers: [{ name: 'broken', stream: 'does-not-exist' }],
+        },
+      ],
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/references unknown stream/);
+  });
+});

--- a/server/src/services/stacks/stack-nats-apply-orchestrator.ts
+++ b/server/src/services/stacks/stack-nats-apply-orchestrator.ts
@@ -23,6 +23,8 @@ import type {
   TemplateNatsCredential,
   TemplateNatsImport,
   TemplateNatsRole,
+  TemplateNatsRoleConsumer,
+  TemplateNatsRoleStream,
   TemplateNatsSigner,
   TemplateNatsStream,
 } from "@mini-infra/types";
@@ -305,6 +307,12 @@ export async function runStackNatsApplyPhase(
     let resolvedExports: string[] = [];
     const renderedRoleProfileNames = new Set<string>();
     const renderedSignerNames = new Set<string>();
+    // Stack-scoped (role-derived) JetStream resources. Names are namespaced
+    // `<roleName>.<streamName>` so two roles can declare a stream named the
+    // same without colliding. Used to resolve consumers' relative `stream:`
+    // references at materialization time.
+    const renderedRoleStreamNames = new Set<string>();
+    const roleStreamIdByRoleAndName = new Map<string, string>();
     if (roles.length > 0 || signers.length > 0 || exportsRelative.length > 0 || imports.length > 0) {
       const defaultAccount = await service.ensureDefaultAccount();
       resolvedSubjectPrefix = await resolveAndValidateSubjectPrefix({
@@ -358,6 +366,50 @@ export async function runStackNatsApplyPhase(
         roleCredentialIdByName.set(role.name, profile.id);
         renderedRoleProfileNames.add(profile.name);
         resources.push({ type: "credential", concreteName: profile.name, scope: "stack" });
+
+        // Phase 6: role-nested JetStream streams + consumers. Declared on
+        // the role, materialized into NatsStream/NatsConsumer rows on the
+        // shared system account with the stack's resolvedSubjectPrefix
+        // prepended to every subject filter. Consumers reference one of
+        // their containing role's streams by relative name; the materializer
+        // resolves that against `roleStreamIdByRoleAndName`. The role's
+        // own credentials retain pub/sub on the role's relative subject
+        // tree, so a service bound to the role can publish into the stream
+        // and consume through any of its consumers without extra grants.
+        for (const stream of role.streams ?? []) {
+          const row = await materializeRoleStream({
+            prisma,
+            roleName: role.name,
+            stream,
+            accountId: defaultAccount.id,
+            subjectPrefix: resolvedSubjectPrefix,
+            stackId,
+            triggeredBy: opts.triggeredBy,
+          });
+          renderedRoleStreamNames.add(row.name);
+          roleStreamIdByRoleAndName.set(`${role.name}.${stream.name}`, row.id);
+          resources.push({ type: "stream", concreteName: row.name, scope: "stack" });
+        }
+        for (const consumer of role.consumers ?? []) {
+          const streamId = roleStreamIdByRoleAndName.get(`${role.name}.${consumer.stream}`);
+          if (!streamId) {
+            // Validator catches this at publish time; defense-in-depth at
+            // apply for corrupt JSON columns or a future schema-drift bug.
+            throw new Error(
+              `NATS apply: role '${role.name}' consumer '${consumer.name}' references unknown stream '${consumer.stream}'`,
+            );
+          }
+          const row = await materializeRoleConsumer({
+            prisma,
+            roleName: role.name,
+            consumer,
+            streamId,
+            subjectPrefix: resolvedSubjectPrefix,
+            stackId,
+            triggeredBy: opts.triggeredBy,
+          });
+          resources.push({ type: "consumer", concreteName: row.name, scope: "stack" });
+        }
       }
 
       // Phase 4: signers materialization. Each signer becomes a NatsSigningKey
@@ -380,7 +432,11 @@ export async function runStackNatsApplyPhase(
 
       // Diff-and-prune. Run before applyConfig() so the re-issued account
       // JWT reflects only the live set of signing keys + the orphan profiles
-      // are gone before any service tries to rebind to them.
+      // are gone before any service tries to rebind to them. Role-derived
+      // streams are pruned before applyJetStreamResources() (run further
+      // down) so the live JetStream view picks up only the desired set; the
+      // delete also cascades to any consumers (NatsConsumer.streamId FK is
+      // ON DELETE CASCADE).
       await pruneOrphanRoleProfiles({
         prisma,
         stackId,
@@ -390,6 +446,11 @@ export async function runStackNatsApplyPhase(
         prisma,
         stackId,
         desiredSignerNames: renderedSignerNames,
+      });
+      await pruneOrphanRoleStreams({
+        prisma,
+        stackId,
+        desiredStreamNames: renderedRoleStreamNames,
       });
     }
 
@@ -661,6 +722,31 @@ async function materializeRole(args: {
     publishAllow.push(`$JS.API.STREAM.INFO.KV_${bucket}`);
   }
 
+  // Phase 6: JetStream API access for role-nested streams + consumers.
+  // Without these grants the role's connection can pub/sub on the stream's
+  // subjects but can't bind the JetStream view (`STREAM.INFO`), pull
+  // messages (`CONSUMER.MSG.NEXT`), or ack them (`$JS.ACK.>`) — so the
+  // feature is only half-shipped without them. Concrete stream + consumer
+  // names match what `materializeRoleStream` / `materializeRoleConsumer`
+  // produce so the grants line up against the live NATS objects.
+  for (const stream of role.streams ?? []) {
+    const concreteStream = concreteName(`${role.name}-${stream.name}`, "stack", args.stackId, null);
+    publishAllow.push(`$JS.API.STREAM.INFO.${concreteStream}`);
+  }
+  for (const consumer of role.consumers ?? []) {
+    const concreteStream = concreteName(`${role.name}-${consumer.stream}`, "stack", args.stackId, null);
+    const concreteConsumer = concreteName(
+      `${role.name}-${consumer.stream}-${consumer.name}`,
+      "stack",
+      args.stackId,
+      null,
+    );
+    publishAllow.push(`$JS.API.CONSUMER.INFO.${concreteStream}.${concreteConsumer}`);
+    publishAllow.push(`$JS.API.CONSUMER.CREATE.${concreteStream}.${concreteConsumer}`);
+    publishAllow.push(`$JS.API.CONSUMER.MSG.NEXT.${concreteStream}.${concreteConsumer}`);
+    publishAllow.push(`$JS.ACK.${concreteStream}.${concreteConsumer}.>`);
+  }
+
   // Profile name: `<stackId>-<roleName>`. `stack.id` is opaque but
   // collision-free — two stacks with the same `name` (host scope) would
   // otherwise clobber each other (design §2.1 decision 2). UI can render
@@ -861,6 +947,174 @@ async function pruneOrphanSigningKeys(args: {
     }
   }
   return orphans.length;
+}
+
+// =====================================================================
+// Phase 6 helpers — role-nested JetStream streams + consumers
+// =====================================================================
+
+/**
+ * Materialize a single `roles[].streams[]` entry into a `NatsStream` row.
+ * Subjects are written *relative* to the stack's subjectPrefix in the
+ * template; the orchestrator prepends the resolved prefix so every
+ * subject filter lives inside the stack's namespace. The row is owned
+ * by the consumer stack via `stackId`, so cascade-delete + the
+ * `pruneOrphanRoleStreams` diff cover the lifecycle without a separate
+ * destroy hook (legacy top-level `nats.streams` keep `stackId = null`
+ * because their lifecycle is owned by the system seeder).
+ */
+async function materializeRoleStream(args: {
+  prisma: PrismaClient;
+  roleName: string;
+  stream: TemplateNatsRoleStream;
+  accountId: string;
+  subjectPrefix: string;
+  stackId: string;
+  triggeredBy: string | undefined;
+}): Promise<{ id: string; name: string }> {
+  const { stream, subjectPrefix, stackId } = args;
+
+  // Defense-in-depth: re-validate every subject at apply. The static
+  // `natsRelativeSubjectSchema` is the primary gate; this catches a
+  // corrupt natsRoles JSON column that bypasses publish-time validation.
+  const validateRelative = (s: string): void => {
+    if (!s || s.startsWith(">") || s.startsWith("*")) {
+      throw new Error(`NATS apply: role '${args.roleName}' stream '${stream.name}' subject '${s}' escapes the prefix`);
+    }
+    if (s.startsWith("_INBOX.")) {
+      throw new Error(`NATS apply: role '${args.roleName}' stream '${stream.name}' subject '${s}' targets _INBOX directly`);
+    }
+    if (s.startsWith("$SYS.") || s === "$SYS") {
+      throw new Error(`NATS apply: role '${args.roleName}' stream '${stream.name}' subject '${s}' targets the $SYS namespace`);
+    }
+    if (s.includes("..") || s.split(".").some((tok) => tok.length === 0)) {
+      throw new Error(`NATS apply: role '${args.roleName}' stream '${stream.name}' subject '${s}' has empty tokens`);
+    }
+  };
+  const absoluteSubjects: string[] = [];
+  for (const s of stream.subjects) {
+    validateRelative(s);
+    absoluteSubjects.push(`${subjectPrefix}.${s}`);
+  }
+
+  // Concrete name: `<stackId>-<roleName>-<streamName>`. Same shape as the
+  // role-credential profile name (`materializeRole`) so two stacks can
+  // declare the same role.stream name without colliding, and a role
+  // rename rotates cleanly through `pruneOrphanRoleStreams`.
+  const concreteStreamName = concreteName(`${args.roleName}-${stream.name}`, "stack", stackId, null);
+
+  const existing = await args.prisma.natsStream.findUnique({ where: { name: concreteStreamName } });
+  const data = {
+    accountId: args.accountId,
+    stackId,
+    description: stream.description ?? null,
+    subjects: absoluteSubjects as unknown as Prisma.InputJsonValue,
+    retention: stream.retention ?? "limits",
+    storage: stream.storage ?? "file",
+    maxMsgs: stream.maxMsgs ?? null,
+    maxBytes: stream.maxBytes ?? null,
+    maxAgeSeconds: stream.maxAgeSeconds ?? null,
+    updatedById: args.triggeredBy ?? null,
+  };
+  const row = existing
+    ? await args.prisma.natsStream.update({ where: { id: existing.id }, data })
+    : await args.prisma.natsStream.create({
+        data: { name: concreteStreamName, ...data, createdById: args.triggeredBy ?? null },
+      });
+  return { id: row.id, name: concreteStreamName };
+}
+
+/**
+ * Materialize a single `roles[].consumers[]` entry into a `NatsConsumer`
+ * row attached to the materialized role-stream. `filterSubject` (when set)
+ * is treated as a relative subject and gets prepended with the stack's
+ * resolved prefix. Consumer name uniqueness is `(streamId, name)`, which
+ * Prisma enforces via the `@@unique([streamId, name])` constraint.
+ */
+async function materializeRoleConsumer(args: {
+  prisma: PrismaClient;
+  roleName: string;
+  consumer: TemplateNatsRoleConsumer;
+  streamId: string;
+  subjectPrefix: string;
+  stackId: string;
+  triggeredBy: string | undefined;
+}): Promise<{ id: string; name: string }> {
+  const { consumer, subjectPrefix, stackId } = args;
+
+  // Defense-in-depth: re-validate filterSubject. Static schema is the
+  // primary gate; this catches a corrupt natsRoles JSON column.
+  if (consumer.filterSubject) {
+    const fs = consumer.filterSubject;
+    if (fs.startsWith(">") || fs.startsWith("*")) {
+      throw new Error(
+        `NATS apply: role '${args.roleName}' consumer '${consumer.name}' filterSubject '${fs}' escapes the prefix`,
+      );
+    }
+    if (fs.startsWith("_INBOX.") || fs.startsWith("$SYS.") || fs === "$SYS") {
+      throw new Error(
+        `NATS apply: role '${args.roleName}' consumer '${consumer.name}' filterSubject '${fs}' targets a reserved namespace`,
+      );
+    }
+    if (fs.includes("..") || fs.split(".").some((tok) => tok.length === 0)) {
+      throw new Error(
+        `NATS apply: role '${args.roleName}' consumer '${consumer.name}' filterSubject '${fs}' has empty tokens`,
+      );
+    }
+  }
+
+  const concreteConsumerName = concreteName(`${args.roleName}-${consumer.stream}-${consumer.name}`, "stack", stackId, null);
+  const existing = await args.prisma.natsConsumer.findFirst({
+    where: { streamId: args.streamId, name: concreteConsumerName },
+  });
+  const data = {
+    durableName: consumer.durableName ? consumer.durableName : concreteConsumerName,
+    description: consumer.description ?? null,
+    filterSubject: consumer.filterSubject ? `${subjectPrefix}.${consumer.filterSubject}` : null,
+    deliverPolicy: consumer.deliverPolicy ?? "all",
+    ackPolicy: consumer.ackPolicy ?? "explicit",
+    maxDeliver: consumer.maxDeliver ?? null,
+    ackWaitSeconds: consumer.ackWaitSeconds ?? null,
+    updatedById: args.triggeredBy ?? null,
+  };
+  const row = existing
+    ? await args.prisma.natsConsumer.update({ where: { id: existing.id }, data })
+    : await args.prisma.natsConsumer.create({
+        data: {
+          streamId: args.streamId,
+          name: concreteConsumerName,
+          ...data,
+          createdById: args.triggeredBy ?? null,
+        },
+      });
+  return { id: row.id, name: concreteConsumerName };
+}
+
+/**
+ * Drop role-derived `NatsStream` rows owned by this stack whose names
+ * aren't in the freshly-rendered set. Catches stream renames + removals;
+ * the `NatsConsumer.streamId` FK's `onDelete: Cascade` handles consumer
+ * cleanup so we don't need a separate consumer prune.
+ *
+ * Legacy top-level `nats.streams` rows have `stackId = null` and stay out
+ * of this filter, so a system template's streams are never accidentally
+ * pruned by a co-applied app stack.
+ */
+async function pruneOrphanRoleStreams(args: {
+  prisma: PrismaClient;
+  stackId: string;
+  desiredStreamNames: Set<string>;
+}): Promise<number> {
+  const existing = await args.prisma.natsStream.findMany({
+    where: { stackId: args.stackId },
+    select: { id: true, name: true },
+  });
+  const orphanIds = existing
+    .filter((row) => !args.desiredStreamNames.has(row.name))
+    .map((row) => row.id);
+  if (orphanIds.length === 0) return 0;
+  await args.prisma.natsStream.deleteMany({ where: { id: { in: orphanIds } } });
+  return orphanIds.length;
 }
 
 // =====================================================================

--- a/server/src/services/stacks/stack-template-schemas.ts
+++ b/server/src/services/stacks/stack-template-schemas.ts
@@ -157,20 +157,92 @@ export const templateNatsConsumerSchema = z.object({
 
 // ----- Phase 1: app-author role / signer / import surface -----
 
-export const templateNatsRoleSchema = z.object({
-  name: z.string().min(1).max(100).regex(nameRegex, "role name can only contain letters, numbers, '_', '-'"),
-  publish: z.array(natsRelativeSubjectSchema).optional(),
-  subscribe: z.array(natsRelativeSubjectSchema).optional(),
-  inboxAuto: z.enum(["both", "reply", "request", "none"]).optional(),
-  // KV bucket names. Each materializes into `$KV.<bucket>.>` on both pub
-  // and sub at apply time. Bucket-name rules mirror NATS' validator:
-  // alphanumeric + `_`/`-`, ≤100 chars. The orchestrator constructs the
-  // absolute subject form so the schema only validates the bucket names.
-  kvBuckets: z
-    .array(z.string().min(1).max(100).regex(/^[a-zA-Z0-9_-]+$/, "kvBuckets entry: alphanumeric + '_' / '-' only"))
-    .optional(),
-  ttlSeconds: z.number().int().min(0).optional(),
+// Role-nested stream: subjects relative to the stack's subjectPrefix. Drops
+// `account` (always the shared system account) and `scope` (always stack-
+// scoped) compared to the legacy top-level `streams[]` — both are implied
+// by the prefix-only isolation model.
+export const templateNatsRoleStreamSchema = z.object({
+  name: z.string().min(1).max(100).regex(nameRegex, "stream name can only contain letters, numbers, '_', '-'"),
+  description: z.string().max(500).optional(),
+  subjects: z.array(natsRelativeSubjectSchema).min(1),
+  retention: z.enum(["limits", "interest", "workqueue"]).optional(),
+  storage: z.enum(["file", "memory"]).optional(),
+  maxMsgs: z.number().int().nullable().optional(),
+  maxBytes: z.number().int().nullable().optional(),
+  maxAgeSeconds: z.number().int().nullable().optional(),
 });
+
+// Role-nested consumer: `stream` references one of the role's own streams
+// by declared name (the orchestrator resolves it to the materialized id);
+// `filterSubject` is relative to the subjectPrefix and gets prepended.
+export const templateNatsRoleConsumerSchema = z.object({
+  name: z.string().min(1).max(100).regex(nameRegex, "consumer name can only contain letters, numbers, '_', '-'"),
+  stream: z.string().min(1).max(100),
+  durableName: z.string().min(1).max(100).optional(),
+  description: z.string().max(500).optional(),
+  filterSubject: natsRelativeSubjectSchema.optional(),
+  deliverPolicy: z.enum(["all", "last", "new", "by_start_sequence", "by_start_time", "last_per_subject"]).optional(),
+  ackPolicy: z.enum(["none", "all", "explicit"]).optional(),
+  maxDeliver: z.number().int().nullable().optional(),
+  ackWaitSeconds: z.number().int().nullable().optional(),
+});
+
+export const templateNatsRoleSchema = z
+  .object({
+    name: z.string().min(1).max(100).regex(nameRegex, "role name can only contain letters, numbers, '_', '-'"),
+    publish: z.array(natsRelativeSubjectSchema).optional(),
+    subscribe: z.array(natsRelativeSubjectSchema).optional(),
+    inboxAuto: z.enum(["both", "reply", "request", "none"]).optional(),
+    // KV bucket names. Each materializes into `$KV.<bucket>.>` on both pub
+    // and sub at apply time. Bucket-name rules mirror NATS' validator:
+    // alphanumeric + `_`/`-`, ≤100 chars. The orchestrator constructs the
+    // absolute subject form so the schema only validates the bucket names.
+    kvBuckets: z
+      .array(z.string().min(1).max(100).regex(/^[a-zA-Z0-9_-]+$/, "kvBuckets entry: alphanumeric + '_' / '-' only"))
+      .optional(),
+    streams: z.array(templateNatsRoleStreamSchema).optional(),
+    consumers: z.array(templateNatsRoleConsumerSchema).optional(),
+    ttlSeconds: z.number().int().min(0).optional(),
+  })
+  .superRefine((role, ctx) => {
+    // Stream + consumer name uniqueness within the role. Names go into
+    // composite materialized identifiers (`<stackId>-<roleName>-<streamName>`),
+    // so a duplicate would silently overwrite the earlier definition.
+    const streamNames = new Set<string>();
+    for (let i = 0; i < (role.streams?.length ?? 0); i++) {
+      const s = role.streams![i];
+      if (streamNames.has(s.name)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Duplicate stream name '${s.name}' in role '${role.name}'`,
+          path: ["streams", i, "name"],
+        });
+      }
+      streamNames.add(s.name);
+    }
+    const consumerNames = new Set<string>();
+    for (let i = 0; i < (role.consumers?.length ?? 0); i++) {
+      const c = role.consumers![i];
+      if (consumerNames.has(c.name)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Duplicate consumer name '${c.name}' in role '${role.name}'`,
+          path: ["consumers", i, "name"],
+        });
+      }
+      consumerNames.add(c.name);
+      // Consumer.stream must reference a stream declared on this same role.
+      if (!streamNames.has(c.stream)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Consumer '${c.name}' references unknown stream '${c.stream}' in role '${role.name}' (defined: ${
+            streamNames.size === 0 ? "none" : Array.from(streamNames).map((n) => `'${n}'`).join(", ")
+          })`,
+          path: ["consumers", i, "stream"],
+        });
+      }
+    }
+  });
 
 export const templateNatsSignerSchema = z.object({
   name: z.string().min(1).max(100).regex(nameRegex, "signer name can only contain letters, numbers, '_', '-'"),
@@ -408,7 +480,7 @@ export const draftVersionSchema = z.object({
  */
 export function validateNatsSectionShape(
   nats: { accounts?: unknown[]; credentials?: unknown[]; streams?: unknown[]; consumers?: unknown[];
-          roles?: Array<{ name: string }>; signers?: Array<{ name: string }>;
+          roles?: Array<{ name: string; streams?: unknown[]; consumers?: unknown[] }>; signers?: Array<{ name: string }>;
           imports?: Array<{ forRoles?: string[] }>; exports?: unknown[]; subjectPrefix?: unknown } | undefined,
   ctx: z.RefinementCtx,
 ): void {
@@ -423,6 +495,25 @@ export function validateNatsSectionShape(
       code: z.ZodIssueCode.custom,
       message: "nats.credentials (legacy) and nats.roles (new) cannot be declared in the same template — pick one surface",
       path: ["nats", "roles"],
+    });
+  }
+
+  // Same rule for streams/consumers: an app template with `roles[]` must
+  // declare its JetStream resources via `roles[].streams` (auto-prefixed,
+  // relative subjects). Top-level `nats.streams` keeps absolute subjects
+  // for system templates and must not coexist with the new role surface.
+  if (hasNewRoles && (nats.streams?.length ?? 0) > 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "nats.streams (legacy, absolute subjects) cannot be declared alongside nats.roles — declare streams via nats.roles[].streams instead",
+      path: ["nats", "streams"],
+    });
+  }
+  if (hasNewRoles && (nats.consumers?.length ?? 0) > 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "nats.consumers (legacy) cannot be declared alongside nats.roles — declare consumers via nats.roles[].consumers instead",
+      path: ["nats", "consumers"],
     });
   }
 


### PR DESCRIPTION
## Summary

Picks up the **JetStream-for-apps** follow-up from [`docs/planning/not-shipped/nats-app-roles-followups.md`](docs/planning/not-shipped/nats-app-roles-followups.md) and ships it.

- Adds `roles[].streams` and `roles[].consumers` to `TemplateNatsSection`. Stream subjects and consumer `filterSubject` are written relative to the stack's `subjectPrefix`; the orchestrator prepends `<prefix>.` at apply time. Same ergonomics as `roles[].publish/subscribe` — app templates never hand-write the opaque `app.<stack-id>` namespace.
- `materializeRole` now adds the matching JetStream API grants (`$JS.API.STREAM.INFO.<stream>`, `$JS.API.CONSUMER.{INFO,CREATE,MSG.NEXT}.<stream>.<consumer>`, `$JS.ACK.<stream>.<consumer>.>`) to the role's credentials so a service bound to the role can publish, bind the durable consumer, pull, and ACK without extra plumbing.
- `NatsStream` rows now carry a `stackId` FK (nullable; legacy system-template streams keep `null`). New `pruneOrphanRoleStreams` mirrors `pruneOrphanRoleProfiles` so renames + removals don't leak DB rows; cascade-delete cleans up on stack destroy.
- Mixing rule extended: `nats.roles[]` cannot coexist with top-level `nats.streams[]` or `nats.consumers[]` — declare them via `nats.roles[].streams` / `[].consumers` instead.
- Real-NATS coverage at `server/src/__tests__/nats-role-streams.external.test.ts` exercises pub-into-stream → bind-durable-consumer → pull → ACK with the **exact** grant set `materializeRole` produces, so a future regression that drops one of the JS API grants surfaces as a permissions violation against a live server.

## Test plan

- [x] `pnpm build:lib && pnpm --filter mini-infra-server build && pnpm --filter mini-infra-client build`
- [x] `pnpm --filter mini-infra-server lint`
- [x] `pnpm --filter mini-infra-server test` — 156 files / 2169 tests pass (incl. 8 new role-streams integration tests + 7 new schema tests)
- [ ] `pnpm --filter mini-infra-server test:nats` — local colima setup can't bind testcontainers ports to the host; pre-existing `nats-account-claim-update.external.test.ts` fails identically. CI runs externals with a proper docker setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)