### PR TITLE
feat(nats): drift detection on lastAppliedNatsSnapshot

### DIFF
--- a/client/src/components/environments/stacks-list.tsx
+++ b/client/src/components/environments/stacks-list.tsx
@@ -10,6 +10,12 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   IconStack2,
   IconRefresh,
   IconChevronDown,
@@ -54,6 +60,48 @@ const statusBadgeVariants: Record<
     label: "Removed",
   },
 };
+
+/**
+ * Surfaces the soft NATS-drift signal layered on top of the stack status.
+ * Operators see a small "NATS out of sync" badge with a tooltip listing
+ * which fields drifted; clicking through to apply re-syncs everything in
+ * one shot. Independent from `stack.status` because container-level sync
+ * and NATS-section sync are orthogonal — a stack can be `synced` for
+ * containers but have a freshly-edited (un-applied) NATS section.
+ */
+function NatsDriftBadge({ reasons }: { reasons: readonly string[] }) {
+  const labelByReason: Record<string, string> = {
+    'subject-prefix': 'Subject prefix',
+    roles: 'Roles',
+    signers: 'Signers',
+    exports: 'Exports',
+    imports: 'Imports',
+    'baseline-incomplete': 'Baseline incomplete (re-apply to refresh)',
+  };
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Badge
+            variant="outline"
+            className="bg-amber-50 text-amber-900 border-amber-300 dark:bg-amber-950 dark:text-amber-200 dark:border-amber-800"
+          >
+            NATS out of sync
+          </Badge>
+        </TooltipTrigger>
+        <TooltipContent>
+          <div className="font-medium mb-1">NATS section differs from last apply</div>
+          <ul className="list-disc pl-4 text-xs">
+            {reasons.map((r) => (
+              <li key={r}>{labelByReason[r] ?? r}</li>
+            ))}
+          </ul>
+          <div className="text-xs mt-2 opacity-80">Re-apply the stack to sync.</div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
 
 export function StacksList({ environmentId, scope, className }: StacksListProps) {
   const [expandedStackId, setExpandedStackId] = useState<string | null>(null);
@@ -202,6 +250,9 @@ export function StacksList({ environmentId, scope, className }: StacksListProps)
                             >
                               {badge.label}
                             </Badge>
+                            {stack.natsDrift?.drifted && (
+                              <NatsDriftBadge reasons={stack.natsDrift.reasons} />
+                            )}
                           </div>
                           <div className="flex items-center gap-3 text-sm text-muted-foreground mt-1">
                             <span>Latest Version v{stack.version}</span>

--- a/docs/planning/not-shipped/nats-app-roles-followups.md
+++ b/docs/planning/not-shipped/nats-app-roles-followups.md
@@ -152,14 +152,28 @@ NATS-using system templates that exist (`egress-fw-agent`,
 template. `roles[].streams` is purely additive for future app
 templates that want their own per-stack JetStream.
 
-### Drift detection in `lastAppliedNatsSnapshot`
+### ~~Drift detection in `lastAppliedNatsSnapshot`~~ — shipped
 
-The snapshot writes accounts/credentials/streams/consumers/roles/exports/
-imports/resolved-prefix on every apply, but no consumer compares against
-it for drift. Once the orchestrator's snapshot is rich enough (it is now,
-post-Phase 5), the next planned change is a drift detector that compares
-the rendered roles + resolved prefix against the snapshot and surfaces
-"out of sync" in the stack list.
+Shipped: the snapshot now also stores `subjectPrefixRaw` + `exportsRaw`
+alongside the existing resolved fields, so `detectNatsDrift` does pure
+raw-to-raw comparisons (no template re-rendering at every list call) of
+`natsRoles`, `natsSigners`, `natsExports`, `natsImports`, and
+`natsSubjectPrefix`. The detector returns
+`NatsDriftInfo { drifted, reasons[] }`, surfaced as `StackInfo.natsDrift`
+on the stack list + get routes. The stacks-list UI renders a small
+"NATS out of sync" badge alongside the existing status badge, with a
+tooltip listing which fields drifted. Independent from `stack.status`
+because container-level sync and NATS-section sync are orthogonal — a
+stack can be `synced` yet still report drift if the template was edited
+and not yet re-applied. Pre-bump snapshots that don't carry the raw
+fields surface as `baseline-incomplete` so a single re-apply refreshes
+the baseline cleanly. Coverage in
+[server/src/__tests__/nats-drift-detector.integration.test.ts](../../../server/src/__tests__/nats-drift-detector.integration.test.ts).
+
+Known limitation: drift driven purely by stack-parameter renaming or
+admin-allowlist edits isn't detected (raw-to-raw doesn't catch
+substitution drift). Re-rendering the template at every list call is the
+straightforward fix; punted until anyone observes a real false-negative.
 
 ---
 

--- a/lib/types/stacks.ts
+++ b/lib/types/stacks.ts
@@ -362,6 +362,44 @@ export interface StackInfo {
   inputValueKeys?: string[];
   /** Human-readable reason the last apply failed; null when the last apply succeeded. */
   lastFailureReason?: string | null;
+  /**
+   * NATS-section drift report. Populated when the stack has a NATS section
+   * AND a `lastAppliedNatsSnapshot`; otherwise `null`. The detector compares
+   * the current template's raw NATS fields (`natsRoles`, `natsSigners`,
+   * `natsExports`, `natsImports`, `natsSubjectPrefix`) against the snapshot
+   * — independent of stack-level container drift, so a stack can be `synced`
+   * status-wise yet still report `natsDrift.drifted = true` if the template
+   * was edited since the last NATS apply.
+   */
+  natsDrift?: NatsDriftInfo | null;
+}
+
+/** Reasons why the NATS section of a stack is out of sync with its last apply. */
+export type NatsDriftReason =
+  /** Resolved subject prefix differs (template edit, allowlist change, or param change). */
+  | 'subject-prefix'
+  /** `roles[]` array differs (added/removed roles, changed pub/sub patterns, etc.). */
+  | 'roles'
+  /** `signers[]` array differs (scope, TTL, or membership). */
+  | 'signers'
+  /** `exports[]` array differs. */
+  | 'exports'
+  /** `imports[]` array differs. */
+  | 'imports'
+  /**
+   * The `lastAppliedNatsSnapshot` predates the v2 raw-fields schema. The
+   * detector can't compare cleanly without re-rendering the template; the
+   * UI surfaces this as "baseline incomplete — re-apply to refresh". A
+   * single re-apply on an already-synced stack populates the missing fields
+   * and clears the reason.
+   */
+  | 'baseline-incomplete';
+
+export interface NatsDriftInfo {
+  /** True if any reason fired. */
+  drifted: boolean;
+  /** Specific fields that differ. Empty when `drifted` is false. */
+  reasons: NatsDriftReason[];
 }
 
 export interface StackServiceInfo {

--- a/server/src/__tests__/nats-drift-detector.integration.test.ts
+++ b/server/src/__tests__/nats-drift-detector.integration.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Integration tests for `detectNatsDrift` — the NATS-section drift surface
+ * that compares a stack's current template version raw NATS fields against
+ * the snapshot recorded at last apply. Lives behind the stack-list API
+ * field (`StackInfo.natsDrift`).
+ *
+ * Coverage:
+ *   - No snapshot → null (never applied; drift signal would be misleading).
+ *   - No NATS section on the current template → null.
+ *   - Matching template + snapshot → not drifted.
+ *   - Role added → drifted with `roles` reason.
+ *   - Role removed → drifted with `roles` reason.
+ *   - Role pub list re-ordered → drifted (ordering matters; pub permissions
+ *     are positional in NATS).
+ *   - Signer scope changed → drifted with `signers` reason.
+ *   - Imports/exports diff → drifted with the right reason.
+ *   - Subject prefix changed (raw level) → drifted with `subject-prefix` reason.
+ *   - Old snapshot missing raw subjectPrefix/exports → emits `baseline-incomplete`
+ *     so the UI can render "drift status unknown — re-apply to refresh baseline".
+ *   - Corrupt JSON snapshot → null (caller falls back to other diagnostic state).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { testPrisma } from './integration-test-helpers';
+import { detectNatsDrift } from '../services/stacks/nats-drift-detector';
+
+interface SeedInput {
+  natsRoles?: unknown;
+  natsSigners?: unknown;
+  natsExports?: unknown;
+  natsImports?: unknown;
+  natsSubjectPrefix?: string | null;
+  /** When provided, written to `stack.lastAppliedNatsSnapshot` verbatim. */
+  snapshot?: unknown;
+}
+
+async function seedStackWithSnapshot(input: SeedInput): Promise<{
+  templateId: string;
+  templateVersion: number;
+  lastAppliedNatsSnapshot: string | null;
+}> {
+  const templateId = createId();
+  const versionId = createId();
+  const stackId = createId();
+  await testPrisma.stackTemplate.create({
+    data: {
+      id: templateId,
+      name: `tpl-${templateId.slice(0, 6)}`,
+      displayName: 'Drift detector test',
+      source: 'user',
+      scope: 'host',
+    },
+  });
+  await testPrisma.stackTemplateVersion.create({
+    data: {
+      id: versionId,
+      templateId,
+      version: 1,
+      status: 'published',
+      parameters: [],
+      defaultParameterValues: {},
+      networkTypeDefaults: {},
+      networks: [],
+      volumes: [],
+      natsRoles: (input.natsRoles ?? null) as never,
+      natsSigners: (input.natsSigners ?? null) as never,
+      natsExports: (input.natsExports ?? null) as never,
+      natsImports: (input.natsImports ?? null) as never,
+      natsSubjectPrefix: input.natsSubjectPrefix ?? null,
+    },
+  });
+  await testPrisma.stack.create({
+    data: {
+      id: stackId,
+      name: `stack-${stackId.slice(0, 6)}`,
+      version: 1,
+      networks: [],
+      volumes: [],
+      templateId,
+      templateVersion: 1,
+      lastAppliedNatsSnapshot: input.snapshot !== undefined ? JSON.stringify(input.snapshot) : null,
+    },
+  });
+  return { templateId, templateVersion: 1, lastAppliedNatsSnapshot: input.snapshot !== undefined ? JSON.stringify(input.snapshot) : null };
+}
+
+/** Build a snapshot value with the v2 raw fields populated. */
+function snapshotV2(args: {
+  subjectPrefixRaw?: string | null;
+  roles?: unknown;
+  signers?: unknown;
+  exportsRaw?: unknown;
+  imports?: unknown;
+}) {
+  return {
+    accounts: [],
+    credentials: [],
+    streams: [],
+    consumers: [],
+    resources: [],
+    subjectPrefix: args.subjectPrefixRaw ?? 'app.x',
+    roles: args.roles ?? [],
+    signers: args.signers ?? [],
+    resolvedExports: (args.exportsRaw as unknown[] | undefined)?.map((s) => `app.x.${s}`) ?? [],
+    imports: args.imports ?? [],
+    subjectPrefixRaw: args.subjectPrefixRaw ?? null,
+    exportsRaw: args.exportsRaw ?? [],
+  };
+}
+
+describe('detectNatsDrift', () => {
+  it('returns null when the stack has no NATS apply snapshot', async () => {
+    const seeded = await seedStackWithSnapshot({
+      natsRoles: [{ name: 'gateway', publish: ['x'] }],
+      // snapshot omitted intentionally
+    });
+    const result = await detectNatsDrift(testPrisma, seeded);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the current template has no NATS section at all', async () => {
+    const seeded = await seedStackWithSnapshot({
+      // No NATS fields on the current template version
+      snapshot: snapshotV2({ subjectPrefixRaw: null, roles: [{ name: 'old' }] }),
+    });
+    const result = await detectNatsDrift(testPrisma, seeded);
+    expect(result).toBeNull();
+  });
+
+  it('returns not-drifted when current template matches snapshot exactly', async () => {
+    const roles = [{ name: 'gateway', publish: ['agent.in'], subscribe: ['slack.api'] }];
+    const seeded = await seedStackWithSnapshot({
+      natsRoles: roles,
+      snapshot: snapshotV2({ roles, subjectPrefixRaw: null, exportsRaw: [] }),
+    });
+    const result = await detectNatsDrift(testPrisma, seeded);
+    expect(result).toEqual({ drifted: false, reasons: [] });
+  });
+
+  it('reports drift when a role is added', async () => {
+    const seeded = await seedStackWithSnapshot({
+      natsRoles: [
+        { name: 'gateway', publish: ['x'] },
+        { name: 'manager', publish: ['y'] },
+      ],
+      snapshot: snapshotV2({
+        subjectPrefixRaw: null,
+        roles: [{ name: 'gateway', publish: ['x'] }],
+        exportsRaw: [],
+      }),
+    });
+    const result = await detectNatsDrift(testPrisma, seeded);
+    expect(result?.drifted).toBe(true);
+    expect(result?.reasons).toContain('roles');
+  });
+
+  it('reports drift when a role is removed', async () => {
+    const seeded = await seedStackWithSnapshot({
+      natsRoles: [{ name: 'gateway', publish: ['x'] }],
+      snapshot: snapshotV2({
+        subjectPrefixRaw: null,
+        roles: [
+          { name: 'gateway', publish: ['x'] },
+          { name: 'manager', publish: ['y'] },
+        ],
+        exportsRaw: [],
+      }),
+    });
+    const result = await detectNatsDrift(testPrisma, seeded);
+    expect(result?.drifted).toBe(true);
+    expect(result?.reasons).toContain('roles');
+  });
+
+  it('reports drift when a role.publish entry is reordered (pub permissions are positional)', async () => {
+    const seeded = await seedStackWithSnapshot({
+      natsRoles: [{ name: 'gateway', publish: ['a.in', 'b.in'] }],
+      snapshot: snapshotV2({
+        subjectPrefixRaw: null,
+        roles: [{ name: 'gateway', publish: ['b.in', 'a.in'] }],
+        exportsRaw: [],
+      }),
+    });
+    const result = await detectNatsDrift(testPrisma, seeded);
+    expect(result?.drifted).toBe(true);
+    expect(result?.reasons).toContain('roles');
+  });
+
+  it('reports drift when signer scope changes', async () => {
+    const seeded = await seedStackWithSnapshot({
+      natsRoles: [{ name: 'gateway', publish: ['x'] }],
+      natsSigners: [{ name: 'minter', subjectScope: 'agent.worker.v2' }],
+      snapshot: snapshotV2({
+        subjectPrefixRaw: null,
+        roles: [{ name: 'gateway', publish: ['x'] }],
+        signers: [{ name: 'minter', subjectScope: 'agent.worker.v1' }],
+        exportsRaw: [],
+      }),
+    });
+    const result = await detectNatsDrift(testPrisma, seeded);
+    expect(result?.drifted).toBe(true);
+    expect(result?.reasons).toContain('signers');
+  });
+
+  it('reports drift when exports change', async () => {
+    const seeded = await seedStackWithSnapshot({
+      natsRoles: [{ name: 'pub', publish: ['x'] }],
+      natsExports: ['events.>', 'metrics.>'],
+      snapshot: snapshotV2({
+        subjectPrefixRaw: null,
+        roles: [{ name: 'pub', publish: ['x'] }],
+        exportsRaw: ['events.>'],
+      }),
+    });
+    const result = await detectNatsDrift(testPrisma, seeded);
+    expect(result?.drifted).toBe(true);
+    expect(result?.reasons).toContain('exports');
+  });
+
+  it('reports drift when imports change', async () => {
+    const seeded = await seedStackWithSnapshot({
+      natsRoles: [{ name: 'watcher', subscribe: ['x'] }],
+      natsImports: [{ fromStack: 'producer', subjects: ['events.foo'], forRoles: ['watcher'] }],
+      snapshot: snapshotV2({
+        subjectPrefixRaw: null,
+        roles: [{ name: 'watcher', subscribe: ['x'] }],
+        imports: [],
+        exportsRaw: [],
+      }),
+    });
+    const result = await detectNatsDrift(testPrisma, seeded);
+    expect(result?.drifted).toBe(true);
+    expect(result?.reasons).toContain('imports');
+  });
+
+  it('reports drift when raw subjectPrefix changes (template-level edit)', async () => {
+    const seeded = await seedStackWithSnapshot({
+      natsRoles: [{ name: 'gateway', publish: ['x'] }],
+      natsSubjectPrefix: 'navi-v2',
+      snapshot: snapshotV2({
+        subjectPrefixRaw: 'navi-v1',
+        roles: [{ name: 'gateway', publish: ['x'] }],
+        exportsRaw: [],
+      }),
+    });
+    const result = await detectNatsDrift(testPrisma, seeded);
+    expect(result?.drifted).toBe(true);
+    expect(result?.reasons).toContain('subject-prefix');
+  });
+
+  it("treats null and [] as equivalent for empty NATS arrays (no false-positive drift)", async () => {
+    // The orchestrator writes `natsRoles: null` for no-roles templates but
+    // a freshly-edited template might end up with `[]` after schema parse.
+    // Without nullish coalescing the detector would false-positive on what
+    // is structurally identical state.
+    const seeded = await seedStackWithSnapshot({
+      natsRoles: [{ name: 'gateway', publish: ['x'] }],
+      natsSigners: [],  // empty array
+      snapshot: snapshotV2({
+        subjectPrefixRaw: null,
+        roles: [{ name: 'gateway', publish: ['x'] }],
+        signers: null,  // null on the snapshot side
+        exportsRaw: [],
+      }),
+    });
+    const result = await detectNatsDrift(testPrisma, seeded);
+    expect(result?.drifted).toBe(false);
+    expect(result?.reasons).toEqual([]);
+  });
+
+  it('emits baseline-incomplete when the snapshot predates the raw-fields bump', async () => {
+    // Old-format snapshot — no `subjectPrefixRaw` or `exportsRaw`. Detector
+    // can still compare roles/signers/imports raw-to-raw, but for fields
+    // that need the raw baseline it surfaces the gap.
+    const oldSnapshot = {
+      accounts: [],
+      credentials: [],
+      streams: [],
+      consumers: [],
+      resources: [],
+      subjectPrefix: 'app.x',
+      roles: [{ name: 'gateway', publish: ['x'] }],
+      signers: [],
+      resolvedExports: [],
+      imports: [],
+      // NOTE: no subjectPrefixRaw / exportsRaw
+    };
+    const seeded = await seedStackWithSnapshot({
+      natsRoles: [{ name: 'gateway', publish: ['x'] }],
+      snapshot: oldSnapshot,
+    });
+    const result = await detectNatsDrift(testPrisma, seeded);
+    expect(result?.drifted).toBe(true);
+    expect(result?.reasons).toContain('baseline-incomplete');
+    // Should NOT also mis-fire on subject-prefix or exports — those are
+    // skipped when raw isn't available, in favour of the explicit baseline
+    // signal.
+    expect(result?.reasons).not.toContain('subject-prefix');
+    expect(result?.reasons).not.toContain('exports');
+  });
+
+  it('returns null on a corrupt JSON snapshot (caller falls back to other state)', async () => {
+    const seeded = await seedStackWithSnapshot({
+      natsRoles: [{ name: 'gateway', publish: ['x'] }],
+    });
+    // Overwrite the snapshot column with garbage to simulate corruption.
+    const stackId = (
+      await testPrisma.stack.findFirst({
+        where: { templateId: seeded.templateId },
+        select: { id: true },
+      })
+    )!.id;
+    await testPrisma.stack.update({
+      where: { id: stackId },
+      data: { lastAppliedNatsSnapshot: '{ not valid json' },
+    });
+
+    const result = await detectNatsDrift(testPrisma, {
+      templateId: seeded.templateId,
+      templateVersion: seeded.templateVersion,
+      lastAppliedNatsSnapshot: '{ not valid json',
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/server/src/routes/stacks/stacks-crud-routes.ts
+++ b/server/src/routes/stacks/stacks-crud-routes.ts
@@ -15,6 +15,7 @@ import {
   serializeStack,
   toServiceCreateInput,
 } from '../../services/stacks/utils';
+import { detectNatsDrift } from '../../services/stacks/nats-drift-detector';
 import {
   encryptInputValues,
   decryptInputValues,
@@ -71,7 +72,25 @@ router.get(
       orderBy: { name: 'asc' },
     });
 
-    res.json({ success: true, data: stacks.map(serializeStack) });
+    // Drift detection runs in parallel per stack — `detectNatsDrift` is one
+    // Prisma read on `stackTemplateVersion` plus a JSON.parse, so for a list
+    // bounded by single-host scale (dozens of stacks) the latency is well
+    // within the existing list-route budget. Stacks without a NATS section
+    // or without a snapshot return null cheaply.
+    const driftByStack = await Promise.all(
+      stacks.map((s) =>
+        detectNatsDrift(prisma, {
+          templateId: s.templateId,
+          templateVersion: s.templateVersion,
+          lastAppliedNatsSnapshot: s.lastAppliedNatsSnapshot,
+        }).catch(() => null),
+      ),
+    );
+
+    res.json({
+      success: true,
+      data: stacks.map((s, i) => ({ ...serializeStack(s), natsDrift: driftByStack[i] })),
+    });
   }),
 );
 
@@ -139,7 +158,13 @@ router.get(
       return res.status(404).json({ success: false, message: 'Stack not found' });
     }
 
-    res.json({ success: true, data: serializeStack(stack) });
+    const natsDrift = await detectNatsDrift(prisma, {
+      templateId: stack.templateId,
+      templateVersion: stack.templateVersion,
+      lastAppliedNatsSnapshot: stack.lastAppliedNatsSnapshot,
+    }).catch(() => null);
+
+    res.json({ success: true, data: { ...serializeStack(stack), natsDrift } });
   }),
 );
 

--- a/server/src/services/stacks/nats-drift-detector.ts
+++ b/server/src/services/stacks/nats-drift-detector.ts
@@ -1,0 +1,166 @@
+import type { PrismaClient } from "../../generated/prisma/client";
+import type { NatsDriftInfo, NatsDriftReason } from "@mini-infra/types";
+
+/**
+ * Compare a stack's current template-version NATS section against its last
+ * applied NATS snapshot and report which fields drifted.
+ *
+ * **Scope.** The detector compares the **raw**, un-rendered template fields
+ * — `natsSubjectPrefix`, `natsRoles`, `natsSigners`, `natsExports`,
+ * `natsImports` — against the equivalents persisted in
+ * `lastAppliedNatsSnapshot`. That catches the common drift drivers (template
+ * edits, role/signer adds/removes, prefix changes). It does **not** catch
+ * drift driven purely by stack-parameter renaming or admin-allowlist edits;
+ * those would require re-running the template engine, which is reserved for
+ * a v2 if the demand surfaces.
+ *
+ * **Independence from stack.status.** This is a soft signal layered on top
+ * of the existing stack status (`synced`/`drifted`/`pending`/...). A stack
+ * can be `synced` container-wise yet still report `natsDrift.drifted = true`
+ * if the template was edited and not yet re-applied. Surfacing both lets
+ * operators distinguish "containers in sync, NATS state out of sync" from
+ * "everything is in sync" without conflating two orthogonal axes.
+ *
+ * **Backwards compat.** Snapshots written before the raw-fields bump don't
+ * carry `subjectPrefixRaw` / `exportsRaw`; in that case the detector emits
+ * `baseline-incomplete` rather than guessing. A single re-apply on a synced
+ * stack writes the new fields and clears the reason.
+ *
+ * @returns `null` when the stack has no NATS section or has never been
+ * applied; otherwise a `NatsDriftInfo` summary.
+ */
+export async function detectNatsDrift(
+  prisma: PrismaClient,
+  stack: {
+    templateId: string | null;
+    templateVersion: number | null;
+    lastAppliedNatsSnapshot: string | null;
+  },
+): Promise<NatsDriftInfo | null> {
+  if (!stack.templateId || stack.templateVersion == null) return null;
+  // No prior NATS apply → nothing to compare against. Status-page UI shows
+  // the stack as `pending`/`undeployed` for an unrelated reason; we don't
+  // need to layer NATS drift on top of that.
+  if (!stack.lastAppliedNatsSnapshot) return null;
+
+  const templateVersion = await prisma.stackTemplateVersion.findFirst({
+    where: { templateId: stack.templateId, version: stack.templateVersion },
+    select: {
+      natsSubjectPrefix: true,
+      natsRoles: true,
+      natsSigners: true,
+      natsExports: true,
+      natsImports: true,
+    },
+  });
+  if (!templateVersion) return null;
+
+  // Skip stacks whose current template version has no NATS section at all.
+  // `lastAppliedNatsSnapshot` from a prior version that DID have one would
+  // already report drift via the field comparisons below — but if the
+  // current version has nothing, the snapshot is a relic of a strictly
+  // earlier shape and the destroy/re-apply path will clean it up.
+  const currentHasNats =
+    templateVersion.natsSubjectPrefix != null ||
+    nonEmpty(templateVersion.natsRoles) ||
+    nonEmpty(templateVersion.natsSigners) ||
+    nonEmpty(templateVersion.natsExports) ||
+    nonEmpty(templateVersion.natsImports);
+  if (!currentHasNats) return null;
+
+  let snapshot: Record<string, unknown>;
+  try {
+    snapshot = JSON.parse(stack.lastAppliedNatsSnapshot) as Record<string, unknown>;
+  } catch {
+    // Corrupt snapshot — every re-apply rewrites it, so `error` is the right
+    // surface (not drift). Returning null leaves the operator looking at the
+    // stack's existing failure reason for context.
+    return null;
+  }
+
+  const reasons: NatsDriftReason[] = [];
+
+  // subjectPrefix: snapshot has both the legacy resolved value and (post-
+  // raw-bump) the raw form. Compare raw-to-raw when available; otherwise
+  // emit baseline-incomplete and skip the field-level check.
+  const snapshotPrefixRaw = "subjectPrefixRaw" in snapshot ? (snapshot.subjectPrefixRaw as string | null) : undefined;
+  const snapshotExportsRaw = "exportsRaw" in snapshot ? (snapshot.exportsRaw as unknown[] | null) : undefined;
+  let baselineIncomplete = false;
+  if (snapshotPrefixRaw === undefined || snapshotExportsRaw === undefined) {
+    baselineIncomplete = true;
+  }
+
+  if (snapshotPrefixRaw !== undefined) {
+    const currentPrefixRaw = templateVersion.natsSubjectPrefix ?? null;
+    if (!stableEqual(currentPrefixRaw, snapshotPrefixRaw)) {
+      reasons.push("subject-prefix");
+    }
+  }
+
+  if (!stableEqual(templateVersion.natsRoles, snapshot.roles)) {
+    reasons.push("roles");
+  }
+  if (!stableEqual(templateVersion.natsSigners, snapshot.signers)) {
+    reasons.push("signers");
+  }
+  if (snapshotExportsRaw !== undefined) {
+    if (!stableEqual(templateVersion.natsExports, snapshotExportsRaw)) {
+      reasons.push("exports");
+    }
+  }
+  if (!stableEqual(templateVersion.natsImports, snapshot.imports)) {
+    reasons.push("imports");
+  }
+  if (baselineIncomplete) {
+    reasons.push("baseline-incomplete");
+  }
+
+  return { drifted: reasons.length > 0, reasons };
+}
+
+function nonEmpty(value: unknown): boolean {
+  if (value == null) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+}
+
+/**
+ * Deep equality with stable key ordering and null/undefined coalescing —
+ * Prisma's JSON columns round-trip through `JSON.parse` so identity-level
+ * comparison would fire false positives on every re-read.
+ *
+ * Treats `null`, `undefined`, and missing as equivalent for top-level
+ * comparison: a template with `natsRoles: null` and a snapshot with
+ * `roles: []` should NOT report drift just because nothing's there.
+ */
+function stableEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (isNullish(a) && isNullish(b)) return true;
+  if (isNullish(a) !== isNullish(b)) {
+    // One side is null/undefined, the other isn't. If the present side is
+    // an empty array/object treat it as no-difference; otherwise drift.
+    const present = isNullish(a) ? b : a;
+    if (Array.isArray(present) && present.length === 0) return true;
+    if (typeof present === "object" && present !== null && Object.keys(present).length === 0) return true;
+    return false;
+  }
+  return canonicalize(a) === canonicalize(b);
+}
+
+function isNullish(v: unknown): boolean {
+  return v === null || v === undefined;
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null || value === undefined) return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return "[" + value.map((item) => canonicalize(item)).join(",") + "]";
+  }
+  if (typeof value === "object") {
+    const sorted = Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((k) => JSON.stringify(k) + ":" + canonicalize((value as Record<string, unknown>)[k]));
+    return "{" + sorted.join(",") + "}";
+  }
+  return JSON.stringify(value);
+}

