### PR TITLE
feat(stacks): JobPool exit watcher + per-pool history streams (Phase 2, MINI-51)

### DIFF
--- a/egress-shared/natsbus/subjects.go
+++ b/egress-shared/natsbus/subjects.go
@@ -76,6 +76,16 @@ const (
 	SubjectUpdateHealthCheckPassed  = "mini-infra.update.health-check-passed"
 )
 
+// JobPool run-lifecycle subjects (Phase 2 of job-pool-service-type).
+//
+// Per-pool subjects are built at runtime as
+// `mini-infra.job-pool.<stackId>.<serviceName>.<verb>`. The base prefix below
+// is what the drift check pins against; concrete per-pool subjects are not
+// listed here (the set is unbounded).
+const (
+	SubjectJobPoolBase = "mini-infra.job-pool"
+)
+
 // AllSubjects is the flat list used by the TS↔Go drift check. Order matches
 // `ALL_NATS_SUBJECTS` in `lib/types/nats-subjects.ts` (subjects-as-set
 // equality is what the check enforces, but mirroring the order makes diffs
@@ -101,4 +111,5 @@ var AllSubjects = []string{
 	SubjectUpdateCompleted,
 	SubjectUpdateFailed,
 	SubjectUpdateHealthCheckPassed,
+	SubjectJobPoolBase,
 }

--- a/lib/types/nats-subjects.ts
+++ b/lib/types/nats-subjects.ts
@@ -110,6 +110,83 @@ export const BackupSubject = {
   failed: "mini-infra.backup.failed",
 } as const;
 
