### PR TITLE
feat(stacks): JobPool trigger registries + manual HTTP route (Phase 3, MINI-52)

### DIFF
--- a/server/src/routes/stacks/stacks-apply-route.ts
+++ b/server/src/routes/stacks/stacks-apply-route.ts
@@ -15,6 +15,9 @@ import { evaluatePrerequisites } from '../../services/stacks/template-prerequisi
 import { runStackVaultApplyPhase } from '../../services/stacks/stack-vault-apply-orchestrator';
 import { runStackNatsApplyPhase } from '../../services/stacks/stack-nats-apply-orchestrator';
 import { applyJobPoolStreamsForStack } from '../../services/stacks/job-pool-stream-reconciler';
+import { JobPoolCronRegistry } from '../../services/stacks/job-pool-cron-registry';
+import { JobPoolNatsRegistry } from '../../services/stacks/job-pool-nats-registry';
+import { dryRunJobPoolCredentials } from '../../services/stacks/job-pool-credential-dry-run';
 import { EgressPolicyLifecycleService } from '../../services/egress/egress-policy-lifecycle';
 import { pruneOrphanedInputValues as doPruneOrphanedInputValues } from '../../services/stacks/orphan-input-pruner';
 import {
@@ -272,6 +275,16 @@ async function runApplyInBackground(args: RunApplyArgs): Promise<void> {
         );
       }
 
+      // JobPool credential dry-run (Phase 3 of job-pool-service-type): apply
+      // fails fast if any JobPool service declares a `dynamicEnv` binding
+      // that resolves to a missing Vault path / NATS credential. Without
+      // this gate, a misconfigured pool silently apples — and only the
+      // first triggered run discovers the problem.
+      //
+      // Throws on failure; the catch below converts that into the standard
+      // apply-failure surface (userEvent.fail + apply-failed Socket.IO event).
+      await dryRunJobPoolCredentials(prisma, stackId);
+
       // Re-promote `requiredEgress` declarations into template-source
       // EgressRules so addon-derived patterns (e.g. Tailscale's control-plane
       // hostnames from the synthetic sidecar) propagate to existing stacks
@@ -363,6 +376,39 @@ async function runApplyInBackground(args: RunApplyArgs): Promise<void> {
       // accumulate silently across versions.
       if (result.success) {
         await doPruneOrphanedInputValues(prisma, stackId);
+      }
+
+      // JobPool trigger registries (Phase 3): reconcile declared cron +
+      // nats-request triggers against live registrations. Only when the
+      // apply itself succeeded — a partially-applied stack should not have
+      // its triggers re-registered, because the underlying `StackService`
+      // rows may no longer match the operator's intent. The next successful
+      // apply re-establishes them. Registry failures are non-fatal: they
+      // surface as a warning in the logs, not as an apply failure (the
+      // services themselves are already up).
+      if (result.success) {
+        const cronRegistry = JobPoolCronRegistry.getInstance();
+        if (cronRegistry) {
+          try {
+            await cronRegistry.refresh(stackId);
+          } catch (err) {
+            logger.warn(
+              { stackId, err: err instanceof Error ? err.message : String(err) },
+              'JobPool cron registry refresh failed (continuing apply)',
+            );
+          }
+        }
+        const natsRegistry = JobPoolNatsRegistry.getInstance();
+        if (natsRegistry) {
+          try {
+            await natsRegistry.refresh(stackId);
+          } catch (err) {
+            logger.warn(
+              { stackId, err: err instanceof Error ? err.message : String(err) },
+              'JobPool NATS registry refresh failed (continuing apply)',
+            );
+          }
+        }
       }
 
       await finalizeApplyEvent(userEvent, result);

--- a/server/src/routes/stacks/stacks-destroy-route.ts
+++ b/server/src/routes/stacks/stacks-destroy-route.ts
@@ -26,6 +26,8 @@ import {
   removeStackNetworksAndVolumes,
 } from '../../services/stacks/stack-destroy-helpers';
 import { revokeStackNatsSigningKeys } from '../../services/stacks/stack-nats-revocation';
+import { JobPoolCronRegistry } from '../../services/stacks/job-pool-cron-registry';
+import { JobPoolNatsRegistry } from '../../services/stacks/job-pool-nats-registry';
 import type { StackNetwork, StackVolume } from '@mini-infra/types';
 import { EgressPolicyLifecycleService } from '../../services/egress/egress-policy-lifecycle';
 
@@ -176,6 +178,21 @@ async function runDestroyInBackground(
     // wipes seeds from Vault KV. Best-effort throughout — errors don't
     // block destroy because the stack record is going away regardless.
     await revokeStackNatsSigningKeys(prisma, stackId, logger);
+
+    // Step 6.6 (Phase 3 of job-pool-service-type): tear down any JobPool
+    // triggers this stack owned before its rows are cascade-deleted. The
+    // registries reconcile against `StackService` rows, so after the
+    // cascade they'd just be orphan node-cron handles / NATS subscriptions
+    // until next refresh. removeStack() is idempotent.
+    try {
+      JobPoolCronRegistry.getInstance()?.removeStack(stackId);
+      JobPoolNatsRegistry.getInstance()?.removeStack(stackId);
+    } catch (err) {
+      logger.warn(
+        { stackId, err: err instanceof Error ? err.message : String(err) },
+        'JobPool trigger registry teardown failed during destroy (non-fatal)',
+      );
+    }
 
     // Step 7: Delete stack record (cascades to deployments, services, resources)
     const duration = Date.now() - startTime;

--- a/server/src/routes/stacks/stacks-job-pool-routes.ts
+++ b/server/src/routes/stacks/stacks-job-pool-routes.ts
@@ -1,31 +1,117 @@
 import { Router } from 'express';
 import { asyncHandler } from '../../lib/async-handler';
 import { requireSessionOrApiKey } from '../../middleware/auth';
+import prisma from '../../lib/prisma';
+import { getLogger } from '../../lib/logger-factory';
+import { DockerExecutorService } from '../../services/docker-executor';
+import { runJobPool } from '../../services/stacks/job-pool-spawner';
+import { jobPoolTriggerRequestSchema } from '../../services/nats/payload-schemas';
 
-/**
- * JobPool runtime routes (Phase 1, MINI-50).
- *
- * Only the manual-trigger stub lives here today — Phase 3 activates the route
- * with the real `runJobPool()` dispatch and adds the cron + NATS-request
- * trigger registries that drive the same entry point. Returning a stable 501
- * envelope (rather than 404) makes the surface discoverable and lets clients
- * differentiate "not implemented yet" from "no such pool" in their error
- * handling.
- */
+const log = getLogger('stacks', 'stacks-job-pool-routes');
 const router = Router();
 
+/**
+ * Build an initialised DockerExecutorService for a single request. Mirrors
+ * the helper in `stacks-pool-routes.ts` — the underlying Docker client is a
+ * singleton, so this is cheap.
+ */
+async function buildDockerExecutor(): Promise<DockerExecutorService> {
+  const executor = new DockerExecutorService();
+  await executor.initialize();
+  return executor;
+}
+
+/**
+ * Manual JobPool trigger route (Phase 3, MINI-52).
+ *
+ * Activated from the Phase 1 501 stub. Forwards an optional JSON body to
+ * the spawned container as `JOB_PAYLOAD`, returns `{ runId }` on success
+ * or `429 { error: "concurrency_cap_reached", maxConcurrent }` when the
+ * pool is at cap. Service / stack-not-found surface as 404; stack-in-error
+ * as 409; any other server-side failure as 500.
+ */
 router.post(
   '/:stackId/job-pools/:serviceName/run',
   requireSessionOrApiKey,
   asyncHandler(async (req, res) => {
     const { stackId, serviceName } = req.params as { stackId: string; serviceName: string };
-    res.status(501).json({
-      success: false,
-      code: 'NOT_IMPLEMENTED',
-      message:
-        'Manual JobPool trigger is not yet implemented — coming in Phase 3 of the job-pool-service-type plan (MINI-52).',
+
+    // Optional JSON body; tolerate empty bodies so a bare POST without
+    // Content-Type still spawns. Validate using the same envelope schema
+    // the NATS registry uses so the two surfaces enforce identical limits.
+    let payload: Record<string, unknown> | undefined;
+    if (req.body !== undefined && req.body !== null && Object.keys(req.body).length > 0) {
+      const parsed = jobPoolTriggerRequestSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({
+          success: false,
+          code: 'INVALID_PAYLOAD',
+          message: parsed.error.issues[0]?.message ?? 'invalid request body',
+        });
+      }
+      payload = parsed.data;
+    }
+
+    const dockerExecutor = await buildDockerExecutor();
+
+    const result = await runJobPool(prisma, dockerExecutor, {
       stackId,
       serviceName,
+      trigger: { kind: 'manual', name: 'manual-http' },
+      payload,
+    });
+
+    if (result.ok) {
+      log.info(
+        { stackId, serviceName, runId: result.runId, containerId: result.containerId },
+        'Manual JobPool trigger spawned run',
+      );
+      return res.status(200).json({ success: true, runId: result.runId });
+    }
+
+    if (result.reason === 'concurrency_cap') {
+      log.info(
+        { stackId, serviceName, maxConcurrent: result.maxConcurrent },
+        'Manual JobPool trigger rejected — concurrency cap',
+      );
+      return res.status(429).json({
+        success: false,
+        code: 'CONCURRENCY_CAP_REACHED',
+        error: 'concurrency_cap_reached',
+        maxConcurrent: result.maxConcurrent,
+      });
+    }
+
+    if (result.reason === 'service_not_found' || result.reason === 'stack_not_found') {
+      return res.status(404).json({
+        success: false,
+        code: result.reason.toUpperCase(),
+        message: result.message,
+      });
+    }
+
+    if (result.reason === 'stack_in_error') {
+      return res.status(409).json({
+        success: false,
+        code: 'STACK_IN_ERROR',
+        message: result.message,
+      });
+    }
+
+    // `spawn_failed` — only branch left
+    log.error(
+      {
+        stackId,
+        serviceName,
+        error: result.message,
+        instanceRowId: result.reason === 'spawn_failed' ? result.instanceRowId : null,
+      },
+      'Manual JobPool trigger spawn failed',
+    );
+    return res.status(500).json({
+      success: false,
+      code: 'SPAWN_FAILED',
+      message: result.message,
     });
   }),
 );

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -49,6 +49,8 @@ import {
 import { CertificateRenewalScheduler } from "./services/tls/certificate-renewal-scheduler";
 import { PoolInstanceReaper } from "./services/stacks/pool-instance-reaper";
 import { JobPoolExitWatcher } from "./services/stacks/job-pool-exit-watcher";
+import { JobPoolCronRegistry } from "./services/stacks/job-pool-cron-registry";
+import { JobPoolNatsRegistry } from "./services/stacks/job-pool-nats-registry";
 import { TlsConfigService } from "./services/tls/tls-config";
 import { StorageCertificateStore } from "./services/tls/storage-certificate-store";
 import { AcmeClientManager } from "./services/tls/acme-client-manager";
@@ -95,6 +97,8 @@ let dnsCacheScheduler: DnsCacheScheduler | null = null;
 // current credentials. Read via `TailscaleDeviceStatusScheduler.getInstance()`.
 let poolInstanceReaper: PoolInstanceReaper | null = null;
 let jobPoolExitWatcher: JobPoolExitWatcher | null = null;
+let jobPoolCronRegistry: JobPoolCronRegistry | null = null;
+let jobPoolNatsRegistry: JobPoolNatsRegistry | null = null;
 
 /**
  * Initialize the internal auth secret from the database, generating one if
@@ -281,16 +285,43 @@ const initializeServices = async () => {
     // subscribes to Docker `die` events to finalise JobPool runs, publish
     // history events to JetStream, and schedule retries.
     console.log("[STARTUP] Initializing JobPool exit watcher...");
-    jobPoolExitWatcher = new JobPoolExitWatcher(prisma, async () => {
+    const resolveJobPoolDockerExecutor = async () => {
       const { DockerExecutorService } = await import(
         "./services/docker-executor"
       );
       const exec = new DockerExecutorService();
       await exec.initialize();
       return exec;
-    });
+    };
+    jobPoolExitWatcher = new JobPoolExitWatcher(prisma, resolveJobPoolDockerExecutor);
     jobPoolExitWatcher.start();
     console.log("[STARTUP] ✓ JobPool exit watcher initialized");
+
+    // Initialize JobPool trigger registries (Phase 3): cron + nats-request.
+    // `loadAll()` rebuilds the live registration set from the DB so a
+    // restart re-establishes every declared trigger without an apply.
+    console.log("[STARTUP] Initializing JobPool trigger registries...");
+    jobPoolCronRegistry = new JobPoolCronRegistry(prisma, resolveJobPoolDockerExecutor);
+    JobPoolCronRegistry.setInstance(jobPoolCronRegistry);
+    try {
+      await jobPoolCronRegistry.loadAll();
+    } catch (err) {
+      logger.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "JobPoolCronRegistry.loadAll failed at startup (apply-time refresh will reconcile)",
+      );
+    }
+    jobPoolNatsRegistry = new JobPoolNatsRegistry(prisma, resolveJobPoolDockerExecutor);
+    JobPoolNatsRegistry.setInstance(jobPoolNatsRegistry);
+    try {
+      await jobPoolNatsRegistry.loadAll();
+    } catch (err) {
+      logger.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "JobPoolNatsRegistry.loadAll failed at startup (apply-time refresh will reconcile)",
+      );
+    }
+    console.log("[STARTUP] ✓ JobPool trigger registries initialized");
 
     // Initialize backup scheduler
     console.log("[STARTUP] Initializing backup scheduler...");
@@ -815,6 +846,27 @@ startServer()
       if (poolInstanceReaper) {
         poolInstanceReaper.stop();
         logger.info("Pool instance reaper stopped");
+      }
+
+      // Stop JobPool trigger registries before tearing down the bus —
+      // the NATS registry's cancel handlers go through the bus.
+      if (jobPoolCronRegistry) {
+        try {
+          jobPoolCronRegistry.stopAll();
+          logger.info("JobPool cron registry stopped");
+        } catch (err) {
+          logger.warn({ err }, "JobPool cron registry stop failed (non-fatal)");
+        }
+        JobPoolCronRegistry.setInstance(null);
+      }
+      if (jobPoolNatsRegistry) {
+        try {
+          jobPoolNatsRegistry.stopAll();
+          logger.info("JobPool NATS registry stopped");
+        } catch (err) {
+          logger.warn({ err }, "JobPool NATS registry stop failed (non-fatal)");
+        }
+        JobPoolNatsRegistry.setInstance(null);
       }
 
       // Stop the fw-agent health watcher before draining the bus —

--- a/server/src/services/nats/payload-schemas.ts
+++ b/server/src/services/nats/payload-schemas.ts
@@ -163,6 +163,54 @@ export const jobPoolRunSkippedSchema = z.object({
 export type JobPoolRunSkipped = z.infer<typeof jobPoolRunSkippedSchema>;
 
 // ====================================================================
+// JobPool nats-request trigger envelope (Phase 3 of job-pool-service-type)
+// ====================================================================
+//
+// `nats-request` triggers subscribe to a user-declared subject (e.g.
+// `mini-infra.backup.run`). The request body is opaque from the registry's
+// POV — it's forwarded to the spawned container as `JOB_PAYLOAD` — so the
+// inbound schema is a free-form JSON object capped at a sensible size.
+//
+// The reply schema is fixed: on success the registry replies `{ runId }`,
+// on a cap-hit `{ error: "concurrency_cap_reached", maxConcurrent }`, and on
+// any other server-side failure `{ error: <message> }`. Both shapes are
+// pinned here so future consumers parse with the same discriminator.
+//
+// The bus's per-subject validator can't bind to a user-declared subject
+// (the registry doesn't know the subjects at boot), so call sites pass
+// `unchecked: true` and validate inline against these schemas.
+
+export const jobPoolTriggerRequestSchema = z
+  .record(z.string(), z.unknown())
+  .refine(
+    (val) => {
+      // Cap the serialised body at 16 KiB — Docker env vars degrade past
+      // ~32 KiB and we want to leave headroom for other JOB_* vars.
+      try {
+        return JSON.stringify(val).length <= 16 * 1024;
+      } catch {
+        return false;
+      }
+    },
+    { message: "payload must serialise to <= 16 KiB" },
+  );
+export type JobPoolTriggerRequest = z.infer<typeof jobPoolTriggerRequestSchema>;
+
+export const jobPoolTriggerReplySchema = z.union([
+  z.object({ runId: z.string().min(1).max(64) }),
+  z.object({
+    error: z.string().min(1).max(256),
+    /**
+     * Only set on `concurrency_cap_reached` replies — the configured cap
+     * value at the time the trigger fired. Surfaces in the caller's error
+     * UI without a second round-trip.
+     */
+    maxConcurrent: z.number().int().min(1).optional(),
+  }),
+]);
+export type JobPoolTriggerReply = z.infer<typeof jobPoolTriggerReplySchema>;
+
+// ====================================================================
 // Egress gateway (Phase 3) — real schemas, replacing the Phase 1 stubs.
 // ====================================================================
 

