### PR TITLE
fix(deployment): restore accidentally-deleted production deploy scaffolding

### DIFF
--- a/deployment/production/.env.example
+++ b/deployment/production/.env.example
@@ -1,0 +1,23 @@
+# Mini Infra — production environment file
+# Copy to `.env` (cp .env.example .env) and adjust as needed.
+# All values below are OPTIONAL — Mini Infra boots with sensible defaults.
+# NEVER commit your real `.env` to version control.
+
+# Application secret for auth/encryption.
+# Auto-generated on first boot if left unset. To pin your own:
+#   openssl rand -base64 32
+# APP_SECRET=
+
+# Comma-separated list of emails allowed to log in (admin access control).
+# ALLOWED_ADMIN_EMAILS=you@example.com,teammate@example.com
+
+# Host port to expose the UI/API on (container always listens on 5000).
+# MINI_INFRA_PORT=5000
+
+# Logging verbosity: trace | debug | info | warn | error | fatal
+# LOG_LEVEL=info
+
+# (Optional) OpenObserve log forwarding
+# OPENOBSERVE_ORGANIZATION_NAME=default
+# OPENOBSERVE_USERNAME=
+# OPENOBSERVE_PASSWORD=

--- a/deployment/production/DEPLOYMENT.md
+++ b/deployment/production/DEPLOYMENT.md
@@ -1,0 +1,302 @@
+# Mini Infra Deployment Guide
+
+## Quick Start with Docker Compose
+
+This guide will help you deploy Mini Infra on a Linux server using Docker Compose.
+
+### Prerequisites
+
+- Linux server with Docker and Docker Compose installed
+- Access to Docker daemon (`/var/run/docker.sock`)
+- Port 5000 available (or configure a different port)
+- (Optional) Domain name for production deployment
+
+### Step 1: Clone or Copy Files
+
+On your Linux server, you'll need:
+- `docker-compose.yaml`
+- `.env` (create from `.env.example`)
+
+```bash
+# Clone the repository (or copy the files manually)
+git clone <repository-url>
+cd mini-infra
+```
+
+### Step 2: Configure Environment Variables
+
+Copy the example environment file and edit it with your values:
+
+```bash
+cp .env.example .env
+nano .env  # or use your preferred editor
+```
+
+**Configuration:**
+
+1. The application auto-generates an `APP_SECRET` on first boot. To provide your own, add it to `.env`:
+   ```bash
+   APP_SECRET=<openssl rand -base64 32>
+   ```
+
+2. **(Optional) Configure Google OAuth** for authentication:
+   - Google OAuth can be enabled and configured through the Authentication Settings page in the UI after initial setup
+   - Create OAuth credentials at https://console.cloud.google.com/
+   - Add authorized redirect URI: `http://your-server:5000/auth/google/callback`
+
+4. **(Optional) Configure OpenObserve** integration for log forwarding:
+   ```bash
+   OPENOBSERVE_ORGANIZATION_NAME=default
+   OPENOBSERVE_USERNAME=your-username
+   OPENOBSERVE_PASSWORD=your-password
+   ```
+
+### Step 3: Deploy with Docker Compose
+
+```bash
+# Pull the latest images
+docker compose pull
+
+# Start the services
+docker compose up -d
+
+# Check service status
+docker compose ps
+
+# View logs
+docker compose logs -f mini-infra
+```
+
+### Step 4: Verify Deployment
+
+1. **Check health status:**
+   ```bash
+   curl http://localhost:5000/health
+   ```
+
+2. **Access the application:**
+   - Open browser: `http://your-server:5000`
+   - You should see the Mini Infra login page
+
+3. **Monitor logs:**
+   ```bash
+   # Application logs
+   docker compose logs -f mini-infra
+
+   # All services
+   docker compose logs -f
+   ```
+
+### Step 5: Post-Deployment Configuration
+
+Once logged in to Mini Infra, configure:
+
+1. **Docker Host Settings** (System Settings → System)
+   - Configure connection to Docker daemon
+   - The default socket is already mounted via docker-compose
+
+2. **Azure Blob Storage** (if using PostgreSQL backups)
+   - Add Azure Storage connection strings
+   - Configure backup schedules
+
+3. **Cloudflare** (if monitoring tunnels)
+   - Add Cloudflare API credentials
+   - Configure tunnel monitoring
+
+## Production Deployment Considerations
+
+### Security
+
+**Docker Socket Access:**
+- The container has full access to Docker daemon via socket mount
+- Only deploy in trusted environments
+- Consider network isolation or firewall rules
+- The container runs as non-root user (`node`) for security
+
+**Environment Variables:**
+- NEVER commit `.env` to version control
+- Ensure `APP_SECRET` is generated (auto-generated on first boot, or set manually)
+- Rotate secrets regularly
+- Consider using Docker secrets for sensitive data
+
+### Reverse Proxy Setup
+
+For production, use a reverse proxy (nginx, Caddy, Traefik) with HTTPS:
+
+**Example nginx configuration:**
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name mini-infra.yourdomain.com;
+
+    ssl_certificate /path/to/cert.pem;
+    ssl_certificate_key /path/to/key.pem;
+
+    location / {
+        proxy_pass http://localhost:5000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+```
+
+After first boot, configure the public URL and CORS origin via Settings in the UI. If `PUBLIC_URL` is set in `.env`, it will be auto-migrated to the database on startup.
+
+### Data Persistence
+
+The docker-compose configuration creates named volumes:
+- `mini-infra-data`: SQLite database and application data
+- `mini-infra-logs`: Application log files
+- `openobserve_data`: OpenObserve data
+
+**Backup these volumes regularly:**
+```bash
+# Backup database
+docker compose exec mini-infra tar czf - /app/data | gzip > mini-infra-backup-$(date +%Y%m%d).tar.gz
+
+# List volumes
+docker volume ls
+
+# Inspect volume location
+docker volume inspect mini-infra_mini-infra-data
+```
+
+### Monitoring
+
+**Health Checks:**
+The container includes automatic health checks:
+```bash
+# View health status
+docker compose ps
+
+# Check health manually
+docker compose exec mini-infra node -e "require('http').get('http://localhost:5000/health', (r) => {r.on('data', d => console.log(d.toString()))})"
+```
+
+**Log Forwarding:**
+- Configure OpenObserve integration in `.env`
+- Enable OpenTelemetry for distributed tracing
+- Logs are also available in `mini-infra-logs` volume
+
+## Managing the Deployment
+
+### Common Commands
+
+```bash
+# Start services
+docker compose up -d
+
+# Stop services
+docker compose down
+
+# Restart services
+docker compose restart
+
+# View logs
+docker compose logs -f
+
+# Update to latest version
+docker compose pull
+docker compose up -d
+
+# Check resource usage
+docker stats mini-infra
+
+# Execute commands in container
+docker compose exec mini-infra sh
+
+# Access database
+docker compose exec mini-infra sh -c "cd /app/data && ls -la"
+```
+
+### Updating the Application
+
+```bash
+# Pull latest image
+docker compose pull mini-infra
+
+# Recreate container with new image
+docker compose up -d --force-recreate mini-infra
+
+# Database migrations run automatically on startup
+```
+
+### Troubleshooting
+
+**Container won't start:**
+```bash
+# Check logs
+docker compose logs mini-infra
+
+# Common issues:
+# - APP_SECRET not generated (should auto-generate on first boot)
+# - Port 5000 already in use
+# - Docker socket permissions
+```
+
+**Database issues:**
+```bash
+# Check database file
+docker compose exec mini-infra ls -la /app/data
+
+# View migration status
+docker compose exec mini-infra npx prisma migrate status
+```
+
+**Docker socket permission denied:**
+```bash
+# On host, check Docker socket permissions
+ls -la /var/run/docker.sock
+
+# Add user to docker group if needed
+sudo usermod -aG docker $USER
+```
+
+**Health check failing:**
+```bash
+# Check if app is responding
+docker compose exec mini-infra wget -O- http://localhost:5000/health
+
+# Check port binding
+docker compose ps
+netstat -tlnp | grep 5000
+```
+
+## Environment Variables Reference
+
+See `.env.example` for a complete list of available configuration options.
+
+### Optional Variables
+- `APP_SECRET` - Application secret for auth and encryption (auto-generated on first boot if not set)
+- `ALLOWED_ADMIN_EMAILS` - Comma-separated list of allowed login emails
+- `MINI_INFRA_PORT` - Port to expose (default: 5000)
+- `LOG_LEVEL` - Logging verbosity (trace|debug|info|warn|error|fatal)
+- `OPENOBSERVE_*` - OpenObserve log forwarding configuration
+- `OTEL_*` - OpenTelemetry tracing configuration
+
+## Docker Image Information
+
+- **Registry:** GitHub Container Registry (ghcr.io)
+- **Image:** `ghcr.io/mrgeoffrich/mini-infra:production`
+- **Base:** Node.js 24 Alpine Linux
+- **Size:** ~300-400MB
+- **Security:** Runs as non-root user (`node`)
+- **Updates:** `:production` is rebuilt only when a GitHub Release is published; `:dev` is rebuilt on every push to `main`. See [RELEASING.md](../../RELEASING.md).
+
+### Available Tags
+- `production` - Latest published GitHub Release (use this for production)
+- `1.2.3` / `1.2` - Exact version / major.minor for an immutable deploy
+- `dev` - Latest build from the `main` branch (testing only)
+- `main-<sha>` - Specific commit from `main`
+
+## Support
+
+For issues and questions:
+- GitHub Issues: <repository-issues-url>
+- Documentation: See CLAUDE.md for development details

--- a/deployment/production/docker-compose.yaml
+++ b/deployment/production/docker-compose.yaml
@@ -1,0 +1,46 @@
+services:
+  mini-infra:
+    # `:production` is published only on a tagged GitHub Release (see RELEASING.md).
+    # Pin a specific version (e.g. `:1.9.1`) instead if you want immutable deploys.
+    image: ghcr.io/mrgeoffrich/mini-infra:production
+    container_name: mini-infra
+    restart: unless-stopped
+    ports:
+      - "${MINI_INFRA_PORT:-5000}:5000"
+    volumes:
+      # Mount Docker socket for container management
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Persistent data storage
+      - mini-infra-data:/app/data
+      # Log files
+      - mini-infra-logs:/app/server/logs
+    environment:
+      # Core Configuration
+      - NODE_ENV=production
+
+      # Security (optional - auto-generated on first boot if not set)
+      - APP_SECRET=${APP_SECRET:-}
+
+      # Admin Access Control (optional, comma-separated emails allowed to log in)
+      - ALLOWED_ADMIN_EMAILS=${ALLOWED_ADMIN_EMAILS:-}
+
+      # Server Configuration
+      - PORT=5000
+      # PUBLIC_URL is now a database setting configured via Settings UI
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+
+      # Database
+      - DATABASE_URL=file:/app/data/production.db?foreign_keys=true&journal_mode=WAL
+
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:5000/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"]
+      interval: 30s
+      timeout: 3s
+      start_period: 40s
+      retries: 3
+
+volumes:
+  mini-infra-data:
+    driver: local
+  mini-infra-logs:
+    driver: local

--- a/deployment/production/start.ps1
+++ b/deployment/production/start.ps1
@@ -1,0 +1,41 @@
+#!/usr/bin/env pwsh
+# Mini Infra Production Deployment Startup Script (PowerShell)
+# This script starts the production Mini Infra deployment using Docker Compose
+
+$ErrorActionPreference = "Stop"
+
+# Check if .env file exists
+$envFile = Join-Path $PSScriptRoot ".env"
+if (-not (Test-Path $envFile)) {
+    Write-Host "ERROR: .env file not found at: $envFile" -ForegroundColor Red
+    Write-Host ""
+    Write-Host "Please create a .env file in the deployment/production/ directory." -ForegroundColor Yellow
+    Write-Host "You can use the following template as a starting point:" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "  # APP_SECRET is auto-generated on first boot if not set"
+    Write-Host "  # APP_SECRET=<optional: openssl rand -base64 32>"
+    Write-Host ""
+    exit 1
+}
+
+Write-Host "Starting Mini Infra production deployment..." -ForegroundColor Green
+Write-Host "Using .env file: $envFile" -ForegroundColor Cyan
+Write-Host ""
+
+# Start Docker Compose with explicit env file
+docker compose --env-file $envFile -f (Join-Path $PSScriptRoot "docker-compose.yaml") up -d
+
+if ($LASTEXITCODE -eq 0) {
+    Write-Host ""
+    Write-Host "Mini Infra started successfully!" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "Useful commands:" -ForegroundColor Cyan
+    Write-Host "  View logs:    docker compose -f deployment/production/docker-compose.yaml logs -f"
+    Write-Host "  Check status: docker compose -f deployment/production/docker-compose.yaml ps"
+    Write-Host "  Stop:         docker compose -f deployment/production/docker-compose.yaml down"
+    Write-Host ""
+} else {
+    Write-Host ""
+    Write-Host "ERROR: Failed to start Mini Infra" -ForegroundColor Red
+    exit 1
+}

--- a/deployment/production/start.sh
+++ b/deployment/production/start.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Mini Infra Production Deployment Startup Script (Bash)
+# This script starts the production Mini Infra deployment using Docker Compose
+
+set -e
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/.env"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yaml"
+
+# Handle --reset flag: remove containers and volumes
+if [ "$1" = "--reset" ]; then
+    echo -e "\033[0;31m⚠  WARNING: This will destroy ALL Mini Infra data including:\033[0m"
+    echo "  - The database (users, settings, configuration)"
+    echo "  - All log files"
+    echo ""
+    read -r -p "Are you sure you want to continue? [y/N] " confirm
+    if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+        echo "Aborted."
+        exit 0
+    fi
+    echo ""
+    echo "Stopping containers and removing volumes..."
+    docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" down -v
+    echo -e "\033[0;32mReset complete. Starting fresh...\033[0m"
+    echo ""
+fi
+
+# Check if .env file exists
+if [ ! -f "$ENV_FILE" ]; then
+    echo -e "\033[0;31mERROR: .env file not found at: $ENV_FILE\033[0m"
+    echo ""
+    echo -e "\033[0;33mPlease create a .env file in the deployment/production/ directory.\033[0m"
+    echo -e "\033[0;33mYou can use the following template as a starting point:\033[0m"
+    echo ""
+    echo "  # APP_SECRET is auto-generated on first boot if not set"
+    echo "  # APP_SECRET=<optional: openssl rand -base64 32>"
+    echo ""
+    exit 1
+fi
+
+echo -e "\033[0;32mStarting Mini Infra production deployment...\033[0m"
+echo -e "\033[0;36mUsing .env file: $ENV_FILE\033[0m"
+echo ""
+
+# Start Docker Compose with explicit env file
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d
+
+if [ $? -eq 0 ]; then
+    echo ""
+    echo -e "\033[0;32mMini Infra started successfully!\033[0m"
+    echo ""
+    echo -e "\033[0;36mUseful commands:\033[0m"
+    echo "  View logs:    docker compose -f deployment/production/docker-compose.yaml logs -f"
+    echo "  Check status: docker compose -f deployment/production/docker-compose.yaml ps"
+    echo "  Stop:         docker compose -f deployment/production/docker-compose.yaml down"
+    echo ""
+else
+    echo ""
+    echo -e "\033[0;31mERROR: Failed to start Mini Infra\033[0m"
+    exit 1
+fi


### PR DESCRIPTION
## Problem

`deployment/production/` was deleted in #191 — a PR titled *"Add features & enhancements roadmap"* whose stated purpose had nothing to do with deleting the production deploy files, so this was almost certainly **accidental**. It's been missing since 2026-04-15 (across v1.7.0 / v1.8.0 / v1.8.1).

Meanwhile `deployment/README.md` still tells users to `cd deployment/production && ./start.sh` and links `production/DEPLOYMENT.md` — both 404'd. There was no canonical fresh-install path in the repo.

## What this restores

`docker-compose.yaml`, `start.sh`, `start.ps1`, `DEPLOYMENT.md` — recovered from `1cddbb7^` and brought current:

- **compose pins `:production`** (not the old `:latest`, which the build workflow **never publishes** — it only emits `:production` on a GitHub Release, plus `:dev` / `:main-<sha>` / semver). The old file would not have pulled.
- **`DEPLOYMENT.md`** image/tag section corrected to the real tag matrix and links `RELEASING.md`.
- **added `.env.example`** so the documented `cp .env.example .env` flow works — it was referenced in two places but never actually committed.
- **`start.sh` marked executable** so the documented `./start.sh` runs without a manual `chmod`.

## Notes

- Repo-only change; nothing is started here. The files are meant to be pulled/copied onto a production host.
- Pairs with the freshly-published **v1.9.1** release, whose `:production` image these files point at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)