### PR TITLE
fix(addons): prefix Tailscale hostnames with stack name to avoid cross-stack clashes

### DIFF
--- a/docs/planning/not-shipped/service-addons-plan.md
+++ b/docs/planning/not-shipped/service-addons-plan.md
@@ -153,11 +153,12 @@ For pool services the same pipeline runs at instance spawn rather than at apply,
 
 | Service shape | Hostname (TS_HOSTNAME / sidecar identity) |
 |---|---|
-| Static (`Stateful`, `StatelessWeb`) | `{service-name}-{env-name}` |
-| Pool instance | `{service-name}-{env-name}-{instance-id}` |
-| Pool instance, instanceId longer than fits | `{service-name}-{env-name}-{instance-id-sha256[:8]}` |
+| Static (`Stateful`, `StatelessWeb`) | `{stack-name}-{service-name}-{env-name}` |
+| Static, oversized | `{cleaned-head[:54]}-{fnv1a32-hex8}` |
+| Pool instance | `{stack-name}-{service-name}-{env-name}-{instance-id}` |
+| Pool instance, oversized | `{cleaned-head[:54]}-{fnv1a32-hex8}` |
 
-Sanitised to `[a-z0-9-]`, lowercased, max 63 chars (DNS label limit). For Tailscale-attached services this becomes the device name in the tailnet admin console, the MagicDNS short name, and the FQDN root for HTTPS exposure.
+Sanitised to `[a-z0-9-]`, lowercased, max 63 chars (DNS label limit). The stack-name prefix exists so two stacks that both ship a `web/prod` service don't race for the same tailnet device record — without it Tailscale auto-suffixes the loser to `web-prod-1` and the suffix is *persistent* even after the original device is removed, which silently rots ACL `host:` rules and integration URLs that reference the bare name. The hash fallback is FNV-1a-32 over the unsanitised triple (or quadruple, for pools) — non-cryptographic but ample for disambiguating a bounded set of overflowing hostnames in one tailnet. For Tailscale-attached services this becomes the device name in the tailnet admin console, the MagicDNS short name, and the FQDN root for HTTPS exposure.
 
 ### 4.6 Permissions and events
 
@@ -216,7 +217,7 @@ Each addon below describes its `targetIntegration` shape, the `StackServiceDefin
 - **Target integration:** `network: "peer-on-target-network"`. The sidecar joins the same Docker network as the target so it can reach `<target>:<port>` by name. The target service is unmodified — no `network_mode` rewrite, no port reclamation.
 - **Provision:** mint a one-time, ephemeral, preauthorized authkey via the OAuth-client-credentials flow (see [tailscale-auth.md](../../architecture/vendor/tailscale-auth.md)). Auth keys are tagged with the single static `tag:mini-infra-managed` (plus any user-supplied `extraTags` the operator has pre-declared in their `tagOwners` ACL). Per-resource identity is conveyed by the device hostname, **not** by additional dynamic tags — Tailscale OAuth clients can only mint keys with tags pre-declared in the operator's ACL `tagOwners`, so dynamic per-stack/per-env/per-service tags would force unbounded ACL edits. Returns `envForSidecar: { TS_AUTHKEY, TS_HOSTNAME }` and `templateVars: { tsExtraArgs: "--ssh" }`.
 - **Sidecar `StackServiceDefinition`:** the official `tailscale/tailscale` image (containerised tailscaled, not embedded `tsnet` — `tsnet` is Go-only and we don't need it because the addon ships as a sidecar container, not a library inside the Node process), the provisioned env, a per-application state volume, no published ports, the standard mini-infra labels, `restart: unless-stopped`, and `containerConfig.requiredEgress` listing the Tailscale control-plane hostnames (`controlplane.tailscale.com`, `*.tailscale.com`, `*.tailscale.io`, DERP relay hostnames) so the egress-policy reconciler pre-allows them in firewalled envs (§4.7).
-- **End-user surface:** `ssh root@<service>-<env>` from any tailnet-joined laptop. Authentication is the tailnet identity provider via the ACL `ssh` stanza configured during connected-service setup. Default ACL is `action: check` with a 12-hour `checkPeriod` — one IdP re-auth per workday.
+- **End-user surface:** `ssh root@<stack>-<service>-<env>` from any tailnet-joined laptop. Authentication is the tailnet identity provider via the ACL `ssh` stanza configured during connected-service setup. Default ACL is `action: check` with a 12-hour `checkPeriod` — one IdP re-auth per workday.
 
 ### 5.2 `tailscale-web`
 
@@ -226,7 +227,7 @@ Each addon below describes its `targetIntegration` shape, the `StackServiceDefin
 - **Target integration:** `network: "peer-on-target-network"`. Same as `tailscale-ssh` — the sidecar reaches the app by service-name DNS over the shared Docker network. No target rewrite.
 - **Provision:** mint authkey (same shape and single-tag scoping as `tailscale-ssh`); resolve the tailnet domain via the `GET /api/v2/tailnet/-` shorthand on the OAuth client (`-` = "the tailnet that owns this OAuth client" — see [tailscale-auth.md](../../architecture/vendor/tailscale-auth.md)); render a `serve.json` that terminates HTTPS on `${TS_CERT_DOMAIN}:443` and proxies to the target service's `port`. Returns the file under `files: [{ path: "/etc/tailscale/serve.json", … }]` and the env (`TS_AUTHKEY`, `TS_HOSTNAME`, `TS_SERVE_CONFIG=/etc/tailscale/serve.json`).
 - **Sidecar `StackServiceDefinition`:** as for `tailscale-ssh` (including the same `requiredEgress` for the Tailscale control plane), plus a config-file mount populated from the provisioned `files`.