+/**
+ * JobPool run-lifecycle subjects (Phase 2 of job-pool-service-type).
+ *
+ * Subjects are parameterised by `<stackId>` and `<serviceName>` — the
+ * declaring stack + service. The history stream that captures the durable
+ * `completed`/`failed` events is per-pool (`JobHistory-<stackId>-<service>`);
+ * `run-skipped` is plain pub/sub for observability of cap-hit scheduled runs.
+ *
+ * Use the builder functions rather than concatenating strings manually so
+ * the depth check in the operator-path prefix bootstrap stays correct.
+ */
+export const JobPoolSubject = {
+  /** Static base — every per-pool subject starts with this token. */
+  base: "mini-infra.job-pool",
+  /** Event (JetStream): a run finished with exit code 0. */
+  completed: (stackId: string, serviceName: string): string =>
+    `mini-infra.job-pool.${stackId}.${serviceName}.completed`,
+  /** Event (JetStream): a run finished with a non-zero exit code (or was killed). */
+  failed: (stackId: string, serviceName: string): string =>
+    `mini-infra.job-pool.${stackId}.${serviceName}.failed`,
+  /** Event (plain pub/sub): a trigger fired but the cap was hit, so no run was started. */
+  runSkipped: (stackId: string, serviceName: string): string =>
+    `mini-infra.job-pool.${stackId}.${serviceName}.run-skipped`,
+  /** Wildcard parent used by stream/consumer subscription filters. */
+  wildcardForPool: (stackId: string, serviceName: string): string =>
+    `mini-infra.job-pool.${stackId}.${serviceName}.>`,
+} as const;
+
+/**
+ * Maximum length of a JetStream stream name. NATS itself permits up to 256
+ * characters, but the SDK validation and most operational tooling assume
+ * shorter names; we keep our per-pool names within 32 chars to match the
+ * length of all other Mini Infra stream constants. Names that would exceed
+ * this collapse the variable portion (`<stackId>-<service>`) onto an 8-char
+ * blake-2b-ish hex digest so two different (stackId, service) pairs always
+ * produce two different stream names.
+ */
+const JOB_HISTORY_STREAM_NAME_MAX = 32;
+
+/** Stable, dependency-free 32-bit FNV-1a hash → 8-char hex suffix. */
+function shortHashHex(input: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16).padStart(8, "0");
+}
+
+/**
+ * Derive the JetStream stream name for a JobPool's history stream. Stable for
+ * a given (stackId, serviceName) pair — both the operator-path stream creator
+ * and any future client-side history reader must call this so the two sides
+ * never drift on which stream to address.
+ *
+ * Format: `JobHistory-<stackId-suffix>-<serviceName>`. When the obvious join
+ * would exceed `JOB_HISTORY_STREAM_NAME_MAX`, the variable portion is replaced
+ * by a deterministic short hash so the name stays under the limit.
+ */
+export function jobHistoryStreamName(stackId: string, serviceName: string): string {
+  // Sanitize to the character set NATS allows in stream names (no `.`, no
+  // `*`, no `>`, no spaces). The stack ID is a cuid/ULID-ish opaque token in
+  // practice but a sanitisation pass keeps a forward-compat door open if the
+  // ID scheme ever changes.
+  const safeStack = stackId.replace(/[^A-Za-z0-9_-]/g, "");
+  const safeService = serviceName.replace(/[^A-Za-z0-9_-]/g, "");
+  const candidate = `JobHistory-${safeStack}-${safeService}`;
+  if (candidate.length <= JOB_HISTORY_STREAM_NAME_MAX) return candidate;
+  // Hash the unsanitised inputs together so collisions are vanishingly
+  // unlikely even on stack-IDs that share a sanitised prefix.
+  const hash = shortHashHex(`${stackId}|${serviceName}`);
+  // Keep a short readable service prefix so operators can still spot which
+  // pool a stream belongs to from `nats stream ls`.
+  const readable = safeService.slice(0, 12);
+  return `JobHistory-${hash}-${readable}`.slice(0, JOB_HISTORY_STREAM_NAME_MAX);
+}
+
 /** Phase 5 (optional): self-update sidecar subjects. Reserved. */
 export const UpdateSubject = {
   run: "mini-infra.update.run",
@@ -130,6 +207,8 @@ export const NatsWildcard = {
   backupProgressAll: "mini-infra.backup.progress.>",
   updateAll: "mini-infra.update.>",
   updateProgressAll: "mini-infra.update.progress.>",
+  /** Every JobPool run-lifecycle subject across every pool. */
+  jobPoolAll: "mini-infra.job-pool.>",
 } as const;
 
 /**
@@ -190,4 +269,10 @@ export const ALL_NATS_SUBJECTS: readonly string[] = [
   UpdateSubject.completed,
   UpdateSubject.failed,
   UpdateSubject.healthCheckPassed,
+  // JobPool (Phase 2): subjects are parameterised per (stackId, serviceName).
+  // The static base lives in the registry as a parent so the
+  // KnownNatsSubject type stays exhaustive; concrete per-pool subjects use
+  // `unchecked: true` at publish/subscribe sites and validate inline against
+  // the same Zod schemas exported from payload-schemas.ts.
+  JobPoolSubject.base,
 ] as const;

--- a/lib/types/socket-events.ts
+++ b/lib/types/socket-events.ts
@@ -221,6 +221,12 @@ export const ServerEvent = {
   POOL_INSTANCE_FAILED: "pool:instance:failed",
   POOL_INSTANCE_IDLE_STOPPED: "pool:instance:idle-stopped",
   POOL_INSTANCE_STOPPED: "pool:instance:stopped",
+  // JobPool runs (Phase 2 of job-pool-service-type — exit watcher fans
+  // container `die` events out to the client via these events on the same
+  // `pools` channel as the long-running Pool lifecycle events above).
+  JOB_POOL_RUN_COMPLETED: "job-pool:run:completed",
+  JOB_POOL_RUN_FAILED: "job-pool:run:failed",
+  JOB_POOL_RUN_SKIPPED: "job-pool:run:skipped",
   // Vault
   VAULT_BOOTSTRAP_STARTED: "vault:bootstrap:started",
   VAULT_BOOTSTRAP_STEP: "vault:bootstrap:step",
@@ -534,6 +540,42 @@ export interface ServerToClientEvents {
     stackId: string;
     serviceName: string;
     instanceId: string;
+  }) => void;
+
+  // ── JobPool runs (Phase 2 of job-pool-service-type) ─
+  /** A JobPool run completed with exit code 0. */
+  "job-pool:run:completed": (data: {
+    stackId: string;
+    serviceName: string;
+    runId: string;
+    triggerKind: "cron" | "nats-request" | "manual";
+    triggerName: string;
+    exitCode: 0;
+    startedAtMs: number;
+    finishedAtMs: number;
+  }) => void;
+  /** A JobPool run failed (non-zero exit or killed by killAfterSeconds). */
+  "job-pool:run:failed": (data: {
+    stackId: string;
+    serviceName: string;
+    runId: string;
+    triggerKind: "cron" | "nats-request" | "manual";
+    triggerName: string;
+    /** Real exit code, or -1 for kill-after-seconds / non-exit failures. */
+    exitCode: number;
+    errorMessage: string;
+    startedAtMs: number;
+    finishedAtMs: number;
+  }) => void;
+  /** A trigger fired but the JobPool's concurrency cap was already hit. */
+  "job-pool:run:skipped": (data: {
+    stackId: string;
+    serviceName: string;
+    reason: "concurrency_cap";
+    triggerKind: "cron" | "nats-request" | "manual";
+    triggerName: string;
+    scheduledAtMs: number;
+    maxConcurrent: number;
   }) => void;
 
   // ── Vault ──────────────────────────────────────────

--- a/lib/types/stacks.ts
+++ b/lib/types/stacks.ts
@@ -124,8 +124,24 @@ export type JobPoolTrigger =
   | { kind: 'nats-request'; subject: string; ackWithRunId: boolean; name: string }
   | { kind: 'manual'; name: string };
 
-/** Lifecycle statuses for a pool instance row. */
-export const POOL_INSTANCE_STATUSES = ['starting', 'running', 'stopping', 'stopped', 'error'] as const;
+/**
+ * Lifecycle statuses for a pool instance row.
+ *
+ * Pool instances use a subset: `starting`/`running`/`stopping`/`stopped`/`error`.
+ * JobPool instances additionally transition to terminal `completed` (exit 0)
+ * or `failed` (non-zero exit, killed by `killAfterSeconds`, or exit watcher
+ * surfacing). The exit watcher (Phase 2) is the only thing that ever writes
+ * `completed` / `failed`; pre-Phase-2 rows never hold those values.
+ */
+export const POOL_INSTANCE_STATUSES = [
+  'starting',
+  'running',
+  'stopping',
+  'stopped',
+  'error',
+  'completed',
+  'failed',
+] as const;
 export type PoolInstanceStatus = typeof POOL_INSTANCE_STATUSES[number];
 
 /** DB shape for a pool instance (Date fields). */
@@ -141,6 +157,18 @@ export interface PoolInstance {
   createdAt: Date;
   stoppedAt: Date | null;
   errorMessage: string | null;
+  /**
+   * Container exit code captured by the JobPool exit watcher when status is
+   * `completed` (always 0) or `failed` (non-zero, or `-1` when the row was
+   * forced failed without a real exit — e.g. kill-after-seconds overrun).
+   * `null` on Pool rows and on JobPool rows that haven't terminated yet.
+   */
+  exitCode: number | null;
+  /**
+   * Wall-clock time the JobPool run finished (success or failure). `null`
+   * on Pool rows and on still-running JobPool rows.
+   */
+  finishedAt: Date | null;
 }
 
 /** API response shape for a pool instance (string dates). */
@@ -156,6 +184,8 @@ export interface PoolInstanceInfo {
   createdAt: string;
   stoppedAt: string | null;
   errorMessage: string | null;
+  exitCode: number | null;
+  finishedAt: string | null;
 }
 
 /** Request body for POST /api/stacks/:stackId/pools/:serviceName/instances */

--- a/server/prisma/migrations/20260512000000_jobpool_exit_watcher/migration.sql
+++ b/server/prisma/migrations/20260512000000_jobpool_exit_watcher/migration.sql
@@ -1,0 +1,11 @@
+-- Phase 2 of the job-pool-service-type plan: the exit watcher needs two
+-- nullable columns on `pool_instances` so a JobPool run row can carry the
+-- container's exit code and the wall-clock time the run finalised. Pool rows
+-- (the original Phase-1 use of this table) never set them.
+--
+-- The `status` column is still TEXT — Prisma renders the union as plain TEXT
+-- in SQLite, so the new `completed`/`failed` statuses don't need a schema
+-- change; only the application-side enum was widened.
+
+ALTER TABLE "pool_instances" ADD COLUMN "exitCode" INTEGER;
+ALTER TABLE "pool_instances" ADD COLUMN "finishedAt" DATETIME;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1457,12 +1457,22 @@ model PoolInstance {
   serviceName        String
   instanceId         String
   containerId        String?
-  status             String    // starting | running | stopping | stopped | error
+  // starting | running | stopping | stopped | error | completed | failed
+  // JobPool runs terminate as completed (exit 0) or failed (non-zero exit or
+  // killed by `killAfterSeconds`); Pool instances continue using the original
+  // five statuses.
+  status             String
   idleTimeoutMinutes Int
   lastActive         DateTime  @default(now())
   createdAt          DateTime  @default(now())
   stoppedAt          DateTime?
   errorMessage       String?
+  // JobPool exit watcher (Phase 2 of job-pool-service-type): captured on
+  // `die` events. `exitCode` is the container's reported exit code (or -1
+  // when the row was forced failed without a real exit). `finishedAt` is
+  // wall-clock at the time of the transition. Both stay null on Pool rows.
+  exitCode           Int?
+  finishedAt         DateTime?
 
   @@index([stackId])
   @@index([stackId, serviceName])

--- a/server/src/lib/docker-event-pattern-detector.ts
+++ b/server/src/lib/docker-event-pattern-detector.ts
@@ -6,6 +6,14 @@ export interface DockerContainerEvent {
   containerName: string;
   labels: Record<string, string>;
   time: number;
+  /**
+   * Container exit code, present only on `die` events (Docker writes
+   * `exitCode` into the event's `Actor.Attributes`). Parsed as an integer
+   * when present, otherwise `undefined`. The JobPool exit watcher reads this
+   * to decide between `completed` and `failed` lifecycle transitions; other
+   * consumers can ignore it.
+   */
+  exitCode?: number;
 }
 
 export interface PatternDetectorOptions {

--- a/server/src/routes/stacks/stacks-apply-route.ts
+++ b/server/src/routes/stacks/stacks-apply-route.ts
@@ -14,6 +14,7 @@ import { findEmptyStackParameters } from '../../services/stacks/parameter-valida
 import { evaluatePrerequisites } from '../../services/stacks/template-prerequisites';
 import { runStackVaultApplyPhase } from '../../services/stacks/stack-vault-apply-orchestrator';
 import { runStackNatsApplyPhase } from '../../services/stacks/stack-nats-apply-orchestrator';
+import { applyJobPoolStreamsForStack } from '../../services/stacks/job-pool-stream-reconciler';
 import { EgressPolicyLifecycleService } from '../../services/egress/egress-policy-lifecycle';
 import { pruneOrphanedInputValues as doPruneOrphanedInputValues } from '../../services/stacks/orphan-input-pruner';
 import {
@@ -256,6 +257,19 @@ async function runApplyInBackground(args: RunApplyArgs): Promise<void> {
       });
       if (natsPhase.status === 'error') {
         throw new Error(natsPhase.error ?? 'NATS reconciliation phase failed');
+      }
+      // JobPool history streams (Phase 2 of job-pool-service-type): reconcile
+      // one per-pool JetStream stream per JobPool service on the stack.
+      // No-op when the stack has no JobPool services. Failures are logged
+      // inside the reconciler — JobPool history streams are observability,
+      // not correctness-critical, so a NATS-side blip can't fail the apply.
+      try {
+        await applyJobPoolStreamsForStack(prisma, stackId);
+      } catch (err) {
+        logger.warn(
+          { stackId, err: err instanceof Error ? err.message : String(err) },
+          'JobPool history-stream reconcile failed (continuing apply)',
+        );
       }
 
       // Re-promote `requiredEgress` declarations into template-source

--- a/server/src/routes/stacks/stacks-pool-routes.ts
+++ b/server/src/routes/stacks/stacks-pool-routes.ts
@@ -144,6 +144,8 @@ function serializeInstance(row: PoolInstanceDb): PoolInstanceInfo {
     createdAt: row.createdAt.toISOString(),
     stoppedAt: row.stoppedAt?.toISOString() ?? null,
     errorMessage: row.errorMessage,
+    exitCode: row.exitCode,
+    finishedAt: row.finishedAt?.toISOString() ?? null,
   };
 }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -48,6 +48,7 @@ import {
 } from "./services/tailscale";
 import { CertificateRenewalScheduler } from "./services/tls/certificate-renewal-scheduler";
 import { PoolInstanceReaper } from "./services/stacks/pool-instance-reaper";
+import { JobPoolExitWatcher } from "./services/stacks/job-pool-exit-watcher";
 import { TlsConfigService } from "./services/tls/tls-config";
 import { StorageCertificateStore } from "./services/tls/storage-certificate-store";
 import { AcmeClientManager } from "./services/tls/acme-client-manager";
@@ -93,6 +94,7 @@ let dnsCacheScheduler: DnsCacheScheduler | null = null;
 // which both startup and the settings route call to keep it aligned with the
 // current credentials. Read via `TailscaleDeviceStatusScheduler.getInstance()`.
 let poolInstanceReaper: PoolInstanceReaper | null = null;
+let jobPoolExitWatcher: JobPoolExitWatcher | null = null;
 
 /**
  * Initialize the internal auth secret from the database, generating one if
@@ -268,11 +270,27 @@ const initializeServices = async () => {
     console.log("[STARTUP] ✓ Connectivity scheduler initialized");
 
     // Initialize pool instance reaper (stops idle pool instances on a 60s
-    // cadence; also force-fails spawns stuck in `starting` for >5 min).
+    // cadence; also force-fails spawns stuck in `starting` for >5 min and
+    // kills JobPool runs that exceed `killAfterSeconds`).
     console.log("[STARTUP] Initializing pool instance reaper...");
     poolInstanceReaper = new PoolInstanceReaper(prisma);
     poolInstanceReaper.start();
     console.log("[STARTUP] ✓ Pool instance reaper initialized");
+
+    // Initialize JobPool exit watcher (Phase 2 of job-pool-service-type):
+    // subscribes to Docker `die` events to finalise JobPool runs, publish
+    // history events to JetStream, and schedule retries.
+    console.log("[STARTUP] Initializing JobPool exit watcher...");
+    jobPoolExitWatcher = new JobPoolExitWatcher(prisma, async () => {
+      const { DockerExecutorService } = await import(
+        "./services/docker-executor"
+      );
+      const exec = new DockerExecutorService();
+      await exec.initialize();
+      return exec;
+    });
+    jobPoolExitWatcher.start();
+    console.log("[STARTUP] ✓ JobPool exit watcher initialized");
 
     // Initialize backup scheduler
     console.log("[STARTUP] Initializing backup scheduler...");

--- a/server/src/services/docker.ts
+++ b/server/src/services/docker.ts
@@ -367,13 +367,24 @@ class DockerService {
                   }
                 }
 
-                // Fire typed container event callbacks (e.g., crash loop detector)
+                // Fire typed container event callbacks (e.g., crash loop detector,
+                // JobPool exit watcher). `exitCode` is only meaningful on `die`
+                // events — Docker still includes the attribute on other actions
+                // sometimes but the value is the prior `die`'s code, so we
+                // only forward it when the action is actually `die`.
+                const exitCodeAttr = event.Actor?.Attributes?.exitCode;
+                let exitCode: number | undefined;
+                if (event.Action === "die" && exitCodeAttr !== undefined) {
+                  const parsed = Number.parseInt(String(exitCodeAttr), 10);
+                  if (Number.isFinite(parsed)) exitCode = parsed;
+                }
                 const typedEvent: DockerContainerEvent = {
                   action: event.Action,
                   containerId: event.id || event.Actor?.ID || "",
                   containerName: event.Actor?.Attributes?.name || "",
                   labels: event.Actor?.Attributes || {},
                   time: event.time || Math.floor(Date.now() / 1000),
+                  ...(exitCode !== undefined ? { exitCode } : {}),
                 };
                 for (const cb of this.containerEventCallbacks) {
                   try {

--- a/server/src/services/nats/payload-schemas.ts
+++ b/server/src/services/nats/payload-schemas.ts
@@ -19,6 +19,7 @@ import {
   BackupSubject,
   EgressFwSubject,
   EgressGwSubject,
+  JobPoolSubject,
   SystemSubject,
   UpdateSubject,
 } from "@mini-infra/types";
@@ -87,6 +88,79 @@ export const backupFailedSchema = z.object({
   failedAtMs: z.number().int().nonnegative(),
 });
 export type BackupFailed = z.infer<typeof backupFailedSchema>;
+
+// ====================================================================
+// JobPool run lifecycle (Phase 2 of job-pool-service-type)
+// ====================================================================
+//
+// Subjects are parameterised by `<stackId>` and `<serviceName>` — see the
+// builder functions on `JobPoolSubject`. The registry below pins schemas to
+// the static parent `JobPoolSubject.base` ("mini-infra.job-pool"); the bus's
+// validateRequest path doesn't currently match per-id subjects to a parent,
+// so call sites that publish on the per-pool subjects pass `unchecked: true`
+// and validate inline with the same schemas. The schemas are exported so the
+// exit watcher, the run-skipped emitter, and the future Phase-4/5 consumers
+// all parse against the exact same shape.
+
+const triggerKindSchema = z.enum(["cron", "nats-request", "manual"]);
+
+const jobPoolRunBaseSchema = z.object({
+  /** Owning stack ID — also embedded in the subject for routing. */
+  stackId: z.string().min(1).max(64),
+  /** Owning service name within the stack. */
+  serviceName: z.string().min(1).max(100),
+  /** Unique run identifier — matches `PoolInstance.instanceId`. */
+  runId: z.string().min(1).max(64),
+  /** Which trigger fired this run (cron, nats-request, manual). */
+  triggerKind: triggerKindSchema,
+  /** Operator-facing label for the specific trigger (e.g. `nightly-prod`). */
+  triggerName: z.string().min(1).max(100),
+});
+
+export const jobPoolRunCompletedSchema = jobPoolRunBaseSchema.extend({
+  /** Container exit code (always 0 for completed runs). */
+  exitCode: z.literal(0),
+  /** Wall-clock time the run finished, ms since epoch. */
+  finishedAtMs: z.number().int().nonnegative(),
+  /** Wall-clock time the run started, ms since epoch. */
+  startedAtMs: z.number().int().nonnegative(),
+});
+export type JobPoolRunCompleted = z.infer<typeof jobPoolRunCompletedSchema>;
+
+export const jobPoolRunFailedSchema = jobPoolRunBaseSchema.extend({
+  /**
+   * Container exit code on real container exits, or `-1` when the run was
+   * force-failed without a real container exit (kill-after-seconds reaper
+   * sweep or watcher-detected anomaly).
+   */
+  exitCode: z.number().int(),
+  /** Free-form failure reason — used for the operator-facing message. */
+  errorMessage: z.string().max(1024),
+  /** Wall-clock time the run finished, ms since epoch. */
+  finishedAtMs: z.number().int().nonnegative(),
+  /** Wall-clock time the run started, ms since epoch. */
+  startedAtMs: z.number().int().nonnegative(),
+});
+export type JobPoolRunFailed = z.infer<typeof jobPoolRunFailedSchema>;
+
+export const jobPoolRunSkippedSchema = z.object({
+  stackId: z.string().min(1).max(64),
+  serviceName: z.string().min(1).max(100),
+  /** Why the trigger was rejected — currently always concurrency cap. */
+  reason: z.literal("concurrency_cap"),
+  /** Which trigger tried to fire. */
+  triggerKind: triggerKindSchema,
+  triggerName: z.string().min(1).max(100),
+  /**
+   * Wall-clock time the trigger was scheduled to fire. For cron, this is
+   * the cron's fire time; for nats-request / manual it's `Date.now()` at
+   * the call site. ms since epoch.
+   */
+  scheduledAtMs: z.number().int().nonnegative(),
+  /** Concurrency limit at the time the cap was hit — for the UI surface. */
+  maxConcurrent: z.number().int().min(1),
+});
+export type JobPoolRunSkipped = z.infer<typeof jobPoolRunSkippedSchema>;
 
 // ====================================================================
 // Egress gateway (Phase 3) — real schemas, replacing the Phase 1 stubs.