--- a/server/src/services/stacks/__tests__/definition-hash-job-pool.test.ts
+++ b/server/src/services/stacks/__tests__/definition-hash-job-pool.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import { computeDefinitionHash } from '../definition-hash';
+import type { JobPoolConfig, StackServiceDefinition } from '@mini-infra/types';
+
+/**
+ * Phase 3 invariant: a JobPool service's definition hash must include the
+ * triggers / history / killAfterSeconds / onFailure fields so the plan-and-
+ * apply flow detects drift when an operator edits any of them. The
+ * running-or-not state of `PoolInstance` rows is NOT in the hash — that
+ * oscillates per-run and is not drift.
+ */
+describe('definition-hash with JobPool config', () => {
+  const baseJobPoolConfig: JobPoolConfig = {
+    maxConcurrent: 2,
+    managedBy: null,
+    triggers: [{ kind: 'cron', schedule: '0 2 * * *', name: 'nightly' }],
+    history: { retainDays: 14 },
+  };
+
+  const baseService: StackServiceDefinition = {
+    serviceName: 'backup',
+    serviceType: 'JobPool',
+    dockerImage: 'ghcr.io/org/backup',
+    dockerTag: '1.0.0',
+    dependsOn: [],
+    order: 1,
+    containerConfig: { env: {} },
+    jobPoolConfig: baseJobPoolConfig,
+  };
+
+  it('changing triggers[] changes the hash', () => {
+    const a = computeDefinitionHash(baseService);
+    const b = computeDefinitionHash({
+      ...baseService,
+      jobPoolConfig: {
+        ...baseJobPoolConfig,
+        triggers: [
+          { kind: 'cron', schedule: '0 2 * * *', name: 'nightly' },
+          { kind: 'manual', name: 'go' },
+        ],
+      },
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it('changing history.retainDays changes the hash', () => {
+    const a = computeDefinitionHash(baseService);
+    const b = computeDefinitionHash({
+      ...baseService,
+      jobPoolConfig: { ...baseJobPoolConfig, history: { retainDays: 30 } },
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it('changing killAfterSeconds changes the hash', () => {
+    const a = computeDefinitionHash(baseService);
+    const b = computeDefinitionHash({
+      ...baseService,
+      jobPoolConfig: { ...baseJobPoolConfig, killAfterSeconds: 600 },
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it('changing onFailure changes the hash', () => {
+    const a = computeDefinitionHash(baseService);
+    const b = computeDefinitionHash({
+      ...baseService,
+      jobPoolConfig: {
+        ...baseJobPoolConfig,
+        onFailure: { retries: 3, backoff: 'exponential' },
+      },
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it('changing maxConcurrent does NOT change the hash (cap is registry-tunable, not drift)', () => {
+    // The plan: maxConcurrent is tunable at apply time without forcing a
+    // service recreate — the registries pick it up from the row on each
+    // refresh and the cap-check runs against the current value at trigger
+    // fire time.
+    const a = computeDefinitionHash(baseService);
+    const b = computeDefinitionHash({
+      ...baseService,
+      jobPoolConfig: { ...baseJobPoolConfig, maxConcurrent: 5 },
+    });
+    expect(a).toBe(b);
+  });
+
+  it('reordering triggers[] does NOT change the hash (canonical sort)', () => {
+    const a = computeDefinitionHash({
+      ...baseService,
+      jobPoolConfig: {
+        ...baseJobPoolConfig,
+        triggers: [
+          { kind: 'manual', name: 'go' },
+          { kind: 'cron', schedule: '0 2 * * *', name: 'nightly' },
+        ],
+      },
+    });
+    const b = computeDefinitionHash({
+      ...baseService,
+      jobPoolConfig: {
+        ...baseJobPoolConfig,
+        triggers: [
+          { kind: 'cron', schedule: '0 2 * * *', name: 'nightly' },
+          { kind: 'manual', name: 'go' },
+        ],
+      },
+    });
+    expect(a).toBe(b);
+  });
+
+  it('Stateful service hash is unaffected by the JobPool branch', () => {
+    // Sanity check: the new JobPool field set on the canonical form is
+    // gated by serviceType === 'JobPool'. A Stateful service must keep
+    // hashing the same as it did before this phase.
+    const stateful: StackServiceDefinition = {
+      serviceName: 'app',
+      serviceType: 'Stateful',
+      dockerImage: 'nginx',
+      dockerTag: 'latest',
+      dependsOn: [],
+      order: 1,
+      containerConfig: { env: { FOO: 'bar' } },
+    };
+    const before = computeDefinitionHash(stateful);
+    // Repeating with explicit `null` jobPoolConfig (matching the legacy
+    // input shape) — must produce the same hash because that field is
+    // ignored on non-JobPool services.
+    const after = computeDefinitionHash({
+      ...stateful,
+      jobPoolConfig: null,
+    });
+    expect(before).toBe(after);
+  });
+});

--- a/server/src/services/stacks/__tests__/job-pool-cron-registry.test.ts
+++ b/server/src/services/stacks/__tests__/job-pool-cron-registry.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// vi.hoisted to make state available to the hoisted vi.mock factories.
+const mocks = vi.hoisted(() => {
+  type FakeTask = { stop: ReturnType<typeof vi.fn>; destroy: ReturnType<typeof vi.fn> };
+  const scheduledTasks: Array<{ schedule: string; timezone: string | undefined; task: FakeTask }> = [];
+  return {
+    scheduledTasks,
+    scheduleMock: vi.fn((schedule: string, _handler: unknown, opts?: { timezone?: string }) => {
+      const task: FakeTask = { stop: vi.fn(), destroy: vi.fn() };
+      scheduledTasks.push({ schedule, timezone: opts?.timezone, task });
+      return task;
+    }),
+    validateMock: vi.fn((schedule: string) => schedule !== 'not-a-cron'),
+    runJobPoolMock: vi.fn(async () => ({
+      ok: true,
+      runId: 'r1',
+      instanceRowId: 'row-1',
+      containerId: 'c1',
+    })),
+  };
+});
+
+vi.mock('node-cron', () => ({
+  schedule: mocks.scheduleMock,
+  validate: mocks.validateMock,
+}));
+
+vi.mock('../job-pool-spawner', () => ({
+  runJobPool: mocks.runJobPoolMock,
+}));
+
+type FakeTask = { stop: ReturnType<typeof vi.fn>; destroy: ReturnType<typeof vi.fn> };
+const scheduledTasks = mocks.scheduledTasks;
+
+import { JobPoolCronRegistry } from '../job-pool-cron-registry';
+
+interface FakePrisma {
+  stackService: {
+    findMany: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makePrisma(rows: Array<{ stackId: string; serviceName: string; jobPoolConfig: unknown }>): FakePrisma {
+  return {
+    stackService: {
+      findMany: vi.fn(async ({ where }: { where: { stackId?: string } }) => {
+        if (where.stackId) {
+          return rows.filter((r) => r.stackId === where.stackId);
+        }
+        // distinct stack-id call shape: returns [{ stackId }]
+        const seen = new Set<string>();
+        const out: Array<{ stackId: string }> = [];
+        for (const r of rows) {
+          if (!seen.has(r.stackId)) {
+            seen.add(r.stackId);
+            out.push({ stackId: r.stackId });
+          }
+        }
+        return out;
+      }),
+    },
+  };
+}
+
+const dockerExecutor = {} as unknown;
+const resolveDockerExecutor = async () => dockerExecutor as never;
+
+beforeEach(() => {
+  scheduledTasks.length = 0;
+  mocks.validateMock.mockClear();
+  mocks.scheduleMock.mockClear();
+  // Reset to the default implementation
+  mocks.scheduleMock.mockImplementation(
+    (schedule: string, _handler: unknown, opts?: { timezone?: string }) => {
+      const task: FakeTask = { stop: vi.fn(), destroy: vi.fn() };
+      scheduledTasks.push({ schedule, timezone: opts?.timezone, task });
+      return task;
+    },
+  );
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('JobPoolCronRegistry.refresh', () => {
+  it('registers a new cron trigger on first refresh', async () => {
+    const prisma = makePrisma([
+      {
+        stackId: 'stack-1',
+        serviceName: 'backup',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [
+            { kind: 'cron', schedule: '0 2 * * *', name: 'nightly' },
+            { kind: 'manual', name: 'go' }, // ignored
+          ],
+          history: { retainDays: 7 },
+        },
+      },
+    ]);
+    const reg = new JobPoolCronRegistry(prisma as never, resolveDockerExecutor);
+
+    await reg.refresh('stack-1');
+
+    expect(reg.size()).toBe(1);
+    expect(scheduledTasks).toHaveLength(1);
+    expect(scheduledTasks[0].schedule).toBe('0 2 * * *');
+  });
+
+  it('removes a trigger on refresh after it disappears from the config', async () => {
+    const prismaWithTrigger = makePrisma([
+      {
+        stackId: 'stack-1',
+        serviceName: 'backup',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [{ kind: 'cron', schedule: '*/5 * * * *', name: 'every-five' }],
+          history: { retainDays: 7 },
+        },
+      },
+    ]);
+    const reg = new JobPoolCronRegistry(prismaWithTrigger as never, resolveDockerExecutor);
+    await reg.refresh('stack-1');
+    expect(reg.size()).toBe(1);
+    const originalTask = scheduledTasks[0].task;
+
+    // Re-point the mock at the same service with no triggers — refresh
+    // should tear down the original registration.
+    prismaWithTrigger.stackService.findMany = vi.fn(async () => [
+      {
+        stackId: 'stack-1',
+        serviceName: 'backup',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [{ kind: 'manual', name: 'go' }],
+          history: { retainDays: 7 },
+        },
+      },
+    ]);
+
+    await reg.refresh('stack-1');
+
+    expect(reg.size()).toBe(0);
+    expect(originalTask.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('orders unsubscribe before subscribe when a trigger schedule changes', async () => {
+    // Order assertion is the plan §7 invariant — a rescheduled trigger
+    // must have its old node-cron handle stopped *before* the new one is
+    // scheduled. We track the absolute event order via a shared counter.
+    let eventOrder = 0;
+    const stopOrder: number[] = [];
+    const scheduleOrder: number[] = [];
+
+    // Re-mock to record order
+    mocks.scheduleMock.mockImplementation(
+      (schedule: string, _handler: unknown, opts?: { timezone?: string }) => {
+        scheduleOrder.push(++eventOrder);
+        const task: FakeTask = {
+          stop: vi.fn(() => {
+            stopOrder.push(++eventOrder);
+          }),
+          destroy: vi.fn(),
+        };
+        scheduledTasks.push({ schedule, timezone: opts?.timezone, task });
+        return task;
+      },
+    );
+
+    const prisma = makePrisma([
+      {
+        stackId: 'stack-1',
+        serviceName: 'backup',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [{ kind: 'cron', schedule: '0 2 * * *', name: 'nightly' }],
+          history: { retainDays: 7 },
+        },
+      },
+    ]);
+    const reg = new JobPoolCronRegistry(prisma as never, resolveDockerExecutor);
+    await reg.refresh('stack-1');
+    expect(scheduleOrder).toHaveLength(1);
+
+    // Change the schedule and re-refresh
+    prisma.stackService.findMany = vi.fn(async () => [
+      {
+        stackId: 'stack-1',
+        serviceName: 'backup',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [{ kind: 'cron', schedule: '0 3 * * *', name: 'nightly' }],
+          history: { retainDays: 7 },
+        },
+      },
+    ]);
+    await reg.refresh('stack-1');
+
+    // Old task stopped, new task scheduled — *and* the stop ran before the
+    // new schedule call.
+    expect(stopOrder).toHaveLength(1);
+    expect(scheduleOrder).toHaveLength(2);
+    expect(stopOrder[0]).toBeLessThan(scheduleOrder[1]);
+    expect(reg.size()).toBe(1);
+    expect(scheduledTasks[1].schedule).toBe('0 3 * * *');
+  });
+
+  it('skips an unparseable cron schedule without failing the whole refresh', async () => {
+    const prisma = makePrisma([
+      {
+        stackId: 'stack-1',
+        serviceName: 'backup',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [
+            { kind: 'cron', schedule: 'not-a-cron', name: 'bad' },
+            { kind: 'cron', schedule: '0 0 * * *', name: 'good' },
+          ],
+          history: { retainDays: 1 },
+        },
+      },
+    ]);
+    const reg = new JobPoolCronRegistry(prisma as never, resolveDockerExecutor);
+
+    await reg.refresh('stack-1');
+
+    // Only the good schedule was registered
+    expect(reg.size()).toBe(1);
+    expect(scheduledTasks).toHaveLength(1);
+    expect(scheduledTasks[0].schedule).toBe('0 0 * * *');
+  });
+
+  it('removeStack tears down every trigger for the stack', async () => {
+    const prisma = makePrisma([
+      {
+        stackId: 'stack-1',
+        serviceName: 'a',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [{ kind: 'cron', schedule: '* * * * *', name: 't1' }],
+          history: { retainDays: 1 },
+        },
+      },
+      {
+        stackId: 'stack-1',
+        serviceName: 'b',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [{ kind: 'cron', schedule: '*/2 * * * *', name: 't2' }],
+          history: { retainDays: 1 },
+        },
+      },
+      {
+        stackId: 'stack-2',
+        serviceName: 'c',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [{ kind: 'cron', schedule: '*/3 * * * *', name: 't3' }],
+          history: { retainDays: 1 },
+        },
+      },
+    ]);
+    const reg = new JobPoolCronRegistry(prisma as never, resolveDockerExecutor);
+    await reg.refresh('stack-1');
+    await reg.refresh('stack-2');
+    expect(reg.size()).toBe(3);
+
+    reg.removeStack('stack-1');
+
+    expect(reg.size()).toBe(1);
+    expect(reg.registeredKeys()).toEqual(['stack-2::c::t3']);
+  });
+
+  it('loadAll re-establishes triggers from every JobPool stack in the DB', async () => {
+    const prisma = makePrisma([
+      {
+        stackId: 'stack-1',
+        serviceName: 'a',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [{ kind: 'cron', schedule: '0 1 * * *', name: 't1' }],
+          history: { retainDays: 1 },
+        },
+      },
+      {
+        stackId: 'stack-2',
+        serviceName: 'c',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [{ kind: 'cron', schedule: '0 2 * * *', name: 't2' }],
+          history: { retainDays: 1 },
+        },
+      },
+    ]);
+    const reg = new JobPoolCronRegistry(prisma as never, resolveDockerExecutor);
+
+    await reg.loadAll();
+
+    expect(reg.size()).toBe(2);
+    expect(reg.registeredKeys()).toEqual(['stack-1::a::t1', 'stack-2::c::t2']);
+  });
+
+  it('is idempotent on a no-change refresh', async () => {
+    // beforeEach already reset the schedule mock to the default
+    const prisma = makePrisma([
+      {
+        stackId: 'stack-1',
+        serviceName: 'backup',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [{ kind: 'cron', schedule: '0 2 * * *', name: 'nightly' }],
+          history: { retainDays: 7 },
+        },
+      },
+    ]);
+    const reg = new JobPoolCronRegistry(prisma as never, resolveDockerExecutor);
+    await reg.refresh('stack-1');
+    const firstCount = scheduledTasks.length;
+
+    await reg.refresh('stack-1');
+
+    // No new schedule calls — the existing entry was reused.
+    expect(scheduledTasks.length).toBe(firstCount);
+    expect(reg.size()).toBe(1);
+  });
+});

--- a/server/src/services/stacks/__tests__/job-pool-nats-registry.test.ts
+++ b/server/src/services/stacks/__tests__/job-pool-nats-registry.test.ts
@@ -1,0 +1,392 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+type Subscription = {
+  subject: string;
+  handler: (req: unknown) => Promise<unknown> | unknown;
+  cancel: ReturnType<typeof vi.fn>;
+};
+
+// Hoisted shared state so the vi.mock factories below can see it.
+const mocks = vi.hoisted(() => {
+  const state = {
+    liveSubs: [] as Array<{
+      subject: string;
+      handler: (req: unknown) => Promise<unknown> | unknown;
+      cancel: ReturnType<typeof vi.fn>;
+    }>,
+    subscribeOrder: [] as Array<{ subject: string; op: number }>,
+    cancelOrder: [] as Array<{ subject: string; op: number }>,
+    opCounter: 0,
+  };
+  return {
+    state,
+    runJobPoolMock: vi.fn(async () => ({
+      ok: true,
+      runId: 'run-123',
+      instanceRowId: 'row-1',
+      containerId: 'c1',
+    })),
+    respondMock: vi.fn(
+      (
+        subject: string,
+        handler: (req: unknown) => Promise<unknown> | unknown,
+      ) => {
+        const op = ++state.opCounter;
+        state.subscribeOrder.push({ subject, op });
+        const sub = {
+          subject,
+          handler,
+          cancel: vi.fn(() => {
+            state.cancelOrder.push({ subject: sub.subject, op: ++state.opCounter });
+            const idx = state.liveSubs.indexOf(sub);
+            if (idx >= 0) state.liveSubs.splice(idx, 1);
+          }),
+        };
+        state.liveSubs.push(sub);
+        return sub.cancel as () => void;
+      },
+    ),
+  };
+});
+
+vi.mock('../job-pool-spawner', () => ({
+  runJobPool: mocks.runJobPoolMock,
+}));
+
+vi.mock('../../nats/nats-bus', () => ({
+  NatsBus: {
+    getInstance: () => ({
+      respond: mocks.respondMock,
+    }),
+  },
+}));
+
+const liveSubs = mocks.state.liveSubs as Subscription[];
+const subscribeOrder = mocks.state.subscribeOrder;
+const cancelOrder = mocks.state.cancelOrder;
+const runJobPoolMock = mocks.runJobPoolMock;
+
+import { JobPoolNatsRegistry } from '../job-pool-nats-registry';
+
+function makePrisma(
+  rows: Array<{ stackId: string; serviceName: string; jobPoolConfig: unknown; natsCredentialId?: string | null }>,
+) {
+  return {
+    stackService: {
+      findMany: vi.fn(async ({ where }: { where: { stackId?: string } }) => {
+        if (where.stackId) return rows.filter((r) => r.stackId === where.stackId);
+        const seen = new Set<string>();
+        const out: Array<{ stackId: string }> = [];
+        for (const r of rows) {
+          if (!seen.has(r.stackId)) {
+            seen.add(r.stackId);
+            out.push({ stackId: r.stackId });
+          }
+        }
+        return out;
+      }),
+    },
+  };
+}
+
+const resolveDockerExecutor = async () => ({} as never);
+
+beforeEach(() => {
+  liveSubs.length = 0;
+  subscribeOrder.length = 0;
+  cancelOrder.length = 0;
+  mocks.state.opCounter = 0;
+  runJobPoolMock.mockClear();
+  mocks.respondMock.mockClear();
+});
+
+describe('JobPoolNatsRegistry.refresh', () => {
+  it('subscribes a new nats-request trigger on first refresh', async () => {
+    const prisma = makePrisma([
+      {
+        stackId: 'stack-1',
+        serviceName: 'backup',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [
+            {
+              kind: 'nats-request',
+              subject: 'mini-infra.backup.run',
+              ackWithRunId: true,
+              name: 'bus',
+            },
+            { kind: 'manual', name: 'go' }, // ignored
+          ],
+          history: { retainDays: 7 },
+        },
+      },
+    ]);
+    const reg = new JobPoolNatsRegistry(prisma as never, resolveDockerExecutor);
+
+    await reg.refresh('stack-1');
+
+    expect(reg.size()).toBe(1);
+    expect(reg.registeredSubjects()).toEqual(['mini-infra.backup.run']);
+    expect(liveSubs).toHaveLength(1);
+  });
+
+  it('orders unsubscribe before subscribe when the subject changes', async () => {
+    // Plan §7 ordering invariant — unsubscribe-on-apply runs before
+    // subscribe-on-apply within a refresh cycle so two handlers never
+    // race on the same subject.
+    const prisma = makePrisma([
+      {
+        stackId: 'stack-1',
+        serviceName: 'backup',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [
+            { kind: 'nats-request', subject: 'a.b.c', ackWithRunId: true, name: 'r1' },
+          ],
+          history: { retainDays: 1 },
+        },
+      },
+    ]);
+    const reg = new JobPoolNatsRegistry(prisma as never, resolveDockerExecutor);
+    await reg.refresh('stack-1');
+    expect(subscribeOrder.map((s) => s.subject)).toEqual(['a.b.c']);
+
+    // Rename the subject — the refresh must cancel the old subscription
+    // before creating the new one.
+    prisma.stackService.findMany = vi.fn(async () => [
+      {
+        stackId: 'stack-1',
+        serviceName: 'backup',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [
+            { kind: 'nats-request', subject: 'd.e.f', ackWithRunId: true, name: 'r1' },
+          ],
+          history: { retainDays: 1 },
+        },
+      },
+    ]);
+    await reg.refresh('stack-1');
+
+    expect(cancelOrder).toHaveLength(1);
+    expect(cancelOrder[0].subject).toBe('a.b.c');
+    expect(subscribeOrder).toHaveLength(2);
+    expect(subscribeOrder[1].subject).toBe('d.e.f');
+    expect(cancelOrder[0].op).toBeLessThan(subscribeOrder[1].op);
+    expect(reg.registeredSubjects()).toEqual(['d.e.f']);
+  });
+
+  it('returns { runId } on successful trigger fire', async () => {
+    const prisma = makePrisma([
+      {
+        stackId: 'stack-1',
+        serviceName: 'backup',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [
+            { kind: 'nats-request', subject: 'x.run', ackWithRunId: true, name: 'r1' },
+          ],
+          history: { retainDays: 1 },
+        },
+      },
+    ]);
+    const reg = new JobPoolNatsRegistry(prisma as never, resolveDockerExecutor);
+    await reg.refresh('stack-1');
+
+    const sub = liveSubs[0];
+    const reply = await sub.handler({ foo: 'bar' });
+
+    expect(runJobPoolMock).toHaveBeenCalledTimes(1);
+    const passed = runJobPoolMock.mock.calls[0][2];
+    expect(passed).toMatchObject({
+      stackId: 'stack-1',
+      serviceName: 'backup',
+      trigger: { kind: 'nats-request', name: 'r1' },
+      payload: { foo: 'bar' },
+    });
+    expect(reply).toEqual({ runId: 'run-123' });
+  });
+
+  it('returns concurrency_cap_reached reply on cap-hit', async () => {
+    runJobPoolMock.mockResolvedValueOnce({
+      ok: false,
+      reason: 'concurrency_cap',
+      maxConcurrent: 2,
+    } as never);
+
+    const prisma = makePrisma([
+      {
+        stackId: 'stack-1',
+        serviceName: 'backup',
+        jobPoolConfig: {
+          maxConcurrent: 2,
+          managedBy: null,
+          triggers: [
+            { kind: 'nats-request', subject: 'x.run', ackWithRunId: true, name: 'r1' },
+          ],
+          history: { retainDays: 1 },
+        },
+      },
+    ]);
+    const reg = new JobPoolNatsRegistry(prisma as never, resolveDockerExecutor);
+    await reg.refresh('stack-1');
+
+    const reply = await liveSubs[0].handler({});
+
+    expect(reply).toEqual({ error: 'concurrency_cap_reached', maxConcurrent: 2 });
+  });
+
+  it('tolerates a null request body (empty payload)', async () => {
+    const prisma = makePrisma([
+      {
+        stackId: 'stack-1',
+        serviceName: 'backup',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [
+            { kind: 'nats-request', subject: 'x.run', ackWithRunId: true, name: 'r1' },
+          ],
+          history: { retainDays: 1 },
+        },
+      },
+    ]);
+    const reg = new JobPoolNatsRegistry(prisma as never, resolveDockerExecutor);
+    await reg.refresh('stack-1');
+
+    const reply = await liveSubs[0].handler(null);
+
+    expect(reply).toEqual({ runId: 'run-123' });
+    expect(runJobPoolMock.mock.calls[0][2]).toMatchObject({
+      payload: undefined,
+    });
+  });
+
+  it('rejects malformed payloads with an error reply (does not spawn)', async () => {
+    const prisma = makePrisma([
+      {
+        stackId: 'stack-1',
+        serviceName: 'backup',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [
+            { kind: 'nats-request', subject: 'x.run', ackWithRunId: true, name: 'r1' },
+          ],
+          history: { retainDays: 1 },
+        },
+      },
+    ]);
+    const reg = new JobPoolNatsRegistry(prisma as never, resolveDockerExecutor);
+    await reg.refresh('stack-1');
+
+    // Non-object — should fail validation
+    const reply = await liveSubs[0].handler('this is not an object');
+
+    expect(runJobPoolMock).not.toHaveBeenCalled();
+    expect(reply).toMatchObject({ error: expect.any(String) });
+  });
+
+  it('removeStack cancels every subscription for the stack', async () => {
+    const prisma = makePrisma([
+      {
+        stackId: 'stack-1',
+        serviceName: 'a',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [{ kind: 'nats-request', subject: 's1', ackWithRunId: true, name: 'r1' }],
+          history: { retainDays: 1 },
+        },
+      },
+      {
+        stackId: 'stack-1',
+        serviceName: 'b',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [{ kind: 'nats-request', subject: 's2', ackWithRunId: true, name: 'r2' }],
+          history: { retainDays: 1 },
+        },
+      },
+      {
+        stackId: 'stack-2',
+        serviceName: 'c',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [{ kind: 'nats-request', subject: 's3', ackWithRunId: true, name: 'r3' }],
+          history: { retainDays: 1 },
+        },
+      },
+    ]);
+    const reg = new JobPoolNatsRegistry(prisma as never, resolveDockerExecutor);
+    await reg.refresh('stack-1');
+    await reg.refresh('stack-2');
+    expect(reg.size()).toBe(3);
+
+    reg.removeStack('stack-1');
+
+    expect(reg.size()).toBe(1);
+    expect(reg.registeredSubjects()).toEqual(['s3']);
+  });
+
+  it('loadAll subscribes triggers from every JobPool stack in the DB', async () => {
+    const prisma = makePrisma([
+      {
+        stackId: 'stack-1',
+        serviceName: 'a',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [{ kind: 'nats-request', subject: 's1', ackWithRunId: true, name: 'r1' }],
+          history: { retainDays: 1 },
+        },
+      },
+      {
+        stackId: 'stack-2',
+        serviceName: 'c',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [{ kind: 'nats-request', subject: 's2', ackWithRunId: true, name: 'r2' }],
+          history: { retainDays: 1 },
+        },
+      },
+    ]);
+    const reg = new JobPoolNatsRegistry(prisma as never, resolveDockerExecutor);
+
+    await reg.loadAll();
+
+    expect(reg.size()).toBe(2);
+    expect(reg.registeredSubjects()).toEqual(['s1', 's2']);
+  });
+
+  it('is idempotent on a no-change refresh', async () => {
+    const prisma = makePrisma([
+      {
+        stackId: 'stack-1',
+        serviceName: 'backup',
+        jobPoolConfig: {
+          maxConcurrent: 1,
+          managedBy: null,
+          triggers: [{ kind: 'nats-request', subject: 's1', ackWithRunId: true, name: 'r1' }],
+          history: { retainDays: 1 },
+        },
+      },
+    ]);
+    const reg = new JobPoolNatsRegistry(prisma as never, resolveDockerExecutor);
+    await reg.refresh('stack-1');
+    const firstSubCount = subscribeOrder.length;
+
+    await reg.refresh('stack-1');
+
+    expect(subscribeOrder.length).toBe(firstSubCount);
+    expect(cancelOrder.length).toBe(0);
+    expect(reg.size()).toBe(1);
+  });
+});