-- **End-user surface:** `https://<service>-<env>.<tailnet>.ts.net` opens directly with auto-provisioned Let's Encrypt certs. No tunnel, no DNS configuration, no port-forwarding.
+- **End-user surface:** `https://<stack>-<service>-<env>.<tailnet>.ts.net` opens directly with auto-provisioned Let's Encrypt certs. No tunnel, no DNS configuration, no port-forwarding.
 - **Merge with `tailscale-ssh`:** the registered `kind: tailscale` merge strategy emits one sidecar definition with both `--ssh` and `TS_SERVE_CONFIG` set, sharing one authkey, one hostname, one tailnet device, one state volume, one published serve.json.
 
 ### 5.3 Forward look: outbound auth proxy
@@ -294,7 +295,7 @@ Deliverables:
 - The `tailscale-ssh` addon directory under `server/src/services/stack-addons/tailscale-ssh/` with its `AddonDefinition` (manifest, `targetIntegration: peer-on-target-network`, `provision`, `buildServiceDefinition`).
 - The Tailscale state-volume convention for static services.
 - Default tag scoping: the single static `tag:mini-infra-managed` (matching the tag the operator assigned to the OAuth client in Phase 2), plus any user-supplied `extraTags` the operator has separately added to their `tagOwners`. Per-resource identity comes from the device hostname, not from dynamic per-stack/per-env/per-service tags — see [tailscale-auth.md](../../architecture/vendor/tailscale-auth.md) for the OAuth-client tag-ownership constraint that rules out dynamic tagging.
-- The static-service hostname rule `{service-name}-{env-name}` (sanitised, ≤63 chars).
+- The static-service hostname rule `{stack-name}-{service-name}-{env-name}` (sanitised, ≤63 chars; FNV-1a-32 hash fallback when oversized — see §4.5).
 - The materialised sidecar's `containerConfig.requiredEgress` lists the Tailscale control-plane hostnames (`controlplane.tailscale.com`, `*.tailscale.com`, `*.tailscale.io`, DERP relays), so the addon works in firewalled envs without manual policy edits (§4.7).
 - The "from addon" badge rendered on synthetic services in the stack-detail and containers pages.
 - `STACK_ADDON_PROVISIONED` and `STACK_ADDON_FAILED` events emitted by the render pipeline and surfaced under the existing apply task in the task tracker.
@@ -305,7 +306,7 @@ UI changes:
 - Stack detail / Containers page: addon-derived sidecars appear in the existing service/container lists with a "from addon" badge and a back-reference to the target service; edit affordances disabled. [design needed] — badge style and how a synthetic sidecar visually relates to its target row (indented? linked icon?) needs a designer call.
 - Stack apply flow: live progress reflects `STACK_ADDON_PROVISIONED` / `STACK_ADDON_FAILED` under the existing apply task in the task tracker. [no design] — slots into existing task-tracker step rendering.
 
-Done when: a stack template with `addons: { tailscale-ssh: {} }` on a Stateful or StatelessWeb service applies cleanly, the synthetic sidecar joins the tailnet under the right tags, shows up on the containers page with the "from addon" badge and working logs/exec, and `ssh root@<service>-<env>` from a tailnet-joined laptop succeeds via the ACL-driven `check` flow — including in an env with `egressFirewallEnabled: true`, where the Tailscale control-plane hostnames must appear as template-sourced rules without manual policy edits.
+Done when: a stack template with `addons: { tailscale-ssh: {} }` on a Stateful or StatelessWeb service applies cleanly, the synthetic sidecar joins the tailnet under the right tags, shows up on the containers page with the "from addon" badge and working logs/exec, and `ssh root@<stack>-<service>-<env>` from a tailnet-joined laptop succeeds via the ACL-driven `check` flow — including in an env with `egressFirewallEnabled: true`, where the Tailscale control-plane hostnames must appear as template-sourced rules without manual policy edits.
 
 Verify in prod: the first stack applied with `addons: { tailscale-ssh: {} }` shows the sidecar online in the Tailscale admin console under `tag:mini-infra-managed`; no spike in `STACK_ADDON_FAILED` events for 24 h after rollout.
 