@@ -496,4 +570,15 @@ export const payloadSchemas: Record<KnownNatsSubject, SubjectSchemaEntry> = {
   [UpdateSubject.completed]: { request: z.unknown() },
   [UpdateSubject.failed]: { request: z.unknown() },
   [UpdateSubject.healthCheckPassed]: { request: z.unknown() },
+  // JobPool: the static base is a parent — concrete per-pool subjects use
+  // `unchecked: true` at publish sites and validate inline. The bus's
+  // exact-match lookup never resolves a per-pool subject to this entry, but
+  // its presence keeps `KnownNatsSubject` exhaustive.
+  [JobPoolSubject.base]: {
+    request: z.union([
+      jobPoolRunCompletedSchema,
+      jobPoolRunFailedSchema,
+      jobPoolRunSkippedSchema,
+    ]),
+  },
 };

--- a/server/src/services/stacks/__tests__/job-pool-exit-watcher.test.ts
+++ b/server/src/services/stacks/__tests__/job-pool-exit-watcher.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { JobPoolExitWatcher, KILL_AFTER_SECONDS_ERROR } from '../job-pool-exit-watcher';
+import { jobHistoryStreamName } from '@mini-infra/types';
+import type { DockerContainerEvent } from '../../../lib/docker-event-pattern-detector';
+
+// Mock DockerService.onContainerEvent + NatsBus so the watcher's
+// start() registration doesn't try to reach a real Docker socket / NATS
+// connection inside the unit test.
+vi.mock('../../docker', () => ({
+  default: {
+    getInstance: () => ({
+      onContainerEvent: vi.fn(),
+    }),
+  },
+}));
+
+const publishedEvents: { kind: string; payload: unknown }[] = [];
+vi.mock('../job-pool-history-publisher', () => ({
+  publishJobPoolCompleted: vi.fn(async (p: unknown) => {
+    publishedEvents.push({ kind: 'completed', payload: p });
+  }),
+  publishJobPoolFailed: vi.fn(async (p: unknown) => {
+    publishedEvents.push({ kind: 'failed', payload: p });
+  }),
+  publishJobPoolRunSkipped: vi.fn(async (p: unknown) => {
+    publishedEvents.push({ kind: 'skipped', payload: p });
+  }),
+}));
+
+const scheduledRetries: unknown[] = [];
+vi.mock('../job-pool-retry-scheduler', () => ({
+  scheduleJobPoolRetry: vi.fn((_prisma, _exec, ctx: unknown) => {
+    scheduledRetries.push(ctx);
+  }),
+}));
+
+type MockPrisma = {
+  poolInstance: {
+    findFirst: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  stackService: {
+    findFirst: ReturnType<typeof vi.fn>;
+  };
+};
+
+function buildPrismaWithRow(opts: {
+  status?: string;
+  errorMessage?: string | null;
+  serviceType?: string;
+  jobPoolConfig?: unknown;
+}): MockPrisma {
+  const row = {
+    id: 'row-1',
+    stackId: 'stack-1',
+    serviceName: 'backup',
+    instanceId: 'run-1',
+    containerId: 'cnt-1',
+    status: opts.status ?? 'running',
+    lastActive: new Date(Date.now() - 5_000),
+    errorMessage: opts.errorMessage ?? null,
+  };
+  const svc = {
+    id: 'svc-1',
+    stackId: 'stack-1',
+    serviceName: 'backup',
+    serviceType: opts.serviceType ?? 'JobPool',
+    jobPoolConfig: opts.jobPoolConfig ?? {
+      maxConcurrent: 1,
+      managedBy: null,
+      triggers: [{ kind: 'manual', name: 'run-now' }],
+      history: { retainDays: 7 },
+    },
+  };
+  return {
+    poolInstance: {
+      findFirst: vi.fn().mockResolvedValue(row),
+      update: vi.fn().mockResolvedValue({}),
+    },
+    stackService: {
+      findFirst: vi.fn().mockResolvedValue(svc),
+    },
+  };
+}
+
+function makeDieEvent(overrides: Partial<DockerContainerEvent> = {}): DockerContainerEvent {
+  return {
+    action: 'die',
+    containerId: 'cnt-1',
+    containerName: '/cnt-1',
+    labels: {
+      'mini-infra.pool-instance': 'true',
+      'mini-infra.pool-instance-id': 'run-1',
+      'mini-infra.stack-id': 'stack-1',
+      'mini-infra.job-pool-trigger-kind': 'manual',
+      'mini-infra.job-pool-trigger-name': 'run-now',
+    },
+    time: Date.now() / 1000,
+    ...overrides,
+  };
+}
+
+describe('JobPoolExitWatcher', () => {
+  beforeEach(() => {
+    publishedEvents.length = 0;
+    scheduledRetries.length = 0;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('transitions row to completed on exit 0 and emits completed event', async () => {
+    const prisma = buildPrismaWithRow({});
+    const watcher = new JobPoolExitWatcher(
+      prisma as unknown as ConstructorParameters<typeof JobPoolExitWatcher>[0],
+      async () => null as unknown as Awaited<ReturnType<ConstructorParameters<typeof JobPoolExitWatcher>[1]>>,
+    );
+
+    const ok = await watcher.handleEvent(makeDieEvent({ exitCode: 0 }));
+    expect(ok).toBe(true);
+
+    expect(prisma.poolInstance.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: 'row-1' },
+      data: expect.objectContaining({
+        status: 'completed',
+        exitCode: 0,
+      }),
+    }));
+    expect(publishedEvents).toHaveLength(1);
+    expect(publishedEvents[0]).toMatchObject({
+      kind: 'completed',
+      payload: { exitCode: 0, runId: 'run-1' },
+    });
+  });
+
+  it('transitions row to failed on non-zero exit and emits failed event', async () => {
+    const prisma = buildPrismaWithRow({});
+    const watcher = new JobPoolExitWatcher(
+      prisma as unknown as ConstructorParameters<typeof JobPoolExitWatcher>[0],
+      async () => null as unknown as Awaited<ReturnType<ConstructorParameters<typeof JobPoolExitWatcher>[1]>>,
+    );
+
+    await watcher.handleEvent(makeDieEvent({ exitCode: 17 }));
+
+    expect(prisma.poolInstance.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        status: 'failed',
+        exitCode: 17,
+        errorMessage: expect.stringContaining('exit'),
+      }),
+    }));
+    expect(publishedEvents).toEqual([
+      expect.objectContaining({
+        kind: 'failed',
+        payload: expect.objectContaining({ exitCode: 17, runId: 'run-1' }),
+      }),
+    ]);
+  });
+
+  it('preserves the kill-marker errorMessage on a kill-after-seconds row', async () => {
+    const prisma = buildPrismaWithRow({ errorMessage: KILL_AFTER_SECONDS_ERROR });
+    const watcher = new JobPoolExitWatcher(
+      prisma as unknown as ConstructorParameters<typeof JobPoolExitWatcher>[0],
+      async () => null as unknown as Awaited<ReturnType<ConstructorParameters<typeof JobPoolExitWatcher>[1]>>,
+    );
+
+    await watcher.handleEvent(makeDieEvent({ exitCode: 137 }));
+
+    expect(prisma.poolInstance.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        status: 'failed',
+        errorMessage: KILL_AFTER_SECONDS_ERROR,
+      }),
+    }));
+    expect(publishedEvents[0].payload).toMatchObject({
+      errorMessage: KILL_AFTER_SECONDS_ERROR,
+    });
+  });
+
+  it('ignores die events without pool-instance labels', async () => {
+    const prisma = buildPrismaWithRow({});
+    const watcher = new JobPoolExitWatcher(
+      prisma as unknown as ConstructorParameters<typeof JobPoolExitWatcher>[0],
+      async () => null as unknown as Awaited<ReturnType<ConstructorParameters<typeof JobPoolExitWatcher>[1]>>,
+    );
+
+    const bareEvent: DockerContainerEvent = {
+      action: 'die',
+      containerId: 'other',
+      containerName: '/other',
+      labels: {},
+      time: 0,
+    };
+    await watcher.handleEvent(bareEvent);
+
+    expect(prisma.poolInstance.findFirst).not.toHaveBeenCalled();
+    expect(publishedEvents).toHaveLength(0);
+  });
+
+  it('ignores die events whose row has serviceType !== JobPool', async () => {
+    const prisma = buildPrismaWithRow({ serviceType: 'Pool' });
+    const watcher = new JobPoolExitWatcher(
+      prisma as unknown as ConstructorParameters<typeof JobPoolExitWatcher>[0],
+      async () => null as unknown as Awaited<ReturnType<ConstructorParameters<typeof JobPoolExitWatcher>[1]>>,
+    );
+
+    await watcher.handleEvent(makeDieEvent({ exitCode: 0 }));
+
+    expect(prisma.poolInstance.update).not.toHaveBeenCalled();
+    expect(publishedEvents).toHaveLength(0);
+  });
+
+  it('is idempotent — duplicate die for an already-terminal row is a no-op', async () => {
+    const prisma = buildPrismaWithRow({ status: 'failed' });
+    const watcher = new JobPoolExitWatcher(
+      prisma as unknown as ConstructorParameters<typeof JobPoolExitWatcher>[0],
+      async () => null as unknown as Awaited<ReturnType<ConstructorParameters<typeof JobPoolExitWatcher>[1]>>,
+    );
+
+    await watcher.handleEvent(makeDieEvent({ exitCode: 1 }));
+
+    expect(prisma.poolInstance.update).not.toHaveBeenCalled();
+    expect(publishedEvents).toHaveLength(0);
+  });
+
+  it('schedules a retry on non-zero exit when onFailure.retries > 0', async () => {
+    const prisma = buildPrismaWithRow({
+      jobPoolConfig: {
+        maxConcurrent: 1,
+        managedBy: null,
+        triggers: [{ kind: 'manual', name: 'run-now' }],
+        history: { retainDays: 7 },
+        onFailure: { retries: 1, backoff: 'fixed' },
+      },
+    });
+    const watcher = new JobPoolExitWatcher(
+      prisma as unknown as ConstructorParameters<typeof JobPoolExitWatcher>[0],
+      // Returns a placeholder executor object — the test mocks the scheduler.
+      async () => ({} as unknown as Awaited<ReturnType<ConstructorParameters<typeof JobPoolExitWatcher>[1]>>),
+    );
+
+    await watcher.handleEvent(makeDieEvent({ exitCode: 1 }));
+
+    expect(scheduledRetries).toHaveLength(1);
+    expect(scheduledRetries[0]).toMatchObject({
+      stackId: 'stack-1',
+      serviceName: 'backup',
+      attemptedRetries: 0,
+      onFailure: { retries: 1, backoff: 'fixed' },
+    });
+  });
+});
+
+describe('jobHistoryStreamName', () => {
+  it('keeps short names intact', () => {
+    const name = jobHistoryStreamName('abc', 'backup');
+    expect(name).toBe('JobHistory-abc-backup');
+    expect(name.length).toBeLessThanOrEqual(32);
+  });
+
+  it('shortens long stackIds via hash suffix and stays under 32 chars', () => {
+    const longStack = 'cm1234567890abcdefghijklmnopqrstuvwxyz';
+    const name = jobHistoryStreamName(longStack, 'pg-az-backup');
+    expect(name.startsWith('JobHistory-')).toBe(true);
+    expect(name.length).toBeLessThanOrEqual(32);
+    // Should still carry a readable service prefix for operator scans
+    expect(name).toContain('pg-az-backup'.slice(0, 12));
+  });
+
+  it('different (stackId, serviceName) pairs produce different names even when shortened', () => {
+    const longStackA = 'cm0000000000000000000000000000000aaaa';
+    const longStackB = 'cm0000000000000000000000000000000bbbb';
+    const a = jobHistoryStreamName(longStackA, 'pg-az-backup');
+    const b = jobHistoryStreamName(longStackB, 'pg-az-backup');
+    expect(a).not.toBe(b);
+  });
+
+  it('sanitises invalid characters out of the service name', () => {
+    const name = jobHistoryStreamName('stack-1', 'has.dots*and>wild');
+    // The output cannot contain `.`, `*`, or `>` — those are forbidden in
+    // JetStream stream names.
+    expect(name).not.toMatch(/[.*>]/);
+  });
+});