--- a/server/src/services/stacks/definition-hash.ts
+++ b/server/src/services/stacks/definition-hash.ts
@@ -4,6 +4,8 @@ import {
   StackConfigFile,
   StackContainerConfig,
   SyntheticServiceInfo,
+  JobPoolConfig,
+  JobPoolTrigger,
 } from '@mini-infra/types';
 
 /**
@@ -18,6 +20,43 @@ function stripDynamic(cc: StackContainerConfig | undefined): StackContainerConfi
   const { dynamicEnv: _omit, ...rest } = cc;
   void _omit;
   return rest;
+}
+
+/**
+ * Canonicalise a JobPoolConfig for hashing. Sorts `triggers[]` by
+ * `(kind, name)` so the hash is stable across re-orderings the operator
+ * might do in the template. Only the drift-relevant fields are included —
+ * `managedBy` is reserved-for-future and not hashed; `maxConcurrent` is
+ * not hashed either (changing the cap doesn't require a service recreate,
+ * just a registry refresh at apply time).
+ */
+function canonicaliseJobPoolConfig(cfg: JobPoolConfig | null | undefined): unknown {
+  if (!cfg) return null;
+  const sortedTriggers = [...(cfg.triggers ?? [])]
+    .map(canonicaliseTrigger)
+    .sort((a, b) => {
+      const ka = `${a.kind}:${a.name}`;
+      const kb = `${b.kind}:${b.name}`;
+      return ka.localeCompare(kb);
+    });
+  return {
+    triggers: sortedTriggers,
+    history: cfg.history ?? null,
+    killAfterSeconds: cfg.killAfterSeconds ?? null,
+    onFailure: cfg.onFailure ?? null,
+  };
+}
+
+/** Normalise a trigger to a plain object that only contains the kind-specific fields. */
+function canonicaliseTrigger(t: JobPoolTrigger): { kind: string; name: string } & Record<string, unknown> {
+  switch (t.kind) {
+    case 'cron':
+      return { kind: 'cron', name: t.name, schedule: t.schedule, timezone: t.timezone ?? null };
+    case 'nats-request':
+      return { kind: 'nats-request', name: t.name, subject: t.subject, ackWithRunId: t.ackWithRunId };
+    case 'manual':
+      return { kind: 'manual', name: t.name };
+  }
 }
 
 function stableStringify(obj: unknown): string {
@@ -71,6 +110,15 @@ export function computeDefinitionHash(
       // means changing addon-config triggers a recreate of the target while
       // mint-on-render values (authkeys, secrets) never enter this hash.
       addons: service.addons ?? null,
+      // JobPool drift inputs (Phase 3): the fields that affect *what* the
+      // pool does — triggers, history retention, kill-after-seconds,
+      // retry policy. The running-or-not state of `PoolInstance` rows is
+      // deliberately NOT hashed (it oscillates per-run; that's not drift).
+      // Per-instance/per-run credential injection happens at spawn time
+      // and is already excluded via `stripDynamic`.
+      jobPoolConfig: service.serviceType === 'JobPool'
+        ? canonicaliseJobPoolConfig(service.jobPoolConfig)
+        : null,
     };
   }
 