@@ -352,7 +353,7 @@ Verify in prod: at least one production service with `tailscale-web` has the Con
 
 Deliverables:
 - `pool-spawner.ts` invokes the render pipeline with `instance: { instanceId }` populated, producing per-instance provisioned credentials and per-instance `StackServiceDefinition`s for each addon application.
-- Per-instance hostname rule `{service-name}-{env-name}-{instance-id}` (sanitised, ≤63 chars; `instance-id-sha256[:8]` fallback when oversized).
+- Per-instance hostname rule `{stack-name}-{service-name}-{env-name}-{instance-id}` (sanitised, ≤63 chars; FNV-1a-32 hash fallback per §4.5 when oversized). Re-uses the static-service `sanitizeTailscaleHostname` helper with the instance-id appended as a fourth segment.
 - Per-instance addon sidecars carry `mini-infra.stack-id`, `mini-infra.service`, `mini-infra.pool-instance-id`, `mini-infra.addon: <kind-or-id>`, and `mini-infra.synthetic: true` labels.
 - `pool-instance-reaper.ts` extension: invokes addon `cleanup()` hooks and removes addon sidecar containers when instances are reaped.
 - Per-instance addon sidecars emit `containerConfig.requiredEgress` flowing into the env's policy reconcile the same way static addon services do (§4.7).
@@ -364,18 +365,18 @@ Reversibility: safe — pool addon support is additive. Pools without `addons:` 
 UI changes:
 - Stack detail Connect panel: pool service rows expand to per-instance rows, each with their own `ssh` / HTTPS actions. [design needed] — disclosure pattern for a pool with N instances; how to handle 50-instance pools without flooding the panel.
 - Containers page: per-instance addon sidecars appear with `mini-infra.synthetic` and `mini-infra.pool-instance-id` labels visible. [no design] — fits existing container-row label rendering.
-- Pool detail: per-instance hostname (`{service}-{env}-{instance-id}`) shown alongside the existing instance-id column. [no design].
+- Pool detail: per-instance hostname (`{stack}-{service}-{env}-{instance-id}`) shown alongside the existing instance-id column. [no design].
 
 Done when: a pool service with `addons: { tailscale-ssh: {} }` spawns N instances, each registers as its own tailnet device with the per-instance hostname pattern, an operator can SSH into a specific instance by name, and idle reaping removes both the worker container and the sidecar (and the device from the tailnet via ephemeral cleanup) — including in a firewalled env where per-instance sidecars must reach the tailnet without manual policy edits.
 