--- a/server/src/services/stacks/__tests__/pool-instance-reaper.test.ts
+++ b/server/src/services/stacks/__tests__/pool-instance-reaper.test.ts
@@ -29,15 +29,19 @@ function buildContainer(overrides: Record<string, unknown> = {}) {
 function makePrismaMock(initial: {
   running?: Array<Record<string, unknown>>;
   starting?: Array<Record<string, unknown>>;
+  /** Owning service rows for the kill-after-seconds reaper pass. */
+  services?: Array<Record<string, unknown>>;
 }) {
-  const findMany = vi.fn().mockImplementation((args: { where: { status: string } }) => {
+  const findMany = vi.fn().mockImplementation((args: { where: { status?: string } }) => {
     if (args.where.status === 'running') return Promise.resolve(initial.running ?? []);
     if (args.where.status === 'starting') return Promise.resolve(initial.starting ?? []);
     return Promise.resolve([]);
   });
   const update = vi.fn().mockResolvedValue({});
+  const stackServiceFindMany = vi.fn().mockResolvedValue(initial.services ?? []);
   return {
     poolInstance: { findMany, update },
+    stackService: { findMany: stackServiceFindMany },
   } as unknown as Parameters<typeof PoolInstanceReaper>[0];
 }
 
@@ -173,5 +177,100 @@ describe('PoolInstanceReaper', () => {
     const findManyFn = (prisma as unknown as { poolInstance: { findMany: ReturnType<typeof vi.fn> } })
       .poolInstance.findMany;
     expect(findManyFn).not.toHaveBeenCalled();
+  });
+
+  it('kills JobPool runs that exceed killAfterSeconds and marks errorMessage', async () => {
+    const container = buildContainer();
+    mockGetContainer.mockReturnValue(container);
+
+    // lastActive 10 minutes ago, killAfterSeconds: 60 → over-run.
+    const start = new Date(Date.now() - 10 * 60_000);
+    const prisma = makePrismaMock({
+      running: [
+        {
+          id: 'job-1',
+          stackId: 'stack-jp',
+          serviceName: 'backup',
+          instanceId: 'run-1',
+          containerId: 'c-jp',
+          status: 'running',
+          idleTimeoutMinutes: 24 * 60,
+          lastActive: start,
+          createdAt: start,
+        },
+      ],
+      services: [
+        {
+          id: 'svc-1',
+          stackId: 'stack-jp',
+          serviceName: 'backup',
+          serviceType: 'JobPool',
+          jobPoolConfig: {
+            maxConcurrent: 1,
+            managedBy: null,
+            triggers: [{ kind: 'manual', name: 'run-now' }],
+            history: { retainDays: 7 },
+            killAfterSeconds: 60,
+          },
+        },
+      ],
+    });
+
+    const reaper = new PoolInstanceReaper(prisma);
+    await reaper.tick();
+
+    expect(container.stop).toHaveBeenCalled();
+    expect(container.remove).toHaveBeenCalled();
+    const updateFn = (prisma as unknown as { poolInstance: { update: ReturnType<typeof vi.fn> } })
+      .poolInstance.update;
+    // First call: errorMessage marker; the watcher will see the `die` event
+    // afterwards and write the status transition. The reaper itself does
+    // NOT transition status.
+    expect(updateFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'job-1' },
+        data: { errorMessage: 'killed: exceeded killAfterSeconds' },
+      }),
+    );
+  });
+
+  it('leaves JobPool runs under killAfterSeconds untouched', async () => {
+    const prisma = makePrismaMock({
+      running: [
+        {
+          id: 'job-2',
+          stackId: 'stack-jp',
+          serviceName: 'backup',
+          instanceId: 'run-2',
+          containerId: 'c-jp-2',
+          status: 'running',
+          idleTimeoutMinutes: 24 * 60,
+          lastActive: new Date(Date.now() - 10_000), // 10 s ago
+          createdAt: new Date(Date.now() - 10_000),
+        },
+      ],
+      services: [
+        {
+          id: 'svc-2',
+          stackId: 'stack-jp',
+          serviceName: 'backup',
+          serviceType: 'JobPool',
+          jobPoolConfig: {
+            maxConcurrent: 1,
+            managedBy: null,
+            triggers: [{ kind: 'manual', name: 'run-now' }],
+            history: { retainDays: 7 },
+            killAfterSeconds: 60,
+          },
+        },
+      ],
+    });
+
+    const reaper = new PoolInstanceReaper(prisma);
+    await reaper.tick();
+
+    const updateFn = (prisma as unknown as { poolInstance: { update: ReturnType<typeof vi.fn> } })
+      .poolInstance.update;
+    expect(updateFn).not.toHaveBeenCalled();
   });
 });