--- a/server/src/services/stacks/job-pool-credential-dry-run.ts
+++ b/server/src/services/stacks/job-pool-credential-dry-run.ts
@@ -1,0 +1,158 @@
+import type { PrismaClient } from '../../generated/prisma/client';
+import type {
+  StackContainerConfig,
+  StackParameterDefinition,
+  StackParameterValue,
+} from '@mini-infra/types';
+import { VaultCredentialInjector } from '../vault/vault-credential-injector';
+import { vaultServicesReady } from '../vault/vault-services';
+import { NatsCredentialInjector } from '../nats/nats-credential-injector';
+import { resolveEffectiveVaultBinding } from './vault-binding-resolver';
+import { getLogger } from '../../lib/logger-factory';
+import {
+  buildStackTemplateContext,
+  mergeParameterValues,
+  resolveServiceConfigs,
+} from './utils';
+
+const log = getLogger('stacks', 'job-pool-credential-dry-run');
+
+/**
+ * Apply-time credential dry-run for every JobPool service on a stack.
+ *
+ * Re-uses the same `VaultCredentialInjector` and `NatsCredentialInjector`
+ * that `pool-spawner.ts` invokes at spawn time, so a misconfigured
+ * `dynamicEnv` binding fails the *apply* fast rather than surfacing later
+ * as a per-run spawn error when an operator tries to trigger the pool.
+ *
+ * Static-service `dynamicEnv` is already resolved by
+ * `StackReconciler.resolveVaultEnv` during apply; JobPool services are
+ * deliberately skipped there (per-instance/per-run resolution at spawn
+ * time), so without this helper a broken binding only shows up when a
+ * trigger fires. The plan calls this out as one of the Phase 3 known
+ * constraints — surfacing latent misconfigurations from existing stacks
+ * on first re-apply post-upgrade.
+ *
+ * Throws on the first JobPool service that fails resolution with a
+ * descriptive error message. The apply route catches and surfaces it as
+ * the apply failure reason.
+ */
+export async function dryRunJobPoolCredentials(
+  prisma: PrismaClient,
+  stackId: string,
+): Promise<void> {
+  const stack = await prisma.stack.findUnique({
+    where: { id: stackId },
+    include: { services: true, environment: true },
+  });
+  if (!stack) return;
+
+  const jobPoolServices = stack.services.filter((s) => s.serviceType === 'JobPool');
+  if (jobPoolServices.length === 0) return;
+
+  const params = mergeParameterValues(
+    (stack.parameters as unknown as StackParameterDefinition[]) ?? [],
+    (stack.parameterValues as unknown as Record<string, StackParameterValue>) ?? {},
+  );
+  const templateContext = buildStackTemplateContext(stack, params);
+  // Pass a stable, identifiable instanceId so any template substitutions
+  // resolve. The dry-run never actually spawns — `instance.instanceId`
+  // exists purely for template-string interpolation parity with the
+  // live spawn path.
+  const { resolvedDefinitions } = await resolveServiceConfigs(
+    stack.services,
+    templateContext,
+    { instance: { instanceId: 'apply-dry-run' } },
+  );
+
+  const vaultReady = vaultServicesReady();
+  const vaultInjector = vaultReady ? new VaultCredentialInjector(prisma) : null;
+  const natsInjector = new NatsCredentialInjector(prisma);
+
+  for (const svc of jobPoolServices) {
+    const resolved = resolvedDefinitions.get(svc.serviceName);
+    if (!resolved) continue;
+
+    const containerConfig = resolved.containerConfig as StackContainerConfig | undefined;
+    const dynamicEnv = containerConfig?.dynamicEnv;
+    if (!dynamicEnv) continue;
+
+    const hasVaultEntries = Object.values(dynamicEnv).some(
+      (src) =>
+        src.kind === 'vault-addr' ||
+        src.kind === 'vault-role-id' ||
+        src.kind === 'vault-wrapped-secret-id' ||
+        src.kind === 'vault-kv',
+    );
+    const hasNatsEntries = Object.values(dynamicEnv).some(
+      (src) =>
+        src.kind === 'nats-url' ||
+        src.kind === 'nats-creds' ||
+        src.kind === 'nats-signer-seed' ||
+        src.kind === 'nats-account-public',
+    );
+
+    if (hasVaultEntries) {
+      if (!vaultInjector) {
+        throw new Error(
+          `JobPool service "${svc.serviceName}" declares Vault dynamicEnv but Vault is not ready — refusing to apply (would silently spawn without credentials)`,
+        );
+      }
+      const binding = resolveEffectiveVaultBinding(stack, svc);
+      const hasAppRoleEntries = Object.values(dynamicEnv).some(
+        (src) => src.kind === 'vault-role-id' || src.kind === 'vault-wrapped-secret-id',
+      );
+      if (hasAppRoleEntries && !binding.appRoleId) {
+        throw new Error(
+          `JobPool service "${svc.serviceName}" declares vault-role-id or vault-wrapped-secret-id but no AppRole is bound on the service or stack`,
+        );
+      }
+      try {
+        await vaultInjector.resolve(
+          {
+            appRoleId: binding.appRoleId,
+            failClosed: false,
+            prevBoundAppRoleId: binding.prevBoundAppRoleId,
+            poolTokens: {},
+          },
+          containerConfig!,
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.warn(
+          { stackId, serviceName: svc.serviceName, err: msg },
+          'JobPool Vault credential dry-run failed',
+        );
+        throw new Error(
+          `Vault credential dry-run failed for JobPool service "${svc.serviceName}": ${msg}`,
+          { cause: err },
+        );
+      }
+    }
+
+    if (hasNatsEntries) {
+      try {
+        await natsInjector.resolve(
+          svc.natsCredentialId ?? null,
+          containerConfig!,
+          { stackId },
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.warn(
+          { stackId, serviceName: svc.serviceName, err: msg },
+          'JobPool NATS credential dry-run failed',
+        );
+        throw new Error(
+          `NATS credential dry-run failed for JobPool service "${svc.serviceName}": ${msg}`,
+          { cause: err },
+        );
+      }
+    }
+  }
+
+  log.info(
+    { stackId, jobPoolCount: jobPoolServices.length },
+    'JobPool credential dry-run passed',
+  );
+}

--- a/server/src/services/stacks/job-pool-cron-registry.ts
+++ b/server/src/services/stacks/job-pool-cron-registry.ts
@@ -1,0 +1,342 @@
+import * as cron from 'node-cron';
+import type { PrismaClient } from '../../generated/prisma/client';
+import type { JobPoolConfig } from '@mini-infra/types';
+import type { DockerExecutorService } from '../docker-executor';
+import { getLogger } from '../../lib/logger-factory';
+import { withOperation } from '../../lib/logging-context';
+import { runJobPool } from './job-pool-spawner';
+
+const log = getLogger('stacks', 'job-pool-cron-registry');
+
+/**
+ * Registry key: one entry per (stackId, serviceName, triggerName). Trigger
+ * names are unique within a pool (the JobPool schema enforces this), so the
+ * three-tuple uniquely identifies a single cron schedule across all stacks.
+ */
+function registryKey(stackId: string, serviceName: string, triggerName: string): string {
+  return `${stackId}::${serviceName}::${triggerName}`;
+}
+
+interface CronRegistryEntry {
+  stackId: string;
+  serviceName: string;
+  triggerName: string;
+  schedule: string;
+  timezone: string | undefined;
+  task: cron.ScheduledTask;
+}
+
+/**
+ * Singleton registry that owns every active cron trigger across every applied
+ * JobPool service. Drives `node-cron` registration from the persisted
+ * `StackService.jobPoolConfig` rows; `refresh(stackId)` is called by the
+ * stack apply handler to diff declared schedules against current
+ * registrations and add / remove / restart as needed.
+ *
+ * Ordering invariant (plan §7): within a single `refresh()` cycle, all
+ * removals run before all adds. A renamed or rescheduled trigger therefore
+ * has a brief window where neither the old nor the new schedule is alive
+ * — but never a window where both are. Misfires during the rename window
+ * are acceptable for v1 (a per-stack apply mutex would close the seam if
+ * it shows up in practice).
+ *
+ * The registry has no state outside the live `cron.ScheduledTask` handles
+ * and the lookup map — `loadAll()` rebuilds the entire view from
+ * `StackService` rows on server boot, so a process restart re-establishes
+ * exactly the same set of schedules without manual intervention.
+ */
+export class JobPoolCronRegistry {
+  private static instance: JobPoolCronRegistry | null = null;
+
+  private readonly entries = new Map<string, CronRegistryEntry>();
+
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly resolveDockerExecutor: () => Promise<DockerExecutorService>,
+  ) {}
+
+  static setInstance(instance: JobPoolCronRegistry | null): void {
+    JobPoolCronRegistry.instance = instance;
+  }
+
+  static getInstance(): JobPoolCronRegistry | null {
+    return JobPoolCronRegistry.instance;
+  }
+
+  /** Number of live cron tasks across every JobPool. Test/observability hook. */
+  size(): number {
+    return this.entries.size;
+  }
+
+  /** Snapshot of the registered keys (test/observability hook). */
+  registeredKeys(): string[] {
+    return [...this.entries.keys()].sort();
+  }
+
+  /**
+   * Load every JobPool's cron triggers from the DB and register them. Idempotent
+   * — call from `server.ts` on boot. A no-op if any rows already match an
+   * existing entry; new entries are scheduled in place.
+   */
+  async loadAll(): Promise<void> {
+    const services = await this.prisma.stackService.findMany({
+      where: { serviceType: 'JobPool' },
+      select: { stackId: true },
+      distinct: ['stackId'],
+    });
+    log.info({ stackCount: services.length }, 'JobPoolCronRegistry: loading cron triggers from DB');
+    for (const { stackId } of services) {
+      try {
+        await this.refresh(stackId);
+      } catch (err) {
+        log.error(
+          { stackId, err: err instanceof Error ? err.message : String(err) },
+          'JobPoolCronRegistry: failed to load cron triggers for stack (continuing)',
+        );
+      }
+    }
+    log.info({ total: this.entries.size }, 'JobPoolCronRegistry: loaded');
+  }
+
+  /**
+   * Re-reconcile the cron triggers for a single stack against the current DB
+   * state. Removals run before adds (the ordering invariant above).
+   *
+   * Called by the stack apply handler after the stack's services have been
+   * written. Tolerant of missing stacks — if the stack was deleted, every
+   * registered entry for it is unregistered.
+   */
+  async refresh(stackId: string): Promise<void> {
+    const services = await this.prisma.stackService.findMany({
+      where: { stackId, serviceType: 'JobPool' },
+    });
+
+    // Build the desired set: every cron trigger declared on every JobPool
+    // service for this stack.
+    interface Desired {
+      key: string;
+      stackId: string;
+      serviceName: string;
+      triggerName: string;
+      schedule: string;
+      timezone: string | undefined;
+    }
+    const desired: Desired[] = [];
+    for (const svc of services) {
+      const cfg = svc.jobPoolConfig as unknown as JobPoolConfig | null;
+      if (!cfg) continue;
+      for (const trigger of cfg.triggers ?? []) {
+        if (trigger.kind !== 'cron') continue;
+        desired.push({
+          key: registryKey(stackId, svc.serviceName, trigger.name),
+          stackId,
+          serviceName: svc.serviceName,
+          triggerName: trigger.name,
+          schedule: trigger.schedule,
+          timezone: trigger.timezone,
+        });
+      }
+    }
+    const desiredByKey = new Map(desired.map((d) => [d.key, d]));
+
+    // Phase 1: removals — anything currently registered for this stack that
+    // isn't in the desired set, or whose schedule/timezone has changed
+    // (changed entries get torn down and re-added so node-cron picks up
+    // the new parameters cleanly).
+    const stackPrefix = `${stackId}::`;
+    const removalKeys: string[] = [];
+    for (const [key, entry] of this.entries) {
+      if (!key.startsWith(stackPrefix)) continue;
+      const want = desiredByKey.get(key);
+      if (!want) {
+        removalKeys.push(key);
+        continue;
+      }
+      if (want.schedule !== entry.schedule || (want.timezone ?? null) !== (entry.timezone ?? null)) {
+        removalKeys.push(key);
+      }
+    }
+    for (const key of removalKeys) {
+      this.unregister(key);
+    }
+
+    // Phase 2: adds — anything in the desired set that isn't currently
+    // registered (either because it was just declared or because the
+    // removal phase tore down a stale variant).
+    for (const want of desired) {
+      if (this.entries.has(want.key)) continue;
+      if (!cron.validate(want.schedule)) {
+        log.warn(
+          { stackId, serviceName: want.serviceName, triggerName: want.triggerName, schedule: want.schedule },
+          'JobPoolCronRegistry: skipping unparseable cron schedule',
+        );
+        continue;
+      }
+      this.register(want);
+    }
+
+    log.info(
+      {
+        stackId,
+        desired: desired.length,
+        registered: this.entries.size,
+        added: desired.filter((d) => !removalKeys.includes(d.key)).length - 0,
+        removed: removalKeys.length,
+      },
+      'JobPoolCronRegistry.refresh completed',
+    );
+  }
+
+  /**
+   * Remove every cron trigger associated with `stackId`. Useful for explicit
+   * stack-destroy paths that bypass the apply handler.
+   */
+  removeStack(stackId: string): void {
+    const stackPrefix = `${stackId}::`;
+    const keys: string[] = [];
+    for (const key of this.entries.keys()) {
+      if (key.startsWith(stackPrefix)) keys.push(key);
+    }
+    for (const key of keys) {
+      this.unregister(key);
+    }
+    if (keys.length > 0) {
+      log.info({ stackId, removed: keys.length }, 'JobPoolCronRegistry: removed all triggers for stack');
+    }
+  }
+
+  /** Stop every scheduled task. Call on server shutdown. */
+  stopAll(): void {
+    for (const entry of this.entries.values()) {
+      try {
+        entry.task.stop();
+      } catch {
+        // best-effort
+      }
+    }
+    this.entries.clear();
+    log.info('JobPoolCronRegistry: stopped all tasks');
+  }
+
+  // ----- internals --------------------------------------------------------
+
+  private register(want: {
+    key: string;
+    stackId: string;
+    serviceName: string;
+    triggerName: string;
+    schedule: string;
+    timezone: string | undefined;
+  }): void {
+    const fireHandler = async (): Promise<void> => {
+      await withOperation(`job-pool-cron-tick-${want.stackId}-${want.serviceName}`, () =>
+        this.fireOnce(want.stackId, want.serviceName, want.triggerName),
+      );
+    };
+
+    let task: cron.ScheduledTask;
+    try {
+      task = cron.schedule(
+        want.schedule,
+        fireHandler,
+        want.timezone ? { timezone: want.timezone } : undefined,
+      );
+    } catch (err) {
+      log.error(
+        {
+          stackId: want.stackId,
+          serviceName: want.serviceName,
+          triggerName: want.triggerName,
+          schedule: want.schedule,
+          timezone: want.timezone,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        'JobPoolCronRegistry: cron.schedule threw — skipping trigger',
+      );
+      return;
+    }
+
+    this.entries.set(want.key, {
+      stackId: want.stackId,
+      serviceName: want.serviceName,
+      triggerName: want.triggerName,
+      schedule: want.schedule,
+      timezone: want.timezone,
+      task,
+    });
+    log.info(
+      {
+        stackId: want.stackId,
+        serviceName: want.serviceName,
+        triggerName: want.triggerName,
+        schedule: want.schedule,
+        timezone: want.timezone,
+      },
+      'JobPoolCronRegistry: registered cron trigger',
+    );
+  }
+
+  private unregister(key: string): void {
+    const entry = this.entries.get(key);
+    if (!entry) return;
+    try {
+      entry.task.stop();
+    } catch (err) {
+      log.warn(
+        { key, err: err instanceof Error ? err.message : String(err) },
+        'JobPoolCronRegistry: task.stop threw (continuing)',
+      );
+    }
+    this.entries.delete(key);
+    log.info(
+      {
+        stackId: entry.stackId,
+        serviceName: entry.serviceName,
+        triggerName: entry.triggerName,
+      },
+      'JobPoolCronRegistry: unregistered cron trigger',
+    );
+  }
+
+  private async fireOnce(stackId: string, serviceName: string, triggerName: string): Promise<void> {
+    try {
+      const dockerExecutor = await this.resolveDockerExecutor();
+      const result = await runJobPool(this.prisma, dockerExecutor, {
+        stackId,
+        serviceName,
+        trigger: { kind: 'cron', name: triggerName },
+      });
+      if (!result.ok) {
+        // Cap-hit / spawn-fail / stack-not-found etc. — `runJobPool` already
+        // logged + (on cap) published a `run-skipped` event. Cron isn't an
+        // interactive surface so there's nothing else to do; log at info
+        // for cap-hit and warn for spawn failures.
+        if (result.reason === 'concurrency_cap') {
+          log.info(
+            { stackId, serviceName, triggerName, maxConcurrent: result.maxConcurrent },
+            'JobPoolCronRegistry: cron tick skipped — concurrency cap',
+          );
+        } else {
+          log.warn(
+            { stackId, serviceName, triggerName, reason: result.reason },
+            'JobPoolCronRegistry: cron tick failed',
+          );
+        }
+      } else {
+        log.info(
+          { stackId, serviceName, triggerName, runId: result.runId },
+          'JobPoolCronRegistry: cron tick spawned run',
+        );
+      }
+    } catch (err) {
+      // Never let a thrown error tear down the scheduled task — node-cron
+      // would log the unhandled rejection but the task would keep firing
+      // anyway. Logging here means the operator gets one structured line
+      // per failure.
+      log.error(
+        { stackId, serviceName, triggerName, err: err instanceof Error ? err.message : String(err) },
+        'JobPoolCronRegistry: cron tick threw',
+      );
+    }
+  }
+}

--- a/server/src/services/stacks/job-pool-nats-registry.ts
+++ b/server/src/services/stacks/job-pool-nats-registry.ts
@@ -1,0 +1,318 @@
+import type { PrismaClient } from '../../generated/prisma/client';
+import type { JobPoolConfig } from '@mini-infra/types';
+import type { DockerExecutorService } from '../docker-executor';
+import { getLogger } from '../../lib/logger-factory';
+import { NatsBus } from '../nats/nats-bus';
+import {
+  jobPoolTriggerRequestSchema,
+  type JobPoolTriggerRequest,
+  type JobPoolTriggerReply,
+} from '../nats/payload-schemas';
+import { runJobPool } from './job-pool-spawner';
+
+const log = getLogger('stacks', 'job-pool-nats-registry');
+
+/** A registered subscription, keyed by subject. */
+interface NatsRegistryEntry {
+  /** Owning stack + service so we can route fired requests through `runJobPool`. */
+  stackId: string;
+  serviceName: string;
+  /** Operator-facing trigger name from `JobPoolTrigger.name`. */
+  triggerName: string;
+  /** Cancel handle returned by `NatsBus.respond`. */
+  cancel: () => void;
+}
+
+/**
+ * Singleton registry that owns every `nats-request`-trigger subscription
+ * across every applied JobPool service. Mirrors `JobPoolCronRegistry`:
+ *
+ *   - `loadAll()` rebuilds the live subscription set from `StackService`
+ *     rows on server boot.
+ *   - `refresh(stackId)` diffs declared subjects against current
+ *     subscriptions and unsubscribes-then-subscribes.
+ *
+ * Ordering invariant (plan §7): within a refresh cycle, removals run before
+ * adds so two handlers never race on the same subject. The plan calls this
+ * out explicitly as a v1 constraint that needs unit-test coverage.
+ *
+ * The registry deliberately keys by **subject**, not by trigger name —
+ * NATS subscriptions are subject-scoped, and the user-declared trigger
+ * subject is what the bus actually routes against. Two triggers on the
+ * same subject (within or across pools) would clobber each other; the
+ * apply-time schema validator already rejects same-subject collisions
+ * inside one pool, but cross-stack collisions slip through the schema
+ * and surface here as "last writer wins" — that's by design for v1.
+ */
+export class JobPoolNatsRegistry {
+  private static instance: JobPoolNatsRegistry | null = null;
+
+  private readonly entries = new Map<string, NatsRegistryEntry>();
+
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly resolveDockerExecutor: () => Promise<DockerExecutorService>,
+  ) {}
+
+  static setInstance(instance: JobPoolNatsRegistry | null): void {
+    JobPoolNatsRegistry.instance = instance;
+  }
+
+  static getInstance(): JobPoolNatsRegistry | null {
+    return JobPoolNatsRegistry.instance;
+  }
+
+  /** Number of live subscriptions across every JobPool. Test/observability hook. */
+  size(): number {
+    return this.entries.size;
+  }
+
+  /** Snapshot of the subscribed subjects (test/observability hook). */
+  registeredSubjects(): string[] {
+    return [...this.entries.keys()].sort();
+  }
+
+  /**
+   * Load every JobPool's `nats-request` triggers from the DB and subscribe.
+   * Idempotent; call from `server.ts` on boot.
+   */
+  async loadAll(): Promise<void> {
+    const services = await this.prisma.stackService.findMany({
+      where: { serviceType: 'JobPool' },
+      select: { stackId: true },
+      distinct: ['stackId'],
+    });
+    log.info({ stackCount: services.length }, 'JobPoolNatsRegistry: loading nats-request triggers from DB');
+    for (const { stackId } of services) {
+      try {
+        await this.refresh(stackId);
+      } catch (err) {
+        log.error(
+          { stackId, err: err instanceof Error ? err.message : String(err) },
+          'JobPoolNatsRegistry: failed to load nats-request triggers for stack (continuing)',
+        );
+      }
+    }
+    log.info({ total: this.entries.size }, 'JobPoolNatsRegistry: loaded');
+  }
+
+  /**
+   * Re-reconcile the `nats-request` subscriptions for a single stack against
+   * the current DB state. Removals run before adds.
+   */
+  async refresh(stackId: string): Promise<void> {
+    const services = await this.prisma.stackService.findMany({
+      where: { stackId, serviceType: 'JobPool' },
+    });
+
+    interface Desired {
+      subject: string;
+      stackId: string;
+      serviceName: string;
+      triggerName: string;
+    }
+    const desired: Desired[] = [];
+    for (const svc of services) {
+      const cfg = svc.jobPoolConfig as unknown as JobPoolConfig | null;
+      if (!cfg) continue;
+      for (const trigger of cfg.triggers ?? []) {
+        if (trigger.kind !== 'nats-request') continue;
+        desired.push({
+          subject: trigger.subject,
+          stackId,
+          serviceName: svc.serviceName,
+          triggerName: trigger.name,
+        });
+      }
+    }
+    const desiredBySubject = new Map(desired.map((d) => [d.subject, d]));
+
+    // Phase 1: removals — every entry that *was* owned by this stack and is
+    // no longer present in the desired set, or whose ownership changed
+    // (different service / triggerName on the same subject — same-subject
+    // rebinds get a clean tear-down before the new subscribe).
+    const removals: string[] = [];
+    for (const [subject, entry] of this.entries) {
+      if (entry.stackId !== stackId) continue;
+      const want = desiredBySubject.get(subject);
+      if (!want) {
+        removals.push(subject);
+        continue;
+      }
+      if (want.serviceName !== entry.serviceName || want.triggerName !== entry.triggerName) {
+        removals.push(subject);
+      }
+    }
+    for (const subject of removals) {
+      this.unsubscribe(subject);
+    }
+
+    // Phase 2: adds — every desired subject not already subscribed.
+    for (const want of desired) {
+      if (this.entries.has(want.subject)) continue;
+      this.subscribe(want);
+    }
+
+    log.info(
+      {
+        stackId,
+        desired: desired.length,
+        registered: this.entries.size,
+        removed: removals.length,
+      },
+      'JobPoolNatsRegistry.refresh completed',
+    );
+  }
+
+  /**
+   * Remove every subscription associated with `stackId`. Useful for explicit
+   * stack-destroy paths that bypass the apply handler.
+   */
+  removeStack(stackId: string): void {
+    const subjects: string[] = [];
+    for (const [subject, entry] of this.entries) {
+      if (entry.stackId === stackId) subjects.push(subject);
+    }
+    for (const subject of subjects) {
+      this.unsubscribe(subject);
+    }
+    if (subjects.length > 0) {
+      log.info({ stackId, removed: subjects.length }, 'JobPoolNatsRegistry: removed all subscriptions for stack');
+    }
+  }
+
+  /** Stop every subscription. Call on server shutdown. */
+  stopAll(): void {
+    for (const entry of this.entries.values()) {
+      try {
+        entry.cancel();
+      } catch {
+        // best-effort
+      }
+    }
+    this.entries.clear();
+    log.info('JobPoolNatsRegistry: stopped all subscriptions');
+  }
+
+  // ----- internals --------------------------------------------------------
+
+  private subscribe(want: {
+    subject: string;
+    stackId: string;
+    serviceName: string;
+    triggerName: string;
+  }): void {
+    const bus = NatsBus.getInstance();
+    // The trigger subject is user-declared (e.g. `mini-infra.backup.run`) —
+    // the bus's per-subject Zod validator can't bind a schema to an
+    // arbitrary user subject, so we pass `unchecked: true` and validate
+    // inline against the trigger envelope schema.
+    const cancel = bus.respond<unknown, JobPoolTriggerReply>(
+      want.subject,
+      async (req): Promise<JobPoolTriggerReply> => {
+        // Tolerate both `{}` and "no body" — `nats request <subject> ''`
+        // delivers an empty body which decodes to `null`. Treat null /
+        // undefined as `{}` so a trigger with no payload still spawns.
+        let payload: JobPoolTriggerRequest | undefined;
+        if (req !== null && req !== undefined) {
+          const parsed = jobPoolTriggerRequestSchema.safeParse(req);
+          if (!parsed.success) {
+            log.warn(
+              {
+                stackId: want.stackId,
+                serviceName: want.serviceName,
+                triggerName: want.triggerName,
+                subject: want.subject,
+                issue: parsed.error.issues[0]?.message,
+              },
+              'JobPoolNatsRegistry: rejected malformed request body',
+            );
+            return { error: parsed.error.issues[0]?.message ?? 'invalid request body' };
+          }
+          payload = parsed.data;
+        }
+
+        try {
+          const dockerExecutor = await this.resolveDockerExecutor();
+          const result = await runJobPool(this.prisma, dockerExecutor, {
+            stackId: want.stackId,
+            serviceName: want.serviceName,
+            trigger: { kind: 'nats-request', name: want.triggerName },
+            payload,
+          });
+          if (result.ok) {
+            return { runId: result.runId };
+          }
+          if (result.reason === 'concurrency_cap') {
+            return {
+              error: 'concurrency_cap_reached',
+              maxConcurrent: result.maxConcurrent,
+            };
+          }
+          if (result.reason === 'service_not_found' || result.reason === 'stack_not_found') {
+            // Subscription is stale relative to DB — the apply handler must
+            // have not run yet, or the stack was destroyed mid-flight.
+            return { error: result.reason };
+          }
+          if (result.reason === 'stack_in_error') {
+            return { error: 'stack_in_error' };
+          }
+          return { error: result.message ?? 'spawn_failed' };
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          log.error(
+            {
+              stackId: want.stackId,
+              serviceName: want.serviceName,
+              triggerName: want.triggerName,
+              subject: want.subject,
+              err: msg,
+            },
+            'JobPoolNatsRegistry: handler threw',
+          );
+          return { error: msg };
+        }
+      },
+      { unchecked: true },
+    );
+
+    this.entries.set(want.subject, {
+      stackId: want.stackId,
+      serviceName: want.serviceName,
+      triggerName: want.triggerName,
+      cancel,
+    });
+    log.info(
+      {
+        stackId: want.stackId,
+        serviceName: want.serviceName,
+        triggerName: want.triggerName,
+        subject: want.subject,
+      },
+      'JobPoolNatsRegistry: subscribed nats-request trigger',
+    );
+  }
+
+  private unsubscribe(subject: string): void {
+    const entry = this.entries.get(subject);
+    if (!entry) return;
+    try {
+      entry.cancel();
+    } catch (err) {
+      log.warn(
+        { subject, err: err instanceof Error ? err.message : String(err) },
+        'JobPoolNatsRegistry: cancel threw (continuing)',
+      );
+    }
+    this.entries.delete(subject);
+    log.info(
+      {
+        stackId: entry.stackId,
+        serviceName: entry.serviceName,
+        triggerName: entry.triggerName,
+        subject,
+      },
+      'JobPoolNatsRegistry: unsubscribed nats-request trigger',
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds two new singletons — `JobPoolCronRegistry` (node-cron) and `JobPoolNatsRegistry` (NATS request/reply) — that own every JobPool trigger across every applied stack, with a strict unsubscribe-before-subscribe ordering invariant on refresh.
- Activates the manual HTTP route `POST /api/stacks/:stackId/job-pools/:serviceName/run` — replaces the Phase 1 501 stub, forwards the optional JSON body to the container as `JOB_PAYLOAD`, returns 200 `{ runId }` / 404 / 409 / 429 / 500 per the plan's fail-fast contract.
- Apply handler now (a) runs a credential dry-run against every JobPool's `dynamicEnv` bindings to fail fast on misconfigurations and (b) calls both registries' `refresh(stackId)` after services are persisted. Drift detection (`computeDefinitionHash`) extended to include `triggers[]`, `history`, `killAfterSeconds`, and `onFailure` for JobPool services.

## Plan reference

`docs/planning/not-shipped/job-pool-service-type-plan.md` — §5 (Trigger sources, shared spawn path, fail-fast contract) and §6 Phase 3 (deliverables).

## Notable behaviour changes

- The plan §7 known constraint about apply-time credential dry-run surfaces here: existing stacks with misconfigured Vault / NATS bindings on a JobPool service will start failing on their first re-apply post-upgrade. Failure surfaces as a clear ` "Vault/NATS credential dry-run failed for JobPool service \"<name>\": …" ` apply error.
- The bespoke `mini-infra.backup.run` responder in `backup-executor.ts` is intentionally left in place — its deletion is a Phase 4 deliverable once `pg-az-backup` migrates to the JobPool template.

## Test plan
- [x] `pnpm build:lib`, `pnpm --filter mini-infra-server build`, `pnpm --filter mini-infra-client build` all clean
- [x] `pnpm --filter mini-infra-server test` — 2286 tests pass (170 files), including 23 new tests across 3 new test files
- [x] `pnpm --filter mini-infra-server lint` — clean
- [x] Live smoke in a worktree dev env:
  - [x] Authored a JobPool template with cron `*/1 * * * *`, `nats-request` on a test subject, manual implicit. Apply succeeded; registries logged `registered cron trigger` and `subscribed nats-request trigger`.
  - [x] Cron fires reliably every minute over multiple cycles (14:02, 15:02, 16:02, 17:02, 18:02 in dev logs).
  - [x] Manual HTTP trigger returns 200 `{ runId }`. Spawned container has correct labels (`mini-infra.job-pool-trigger-kind=manual`, `…trigger-name=manual-http`) and `JOB_PAYLOAD={"foo":"bar","seq":1}` in env.
  - [x] Cron-spawned container has the matching labels (`kind=cron`, `name=every-minute`) and empty `JOB_PAYLOAD`.
  - [x] `maxConcurrent: 2` cap-hit verified — three consecutive HTTP calls return `429 { error: "concurrency_cap_reached", maxConcurrent: 2 }`.
  - [x] Server restart triggered by Vault unlock — `loadAll()` re-registers every trigger from DB without manual intervention; cron continues firing on the next minute boundary.
  - [x] Stack destroy correctly tears down both registries (`removed all triggers for stack`, `removed all subscriptions for stack`).
  - [ ] Live `nats request` against the registered subject — deferred. The dev env's NATS auth requires authed creds that aren't trivially available to a host-side CLI, and the in-container `nats` CLI isn't present. Subscription is verified by the boot log; the request-handler shape (success / cap-hit / malformed-payload / null-body) is covered by `job-pool-nats-registry.test.ts`.

Closes MINI-52