-Verify in prod: at least one production pool service with `tailscale-ssh` shows N tailnet devices for N instances, names match the `{service-name}-{env-name}-{instance-id}` pattern, and idle reaping removes both worker and sidecar within the ephemeral-cleanup window without orphan devices.
+Verify in prod: at least one production pool service with `tailscale-ssh` shows N tailnet devices for N instances, names match the `{stack-name}-{service-name}-{env-name}-{instance-id}` pattern, and idle reaping removes both worker and sidecar within the ephemeral-cleanup window without orphan devices.
 
 ## 7. Risks & open questions
 
 - **Connected Service config model.** Three Tailscale-specific columns on `ConnectedService` may be the wrong shape if other connected services need similar growth. Worth a 30-minute look at the existing connected-services directory before Phase 2 to decide between a shared-table extension and a per-type satellite table.
 - **ACL bootstrap rendering.** JSON is parseable; HuJSON (Tailscale's commenting variant) is friendlier for the operator's eventual hand-editing but introduces a dependency. Default to JSON unless a user objects.
 - **Pool instance Tailscale state volume.** Per-instance state volumes are cheap, but pool instances are short-lived and authkeys are minted per-spawn. With ephemeral nodes auto-cleaning, the volume is effectively write-only. Phase 6 should validate that skipping the volume on pool instances doesn't introduce a re-registration race, and pick the cleaner of the two paths.
-- **Pool instance hostname collisions across stacks.** `worker-prod-u12345` in stack A and `worker-prod-u12345` in stack B produce duplicate device names in the tailnet. Because all devices share the single `tag:mini-infra-managed` (see the tag-taxonomy note below), the device list is the only disambiguator — Phase 6 likely needs to prefix pool hostnames with the stack name and accept longer hostnames (with the SHA-256 fallback already in §4.5 catching DNS-label overflow).
+- **Pool instance hostname collisions across stacks.** Resolved at the framework layer: `sanitizeTailscaleHostname` now prefixes the stack name (§4.5), so `{stack-a}-worker-prod-u12345` and `{stack-b}-worker-prod-u12345` are distinct by construction. Phase 6 just appends the instance-id as a fourth segment and inherits the same FNV-1a hash fallback when oversized.
 - **Tag taxonomy is single-tag, not hierarchical.** Earlier drafts of §5.1 / §5.2 minted authkeys with `tag:stack-<id>,tag:env-<env>,tag:service-<name>` — infeasible because Tailscale OAuth clients can only mint keys with tags pre-declared in the operator's `tagOwners` ACL, and dynamic resource tags would force unbounded ACL edits. v1 ships with one static `tag:mini-infra-managed` and conveys per-resource identity via hostname. If a future need emerges (e.g. ACL rules that scope SSH access to specific environments), revisit by introducing a small fixed set of operator-declared environment tags rather than going fully dynamic.
 - **Funnel-shaped follow-up.** Once Tailscale-only HTTPS is shipped, the smallest extension to reach the public internet is enabling Tailscale Funnel. It overlaps the Cloudflare tunnel feature, so a deliberate "when do you pick which?" call is needed before any post-v1 extension touches Funnel.
 - **Definition-hash determinism.** The rendered stack definition includes addon-derived services and target-integration rewrites. Provision values like authkeys are minted fresh on each render, which would oscillate the hash and force needless re-applies. Phase 1 must ensure the hash is computed from the *authored* definition (plus addon-config), not the rendered form, or that mint-once values are cached and reused across renders. Confirm during Phase 1 that the existing definition-hash logic naturally extends to the new field rather than drifting.

--- a/lib/types/tailscale.ts
+++ b/lib/types/tailscale.ts
@@ -204,24 +204,30 @@ export function buildTailscaleTagSet(extraTags: readonly string[] = []): string[
 }
 
 /**
- * Hostname-sanitise `{service}-{env}` for use as a Tailscale device hostname.
+ * Hostname-sanitise `{stack}-{service}-{env}` for use as a Tailscale device
+ * hostname.
  *
  * RFC 1123 hostname rules: ≤63 octets, lowercase ASCII alphanumerics + hyphen,
  * no leading or trailing hyphen. Tailscale further requires the hostname to
  * be unique across the tailnet within the OAuth client's scope, so the
- * combined `{service}-{env}` form encodes per-resource identity (the OAuth
- * client tag set is fixed at `tag:mini-infra-managed`, see §Phase 3).
+ * combined triple encodes per-resource identity — the OAuth client tag set
+ * is fixed at `tag:mini-infra-managed` (see §Phase 3), and stack name is
+ * already unique within a Mini Infra instance, so prefixing with stack name
+ * is what stops two stacks that both define `web/prod` from racing for the
+ * same tailnet device.
  *
- * Mirrors the spirit of `buildPoolContainerName` in pool-spawner.ts but lives
- * here in lib/ because the addon framework is the only consumer that needs
- * RFC-compliant Tailscale-specific output (pool spawner targets Docker
- * container names which are looser).
+ * Overflow rule: when the sanitised triple exceeds 63 chars, truncate the
+ * readable head to 54 chars and append a `-{fnv1a32-hex8}` disambiguator
+ * computed over the unsanitised inputs. The hash isn't cryptographic —
+ * it's collision-resistance for short strings, and 32 bits is plenty given
+ * how few oversized hostnames any one tailnet will see.
  */
 export function sanitizeTailscaleHostname(
+  stackName: string,
   serviceName: string,
   envName: string,
 ): string {
-  const raw = `${serviceName}-${envName}`;
+  const raw = `${stackName}-${serviceName}-${envName}`;
   // Lowercase, replace non-[a-z0-9-] with `-`, collapse runs of `-`.
   const cleaned = raw
     .toLowerCase()
@@ -230,13 +236,35 @@ export function sanitizeTailscaleHostname(
     .replace(/^-+|-+$/g, "");
   if (cleaned.length === 0) {
     throw new Error(
-      `Cannot derive Tailscale hostname from "${serviceName}-${envName}" — no valid characters`,
+      `Cannot derive Tailscale hostname from "${stackName}-${serviceName}-${envName}" — no valid characters`,
     );
   }
-  // Truncate to 63 octets; trim a trailing hyphen left after the cut.
-  return cleaned.length <= 63
-    ? cleaned
-    : cleaned.slice(0, 63).replace(/-+$/, "");
+  if (cleaned.length <= 63) return cleaned;
+  // Overflow: keep the first 54 chars of the cleaned head (after trimming
+  // any trailing hyphen left by the cut), then append `-{hash}` where hash
+  // is FNV-1a-32 of the unsanitised triple, hex-encoded to 8 chars. The
+  // pipe separator can't appear in any sanitised hostname so the hash
+  // domain stays distinct from the visible head.
+  const HASH_HEX_LEN = 8;
+  const HEAD_BUDGET = 63 - 1 - HASH_HEX_LEN; // 54
+  const head = cleaned.slice(0, HEAD_BUDGET).replace(/-+$/, "");
+  const hash = fnv1a32Hex(`${stackName}|${serviceName}|${envName}`);
+  return `${head}-${hash}`;
+}
+
+/**
+ * 32-bit FNV-1a → 8-char hex. Non-cryptographic but adequate for
+ * disambiguating overflowing Tailscale hostnames (32 bits, birthday-bound
+ * around ~65k inputs). Inline so `lib/` keeps its zero-dependency posture
+ * and the bundle stays browser-safe (no `node:crypto` import).
+ */
+function fnv1a32Hex(input: string): string {
+  let h = 0x811c9dc5; // FNV offset basis
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16).padStart(8, "0");
 }
 
 /**

--- a/server/src/routes/stacks/__tests__/stacks-addon-endpoints-route.test.ts
+++ b/server/src/routes/stacks/__tests__/stacks-addon-endpoints-route.test.ts
@@ -36,15 +36,15 @@ describe('deriveEndpoints', () => {
       },
     ]);
 
-    const endpoints = deriveEndpoints(snapshot, 'prod', 'tailnet-1234.ts.net');
+    const endpoints = deriveEndpoints(snapshot, 'web-stack', 'prod', 'tailnet-1234.ts.net');
 
     expect(endpoints).toHaveLength(1);
     expect(endpoints[0]).toMatchObject({
       targetService: 'web',
       syntheticServiceName: 'web-tailscale',
       kind: 'https',
-      hostname: sanitizeTailscaleHostname('web', 'prod'),
-      url: `https://${sanitizeTailscaleHostname('web', 'prod')}.tailnet-1234.ts.net`,
+      hostname: sanitizeTailscaleHostname('web-stack', 'web', 'prod'),
+      url: `https://${sanitizeTailscaleHostname('web-stack', 'web', 'prod')}.tailnet-1234.ts.net`,
     });
   });
 
@@ -72,11 +72,11 @@ describe('deriveEndpoints', () => {
       },
     ]);
 
-    const endpoints = deriveEndpoints(snapshot, 'prod', 'tailnet-1234.ts.net');
+    const endpoints = deriveEndpoints(snapshot, 'web-stack', 'prod', 'tailnet-1234.ts.net');
 
     expect(endpoints).toHaveLength(1);
     expect(endpoints[0]?.url).toBe(
-      `https://${sanitizeTailscaleHostname('web', 'prod')}.tailnet-1234.ts.net/api`,
+      `https://${sanitizeTailscaleHostname('web-stack', 'web', 'prod')}.tailnet-1234.ts.net/api`,
     );
   });
 
@@ -104,11 +104,11 @@ describe('deriveEndpoints', () => {
       },
     ]);
 
-    const endpoints = deriveEndpoints(snapshot, 'prod', null);
+    const endpoints = deriveEndpoints(snapshot, 'web-stack', 'prod', null);
 
     expect(endpoints).toHaveLength(1);
     expect(endpoints[0]?.url).toBeNull();
-    expect(endpoints[0]?.hostname).toBe(sanitizeTailscaleHostname('web', 'prod'));
+    expect(endpoints[0]?.hostname).toBe(sanitizeTailscaleHostname('web-stack', 'web', 'prod'));
   });
 
   it('returns both ssh and https endpoints, sorted ssh before https, when both addons merge on one service', () => {
@@ -142,7 +142,7 @@ describe('deriveEndpoints', () => {
       },
     ]);
 
-    const endpoints = deriveEndpoints(snapshot, 'prod', 'tailnet-1234.ts.net');
+    const endpoints = deriveEndpoints(snapshot, 'web-stack', 'prod', 'tailnet-1234.ts.net');
 
     expect(endpoints.map((e) => e.kind)).toEqual(['ssh', 'https']);
     expect(endpoints[0]?.url).toMatch(/^ssh root@/);
@@ -166,7 +166,7 @@ describe('deriveEndpoints', () => {
       },
     ]);
 
-    const endpoints = deriveEndpoints(snapshot, 'prod', 'tailnet-1234.ts.net');
+    const endpoints = deriveEndpoints(snapshot, 'web-stack', 'prod', 'tailnet-1234.ts.net');
 
     expect(endpoints).toEqual([]);
   });

--- a/server/src/routes/stacks/stacks-addon-endpoints-route.ts
+++ b/server/src/routes/stacks/stacks-addon-endpoints-route.ts
@@ -69,6 +69,7 @@ function readWebConfig(
 // Exported for unit testing — the route handler still calls it locally.
 export function deriveEndpoints(
   snapshot: StackDefinition,
+  stackName: string,
   envName: string,
   tailnet: string | null,
 ): TailscaleAddonEndpoint[] {
@@ -89,7 +90,7 @@ export function deriveEndpoints(
     const targetService = findTargetService(service);
     if (!targetService) continue;
 
-    const hostname = sanitizeTailscaleHostname(targetService, envSlug);
+    const hostname = sanitizeTailscaleHostname(stackName, targetService, envSlug);
     const fqdn = tailnet ? `${hostname}.${tailnet}` : null;
 
     if (synth.addonIds.includes("tailscale-ssh")) {
@@ -172,6 +173,7 @@ router.get(
     try {
       endpoints = deriveEndpoints(
         snapshot,
+        stack.name,
         stack.environment?.name ?? "",
         tailnet,
       );

--- a/server/src/services/stack-addons/__tests__/tailscale-ssh.test.ts
+++ b/server/src/services/stack-addons/__tests__/tailscale-ssh.test.ts
@@ -152,10 +152,11 @@ describe('tailscale-ssh addon', () => {
       targetService: 'web',
     });
     // Authkey + hostname env are present and the hostname follows the
-    // `<service>-<env>` rule.
+    // `<stack>-<service>-<env>` rule (stack-name prefix disambiguates two
+    // stacks that happen to share a service+env namespace).
     expect(sidecar.containerConfig.env).toMatchObject({
       TS_AUTHKEY: 'tskey-auth-stub',
-      TS_HOSTNAME: 'web-prod',
+      TS_HOSTNAME: 'web-stack-web-prod',
       TS_EXTRA_ARGS: '--ssh',
     });
     // Required egress lists the Tailscale control-plane hostnames (§4.7
@@ -200,11 +201,11 @@ describe('tailscale-ssh addon', () => {
       connectedServices: undefined,
     };
     const a = def.buildServiceDefinition(ctx, {
-      envForSidecar: { TS_AUTHKEY: 'a', TS_HOSTNAME: 'web-prod' },
+      envForSidecar: { TS_AUTHKEY: 'a', TS_HOSTNAME: 'web-stack-web-prod' },
       templateVars: {},
     });
     const b = def.buildServiceDefinition(ctx, {
-      envForSidecar: { TS_AUTHKEY: 'b', TS_HOSTNAME: 'web-prod' },
+      envForSidecar: { TS_AUTHKEY: 'b', TS_HOSTNAME: 'web-stack-web-prod' },
       templateVars: {},
     });
     expect({ ...a, containerConfig: { ...a.containerConfig, env: {} } })
@@ -235,19 +236,50 @@ describe('lib/ helpers used by the tailscale-ssh addon', () => {
     ).toEqual([TAILSCALE_DEFAULT_TAG, 'tag:dev']);
   });
 
-  it('sanitizeTailscaleHostname enforces the {service}-{env} ≤63 char rule', () => {
-    expect(sanitizeTailscaleHostname('web', 'prod')).toBe('web-prod');
-    expect(sanitizeTailscaleHostname('Web_App', 'PROD')).toBe('web-app-prod');
-    expect(sanitizeTailscaleHostname('foo--bar', 'baz')).toBe('foo-bar-baz');
+  it('sanitizeTailscaleHostname enforces the {stack}-{service}-{env} ≤63 char rule', () => {
+    expect(sanitizeTailscaleHostname('shop', 'web', 'prod')).toBe('shop-web-prod');
+    expect(sanitizeTailscaleHostname('Shop_App', 'Web_App', 'PROD')).toBe(
+      'shop-app-web-app-prod',
+    );
+    expect(sanitizeTailscaleHostname('foo--bar', 'baz', 'qux')).toBe(
+      'foo-bar-baz-qux',
+    );
   });
 
-  it('sanitizeTailscaleHostname truncates to ≤63 octets and trims trailing hyphens', () => {
-    const long = sanitizeTailscaleHostname('a'.repeat(70), 'b');
+  it('sanitizeTailscaleHostname disambiguates same-service-name across stacks', () => {
+    // The whole reason the stack prefix exists: two stacks that each ship a
+    // `web/prod` service must produce different hostnames so they don't
+    // race for the same tailnet device record.
+    const a = sanitizeTailscaleHostname('shop', 'web', 'prod');
+    const b = sanitizeTailscaleHostname('blog', 'web', 'prod');
+    expect(a).not.toBe(b);
+    expect(a).toBe('shop-web-prod');
+    expect(b).toBe('blog-web-prod');
+  });
+
+  it('sanitizeTailscaleHostname falls back to FNV-1a hash when oversized', () => {
+    // Long stack name forces the cleaned triple past 63 chars; the result
+    // must stay ≤63, end in 8 hex chars after a hyphen, and remain
+    // deterministic for a given (stack, service, env) triple.
+    const long = sanitizeTailscaleHostname('a'.repeat(80), 'web', 'prod');
     expect(long.length).toBeLessThanOrEqual(63);
-    expect(long).not.toMatch(/-$/);
+    expect(long).toMatch(/-[0-9a-f]{8}$/);
+    // Stable across calls.
+    const longAgain = sanitizeTailscaleHostname('a'.repeat(80), 'web', 'prod');
+    expect(long).toBe(longAgain);
+  });
+
+  it('sanitizeTailscaleHostname hash differs when any input changes', () => {
+    // Same overflow-triggering length, different stack — different hash
+    // suffix proves the disambiguator is content-addressed, not just
+    // length-bound.
+    const a = sanitizeTailscaleHostname('a'.repeat(80), 'web', 'prod');
+    const b = sanitizeTailscaleHostname('b'.repeat(80), 'web', 'prod');
+    expect(a).not.toBe(b);
+    expect(a.slice(-8)).not.toBe(b.slice(-8));
   });
 
   it('sanitizeTailscaleHostname throws when no valid characters survive', () => {
-    expect(() => sanitizeTailscaleHostname('___', '___')).toThrow();
+    expect(() => sanitizeTailscaleHostname('___', '___', '___')).toThrow();
   });
 });

--- a/server/src/services/stack-addons/__tests__/tailscale-web.test.ts
+++ b/server/src/services/stack-addons/__tests__/tailscale-web.test.ts
@@ -141,7 +141,7 @@ describe('tailscale-web addon', () => {
 
     expect(sidecar.containerConfig.env).toMatchObject({
       TS_AUTHKEY: 'tskey-auth-stub',
-      TS_HOSTNAME: 'web-prod',
+      TS_HOSTNAME: 'web-stack-web-prod',
       TS_SERVE_CONFIG: '/etc/tailscale/serve.json',
     });
     expect(sidecar.containerConfig.env?.TS_EXTRA_ARGS).toBeUndefined();

--- a/server/src/services/stack-addons/merge-strategies/__tests__/tailscale.test.ts
+++ b/server/src/services/stack-addons/merge-strategies/__tests__/tailscale.test.ts
@@ -144,7 +144,7 @@ describe('tailscale merge strategy (kind:"tailscale")', () => {
     // sidecar, two surfaces".
     expect(sidecar.containerConfig.env).toMatchObject({
       TS_AUTHKEY: expect.stringMatching(/^tskey-auth-stub-/),
-      TS_HOSTNAME: 'web-prod',
+      TS_HOSTNAME: 'web-stack-web-prod',
       TS_EXTRA_ARGS: '--ssh',
       TS_SERVE_CONFIG: '/etc/tailscale/serve.json',
     });
@@ -373,7 +373,7 @@ describe('tailscale merge strategy (kind:"tailscale")', () => {
     // Only one authkey mint → only one chance to assert tags. Validate the
     // sidecar's hostname is present and synthetic info is right; the tag
     // dedup is exercised by the buildTailscaleTagSet contract test.
-    expect(sidecar.containerConfig.env?.TS_HOSTNAME).toBe('web-prod');
+    expect(sidecar.containerConfig.env?.TS_HOSTNAME).toBe('web-stack-web-prod');
     expect(mintCalls).toBe(1);
   });
 

--- a/server/src/services/stack-addons/merge-strategies/tailscale.ts
+++ b/server/src/services/stack-addons/merge-strategies/tailscale.ts
@@ -96,7 +96,11 @@ async function provisionTailscaleMerged(
     ctx.environment.name && ctx.environment.name.length > 0
       ? ctx.environment.name
       : 'host';
-  const hostname = sanitizeTailscaleHostname(ctx.service.name, envSlug);
+  const hostname = sanitizeTailscaleHostname(
+    ctx.stack.name,
+    ctx.service.name,
+    envSlug,
+  );
 
   // Best-effort cleanup of stale offline registrations on this hostname —
   // see the matching call in `tailscale-web/provision.ts` for the rationale.

--- a/server/src/services/stack-addons/tailscale-ssh/provision.ts
+++ b/server/src/services/stack-addons/tailscale-ssh/provision.ts
@@ -35,9 +35,10 @@ function asLookup(input: unknown): AddonConnectedServicesLookup {
  * The default `tag:mini-infra-managed` is always present (asserted by the
  * authkey minter); operator-supplied `extraTags` are merged on top via the
  * shared lib helper. Per-resource identity rides on the device hostname
- * (`<service>-<env>` sanitised, ≤63 chars), not on dynamic per-resource tags
- * — Tailscale OAuth clients can only mint keys with tags pre-declared in
- * the operator's ACL `tagOwners`, so dynamic tagging is infeasible.
+ * (`<stack>-<service>-<env>` sanitised, ≤63 chars), not on dynamic
+ * per-resource tags — Tailscale OAuth clients can only mint keys with tags
+ * pre-declared in the operator's ACL `tagOwners`, so dynamic tagging is
+ * infeasible.
  */
 export async function provisionTailscaleSsh(
   ctx: ProvisionContext,
@@ -51,14 +52,20 @@ export async function provisionTailscaleSsh(
     );
   }
 
-  // Hostname rule: `{service}-{env}` sanitised, ≤63 chars. For the rare
-  // case of a host-level stack (no environment) we fall back to the service
-  // name alone — which still encodes per-resource identity because there's
-  // only one host scope.
+  // Hostname rule: `{stack}-{service}-{env}` sanitised, ≤63 chars (FNV-1a
+  // hash fallback when oversized — see sanitizeTailscaleHostname). The
+  // stack-name prefix prevents two stacks that both ship a `web/prod`
+  // service from racing for the same tailnet device. For the rare case of
+  // a host-level stack (no environment) we fall back to `host` so the
+  // triple still encodes per-resource identity.
   const envSlug = ctx.environment.name && ctx.environment.name.length > 0
     ? ctx.environment.name
     : 'host';
-  const hostname = sanitizeTailscaleHostname(ctx.service.name, envSlug);
+  const hostname = sanitizeTailscaleHostname(
+    ctx.stack.name,
+    ctx.service.name,
+    envSlug,
+  );
 
   // Best-effort cleanup of stale offline registrations on this hostname —
   // see the matching call in `tailscale-web/provision.ts` for the rationale.

--- a/server/src/services/stack-addons/tailscale-web/index.ts
+++ b/server/src/services/stack-addons/tailscale-web/index.ts
@@ -12,7 +12,7 @@ import { buildTailscaleSidecarDefinition } from '../shared/tailscale-sidecar';
 /**
  * `tailscale-web` addon — Phase 4 sibling to `tailscale-ssh`. Materialises a
  * tailscaled sidecar running `tailscale serve` so the target service is
- * reachable at `https://<service>-<env>.<tailnet>.ts.net` with auto-issued
+ * reachable at `https://<stack>-<service>-<env>.<tailnet>.ts.net` with auto-issued
  * Let's Encrypt certs and no port forwarding. Shares `kind: tailscale` with
  * `tailscale-ssh` — when both are declared on the same service the merge
  * strategy collapses them into one sidecar.

--- a/server/src/services/stack-addons/tailscale-web/provision.ts
+++ b/server/src/services/stack-addons/tailscale-web/provision.ts
@@ -54,7 +54,11 @@ export async function provisionTailscaleWeb(
     ctx.environment.name && ctx.environment.name.length > 0
       ? ctx.environment.name
       : 'host';
-  const hostname = sanitizeTailscaleHostname(ctx.service.name, envSlug);
+  const hostname = sanitizeTailscaleHostname(
+    ctx.stack.name,
+    ctx.service.name,
+    envSlug,
+  );
 
   // Best-effort: purge any *offline* managed device already squatting on
   // this hostname so the new registration takes the unsuffixed DNS name

--- a/server/src/services/stack-addons/tailscale-web/serve-config.ts
+++ b/server/src/services/stack-addons/tailscale-web/serve-config.ts
@@ -5,7 +5,7 @@ import { tailscaleSidecarServiceName } from '../shared/sidecar-naming';
  * `serve.json` template for `tailscale serve`. The tailscaled container reads
  * this file when `TS_SERVE_CONFIG` is set and substitutes `${TS_CERT_DOMAIN}`
  * at runtime with the device's MagicDNS hostname (e.g.
- * `<service>-<env>.<tailnet>.ts.net`). Keeping the host literal in the file
+ * `<stack>-<service>-<env>.<tailnet>.ts.net`). Keeping the host literal in the file
  * means the sidecar works identically across tailnets without re-rendering
  * the file at apply time.
  *

--- a/server/src/services/stacks/__tests__/stack-applied-snapshot.test.ts
+++ b/server/src/services/stacks/__tests__/stack-applied-snapshot.test.ts
@@ -64,7 +64,7 @@ describe('buildAppliedSnapshot', () => {
       dockerTag: 'stable',
       order: 1,
       containerConfig: {
-        env: { TS_HOSTNAME: 'web-prod' },
+        env: { TS_HOSTNAME: 'web-stack-web-prod' },
         labels: {
           'mini-infra.synthetic': 'true',
           'mini-infra.addon-target': 'web',


### PR DESCRIPTION
## Summary

- `sanitizeTailscaleHostname` now takes the stack name and emits `{stack}-{service}-{env}` (was `{service}-{env}`), so two stacks that both declare a `web` service in the same env stop racing for the same tailnet device record. Tailscale's auto-suffix (`web-prod-1`) is persistent for the device's lifetime, which silently rots ACL `host:` rules and integration URLs — this closes that off at the framework layer.
- Adds an FNV-1a-32 hash fallback when the cleaned triple exceeds 63 chars (DNS label limit). Inline FNV-1a keeps `lib/` zero-dep and browser-safe.
- Pre-emptively closes the same concern for Phase 6 pools that the not-shipped service-addons plan flagged at §7 — pool hostnames will inherit the stack prefix and the same overflow behaviour.

Forward-only: existing tailnet device records keep their old names until they re-register on the next apply. No migration plumbing needed (per request — only new tailnets matter).

## Smoke-tested in dev

Created two stacks (`myshop`, `myshop2`) from the docs' nginx + tailscale-web worked example. After rebuild, the new stack's snapshot, addon-endpoints API response, live container env, and live tailnet device all agree on `myshop2-web-local`. The pre-rebuild `myshop` sidecar still reads `web-local` — confirms the change is forward-only as intended.

## Test plan

- [x] `pnpm --filter @mini-infra/types build` — clean
- [x] `pnpm --filter mini-infra-server build` — clean
- [x] `pnpm --filter mini-infra-server lint` — clean
- [x] `pnpm --filter mini-infra-server test` — 165 files / 2231 tests pass (3 new cases pin cross-stack disambiguation, hash determinism, and hash content-addressing)
- [x] Live smoke: `myshop2/web/local` → `TS_HOSTNAME=myshop2-web-local` end-to-end (snapshot env, addon-endpoints route, container env, tailnet device registration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)