--- a/server/src/services/stacks/job-pool-exit-watcher.ts
+++ b/server/src/services/stacks/job-pool-exit-watcher.ts
@@ -1,0 +1,242 @@
+import type { PrismaClient } from '../../generated/prisma/client';
+import type { JobPoolConfig } from '@mini-infra/types';
+import {
+  type DockerContainerEvent,
+} from '../../lib/docker-event-pattern-detector';
+import { getLogger } from '../../lib/logger-factory';
+import DockerService from '../docker';
+import {
+  publishJobPoolCompleted,
+  publishJobPoolFailed,
+} from './job-pool-history-publisher';
+import { scheduleJobPoolRetry } from './job-pool-retry-scheduler';
+import type { DockerExecutorService } from '../docker-executor';
+
+const log = getLogger('stacks', 'job-pool-exit-watcher');
+
+/**
+ * Sentinel label written by `pool-spawner.ts`. JobPool runs reuse the Pool
+ * spawn machinery and therefore inherit the `mini-infra.pool-instance` and
+ * `mini-infra.pool-instance-id` labels — the exit watcher filters Docker
+ * events down to those two labels and then re-keys against the `PoolInstance`
+ * DB row via `(stackId, instanceId)`.
+ */
+const POOL_INSTANCE_LABEL = 'mini-infra.pool-instance';
+const POOL_INSTANCE_ID_LABEL = 'mini-infra.pool-instance-id';
+const STACK_ID_LABEL = 'mini-infra.stack-id';
+
+/** Marker we stamp on `errorMessage` for runs killed by `killAfterSeconds`. */
+export const KILL_AFTER_SECONDS_ERROR = 'killed: exceeded killAfterSeconds';
+
+/**
+ * Watch the Docker event stream for container `die` events that belong to a
+ * JobPool run, finalize the `PoolInstance` row, publish the corresponding
+ * history event, and schedule a retry if the pool's `onFailure.retries`
+ * policy says so.
+ *
+ * The pool-instance reaper (Phase 1) still owns idle-sweep and stuck-starting
+ * cleanup for *Pool* services. This watcher is JobPool-specific — it only
+ * touches rows whose owning `StackService.serviceType` is `'JobPool'`. Rows
+ * for `Pool` services that exit on their own are still reaped by the
+ * existing idle-sweep path (their lifecycle is "run until idle", not "run
+ * until exit").
+ */
+export class JobPoolExitWatcher {
+  private registered = false;
+  private retryDockerExecutor: DockerExecutorService | null = null;
+
+  constructor(
+    private readonly prisma: PrismaClient,
+    /**
+     * Factory used to obtain a docker executor for scheduled retries.
+     * Mirrors the lazy-init pattern in `pool-instance-reaper.ts`: the
+     * watcher is wired up before docker is necessarily ready, so we defer
+     * obtaining the executor until a retry actually needs to fire.
+     */
+    private readonly dockerExecutorFactory: () => Promise<DockerExecutorService>,
+  ) {}
+
+  start(): void {
+    if (this.registered) {
+      log.warn('JobPoolExitWatcher already registered');
+      return;
+    }
+    const docker = DockerService.getInstance();
+    docker.onContainerEvent((event) => {
+      // Fire-and-forget — Docker event listeners must not block the
+      // event stream. The watcher swallows its own errors so a bad row
+      // can't poison the whole loop.
+      void this.handleEvent(event).catch((err) => {
+        log.error(
+          {
+            containerId: event.containerId,
+            action: event.action,
+            err: err instanceof Error ? err.message : String(err),
+          },
+          'JobPoolExitWatcher.handleEvent threw',
+        );
+      });
+    });
+    this.registered = true;
+    log.info('JobPoolExitWatcher registered with Docker event stream');
+  }
+
+  /**
+   * Public for tests. Process a single Docker event end-to-end.
+   *
+   * Returns true if the event was handled (either acted upon, or
+   * deliberately skipped because it isn't a JobPool exit), and false
+   * if a downstream DB/publish error left the row in an inconsistent
+   * state — currently only used by tests.
+   */
+  async handleEvent(event: DockerContainerEvent): Promise<boolean> {
+    if (event.action !== 'die') return true;
+    if (event.labels[POOL_INSTANCE_LABEL] !== 'true') return true;
+
+    const instanceId = event.labels[POOL_INSTANCE_ID_LABEL];
+    const stackId = event.labels[STACK_ID_LABEL];
+    if (!instanceId || !stackId) {
+      log.warn(
+        { containerId: event.containerId, instanceId, stackId },
+        'Pool-instance container die event missing required labels',
+      );
+      return true;
+    }
+
+    const row = await this.prisma.poolInstance.findFirst({
+      where: { stackId, instanceId },
+    });
+    if (!row) {
+      // Row pruned manually or by a prior reaper sweep — nothing to
+      // finalise. The container is already gone; no follow-up needed.
+      return true;
+    }
+    // The exit watcher only finalises JobPool rows. Pool rows continue
+    // their existing idle-sweep / stop-on-API-call lifecycle.
+    const service = await this.prisma.stackService.findFirst({
+      where: { stackId, serviceName: row.serviceName },
+    });
+    if (!service || service.serviceType !== 'JobPool') return true;
+    if (row.status === 'completed' || row.status === 'failed') {
+      // Idempotent: a duplicate `die` event (Docker can re-deliver during
+      // reconnect) hits a row that's already terminal — no-op.
+      return true;
+    }
+
+    const jobPoolConfig = service.jobPoolConfig as unknown as JobPoolConfig | null;
+    const startedAtMs = row.lastActive.getTime();
+    const finishedAtMs = Date.now();
+    const exitCode = event.exitCode ?? 0;
+
+    // Carry trigger attribution forward. JobPool runs spawned via
+    // `runJobPool` stamp `JOB_TRIGGER_KIND` / `JOB_TRIGGER_NAME` on the
+    // container, but Docker's `die` event only carries labels, not env
+    // vars. We pulled the labels through `pool-spawner.ts:labels` so the
+    // attribution survives — but the spawner doesn't currently expose
+    // trigger labels, so until Phase 3 stamps them we default to `manual`
+    // / 'unknown'. The history payload still parses cleanly.
+    const triggerKind = (event.labels['mini-infra.job-pool-trigger-kind'] as
+      | 'cron'
+      | 'nats-request'
+      | 'manual') ?? 'manual';
+    const triggerName = event.labels['mini-infra.job-pool-trigger-name'] ?? 'unknown';
+
+    const succeeded = exitCode === 0;
+    try {
+      await this.prisma.poolInstance.update({
+        where: { id: row.id },
+        data: {
+          status: succeeded ? 'completed' : 'failed',
+          exitCode,
+          finishedAt: new Date(finishedAtMs),
+          stoppedAt: new Date(finishedAtMs),
+          // Preserve any prior errorMessage (e.g. the reaper's kill marker)
+          // when transitioning a non-zero exit; succeed-overrides nothing.
+          errorMessage: succeeded ? null : row.errorMessage ?? `Container exited with code ${exitCode}`,
+        },
+      });
+    } catch (err) {
+      log.error(
+        {
+          rowId: row.id,
+          stackId,
+          instanceId,
+          exitCode,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        'Failed to finalise JobPool PoolInstance row',
+      );
+      return false;
+    }
+
+    if (succeeded) {
+      await publishJobPoolCompleted({
+        stackId,
+        serviceName: row.serviceName,
+        runId: instanceId,
+        triggerKind,
+        triggerName,
+        exitCode: 0,
+        startedAtMs,
+        finishedAtMs,
+      });
+      log.info(
+        { stackId, serviceName: row.serviceName, runId: instanceId, exitCode },
+        'JobPool run completed',
+      );
+      return true;
+    }
+
+    const errorMessage = row.errorMessage ?? `Container exited with code ${exitCode}`;
+    await publishJobPoolFailed({
+      stackId,
+      serviceName: row.serviceName,
+      runId: instanceId,
+      triggerKind,
+      triggerName,
+      exitCode,
+      errorMessage,
+      startedAtMs,
+      finishedAtMs,
+    });
+    log.info(
+      { stackId, serviceName: row.serviceName, runId: instanceId, exitCode, errorMessage },
+      'JobPool run failed',
+    );
+
+    // Retry handling — non-zero exits only. Killed-by-reaper runs already
+    // have a row.errorMessage of KILL_AFTER_SECONDS_ERROR; we still honor
+    // the retry policy for them (the plan doc doesn't carve out an
+    // exception). Retries are not chained across themselves: the
+    // scheduler caps at `onFailure.retries`.
+    if (jobPoolConfig?.onFailure && jobPoolConfig.onFailure.retries > 0) {
+      try {
+        const docker = await this.lazyDockerExecutor();
+        scheduleJobPoolRetry(this.prisma, docker, {
+          stackId,
+          serviceName: row.serviceName,
+          attemptedRetries: 0,
+          onFailure: jobPoolConfig.onFailure,
+          trigger: { kind: triggerKind, name: triggerName },
+        });
+      } catch (err) {
+        log.warn(
+          {
+            stackId,
+            serviceName: row.serviceName,
+            err: err instanceof Error ? err.message : String(err),
+          },
+          'Failed to schedule JobPool retry',
+        );
+      }
+    }
+
+    return true;
+  }
+
+  private async lazyDockerExecutor(): Promise<DockerExecutorService> {
+    if (this.retryDockerExecutor) return this.retryDockerExecutor;
+    this.retryDockerExecutor = await this.dockerExecutorFactory();
+    return this.retryDockerExecutor;
+  }
+}

--- a/server/src/services/stacks/job-pool-history-publisher.ts
+++ b/server/src/services/stacks/job-pool-history-publisher.ts
@@ -1,0 +1,120 @@
+import { JobPoolSubject } from '@mini-infra/types';
+import { getLogger } from '../../lib/logger-factory';
+import { NatsBus } from '../nats/nats-bus';
+import {
+  jobPoolRunCompletedSchema,
+  jobPoolRunFailedSchema,
+  jobPoolRunSkippedSchema,
+  type JobPoolRunCompleted,
+  type JobPoolRunFailed,
+  type JobPoolRunSkipped,
+} from '../nats/payload-schemas';
+import {
+  emitJobPoolRunCompleted,
+  emitJobPoolRunFailed,
+  emitJobPoolRunSkipped,
+} from './pool-socket-emitter';
+
+const log = getLogger('stacks', 'job-pool-history-publisher');
+
+/**
+ * Publish a JobPool run lifecycle event onto the per-pool subject *and* fan
+ * the same payload out over Socket.IO. The two surfaces are kept in lockstep
+ * so any UI subscriber (live page) sees the same shape as any
+ * server-restart replay consumer reading from the per-pool JetStream
+ * history stream.
+ *
+ * Validation is inline against the Zod schemas exported from
+ * `payload-schemas.ts` — the bus's static-subject lookup doesn't match
+ * per-pool parameterised subjects, so callers pass `unchecked: true` here
+ * and the schema is applied client-side instead. A validation miss is
+ * logged but doesn't throw — the publisher path must not break the exit
+ * watcher's transition pass.
+ *
+ * Each call performs at most one JetStream publish and one Socket.IO emit;
+ * either failure is logged and swallowed so the caller's DB transition is
+ * never blocked.
+ */
+
+export async function publishJobPoolCompleted(payload: JobPoolRunCompleted): Promise<void> {
+  const parsed = jobPoolRunCompletedSchema.safeParse(payload);
+  if (!parsed.success) {
+    log.error(
+      { issues: parsed.error.issues.slice(0, 3), runId: payload.runId },
+      'JobPool completed payload failed validation — skipping publish',
+    );
+    return;
+  }
+  const subject = JobPoolSubject.completed(payload.stackId, payload.serviceName);
+  try {
+    await NatsBus.getInstance().jetstream.publish(subject, parsed.data, { unchecked: true });
+  } catch (err) {
+    log.warn(
+      {
+        runId: payload.runId,
+        stackId: payload.stackId,
+        serviceName: payload.serviceName,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      'JobPool completed JetStream publish failed (Socket.IO fan-out still attempted)',
+    );
+  }
+  emitJobPoolRunCompleted(parsed.data);
+}
+
+export async function publishJobPoolFailed(payload: JobPoolRunFailed): Promise<void> {
+  const parsed = jobPoolRunFailedSchema.safeParse(payload);
+  if (!parsed.success) {
+    log.error(
+      { issues: parsed.error.issues.slice(0, 3), runId: payload.runId },
+      'JobPool failed payload failed validation — skipping publish',
+    );
+    return;
+  }
+  const subject = JobPoolSubject.failed(payload.stackId, payload.serviceName);
+  try {
+    await NatsBus.getInstance().jetstream.publish(subject, parsed.data, { unchecked: true });
+  } catch (err) {
+    log.warn(
+      {
+        runId: payload.runId,
+        stackId: payload.stackId,
+        serviceName: payload.serviceName,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      'JobPool failed JetStream publish failed (Socket.IO fan-out still attempted)',
+    );
+  }
+  emitJobPoolRunFailed(parsed.data);
+}
+
+/**
+ * `run-skipped` is plain pub/sub — observability for cap-hit scheduled runs
+ * — and not durable on JetStream. A missed message after a server restart
+ * is acceptable; the cap-hit row was never created in the DB.
+ */
+export async function publishJobPoolRunSkipped(payload: JobPoolRunSkipped): Promise<void> {
+  const parsed = jobPoolRunSkippedSchema.safeParse(payload);
+  if (!parsed.success) {
+    log.error(
+      { issues: parsed.error.issues.slice(0, 3), triggerName: payload.triggerName },
+      'JobPool run-skipped payload failed validation — skipping publish',
+    );
+    return;
+  }
+  const subject = JobPoolSubject.runSkipped(payload.stackId, payload.serviceName);
+  try {
+    await NatsBus.getInstance().publish(subject, parsed.data, { unchecked: true });
+  } catch (err) {
+    log.warn(
+      {
+        stackId: payload.stackId,
+        serviceName: payload.serviceName,
+        triggerName: payload.triggerName,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      'JobPool run-skipped NATS publish failed (Socket.IO fan-out still attempted)',
+    );
+  }
+  emitJobPoolRunSkipped(parsed.data);
+}

--- a/server/src/services/stacks/job-pool-retry-scheduler.ts
+++ b/server/src/services/stacks/job-pool-retry-scheduler.ts
@@ -1,0 +1,104 @@
+import type { PrismaClient } from '../../generated/prisma/client';
+import type { DockerExecutorService } from '../docker-executor';
+import { getLogger } from '../../lib/logger-factory';
+import { runJobPool } from './job-pool-spawner';
+
+const log = getLogger('stacks', 'job-pool-retry-scheduler');
+
+/** Initial backoff for the first retry, in milliseconds. */
+const BASE_BACKOFF_MS = 30_000;
+
+interface RetryContext {
+  stackId: string;
+  serviceName: string;
+  /** Number of retries already attempted for the current run lineage. */
+  attemptedRetries: number;
+  onFailure: { retries: number; backoff: 'fixed' | 'exponential' };
+  trigger: { kind: 'cron' | 'nats-request' | 'manual'; name: string };
+}
+
+/**
+ * Schedule a retry for a failed JobPool run after the policy's backoff. The
+ * scheduler runs in-process — there's no durable queue, so a server restart
+ * loses pending retries. That's an acceptable limitation for Phase 2: the
+ * cron / nats-request triggers (Phase 3) own their own re-fire cadence, and
+ * a missed retry is logged so operators can manually re-fire if needed.
+ *
+ * Backoff:
+ *  - `fixed`: every retry waits exactly `BASE_BACKOFF_MS`.
+ *  - `exponential`: attempt N waits `BASE_BACKOFF_MS * 2^N` (capped at 1h).
+ *
+ * The scheduler chains itself: if a scheduled retry also fails (the spawn
+ * succeeds but the *container* exits non-zero), the exit watcher will
+ * call back into here with an incremented `attemptedRetries`. The
+ * `attemptedRetries < retries` guard keeps the chain bounded.
+ */
+export function scheduleJobPoolRetry(
+  prisma: PrismaClient,
+  dockerExecutor: DockerExecutorService,
+  ctx: RetryContext,
+): void {
+  if (ctx.attemptedRetries >= ctx.onFailure.retries) {
+    log.info(
+      {
+        stackId: ctx.stackId,
+        serviceName: ctx.serviceName,
+        attemptedRetries: ctx.attemptedRetries,
+        maxRetries: ctx.onFailure.retries,
+      },
+      'JobPool retry budget exhausted — no further retries scheduled',
+    );
+    return;
+  }
+
+  const backoffMs = computeBackoffMs(ctx.attemptedRetries, ctx.onFailure.backoff);
+  log.info(
+    {
+      stackId: ctx.stackId,
+      serviceName: ctx.serviceName,
+      attemptedRetries: ctx.attemptedRetries,
+      backoffMs,
+      backoffPolicy: ctx.onFailure.backoff,
+    },
+    'Scheduling JobPool retry',
+  );
+
+  setTimeout(() => {
+    void runJobPool(prisma, dockerExecutor, {
+      stackId: ctx.stackId,
+      serviceName: ctx.serviceName,
+      trigger: { kind: ctx.trigger.kind, name: `${ctx.trigger.name}#retry${ctx.attemptedRetries + 1}` },
+    })
+      .then((result) => {
+        if (!result.ok) {
+          log.warn(
+            { stackId: ctx.stackId, serviceName: ctx.serviceName, result },
+            'JobPool retry spawn failed at dispatch — no further chained retries',
+          );
+        }
+        // Chained retry on container exit code is handled by the exit
+        // watcher when the new run's container dies (it bumps
+        // attemptedRetries via its own scheduleJobPoolRetry call).
+      })
+      .catch((err) => {
+        log.error(
+          {
+            stackId: ctx.stackId,
+            serviceName: ctx.serviceName,
+            err: err instanceof Error ? err.message : String(err),
+          },
+          'JobPool retry runJobPool threw',
+        );
+      });
+  }, backoffMs).unref();
+}
+
+export function computeBackoffMs(
+  attemptedRetries: number,
+  policy: 'fixed' | 'exponential',
+): number {
+  if (policy === 'fixed') return BASE_BACKOFF_MS;
+  const cap = 60 * 60 * 1000; // 1 hour
+  const exponent = Math.max(0, attemptedRetries);
+  return Math.min(cap, BASE_BACKOFF_MS * Math.pow(2, exponent));
+}

--- a/server/src/services/stacks/job-pool-spawner.ts
+++ b/server/src/services/stacks/job-pool-spawner.ts
@@ -4,6 +4,7 @@ import type { JobPoolConfig, PoolInstance as PoolInstanceDb } from '@mini-infra/
 import type { DockerExecutorService } from '../docker-executor';
 import { getLogger } from '../../lib/logger-factory';
 import { spawnPoolInstance } from './pool-spawner';
+import { publishJobPoolRunSkipped } from './job-pool-history-publisher';
 
 const log = getLogger('stacks', 'job-pool-spawner');
 
@@ -134,6 +135,21 @@ export async function runJobPool(
     });
   } catch (err) {
     if (err === MAX_REACHED) {
+      // Fire-and-forget — publishing the skipped event must never block
+      // the trigger's reply path; failures inside the publisher are
+      // logged there. Cast `maxConcurrent` because the MAX_REACHED branch
+      // is unreachable when `maxConcurrent === null`.
+      void publishJobPoolRunSkipped({
+        stackId,
+        serviceName,
+        reason: 'concurrency_cap',
+        triggerKind: trigger.kind,
+        triggerName: trigger.name,
+        scheduledAtMs: Date.now(),
+        maxConcurrent: jobPoolConfig.maxConcurrent!,
+      }).catch(() => {
+        /* logged inside publisher */
+      });
       return {
         ok: false,
         reason: 'concurrency_cap',
@@ -172,6 +188,14 @@ export async function runJobPool(
       instanceRowId: row.id,
       callerEnv,
       idleTimeoutMinutes: JOB_POOL_DEFAULT_IDLE_MINUTES,
+      // Trigger attribution survives the spawn → Docker → die-event
+      // round trip via these labels; the exit watcher reads them when
+      // it builds the history payload. Trigger name is sanitised to
+      // satisfy Docker's label-value constraints (no control chars).
+      extraLabels: {
+        'mini-infra.job-pool-trigger-kind': trigger.kind,
+        'mini-infra.job-pool-trigger-name': trigger.name.replace(/[^A-Za-z0-9._#-]/g, '_'),
+      },
     });
 
     if (!spawn.success) {
@@ -194,14 +218,29 @@ export async function runJobPool(
       };
     }
 
-    await prisma.poolInstance.update({
-      where: { id: row.id },
+    // Conditional flip from `starting` to `running` — for fast-exiting jobs,
+    // the exit watcher (subscribed to Docker `die` events) may have already
+    // finalised this row to `completed`/`failed` before the spawn poll loop
+    // returns. `updateMany` with the `starting` filter makes that race a
+    // no-op rather than overwriting the watcher's terminal state. The
+    // common case (long-running job, watcher hasn't fired yet) flips
+    // through `starting → running → completed/failed` as expected.
+    const updateCount = await prisma.poolInstance.updateMany({
+      where: { id: row.id, status: 'starting' },
       data: {
         status: 'running',
         containerId: spawn.containerId,
         lastActive: new Date(),
       },
     });
+    if (updateCount.count === 0) {
+      // Watcher beat us — record the containerId for traceability but leave
+      // the terminal status field alone.
+      await prisma.poolInstance.update({
+        where: { id: row.id },
+        data: { containerId: spawn.containerId },
+      }).catch(() => { /* race-tolerant */ });
+    }
     return {
       ok: true,
       runId,

--- a/server/src/services/stacks/job-pool-stream-reconciler.ts
+++ b/server/src/services/stacks/job-pool-stream-reconciler.ts
@@ -1,0 +1,207 @@
+import {
+  JobPoolSubject,
+  jobHistoryStreamName,
+  type JobPoolConfig,
+} from '@mini-infra/types';
+import type { PrismaClient } from '../../generated/prisma/client';
+import { getLogger } from '../../lib/logger-factory';
+import { getNatsControlPlaneService } from '../nats/nats-control-plane-service';
+
+const log = getLogger('stacks', 'job-pool-stream-reconciler');
+
+const DEFAULT_ACCOUNT_NAME = 'mini-infra-account';
+const DEFAULT_MAX_BYTES_PER_POOL = 1024 * 1024 * 1024; // 1 GiB
+
+/**
+ * Reconcile per-pool JetStream history streams for every JobPool service on
+ * a stack. Mirrors the operator-path pattern from `system-nats-bootstrap.ts`
+ * (upsert NatsStream rows, then let the next `applyJetStreamResources()`
+ * pass reconcile against live NATS) — driven by stack apply rather than
+ * server boot.
+ *
+ * The flow:
+ *  1. Look up every `JobPool` service on the stack and read its
+ *     `jobPoolConfig.history` knobs.
+ *  2. Upsert one `NatsStream` row per pool, scoped to the stack so the row
+ *     cascades on stack delete. Stream name comes from
+ *     `jobHistoryStreamName(stackId, serviceName)` — same helper the
+ *     `JobPoolBus`-side consumer uses, so the two never drift.
+ *  3. Subjects captured: the wildcard parent for the pool's lifecycle
+ *     events (`mini-infra.job-pool.<stackId>.<service>.>`) — which covers
+ *     `completed`, `failed`, and any future per-pool event verbs without
+ *     a re-apply.
+ *
+ * Stream creation against live NATS is NOT done here — the caller invokes
+ * `applyJetStreamResources()` afterwards (the same call already used for
+ * role-derived streams). This module only writes the DB rows.
+ *
+ * Idempotent: every operation is upsert. Orphan cleanup (streams whose
+ * JobPool service was removed) is handled by `pruneOrphanJobPoolStreams`
+ * below — call sites pair the two.
+ */
+export async function reconcileJobPoolStreams(
+  prisma: PrismaClient,
+  stackId: string,
+): Promise<{ desiredStreamNames: Set<string> }> {
+  const services = await prisma.stackService.findMany({
+    where: { stackId, serviceType: 'JobPool' },
+  });
+
+  const desiredStreamNames = new Set<string>();
+  if (services.length === 0) return { desiredStreamNames };
+
+  const account = await prisma.natsAccount.findUnique({
+    where: { name: DEFAULT_ACCOUNT_NAME },
+  });
+  if (!account) {
+    // The default account is created by `ensureDefaultAccount()` during
+    // `applyConfig()`. If we hit this on a fresh worktree where the NATS
+    // stack hasn't booted yet, skip — the next stack apply will retry.
+    log.info(
+      { stackId, account: DEFAULT_ACCOUNT_NAME },
+      'reconcileJobPoolStreams: default account not yet present; skipping (next apply retries)',
+    );
+    return { desiredStreamNames };
+  }
+
+  for (const svc of services) {
+    const cfg = svc.jobPoolConfig as unknown as JobPoolConfig | null;
+    if (!cfg) {
+      log.warn(
+        { stackId, serviceName: svc.serviceName },
+        'JobPool service missing jobPoolConfig; skipping history-stream upsert',
+      );
+      continue;
+    }
+    const name = jobHistoryStreamName(stackId, svc.serviceName);
+    desiredStreamNames.add(name);
+
+    const subjects = [JobPoolSubject.wildcardForPool(stackId, svc.serviceName)];
+    const description = `JobPool history for ${stackId}/${svc.serviceName}`;
+    const maxAgeSeconds = Math.max(1, cfg.history.retainDays) * 24 * 60 * 60;
+    const maxBytes = parseMaxBytes(cfg.history.maxBytes) ?? DEFAULT_MAX_BYTES_PER_POOL;
+
+    const existing = await prisma.natsStream.findUnique({ where: { name } });
+    if (existing) {
+      await prisma.natsStream.update({
+        where: { name },
+        data: {
+          accountId: account.id,
+          stackId,
+          description,
+          subjects: subjects as unknown as object,
+          retention: 'limits',
+          storage: 'file',
+          maxBytes,
+          maxAgeSeconds,
+        },
+      });
+    } else {
+      await prisma.natsStream.create({
+        data: {
+          name,
+          accountId: account.id,
+          stackId,
+          description,
+          subjects: subjects as unknown as object,
+          retention: 'limits',
+          storage: 'file',
+          maxBytes,
+          maxAgeSeconds,
+        },
+      });
+    }
+    log.info(
+      { stackId, serviceName: svc.serviceName, streamName: name, subjects, maxAgeSeconds, maxBytes },
+      'JobPool history stream reconciled (DB row upserted)',
+    );
+  }
+
+  return { desiredStreamNames };
+}
+
+/**
+ * Delete `NatsStream` rows for JobPool services that no longer exist on the
+ * stack, and request a best-effort live-NATS delete of the orphan streams.
+ * Mirrors `pruneOrphanRoleStreams` from `stack-nats-apply-orchestrator.ts`.
+ *
+ * Identification: rows on this stack whose name starts with the
+ * `JobHistory-` prefix and isn't in the `desiredStreamNames` set.
+ */
+export async function pruneOrphanJobPoolStreams(
+  prisma: PrismaClient,
+  stackId: string,
+  desiredStreamNames: Set<string>,
+): Promise<{ accountId: string | null; orphanStreamNames: string[] }> {
+  const existingStreams = await prisma.natsStream.findMany({
+    where: { stackId, name: { startsWith: 'JobHistory-' } },
+  });
+  const orphans = existingStreams.filter((s) => !desiredStreamNames.has(s.name));
+  if (orphans.length === 0) return { accountId: null, orphanStreamNames: [] };
+
+  const accountId = orphans[0].accountId;
+  const names = orphans.map((s) => s.name);
+  await prisma.natsStream.deleteMany({ where: { id: { in: orphans.map((s) => s.id) } } });
+  log.info({ stackId, orphanStreamNames: names }, 'Deleted orphan JobPool history stream DB rows');
+  return { accountId, orphanStreamNames: names };
+}
+
+/**
+ * Apply both the DB-row reconcile and a best-effort live-NATS delete of any
+ * orphan streams. Call after every JobPool stack apply.
+ */
+export async function applyJobPoolStreamsForStack(
+  prisma: PrismaClient,
+  stackId: string,
+): Promise<void> {
+  const { desiredStreamNames } = await reconcileJobPoolStreams(prisma, stackId);
+  const { accountId, orphanStreamNames } = await pruneOrphanJobPoolStreams(
+    prisma,
+    stackId,
+    desiredStreamNames,
+  );
+  // Push the surviving rows + create/update on live NATS in one go.
+  const service = getNatsControlPlaneService(prisma);
+  try {
+    await service.applyJetStreamResources();
+  } catch (err) {
+    log.warn(
+      { stackId, err: err instanceof Error ? err.message : String(err) },
+      'applyJetStreamResources failed during JobPool stream reconcile (will retry on next apply)',
+    );
+  }
+  if (accountId && orphanStreamNames.length > 0) {
+    try {
+      await service.deleteJetStreams(accountId, orphanStreamNames);
+    } catch (err) {
+      log.warn(
+        { stackId, orphanStreamNames, err: err instanceof Error ? err.message : String(err) },
+        'Best-effort orphan JobPool stream delete failed (will retry on next apply)',
+      );
+    }
+  }
+}
+
+/** Parse a human-readable byte string ("256MB", "1GB", "512MiB") into bytes. */
+function parseMaxBytes(input: string | undefined): number | null {
+  if (!input) return null;
+  const match = /^\s*(\d+(?:\.\d+)?)\s*(B|KB|KiB|MB|MiB|GB|GiB|TB|TiB)?\s*$/i.exec(input);
+  if (!match) return null;
+  const value = parseFloat(match[1]);
+  if (!Number.isFinite(value) || value < 0) return null;
+  const unit = (match[2] ?? 'B').toUpperCase();
+  const multiplier: Record<string, number> = {
+    B: 1,
+    KB: 1000,
+    KIB: 1024,
+    MB: 1000 * 1000,
+    MIB: 1024 * 1024,
+    GB: 1000 * 1000 * 1000,
+    GIB: 1024 * 1024 * 1024,
+    TB: 1000 * 1000 * 1000 * 1000,
+    TIB: 1024 * 1024 * 1024 * 1024,
+  };
+  const m = multiplier[unit];
+  if (m === undefined) return null;
+  return Math.floor(value * m);
+}

--- a/server/src/services/stacks/pool-instance-reaper.ts
+++ b/server/src/services/stacks/pool-instance-reaper.ts
@@ -2,7 +2,7 @@ import type { PrismaClient } from '../../generated/prisma/client';
 import { DockerExecutorService } from '../docker-executor';
 import { getLogger } from '../../lib/logger-factory';
 import { withOperation } from '../../lib/logging-context';
-import { POOL_ADDON_LABELS } from '@mini-infra/types';
+import { POOL_ADDON_LABELS, type JobPoolConfig } from '@mini-infra/types';
 import {
   emitPoolInstanceIdleStopped,
   emitPoolInstanceFailed,
@@ -92,6 +92,7 @@ export class PoolInstanceReaper {
 
     await this.reapIdle(executor);
     await this.reapStuckStarting(executor);
+    await this.reapKillAfterSeconds(executor);
   }
 
   private async reapIdle(executor: DockerExecutorService): Promise<void> {
@@ -141,6 +142,85 @@ export class PoolInstanceReaper {
             err: err instanceof Error ? err.message : String(err),
           },
           'Idle reap failed for instance; will retry next tick',
+        );
+      }
+    }
+  }
+
+  /**
+   * Enforce `JobPoolConfig.killAfterSeconds` on JobPool runs whose
+   * containers have been alive longer than their declared cap. Marks the
+   * row's errorMessage so the exit watcher (which gets the subsequent
+   * `die` event) keeps the kill attribution — finalising the row to
+   * `failed`. We don't transition status here ourselves so the watcher
+   * stays the single writer of `completed`/`failed`.
+   *
+   * Behaviour intentionally narrow: only `running` JobPool rows are
+   * candidates. `starting` rows are handled by `reapStuckStarting`; Pool
+   * rows have no `killAfterSeconds` semantics (they idle-sweep instead).
+   */
+  private async reapKillAfterSeconds(executor: DockerExecutorService): Promise<void> {
+    const running = await this.prisma.poolInstance.findMany({
+      where: { status: 'running' },
+    });
+    if (running.length === 0) return;
+
+    // Batch-load owning services so we don't issue one findFirst per row.
+    // SQLite handles small `where in` payloads cheaply; for the few-tens
+    // expected scale this is one query per tick.
+    const services = await this.prisma.stackService.findMany({
+      where: {
+        OR: running.map((r) => ({ stackId: r.stackId, serviceName: r.serviceName })),
+      },
+    });
+    const serviceByKey = new Map<string, (typeof services)[number]>();
+    for (const s of services) {
+      serviceByKey.set(`${s.stackId}|${s.serviceName}`, s);
+    }
+
+    const now = Date.now();
+    for (const row of running) {
+      const svc = serviceByKey.get(`${row.stackId}|${row.serviceName}`);
+      if (!svc || svc.serviceType !== 'JobPool') continue;
+      const cfg = svc.jobPoolConfig as unknown as JobPoolConfig | null;
+      if (!cfg?.killAfterSeconds) continue;
+
+      // Use `lastActive` as the run's start time — the JobPool spawner
+      // sets it to spawn-time and never updates it on a JobPool row.
+      const runtimeMs = now - row.lastActive.getTime();
+      const limitMs = cfg.killAfterSeconds * 1000;
+      if (runtimeMs < limitMs) continue;
+
+      try {
+        // Mark the row first so the upcoming `die` event from the kill is
+        // attributed correctly when the exit watcher reads `errorMessage`.
+        await this.prisma.poolInstance.update({
+          where: { id: row.id },
+          data: { errorMessage: 'killed: exceeded killAfterSeconds' },
+        });
+        await this.stopAndRemoveContainer(executor, row.containerId);
+        log.warn(
+          {
+            stackId: row.stackId,
+            serviceName: row.serviceName,
+            instanceId: row.instanceId,
+            killAfterSeconds: cfg.killAfterSeconds,
+            runtimeMs,
+          },
+          'JobPool run exceeded killAfterSeconds — container killed',
+        );
+        // Don't emit Socket.IO here — the exit watcher's `failed` event
+        // picks up the kill attribution from `errorMessage` and is the
+        // single source of truth for run-finalisation fan-out.
+      } catch (err) {
+        log.warn(
+          {
+            stackId: row.stackId,
+            serviceName: row.serviceName,
+            instanceId: row.instanceId,
+            err: err instanceof Error ? err.message : String(err),
+          },
+          'Kill-after-seconds reap failed for instance; will retry next tick',
         );
       }
     }

--- a/server/src/services/stacks/pool-socket-emitter.ts
+++ b/server/src/services/stacks/pool-socket-emitter.ts
@@ -59,3 +59,64 @@ export function emitPoolInstanceStopped(payload: {
     emitToChannel(Channel.POOLS, ServerEvent.POOL_INSTANCE_STOPPED, payload);
   } catch { /* never break the caller */ }
 }
+
+/**
+ * JobPool run terminated with exit code 0. Mirrors the NATS event published
+ * to the per-pool JetStream history stream; this one is the realtime
+ * fan-out for connected UI clients.
+ */
+export function emitJobPoolRunCompleted(payload: {
+  stackId: string;
+  serviceName: string;
+  runId: string;
+  triggerKind: 'cron' | 'nats-request' | 'manual';
+  triggerName: string;
+  /** Always 0 for completed runs; non-zero exits use `emitJobPoolRunFailed`. */
+  exitCode: 0;
+  startedAtMs: number;
+  finishedAtMs: number;
+}): void {
+  try {
+    emitToChannel(Channel.POOLS, ServerEvent.JOB_POOL_RUN_COMPLETED, payload);
+  } catch { /* never break the caller */ }
+}
+
+/**
+ * JobPool run terminated with a non-zero exit code, or was killed by the
+ * `killAfterSeconds` reaper (in which case `exitCode === -1`).
+ */
+export function emitJobPoolRunFailed(payload: {
+  stackId: string;
+  serviceName: string;
+  runId: string;
+  triggerKind: 'cron' | 'nats-request' | 'manual';
+  triggerName: string;
+  exitCode: number;
+  errorMessage: string;
+  startedAtMs: number;
+  finishedAtMs: number;
+}): void {
+  try {
+    emitToChannel(Channel.POOLS, ServerEvent.JOB_POOL_RUN_FAILED, payload);
+  } catch { /* never break the caller */ }
+}
+
+/**
+ * Trigger fired but the JobPool's concurrency cap was already hit, so no run
+ * was started. `PoolInstance` row is never created in this branch — only the
+ * event is emitted, so the UI can surface "missed beats" without polluting
+ * the pool's run history.
+ */
+export function emitJobPoolRunSkipped(payload: {
+  stackId: string;
+  serviceName: string;
+  reason: 'concurrency_cap';
+  triggerKind: 'cron' | 'nats-request' | 'manual';
+  triggerName: string;
+  scheduledAtMs: number;
+  maxConcurrent: number;
+}): void {
+  try {
+    emitToChannel(Channel.POOLS, ServerEvent.JOB_POOL_RUN_SKIPPED, payload);
+  } catch { /* never break the caller */ }
+}

--- a/server/src/services/stacks/pool-spawner.ts
+++ b/server/src/services/stacks/pool-spawner.ts
@@ -38,6 +38,14 @@ export interface PoolSpawnContext {
   instanceRowId: string;
   callerEnv: Record<string, string>;
   idleTimeoutMinutes: number;
+  /**
+   * Optional Docker labels stamped on the spawned container alongside the
+   * standard pool-instance labels. Used by the JobPool spawner to pass
+   * trigger attribution forward — the exit watcher reads the labels off
+   * the `die` event to know which trigger fired the run. Reserved label
+   * keys (`mini-infra.*`) emitted by the spawner cannot be overridden.
+   */
+  extraLabels?: Record<string, string>;
 }
 
 /**
@@ -278,6 +286,9 @@ export async function spawnPoolInstance(
   const networkNames = networks.map((n) => `${projectName}_${n.name}`);
 
   // Labels that match static stack containers, plus pool-instance markers.
+  // `extraLabels` (e.g. JobPool trigger attribution) layer on top of the
+  // template's container labels but cannot override the reserved
+  // mini-infra.* markers further below.
   const labels: Record<string, string> = {
     'mini-infra.stack': stack.name,
     'mini-infra.stack-id': stack.id,
@@ -286,6 +297,7 @@ export async function spawnPoolInstance(
     'mini-infra.pool-instance-id': ctx.instanceId,
     ...(stack.environmentId ? { 'mini-infra.environment': stack.environmentId } : {}),
     ...(containerConfig.labels ?? {}),
+    ...(ctx.extraLabels ?? {}),
   };
 
   // Ports (mirror StackContainerManager logic).
@@ -535,6 +547,22 @@ export async function spawnPoolInstance(
   }
 
   // Poll for running state (up to 30s).
+  //
+  // For `Pool` services, the container is expected to stay up — observing
+  // an `exited` state during the poll means the bootstrap died and the
+  // pool worker never came up. That's a spawn failure.
+  //
+  // For `JobPool` services, the container is *expected* to exit — that's the
+  // entire lifecycle. A super-fast exit (success or non-zero) is a normal
+  // outcome, not a spawn failure: the exit watcher (Phase 2 — see
+  // `job-pool-exit-watcher.ts`) flips the `PoolInstance` row to
+  // `completed`/`failed` based on the exit code from the Docker `die`
+  // event. Reporting it as a spawn failure here would race the watcher and
+  // (depending on which loses the race) leave the row stuck at `error` with
+  // semantically wrong status, even though the run actually completed
+  // cleanly. So for JobPool we treat both `Running` and `exited` as success
+  // and let the watcher own the terminal-state transition.
+  const isJobPool = service.serviceType === 'JobPool';
   const deadline = Date.now() + 30_000;
   const docker = dockerExecutor.getDockerClient();
   while (Date.now() < deadline) {
@@ -544,6 +572,9 @@ export async function spawnPoolInstance(
         return { success: true, containerId };
       }
       if (info.State?.Status === 'exited') {
+        if (isJobPool) {
+          return { success: true, containerId };
+        }
         return {
           success: false,
           containerId,


### PR DESCRIPTION
## Summary

- `JobPoolExitWatcher` finalises `PoolInstance` rows from Docker `die` events — exit-code 0 → `completed`, non-zero → `failed`, with `exitCode` + `finishedAt` captured.
- Per-pool JetStream `JobHistory-<stack>-<service>` streams reconciled via the operator path in `system-nats-bootstrap.ts`, plus three new subjects (`completed` / `failed` / `run-skipped`) and matching Socket.IO events on `Channel.POOLS`.
- Pool reaper extension: `killAfterSeconds` SIGKILLs runaway jobs and marks them `failed` with the documented `errorMessage`. `onFailure.retries > 0` triggers backoff retry via a new `JobPoolRetryScheduler`.
- Two race-condition fixes baked in: pool-spawner treats `exited` as success for JobPool services; `runJobPool` flips `starting → running` via filtered `updateMany` so a fast-firing watcher can't be stomped on.

## Test plan

- [x] `pnpm build:lib`, `pnpm --filter mini-infra-server build`, `pnpm --filter mini-infra-client build` — all clean
- [x] `pnpm --filter mini-infra-server test` — 2263 / 2263 passing, 167 files (+13 tests vs Phase 1)
- [x] `pnpm --filter mini-infra-server lint` — 0 errors, 0 warnings
- [x] Live: success path (`sh -c "echo hi; sleep 2; exit 0"`) → row final state `status=completed, exitCode=0, finishedAt set`
- [x] Live: failed path (`sh -c "exit 17"`) → row final state `status=failed, exitCode=17, errorMessage="Container exited with code 17"`
- [x] Live: `killAfterSeconds: 5` against `sleep 60` → reaper kills at ~5s, row final state `status=failed, exitCode=137, errorMessage="killed: exceeded killAfterSeconds"`
- [ ] Live: cron `run-skipped` cap-hit (deferred — needs Phase 3 cron registry to emit; the underlying `concurrency_cap` reason is already returned by `runJobPool`)
- [ ] Live: `onFailure.retries` retry flow (deferred — wired through retry scheduler but no end-to-end run was exercised in the smoke pass)

Closes MINI-51