### PR TITLE
feat(nats): cycle detection in cross-stack imports

### DIFF
--- a/docs/planning/not-shipped/nats-app-roles-followups.md
+++ b/docs/planning/not-shipped/nats-app-roles-followups.md
@@ -49,21 +49,19 @@ The slackbot can now be ported.
 These came up during code review of Phases 1–5. None are blocking, all are
 worth doing before the first non-trivial third-party app onboards.
 
-### Cycle detection in cross-stack imports
+### ~~Cycle detection in cross-stack imports~~ — shipped
 
-**Problem.** Stack A imports from B; B imports from A. The Phase 5
-orchestrator has no cycle check. Both apply in some order: each generation
-sees the other's *prior* snapshot, so they ping-pong eventually-
-consistent rather than failing fast. This was acknowledged in the design
-(§6) but no implementation yet.
-
-**Where flagged:**
-- [server/src/services/stacks/stack-nats-apply-orchestrator.ts](../../../server/src/services/stacks/stack-nats-apply-orchestrator.ts) — TODO comment in `resolveImport`.
-
-**Approach.** Before resolving an import, walk the producer's `imports[]`
-recursively (DFS through `lastAppliedNatsSnapshot.imports`) looking for the
-consumer's stack name. Refuse to apply if found, surface the cycle path.
-Cheap because cross-stack import depth is small in practice.
+Shipped: `resolveImport` now BFS-walks the producer's
+`lastAppliedNatsSnapshot.imports[]` (environment-scoped) before resolving
+the import. If any transitive import references the consumer's stack
+name, apply fails with the cycle path in the error message
+(`A → B → C → A`). Pre-existing producer-side cycles that don't include
+the consumer (e.g. B↔C while A is the new consumer) are tolerated — the
+visited set bounds the search so the BFS terminates, but the error only
+fires for cycles introduced by *this* apply. Coverage in
+[server/src/__tests__/stack-nats-apply-orchestrator-imports.integration.test.ts](../../../server/src/__tests__/stack-nats-apply-orchestrator-imports.integration.test.ts)
+covers direct (A↔B), transitive (A→B→C→A), diamond (no false positive),
+and the producer-side-cycle-not-involving-consumer case.
 
 ### Global NATS-apply lock (concurrency hardening)
 

--- a/server/src/__tests__/stack-nats-apply-orchestrator-imports.integration.test.ts
+++ b/server/src/__tests__/stack-nats-apply-orchestrator-imports.integration.test.ts
@@ -321,3 +321,195 @@ describe('runStackNatsApplyPhase — Phase 5 imports/exports', () => {
     expect(result.error).toMatch(/undeclared role/);
   });
 });
