### PR TITLE
feat(nats): apply lock + orphan JetStream cleanup

### DIFF
--- a/docs/planning/not-shipped/nats-app-roles-followups.md
+++ b/docs/planning/not-shipped/nats-app-roles-followups.md
@@ -63,19 +63,26 @@ fires for cycles introduced by *this* apply. Coverage in
 covers direct (A↔B), transitive (A→B→C→A), diamond (no false positive),
 and the producer-side-cycle-not-involving-consumer case.
 
-### Global NATS-apply lock (concurrency hardening)
+### ~~Global NATS-apply lock (concurrency hardening)~~ — shipped
 
-**Problem.** Phase 5's `resolveImport` is a plain Prisma read of the
-producer's `lastAppliedNatsSnapshot`. If producer + consumer apply
-simultaneously, the consumer can race on a stale snapshot. The design
-recommended a global NATS-apply lock; v1 takes the eventual-consistency
-tradeoff (consumer's next apply picks up the new snapshot).
+Shipped: a module-scoped chain promise in
+`stack-nats-apply-orchestrator.ts` serializes `runStackNatsApplyPhase`
+calls on a single Node process. Producer + consumer applies can no longer
+race on `lastAppliedNatsSnapshot` mid-rotation. Errors from one apply are
+isolated from the chain so a single failure doesn't poison subsequent
+applies. Coverage in
+[server/src/__tests__/stack-nats-apply-lock.integration.test.ts](../../../server/src/__tests__/stack-nats-apply-lock.integration.test.ts):
+two concurrent applies stay at max-in-flight = 1, a forced failure on
+one apply leaves the next apply unaffected, and the chain drains cleanly
+after all in-flight work finishes.
 
-**Approach.** A single advisory lock keyed by `"nats-apply"` taken at
-the top of `runStackNatsApplyPhase`. Cheap, single-host system, contention
-is rare. Implementation note: keep the lock scope tight (don't hold across
-the legacy `applyConfig`/`applyJetStreamResources` since those touch a
-live NATS connection that may be slow).
+Trade-off (deviation from the design's "scope tight" note): the lock is
+held across the slow `applyConfig` / `applyJetStreamResources` NATS
+network calls. Splitting the lock into "DB-only-locked, NATS-unlocked,
+DB-write-locked" phases would refactor the orchestrator's monolithic
+`try` block — meaningful churn for a perf concern that doesn't matter at
+single-host single-process scale (concurrent applies are already rare).
+Documented as a follow-up if contention surfaces.
 
 ### Forced revocation path for in-flight JWTs
 

--- a/docs/planning/not-shipped/nats-app-roles-followups.md
+++ b/docs/planning/not-shipped/nats-app-roles-followups.md
@@ -134,14 +134,17 @@ template; declare them via `nats.roles[].streams` instead. Real-NATS
 external coverage in
 [server/src/__tests__/nats-role-streams.external.test.ts](../../../server/src/__tests__/nats-role-streams.external.test.ts).
 
-Known follow-up: removing a role-stream from a template deletes the
+~~Known follow-up: removing a role-stream from a template deletes the
 `NatsStream` DB row but does not delete the underlying JetStream stream
-in NATS itself (the orchestrator only adds/updates via
-`applyJetStreamResources`). Stale streams stop receiving traffic because
-nothing else publishes to the prefixed subjects, but they leak storage
-until manually pruned. A reconciliation step that lists JetStream
-streams and deletes any that aren't in the DB is the natural fix; punted
-out of this PR to keep the change focused.
+in NATS itself.~~ — closed. `pruneOrphanRoleStreams` now returns the
+captured orphan names + accountId, the orchestrator hands them to a new
+`NatsControlPlaneService.deleteJetStreams(...)` after
+`applyJetStreamResources` has run, and the live JS streams are deleted
+on the same apply that prunes the DB rows. Best-effort: a NATS-side blip
+during the cleanup is logged and the apply still succeeds (DB is
+authoritative). 404s from the live server are treated as success
+(stream already gone). Coverage in
+[server/src/__tests__/stack-nats-orphan-stream-cleanup.integration.test.ts](../../../server/src/__tests__/stack-nats-orphan-stream-cleanup.integration.test.ts).
 
 No system templates need to migrate to the new surface. The shared
 system JetStream streams (`EgressFwEvents`, `BackupHistory`, etc.) and KV

--- a/server/src/__tests__/stack-nats-apply-lock.integration.test.ts
+++ b/server/src/__tests__/stack-nats-apply-lock.integration.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Integration tests for the NATS-apply lock — the single-host serializer
+ * that prevents producer + consumer races on `lastAppliedNatsSnapshot`.
+ *
+ * Coverage:
+ *   - Concurrent applies are serialized (max in-flight = 1).
+ *   - One apply's failure doesn't break the chain — subsequent applies
+ *     still queue and complete.
+ *   - The chain drains cleanly after all in-flight work finishes.
+ *
+ * The mocked control plane injects a delay into `applyConfig` so the test
+ * can observe the lock holding the second apply until the first one
+ * finishes its network-call phase. Without the lock the two applies would
+ * interleave and the in-flight counter would briefly reach 2.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { testPrisma } from './integration-test-helpers';
+
+let inFlight = 0;
+let maxInFlight = 0;
+let applyConfigDelayMs = 0;
+let applyConfigShouldFail = false;
+
+/** Reset the cross-test counters/knobs the mock reads from. */
+function resetMockState() {
+  inFlight = 0;
+  maxInFlight = 0;
+  applyConfigDelayMs = 0;
+  applyConfigShouldFail = false;
+}
+
+vi.mock('../services/nats/nats-control-plane-service', async (orig) => {
+  const real = await orig<typeof import('../services/nats/nats-control-plane-service')>();
+  return {
+    ...real,
+    getNatsControlPlaneService: (db: unknown) => ({
+      getStatus: async () => ({ configured: true }),
+      ensureDefaultAccount: async () => {
+        const prisma = db as typeof testPrisma;
+        const existing = await prisma.natsAccount.findUnique({ where: { name: 'default' } });
+        if (existing) return { id: existing.id, name: existing.name, isSystem: true };
+        const created = await prisma.natsAccount.create({
+          data: {
+            name: 'default',
+            displayName: 'Default',
+            isSystem: true,
+            seedKvPath: 'shared/nats-default',
+          },
+        });
+        return { id: created.id, name: created.name, isSystem: true };
+      },
+      // applyConfig is the slow step where the lock contention matters most.
+      // Track in-flight count + max-in-flight to assert serialization.
+      applyConfig: async () => {
+        inFlight++;
+        if (inFlight > maxInFlight) maxInFlight = inFlight;
+        try {
+          if (applyConfigDelayMs > 0) {
+            await new Promise((r) => setTimeout(r, applyConfigDelayMs));
+          }
+          if (applyConfigShouldFail) {
+            throw new Error('mock applyConfig failure');
+          }
+        } finally {
+          inFlight--;
+        }
+      },
+      applyJetStreamResources: async () => undefined,
+    }),
+  };
+});
+
+import {
+  runStackNatsApplyPhase,
+  __waitForNatsApplyChainDrainForTests,
+} from '../services/stacks/stack-nats-apply-orchestrator';
+
+interface SeedInput {
+  stackName?: string;
+}
+
+async function seedNatsBearingStack(input: SeedInput = {}): Promise<{ stackId: string }> {
+  const templateId = createId();
+  const stackId = createId();
+  const versionId = createId();
+
+  await testPrisma.stackTemplate.create({
+    data: {
+      id: templateId,
+      name: `tpl-${templateId.slice(0, 6)}`,
+      displayName: 'Apply lock test',
+      source: 'user',
+      scope: 'host',
+    },
+  });
+  await testPrisma.stackTemplateVersion.create({
+    data: {
+      id: versionId,
+      templateId,
+      version: 1,
+      status: 'published',
+      parameters: [],
+      defaultParameterValues: {},
+      networkTypeDefaults: {},
+      networks: [],
+      volumes: [],
+      natsRoles: [{ name: 'gateway', publish: ['x'] }],
+    },
+  });
+  await testPrisma.stack.create({
+    data: {
+      id: stackId,
+      name: input.stackName ?? `stack-${stackId.slice(0, 6)}`,
+      version: 1,
+      networks: [],
+      volumes: [],
+      templateId,
+      templateVersion: 1,
+    },
+  });
+  return { stackId };
+}
+
+describe('runStackNatsApplyPhase — apply lock', () => {
+  beforeEach(() => {
+    resetMockState();
+    vi.clearAllMocks();
+  });
+
+  it('serializes two concurrent applies (max in-flight stays at 1)', async () => {
+    applyConfigDelayMs = 60;
+    const a = await seedNatsBearingStack({ stackName: `lock-a-${Date.now()}` });
+    const b = await seedNatsBearingStack({ stackName: `lock-b-${Date.now()}` });
+
+    const [resultA, resultB] = await Promise.all([
+      runStackNatsApplyPhase(testPrisma, a.stackId, { triggeredBy: undefined }),
+      runStackNatsApplyPhase(testPrisma, b.stackId, { triggeredBy: undefined }),
+    ]);
+
+    expect(resultA.status).toBe('applied');
+    expect(resultB.status).toBe('applied');
+    // Without the lock, both applyConfig calls would overlap and maxInFlight
+    // would briefly hit 2. The whole-phase lock serializes them.
+    expect(maxInFlight).toBe(1);
+  });
+
+  it('a failed apply does not poison the chain — subsequent applies still complete', async () => {
+    const a = await seedNatsBearingStack({ stackName: `pois-a-${Date.now()}` });
+    const b = await seedNatsBearingStack({ stackName: `pois-b-${Date.now()}` });
+
+    // First apply: forced failure inside applyConfig.
+    applyConfigShouldFail = true;
+    const resultA = await runStackNatsApplyPhase(testPrisma, a.stackId, { triggeredBy: undefined });
+    expect(resultA.status).toBe('error');
+    expect(resultA.error).toContain('mock applyConfig failure');
+
+    // Second apply: clean run — must not be blocked or rejected by the
+    // first apply's failure propagating through the chain.
+    applyConfigShouldFail = false;
+    const resultB = await runStackNatsApplyPhase(testPrisma, b.stackId, { triggeredBy: undefined });
+    expect(resultB.status).toBe('applied');
+  });
+
+  it('chain drains cleanly after all in-flight applies finish', async () => {
+    applyConfigDelayMs = 30;
+    const stacks = await Promise.all([
+      seedNatsBearingStack({ stackName: `drain-1-${Date.now()}` }),
+      seedNatsBearingStack({ stackName: `drain-2-${Date.now()}` }),
+      seedNatsBearingStack({ stackName: `drain-3-${Date.now()}` }),
+    ]);
+
+    const all = Promise.all(
+      stacks.map((s) => runStackNatsApplyPhase(testPrisma, s.stackId, { triggeredBy: undefined })),
+    );
+    await all;
+    await __waitForNatsApplyChainDrainForTests();
+
+    // After drain, in-flight is back to zero — nothing leaked into the
+    // chain that would keep it busy.
+    expect(inFlight).toBe(0);
+    expect(maxInFlight).toBe(1);
+  });
+});

--- a/server/src/__tests__/stack-nats-orphan-stream-cleanup.integration.test.ts
+++ b/server/src/__tests__/stack-nats-orphan-stream-cleanup.integration.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Integration test for the orphan-JetStream cleanup hand-off introduced
+ * to close the gap from #399 (`roles[].streams`):
+ *
+ *   - Removing a `roles[].streams[]` entry from a template deletes the
+ *     `NatsStream` DB row via `pruneOrphanRoleStreams`.
+ *   - Without further plumbing, the underlying JetStream stream stayed
+ *     live in NATS forever (the `applyJetStreamResources` pass only
+ *     iterates DB rows that *are* still present — it has no signal for
+ *     "this stream used to exist and should now be gone").
+ *
+ * The fix: `pruneOrphanRoleStreams` now returns the captured orphan
+ * names + accountId, and the orchestrator passes them to
+ * `service.deleteJetStreams(...)` after `applyJetStreamResources()`. This
+ * test pins the hand-off via a spy on the mocked control plane.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { testPrisma } from './integration-test-helpers';
+
+const deleteJetStreamsSpy = vi.fn(async () => undefined);
+
+vi.mock('../services/nats/nats-control-plane-service', async (orig) => {
+  const real = await orig<typeof import('../services/nats/nats-control-plane-service')>();
+  return {
+    ...real,
+    getNatsControlPlaneService: (db: unknown) => ({
+      getStatus: async () => ({ configured: true }),
+      ensureDefaultAccount: async () => {
+        const prisma = db as typeof testPrisma;
+        const existing = await prisma.natsAccount.findUnique({ where: { name: 'default' } });
+        if (existing) return { id: existing.id, name: existing.name, isSystem: true };
+        const created = await prisma.natsAccount.create({
+          data: {
+            name: 'default',
+            displayName: 'Default',
+            isSystem: true,
+            seedKvPath: 'shared/nats-default',
+          },
+        });
+        return { id: created.id, name: created.name, isSystem: true };
+      },
+      applyConfig: async () => undefined,
+      applyJetStreamResources: async () => undefined,
+      deleteJetStreams: deleteJetStreamsSpy,
+    }),
+  };
+});
+
+import { runStackNatsApplyPhase } from '../services/stacks/stack-nats-apply-orchestrator';
+
+async function seedStackWithStreams(streams: Array<{ name: string; subjects: string[] }>): Promise<{
+  stackId: string;
+  templateId: string;
+  versionId: string;
+}> {
+  const templateId = createId();
+  const stackId = createId();
+  const versionId = createId();
+
+  await testPrisma.stackTemplate.create({
+    data: {
+      id: templateId,
+      name: `tpl-${templateId.slice(0, 6)}`,
+      displayName: 'Orphan stream cleanup test',
+      source: 'user',
+      scope: 'host',
+    },
+  });
+  await testPrisma.stackTemplateVersion.create({
+    data: {
+      id: versionId,
+      templateId,
+      version: 1,
+      status: 'published',
+      parameters: [],
+      defaultParameterValues: {},
+      networkTypeDefaults: {},
+      networks: [],
+      volumes: [],
+      natsRoles: [
+        {
+          name: 'worker',
+          publish: ['x'],
+          streams,
+        },
+      ],
+    },
+  });
+  await testPrisma.stack.create({
+    data: {
+      id: stackId,
+      name: `stack-orphan-${stackId.slice(0, 6)}`,
+      version: 1,
+      networks: [],
+      volumes: [],
+      templateId,
+      templateVersion: 1,
+      lastAppliedVersion: 1,
+    },
+  });
+  return { stackId, templateId, versionId };
+}
+
+describe('orphan JetStream stream cleanup', () => {
+  beforeEach(() => {
+    deleteJetStreamsSpy.mockClear();
+  });
+
+  it('does not call deleteJetStreams on an apply with no orphans', async () => {
+    const { stackId } = await seedStackWithStreams([
+      { name: 'jobs', subjects: ['x.>'] },
+    ]);
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('applied');
+    expect(deleteJetStreamsSpy).not.toHaveBeenCalled();
+  });
+
+  it('deletes orphan JS streams when a role.stream is removed on re-apply', async () => {
+    // Initial: two streams A, B.
+    const { stackId, templateId } = await seedStackWithStreams([
+      { name: 'keep', subjects: ['k.>'] },
+      { name: 'drop', subjects: ['d.>'] },
+    ]);
+    const first = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(first.status).toBe('applied');
+    expect(deleteJetStreamsSpy).not.toHaveBeenCalled();
+
+    // Capture the concrete name of the to-be-orphaned stream so we can
+    // assert deleteJetStreams was called with it specifically.
+    const dropRow = await testPrisma.natsStream.findFirst({
+      where: { stackId, name: { contains: 'worker-drop' } },
+    });
+    expect(dropRow).not.toBeNull();
+    const orphanConcreteName = dropRow!.name;
+
+    // Edit the template — drop the second stream.
+    await testPrisma.stackTemplateVersion.updateMany({
+      where: { templateId, version: 1 },
+      data: {
+        natsRoles: [
+          {
+            name: 'worker',
+            publish: ['x'],
+            streams: [{ name: 'keep', subjects: ['k.>'] }],
+          },
+        ],
+      },
+    });
+
+    const second = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(second.status).toBe('applied');
+
+    // The DB row is gone.
+    const remaining = await testPrisma.natsStream.findMany({ where: { stackId } });
+    expect(remaining.map((r) => r.name)).toEqual([
+      expect.stringContaining('worker-keep'),
+    ]);
+
+    // The orchestrator handed the orphan off to the control plane for
+    // live deletion. Verifying the call captures the contract — without
+    // it the JS stream would leak storage forever (the gap that #399's
+    // doc addendum flagged as a known follow-up).
+    expect(deleteJetStreamsSpy).toHaveBeenCalledTimes(1);
+    const [accountIdArg, namesArg] = deleteJetStreamsSpy.mock.calls[0]!;
+    expect(typeof accountIdArg).toBe('string');
+    expect(namesArg).toEqual([orphanConcreteName]);
+  });
+
+  it("apply succeeds even if deleteJetStreams throws — DB is authoritative, NATS-side cleanup is best-effort", async () => {
+    deleteJetStreamsSpy.mockRejectedValueOnce(new Error('NATS unreachable'));
+
+    const { stackId, templateId } = await seedStackWithStreams([
+      { name: 'keep', subjects: ['k.>'] },
+      { name: 'drop', subjects: ['d.>'] },
+    ]);
+    await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    deleteJetStreamsSpy.mockClear();
+    deleteJetStreamsSpy.mockRejectedValueOnce(new Error('NATS unreachable'));
+
+    await testPrisma.stackTemplateVersion.updateMany({
+      where: { templateId, version: 1 },
+      data: {
+        natsRoles: [
+          {
+            name: 'worker',
+            publish: ['x'],
+            streams: [{ name: 'keep', subjects: ['k.>'] }],
+          },
+        ],
+      },
+    });
+
+    const result = await runStackNatsApplyPhase(testPrisma, stackId, { triggeredBy: undefined });
+    expect(result.status).toBe('applied');
+    expect(deleteJetStreamsSpy).toHaveBeenCalledTimes(1);
+    // DB row still gone — the prune ran before deleteJetStreams threw.
+    const remaining = await testPrisma.natsStream.findMany({ where: { stackId } });
+    expect(remaining).toHaveLength(1);
+  });
+});

--- a/server/src/services/nats/nats-control-plane-service.ts
+++ b/server/src/services/nats/nats-control-plane-service.ts
@@ -778,6 +778,60 @@ export class NatsControlPlaneService {
   }
 
   /**
+   * Best-effort delete of JetStream streams that should no longer exist on
+   * the live NATS server.
+   *
+   * The orchestrator's apply path deletes `NatsStream` rows when a role's
+   * declared streams change (rename or removal — see
+   * `pruneOrphanRoleStreams` in `stack-nats-apply-orchestrator.ts`), but
+   * `applyJetStreamResources` only iterates over rows that *are* still in
+   * the DB — it has no signal for "this stream used to exist but is now
+   * gone." Without this method, those JetStream streams stay live in NATS
+   * with no producers and no consumers, leaking storage indefinitely.
+   *
+   * Callers MUST guard the names they pass: anything in `streamNames` will
+   * be deleted on the live server. The orchestrator passes only the
+   * concrete names it captured *before* deleting the corresponding DB
+   * rows, scoped to the current stack — no cross-stack or system-stream
+   * surface area.
+   *
+   * 404 from the server (stream already absent) is treated as success;
+   * any other failure is logged and swallowed so a NATS-side blip doesn't
+   * block the broader apply. The DB is already authoritative — a stale
+   * JetStream stream is a storage leak, not a correctness problem.
+   */
+  async deleteJetStreams(accountId: string, streamNames: string[]): Promise<void> {
+    if (streamNames.length === 0) return;
+    const account = await this.db.natsAccount.findUnique({ where: { id: accountId } });
+    if (!account) {
+      log.warn(
+        { accountId, streamNames },
+        "deleteJetStreams: account not found, skipping orphan stream cleanup",
+      );
+      return;
+    }
+    const creds = await this.mintAccountAdminCreds(account);
+    await this.withNats(creds, async (jsm) => {
+      for (const name of streamNames) {
+        try {
+          await jsm.streams.delete(name);
+          log.info({ streamName: name, account: account.name }, "deleted orphan JetStream stream");
+        } catch (err) {
+          // The NATS client throws an Error whose message contains
+          // "stream not found" / 404 when the target is already absent —
+          // treat as success. Anything else is best-effort logged.
+          const msg = err instanceof Error ? err.message : String(err);
+          if (/stream not found|404/i.test(msg)) continue;
+          log.warn(
+            { err: msg, streamName: name, account: account.name },
+            "best-effort orphan JetStream stream delete failed; will retry on next apply",
+          );
+        }
+      }
+    });
+  }
+
+  /**
    * Idempotently ensure JetStream KV buckets exist on the system account.
    * KV buckets are JetStream streams under the hood (named `KV_<bucket>`),
    * but creating one requires admin permission on the account — which only

--- a/server/src/services/stacks/stack-nats-apply-orchestrator.ts
+++ b/server/src/services/stacks/stack-nats-apply-orchestrator.ts
@@ -43,7 +43,69 @@ export interface NatsApplyPhaseOptions {
   requireNatsReady?: boolean;
 }
 
+/**
+ * Module-scoped serializer for `runStackNatsApplyPhase`. Implements the
+ * "single advisory lock keyed by `nats-apply`" recommended in the design's
+ * §6 risks list — a producer + consumer applying simultaneously would
+ * otherwise race on the producer's `lastAppliedNatsSnapshot`, the consumer
+ * potentially observing a stale snapshot mid-flight as the producer is
+ * rotating it.
+ *
+ * Mini Infra runs as a single Node process per host, so an in-memory chain
+ * promise is the right primitive — no PostgreSQL advisory locks, no Redis
+ * round-trip. Errors from one apply are isolated from the chain so a
+ * single failed apply does not poison subsequent ones.
+ *
+ * **Trade-off.** The lock is held for the entire phase, including the slow
+ * `applyConfig` / `applyJetStreamResources` NATS network calls. The design
+ * note in `nats-app-roles-followups.md` flagged this as a perf concern at
+ * scale (the recommended split would be DB-only-locked, NATS-unlocked, DB-
+ * write-locked). At single-host scale concurrent applies are rare; the
+ * simple whole-phase lock is correct and the optimization is a documented
+ * follow-up if contention surfaces.
+ */
+let natsApplyChain: Promise<void> = Promise.resolve();
+
+async function acquireNatsApplyLock<T>(fn: () => Promise<T>): Promise<T> {
+  let resolveOuter!: (value: T) => void;
+  let rejectOuter!: (reason: unknown) => void;
+  const outer = new Promise<T>((resolve, reject) => {
+    resolveOuter = resolve;
+    rejectOuter = reject;
+  });
+
+  const next = natsApplyChain.then(async () => {
+    try {
+      resolveOuter(await fn());
+    } catch (err) {
+      rejectOuter(err);
+    }
+  });
+  // Swallow chain errors so one failed apply doesn't break the queue for
+  // every subsequent apply. Caller still sees the rejection via `outer`.
+  natsApplyChain = next.catch(() => undefined);
+
+  return outer;
+}
+
+/**
+ * Test-only: returns a promise that resolves when the in-flight chain has
+ * fully drained. Lets tests assert "no apply currently running" without
+ * having to thread state through their own scaffolding.
+ */
+export function __waitForNatsApplyChainDrainForTests(): Promise<void> {
+  return natsApplyChain.then(() => undefined).catch(() => undefined);
+}
+
 export async function runStackNatsApplyPhase(
+  prisma: PrismaClient,
+  stackId: string,
+  opts: NatsApplyPhaseOptions,
+): Promise<NatsApplyPhaseResult> {
+  return acquireNatsApplyLock(() => runStackNatsApplyPhaseUnlocked(prisma, stackId, opts));
+}
+
+async function runStackNatsApplyPhaseUnlocked(
   prisma: PrismaClient,
   stackId: string,
   opts: NatsApplyPhaseOptions,

--- a/server/src/services/stacks/stack-nats-apply-orchestrator.ts
+++ b/server/src/services/stacks/stack-nats-apply-orchestrator.ts
@@ -375,6 +375,13 @@ async function runStackNatsApplyPhaseUnlocked(
     // references at materialization time.
     const renderedRoleStreamNames = new Set<string>();
     const roleStreamIdByRoleAndName = new Map<string, string>();
+    // Captured before the DB rows are deleted in `pruneOrphanRoleStreams`
+    // so the orchestrator can ask the control plane to delete the live
+    // JetStream streams after `applyJetStreamResources()` has run. Without
+    // this hand-off the JS streams stay alive in NATS forever (the apply
+    // path only adds/updates from the current DB rows; it has no signal
+    // for "this stream used to exist and should now be gone").
+    let orphanStreamCleanup: { accountId: string; orphanStreamNames: string[] } | null = null;
     if (roles.length > 0 || signers.length > 0 || exportsRelative.length > 0 || imports.length > 0) {
       const defaultAccount = await service.ensureDefaultAccount();
       resolvedSubjectPrefix = await resolveAndValidateSubjectPrefix({
@@ -510,7 +517,7 @@ async function runStackNatsApplyPhaseUnlocked(
         stackId,
         desiredSignerNames: renderedSignerNames,
       });
-      await pruneOrphanRoleStreams({
+      orphanStreamCleanup = await pruneOrphanRoleStreams({
         prisma,
         stackId,
         desiredStreamNames: renderedRoleStreamNames,
@@ -525,6 +532,35 @@ async function runStackNatsApplyPhaseUnlocked(
     // gap that bit Phase 1's `/api/nats/apply` route. Mirror that fix here.
     NatsBus.getInstance().invalidateCreds();
     await service.applyJetStreamResources();
+
+    // Best-effort delete of orphan JetStream streams whose DB rows we just
+    // pruned. Runs AFTER `applyJetStreamResources` so the create/update
+    // pass for the surviving streams completes first — the order matters
+    // only if a rename collision could see the old name briefly survive
+    // alongside the new, which can't happen here because the prune
+    // already removed the old DB row before applyJetStream's iteration.
+    // Wrapped in try/catch: the DB is already authoritative, so a NATS-
+    // side blip leaks storage but doesn't fail the apply.
+    if (orphanStreamCleanup) {
+      try {
+        await service.deleteJetStreams(orphanStreamCleanup.accountId, orphanStreamCleanup.orphanStreamNames);
+      } catch (err) {
+        // The DB row for the orphan is already gone, so a future apply
+        // can't re-discover this orphan from its own state — manual NATS
+        // CLI cleanup is the recovery path if NATS is unreachable here.
+        // Storage-only consequence: the orphan stream sits in NATS with
+        // no producers/consumers (no role's permissions reference its
+        // subjects).
+        getLogger("integrations", "nats-apply-orchestrator").warn(
+          {
+            err: err instanceof Error ? err.message : String(err),
+            stackId,
+            orphanStreamNames: orphanStreamCleanup.orphanStreamNames,
+          },
+          "orphan JetStream stream cleanup failed; manual NATS CLI delete required",
+        );
+      }
+    }
 
     const credentialRefByService = new Map(
       templateVersion.services
@@ -1175,17 +1211,22 @@ async function pruneOrphanRoleStreams(args: {
   prisma: PrismaClient;
   stackId: string;
   desiredStreamNames: Set<string>;
-}): Promise<number> {
+}): Promise<{ accountId: string; orphanStreamNames: string[] } | null> {
   const existing = await args.prisma.natsStream.findMany({
     where: { stackId: args.stackId },
-    select: { id: true, name: true },
+    select: { id: true, name: true, accountId: true },
   });
-  const orphanIds = existing
-    .filter((row) => !args.desiredStreamNames.has(row.name))
-    .map((row) => row.id);
-  if (orphanIds.length === 0) return 0;
-  await args.prisma.natsStream.deleteMany({ where: { id: { in: orphanIds } } });
-  return orphanIds.length;
+  const orphans = existing.filter((row) => !args.desiredStreamNames.has(row.name));
+  if (orphans.length === 0) return null;
+  // Capture names + account BEFORE delete so the orchestrator can pass
+  // them to the control plane's `deleteJetStreams` after
+  // `applyJetStreamResources` runs. Without this hand-off the JS streams
+  // stay live in NATS with no producers/consumers — a storage leak the
+  // operator has to clean up by hand.
+  const accountId = orphans[0].accountId;
+  const orphanStreamNames = orphans.map((o) => o.name);
+  await args.prisma.natsStream.deleteMany({ where: { id: { in: orphans.map((o) => o.id) } } });
+  return { accountId, orphanStreamNames };
 }
 
 // =====================================================================


### PR DESCRIPTION
## Summary

Two NATS-orchestrator hardening fixes from [`docs/planning/not-shipped/nats-app-roles-followups.md`](docs/planning/not-shipped/nats-app-roles-followups.md), both touching the apply path.

### 1. Single-host apply lock (`acquireNatsApplyLock`)

Module-scoped chain promise serializes all `runStackNatsApplyPhase` calls on a single Node process. Producer + consumer applies can no longer race on `lastAppliedNatsSnapshot` mid-rotation. Errors from one apply are isolated from the chain so a single failure doesn't poison subsequent applies.

Trade-off: held across `applyConfig` / `applyJetStreamResources` (deviation from the design's "scope tight" note). Splitting into "DB-only-locked, NATS-unlocked, DB-write-locked" phases would refactor the orchestrator's monolithic `try` block — meaningful churn for a perf concern that doesn't bite at single-host single-process scale. Documented as a follow-up.

### 2. Orphan JetStream stream cleanup

Closes the gap from #399's doc addendum: removing a `roles[].streams` entry deleted the `NatsStream` DB row but left the underlying JetStream stream live in NATS forever. `pruneOrphanRoleStreams` now captures orphan names + accountId before deleting the rows, and the orchestrator hands them to a new `NatsControlPlaneService.deleteJetStreams(accountId, names)` after `applyJetStreamResources` has run. 404s = success; other failures are best-effort logged so the apply still succeeds (DB is authoritative).

## Test plan

- [x] `pnpm build:lib && pnpm --filter mini-infra-server build`
- [x] `pnpm --filter mini-infra-server lint`
- [x] `pnpm --filter mini-infra-server test` — 159 files / 2193 tests pass.
  - 3 new lock tests: max-in-flight = 1, failure doesn't poison chain, chain drains cleanly.
  - 3 new orphan-cleanup tests: no-orphan path doesn't call deleteJetStreams; orphan present → called with the right concrete name + account; throwing → apply still succeeds and DB stays correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)