--- a/server/src/services/stacks/stack-nats-apply-orchestrator.ts
+++ b/server/src/services/stacks/stack-nats-apply-orchestrator.ts
@@ -512,6 +512,14 @@ export async function runStackNatsApplyPhase(
             // producer's prefix at consumer-apply time.
             resolvedExports,
             imports,
+            // Drift-detector inputs — the raw, un-rendered template values
+            // captured at apply time. Lets `detectNatsDrift` compare the
+            // current template's raw fields apples-to-apples without
+            // re-running the template engine on every list call. The
+            // detector falls back to a `baseline-incomplete` reason for
+            // pre-bump snapshots that don't carry these.
+            subjectPrefixRaw: templateVersion.natsSubjectPrefix ?? null,
+            exportsRaw: exportsRelative,
           }),
           lastFailureReason: null,
         },


### PR DESCRIPTION
## Summary

Picks up the **Drift detection in `lastAppliedNatsSnapshot`** follow-up from [`docs/planning/not-shipped/nats-app-roles-followups.md`](docs/planning/not-shipped/nats-app-roles-followups.md).

- **Snapshot bump** (`stack-nats-apply-orchestrator.ts`): the orchestrator now also stores `subjectPrefixRaw` + `exportsRaw` alongside the existing resolved fields. Lets the detector compare apples-to-apples without re-running the template engine at every stack-list call.
- **Detector** (`server/src/services/stacks/nats-drift-detector.ts`): `detectNatsDrift` does pure raw-to-raw comparison of `natsRoles`, `natsSigners`, `natsExports`, `natsImports`, and `natsSubjectPrefix`. Returns `NatsDriftInfo { drifted, reasons[] }`.
- **API** (`stacks-crud-routes.ts`): list + get routes now attach `natsDrift` to each `StackInfo`. Per-stack cost is one Prisma read on `stackTemplateVersion` plus a JSON.parse — within the existing list-route budget.
- **UI** (`stacks-list.tsx`): a small `NATS out of sync` badge appears alongside the existing status badge when drift is detected. Tooltip lists the specific fields that differ.
- **Independence**: this is layered on top of the existing stack status, not a replacement. A stack can be `synced` (containers in sync) yet report `natsDrift.drifted = true` (template edited but not re-applied). Surfacing both lets operators distinguish the two axes.
- **Backwards compat**: pre-bump snapshots that lack `subjectPrefixRaw`/`exportsRaw` surface as `baseline-incomplete` so a single re-apply on a synced stack refreshes the baseline cleanly without false-positive subject-prefix/exports drift.

## Known limitation

Drift driven purely by stack-parameter renaming or admin-allowlist edits isn't detected (raw-to-raw doesn't see substitution drift). Re-rendering the template at list time is the natural fix; punted until anyone observes a real false-negative — documented in the followups doc.

## Test plan

- [x] `pnpm build:lib && pnpm --filter mini-infra-server build && pnpm --filter mini-infra-client build`
- [x] `pnpm --filter mini-infra-server lint`
- [x] `pnpm --filter mini-infra-server test` — 157 files / 2182 tests pass (13 new drift-detector tests covering: no snapshot, no NATS section, exact match, role added/removed/reordered, signer scope, exports/imports/prefix changes, null/empty equivalence, baseline-incomplete on old snapshots, corrupt JSON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)