### PR TITLE
ci: add docs-only required-check bypass for build-main

### DIFF
--- a/.github/workflows/docs-bypass.yml
+++ b/.github/workflows/docs-bypass.yml
@@ -1,0 +1,30 @@
+name: Docs-only required-check bypass
+
+# The `build-main` job in docker-build.yml is a required status check on main,
+# but that workflow has `paths-ignore: '**.md'` so it never fires on docs-only
+# PRs — leaving the required check structurally unsatisfiable and the PR
+# unmergeable. This workflow fires on docs-only changes and emits a passing
+# `build-main` check so docs-only PRs can merge without bypassing branch
+# protection.
+#
+# On mixed PRs (some .md, some code), both this workflow and docker-build.yml
+# fire; both must pass, which is the correct behaviour.
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**.md'
+  push:
+    branches:
+      - main
+    paths:
+      - '**.md'
+
+jobs:
+  build-main:
+    name: build-main
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change — required-check bypass."


### PR DESCRIPTION
## Summary

The required \`build-main\` check is defined in \`docker-build.yml\`, which uses \`paths-ignore: '**.md'\` — so docs-only PRs never produce the check, leaving them unmergeable unless someone (a) bypasses the rule with admin overrides, or (b) loosens branch protection. PR #406 hit exactly this earlier today.

This adds a tiny sibling workflow that fires only on \`**.md\` path changes, with a single \`build-main\` job that immediately exits 0. Net effect:

- **Docs-only PR** → only the bypass fires; \`build-main\` passes; rule satisfied.
- **Code-only PR** → only the real \`docker-build.yml\` fires; unchanged behaviour.
- **Mixed PR** → both fire; both must pass; the real build still runs against the code change. Correct behaviour.

## Test plan

- [ ] After merge, the next docs-only PR should show a green \`build-main\` check from \`docs-bypass.yml\` and merge without admin override.
- [ ] Code PRs should continue to see exactly one \`build-main\` check, from \`docker-build.yml\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)