+
+// ─── Cycle detection ─────────────────────────────────────────────────────────
+
+/**
+ * Helper for the cycle tests. Applies a producer stack with the given exports
+ * (so it has a real `lastAppliedNatsSnapshot` written by the orchestrator),
+ * then overlays a custom `imports[]` array onto that snapshot to simulate
+ * the producer's own past-apply imports. This is the only way to construct
+ * the closing edge of a cycle without bootstrapping the cycle through real
+ * applies (which the validator would reject in the first place).
+ */
+async function seedAppliedProducerWithImports(args: {
+  stackName: string;
+  exports: string[];
+  importsFromNames: string[];
+}): Promise<{ stackId: string; stackName: string }> {
+  const { stackId } = await seedStack({
+    natsRoles: [{ name: 'pub', publish: ['x'] }],
+    natsExports: args.exports,
+    stackName: args.stackName,
+  });
+  const r = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+  expect(r.status).toBe('applied');
+
+  const row = (await testPrisma.stack.findUnique({ where: { id: stackId } }))!;
+  const snap = JSON.parse(row.lastAppliedNatsSnapshot!);
+  // Splice fake imports into the snapshot. The orchestrator wrote
+  // `imports: []` based on this seed's input; overwrite to simulate that
+  // this producer has previously applied with imports of its own.
+  snap.imports = args.importsFromNames.map((fromStack) => ({
+    fromStack,
+    subjects: ['events.foo'],
+    forRoles: ['pub'],
+  }));
+  await testPrisma.stack.update({
+    where: { id: stackId },
+    data: { lastAppliedNatsSnapshot: JSON.stringify(snap) },
+  });
+  return { stackId, stackName: row.name };
+}
+
+describe('runStackNatsApplyPhase — Phase 5 cycle detection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects a direct cycle (A imports B, B imports A) with the cycle path in the error', async () => {
+    const consumerName = `cycle-A-${Date.now()}`;
+
+    // B is already applied AND its snapshot already records `imports: [{ fromStack: A }]`.
+    const b = await seedAppliedProducerWithImports({
+      stackName: `cycle-B-${Date.now()}`,
+      exports: ['events.>'],
+      importsFromNames: [consumerName],
+    });
+
+    // A applies, importing from B. Cycle detection walks B's snapshot →
+    // sees A in B's imports → refuses.
+    const a = await seedStack({
+      natsRoles: [{ name: 'watcher', subscribe: ['x'] }],
+      natsImports: [{ fromStack: b.stackName, subjects: ['events.foo'], forRoles: ['watcher'] }],
+      stackName: consumerName,
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, a.stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/would create a cycle/);
+    // Path renders consumer → producer → consumer.
+    expect(result.error).toContain(`${consumerName} → ${b.stackName} → ${consumerName}`);
+  });
+
+  it('rejects a transitive cycle (A imports B, B imports C, C imports A)', async () => {
+    const aName = `tcycle-A-${Date.now()}`;
+
+    // C imports A (closes the cycle).
+    const c = await seedAppliedProducerWithImports({
+      stackName: `tcycle-C-${Date.now()}`,
+      exports: ['events.>'],
+      importsFromNames: [aName],
+    });
+    // B imports C. B is the direct producer A is about to import from.
+    const b = await seedAppliedProducerWithImports({
+      stackName: `tcycle-B-${Date.now()}`,
+      exports: ['events.>'],
+      importsFromNames: [c.stackName],
+    });
+
+    const a = await seedStack({
+      natsRoles: [{ name: 'watcher', subscribe: ['x'] }],
+      natsImports: [{ fromStack: b.stackName, subjects: ['events.foo'], forRoles: ['watcher'] }],
+      stackName: aName,
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, a.stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/would create a cycle/);
+    // BFS walks A → B → C → A; path renders that order.
+    expect(result.error).toContain(`${aName} → ${b.stackName} → ${c.stackName} → ${aName}`);
+  });
+
+  it('does NOT error on a diamond (A → B → D and A → C → D, no back-edge)', async () => {
+    // D is a leaf — no imports.
+    const d = await seedStack({
+      natsRoles: [{ name: 'pub', publish: ['x'] }],
+      natsExports: ['events.>'],
+      stackName: `diamond-D-${Date.now()}`,
+    });
+    await runStackNatsApplyPhase(testPrisma, d.stackId, { triggeredBy: undefined });
+    const dName = (await testPrisma.stack.findUnique({ where: { id: d.stackId } }))!.name;
+
+    // B imports D, also exports.
+    const b = await seedAppliedProducerWithImports({
+      stackName: `diamond-B-${Date.now()}`,
+      exports: ['events.>'],
+      importsFromNames: [dName],
+    });
+    // C also imports D, also exports.
+    const c = await seedAppliedProducerWithImports({
+      stackName: `diamond-C-${Date.now()}`,
+      exports: ['events.>'],
+      importsFromNames: [dName],
+    });
+
+    // A imports from both B and C — diamond shape, no cycle.
+    const a = await seedStack({
+      natsRoles: [{ name: 'watcher', subscribe: ['x'] }],
+      natsImports: [
+        { fromStack: b.stackName, subjects: ['events.foo'], forRoles: ['watcher'] },
+        { fromStack: c.stackName, subjects: ['events.foo'], forRoles: ['watcher'] },
+      ],
+      stackName: `diamond-A-${Date.now()}`,
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, a.stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('applied');
+  });
+
+  it('does NOT error on a producer-side cycle that does not include the consumer (B → C → B with new A)', async () => {
+    // A pre-existing cycle between B and C is the operator's problem to fix
+    // when they next re-apply B or C — propagating it to every consumer's
+    // apply would be high-blast-radius and wrong. The visited set keeps
+    // the BFS from looping forever; the cycle isn't surfaced because A
+    // isn't in it.
+    const bName = `pre-B-${Date.now()}`;
+    const cName = `pre-C-${Date.now()}`;
+    // C imports B.
+    const c = await seedAppliedProducerWithImports({
+      stackName: cName,
+      exports: ['events.>'],
+      importsFromNames: [bName],
+    });
+    // B imports C — this is the pre-existing cycle the orchestrator should
+    // tolerate when walking from a fresh consumer A.
+    const b = await seedAppliedProducerWithImports({
+      stackName: bName,
+      exports: ['events.>'],
+      importsFromNames: [c.stackName],
+    });
+
+    const a = await seedStack({
+      natsRoles: [{ name: 'watcher', subscribe: ['x'] }],
+      natsImports: [{ fromStack: b.stackName, subjects: ['events.foo'], forRoles: ['watcher'] }],
+      stackName: `pre-A-${Date.now()}`,
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, a.stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('applied');
+  });
+
+  it('happy-path imports still resolve after consumer name plumbing', async () => {
+    // Sanity pin: the post-cycle-detection branch of resolveImport still
+    // resolves a normal import correctly. Catches any regression where the
+    // detector fires false positives or short-circuits past the matcher.
+    const producer = await seedStack({
+      natsRoles: [{ name: 'pub', publish: ['x'] }],
+      natsExports: ['events.>'],
+      stackName: `happy-prod-${Date.now()}`,
+    });
+    await runStackNatsApplyPhase(testPrisma, producer.stackId, { triggeredBy: undefined });
+    const producerName = (await testPrisma.stack.findUnique({ where: { id: producer.stackId } }))!.name;
+
+    const consumer = await seedStack({
+      natsRoles: [{ name: 'watcher', subscribe: ['x'] }],
+      natsImports: [{ fromStack: producerName, subjects: ['events.foo'], forRoles: ['watcher'] }],
+      stackName: `happy-cons-${Date.now()}`,
+    });
+    const result = await runStackNatsApplyPhase(testPrisma, consumer.stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('applied');
+
+    const profile = await testPrisma.natsCredentialProfile.findFirst({
+      where: { stackId: consumer.stackId, name: { contains: 'watcher' } },
+    });
+    const sub = profile!.subscribeAllow as unknown as string[];
+    expect(sub).toContain(`app.${producer.stackId}.events.foo`);
+  });
+});

--- a/server/src/services/stacks/stack-nats-apply-orchestrator.ts
+++ b/server/src/services/stacks/stack-nats-apply-orchestrator.ts
@@ -343,6 +343,7 @@ export async function runStackNatsApplyPhase(
           prisma,
           imp,
           consumerStackId: stackId,
+          consumerStackName: stack.name,
           consumerEnvironmentId: stack.environmentId,
         });
         for (const r of imp.forRoles) {
@@ -1153,6 +1154,7 @@ async function resolveImport(args: {
   prisma: PrismaClient;
   imp: TemplateNatsImport;
   consumerStackId: string;
+  consumerStackName: string;
   consumerEnvironmentId: string | null;
 }): Promise<string[]> {
   if (args.imp.fromStack === "") {
@@ -1169,11 +1171,6 @@ async function resolveImport(args: {
   //
   // Cross-environment imports are explicitly out of scope for v1 per the
   // design's §2.1 ("Out of scope: cross-environment imports").
-  //
-  // TODO: detect circular import dependencies (A imports B imports A).
-  // Currently the orchestrator allows ping-pong eventual consistency: each
-  // apply uses the other's prior snapshot. Phase-5+ should add a cycle
-  // check and refuse to apply, surfacing the cycle to the operator.
   const producer = await args.prisma.stack.findFirst({
     where: {
       name: args.imp.fromStack,
@@ -1201,6 +1198,26 @@ async function resolveImport(args: {
   if (!producer.lastAppliedNatsSnapshot) {
     throw new Error(
       `NATS apply: producer stack '${args.imp.fromStack}' has no applied NATS snapshot — apply it before importing`,
+    );
+  }
+
+  // Refuse to apply if the producer's import chain transitively references
+  // the consumer. Without this guard the orchestrator would silently allow
+  // A imports B / B imports A — each apply would use the other side's prior
+  // snapshot and the two stacks would ping-pong eventual consistency rather
+  // than the cycle being surfaced as a structural error. The walk is BFS
+  // through `lastAppliedNatsSnapshot.imports[].fromStack`, scoped to the
+  // consumer's environment to mirror the lookup above.
+  const cyclePath = await detectImportCycle({
+    prisma: args.prisma,
+    consumerStackName: args.consumerStackName,
+    startProducerName: producer.name,
+    environmentId: args.consumerEnvironmentId,
+  });
+  if (cyclePath) {
+    throw new Error(
+      `NATS apply: cross-stack import would create a cycle (${cyclePath.join(" → ")}). ` +
+        `Cross-stack imports must form a DAG — break the cycle by removing one direction.`,
     );
   }
 
@@ -1232,6 +1249,88 @@ async function resolveImport(args: {
     resolved.push(absolute);
   }
   return resolved;
+}
+
+/**
+ * Walk the producer's `lastAppliedNatsSnapshot.imports[]` (BFS), looking for
+ * the consumer's stack name. Returns the cycle path on detection, `null`
+ * otherwise.
+ *
+ *   consumer A is importing from producer B. We walk B's snapshot.imports →
+ *   any of those stacks' snapshot.imports → ... If we ever encounter A's
+ *   name, the new import would close a cycle (A → B → ... → A).
+ *
+ * The walk is environment-scoped to mirror `resolveImport`'s producer
+ * lookup — cross-environment imports are out of scope, so the cycle search
+ * stays in the consumer's environment too. A `visited` set bounds the
+ * traversal even if the chain itself contains a cycle that doesn't include
+ * the consumer (e.g. B → C → B); we don't error on those because they're
+ * pre-existing producer-side state, not introduced by this apply.
+ *
+ * Cross-stack import depth is small in practice, so the BFS is cheap even
+ * for templates with many `imports[]` entries — each visited stack's
+ * snapshot is parsed once.
+ */
+async function detectImportCycle(args: {
+  prisma: PrismaClient;
+  consumerStackName: string;
+  startProducerName: string;
+  environmentId: string | null;
+}): Promise<string[] | null> {
+  // Defensive name-loop check. The stackId-based check in `resolveImport`
+  // already rejects self-import (producer.id === consumerStackId), but a
+  // mid-flight rename could in theory drift the name; surfacing it via
+  // the cycle path keeps the operator-facing error consistent.
+  if (args.startProducerName === args.consumerStackName) {
+    return [args.consumerStackName, args.consumerStackName];
+  }
+
+  const visited = new Set<string>();
+  const queue: Array<{ name: string; path: string[] }> = [
+    { name: args.startProducerName, path: [args.consumerStackName, args.startProducerName] },
+  ];
+
+  while (queue.length > 0) {
+    const { name, path } = queue.shift()!;
+    if (visited.has(name)) continue;
+    visited.add(name);
+
+    const stackRow = await args.prisma.stack.findFirst({
+      where: {
+        name,
+        removedAt: null,
+        environmentId: args.environmentId,
+      },
+      select: { lastAppliedNatsSnapshot: true },
+    });
+    // No matching stack, or the producer in question hasn't applied — no
+    // cycle through this branch. (`resolveImport` separately enforces that
+    // the *direct* producer is applied; intermediate hops being un-applied
+    // just means the cycle isn't realized yet.)
+    if (!stackRow?.lastAppliedNatsSnapshot) continue;
+
+    let snapshot: { imports?: Array<{ fromStack?: unknown }> };
+    try {
+      snapshot = JSON.parse(stackRow.lastAppliedNatsSnapshot);
+    } catch {
+      // Corrupt snapshot — treat as no-imports. The owning stack's next
+      // apply will surface the corruption via its own JSON.parse path.
+      continue;
+    }
+
+    for (const imp of snapshot.imports ?? []) {
+      const next = typeof imp?.fromStack === "string" ? imp.fromStack : null;
+      if (!next) continue;
+      if (next === args.consumerStackName) {
+        return [...path, args.consumerStackName];
+      }
+      if (!visited.has(next)) {
+        queue.push({ name: next, path: [...path, next] });
+      }
+    }
+  }
+
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Picks up the **Cycle detection in cross-stack imports** follow-up from [`docs/planning/not-shipped/nats-app-roles-followups.md`](docs/planning/not-shipped/nats-app-roles-followups.md).

`resolveImport` now BFS-walks the producer's `lastAppliedNatsSnapshot.imports[]` (environment-scoped, mirroring the producer lookup) before resolving the import. If any transitive import references the consumer's stack name, apply fails with the cycle path rendered in the error message (`A → B → C → A`). Without this guard the orchestrator silently allowed A imports B / B imports A — each apply would use the other side's prior snapshot and the two stacks would ping-pong eventual consistency rather than the cycle being surfaced as a structural error.

Pre-existing producer-side cycles that don't include the consumer (e.g. B↔C while A is a new consumer of B) are tolerated. Surfacing them on every consumer's apply would be high blast radius for state that isn't the consumer's problem; the operator's next re-apply of B or C is the right place. The visited set bounds the BFS so unrelated cycles don't loop forever.

## Test plan

- [x] `pnpm build:lib && pnpm --filter mini-infra-server build`
- [x] `pnpm --filter mini-infra-server lint`
- [x] `pnpm --filter mini-infra-server test` — 156 files / 2174 tests pass (5 new cycle-detection tests: direct cycle, transitive cycle, diamond no-false-positive, producer-side-cycle-not-involving-consumer, happy-path sanity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)