### PR TITLE
fix(docker): unpin dumb-init to fix main image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ FROM node:24-alpine AS production
 
 # Install dumb-init for proper signal handling, Docker CLI for container management,
 # and GitHub CLI for repository operations
-RUN apk add --no-cache dumb-init=1.2.5-r3 docker-cli github-cli
+RUN apk add --no-cache dumb-init docker-cli github-cli
 
 WORKDIR /app
 


### PR DESCRIPTION
## Problem

The v1.9.0 release build failed in the `build-main` job:

```
ERROR: process "/bin/sh -c apk add --no-cache dumb-init=1.2.5-r3 docker-cli github-cli" did not complete successfully: exit code: 1
```

The pinned `dumb-init=1.2.5-r3` aged out of Alpine's package index when the `node:24-alpine` base image rolled forward (Alpine drops old package revisions). `apk` can no longer resolve that exact revision, so the main app image never built — meaning the `:production` tag was **not** updated for the main image (the 6 ancillary images, which are `needs:` of `build-main`, built fine).

## Fix

Unpin `dumb-init`. This matches:
- `docker-cli` / `github-cli` on the **same line** (already unpinned), and
- `update-sidecar/Dockerfile`, which already uses `apk add --no-cache dumb-init`.

Unpinning is robust against future base-image rolls. Scanned all other Dockerfiles — no remaining version-pinned `apk` packages.

## Impact

Unblocks the v1.9.0 release so `:production` can be rebuilt and deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)