### PR TITLE
feat(egress): delegate egress network subnet to Docker (Phase 1, MINI-64)

### DIFF
--- a/server/src/__tests__/egress-network-allocator.test.ts
+++ b/server/src/__tests__/egress-network-allocator.test.ts
@@ -12,126 +12,16 @@ vi.mock('../services/docker', () => ({
 }));
 
 function makeMockPrisma(overrides: Partial<{
-  infraResourceFindMany: unknown;
   infraResourceFindFirst: unknown;
 }> = {}): Mocked<PrismaClient> {
   return {
     infraResource: {
-      findMany: vi.fn().mockResolvedValue(overrides.infraResourceFindMany ?? []),
       findFirst: vi.fn().mockResolvedValue(overrides.infraResourceFindFirst ?? null),
     },
   } as unknown as Mocked<PrismaClient>;
 }
 
 describe('EgressNetworkAllocator', () => {
-  beforeEach(() => {
-    // Clear env var override between tests
-    delete process.env['MINI_INFRA_EGRESS_POOL_CIDR'];
-  });
-
-  describe('allocateSubnet', () => {
-    it('allocates the first /24 from the default pool when no subnets are in use', async () => {
-      const prisma = makeMockPrisma();
-      const allocator = new EgressNetworkAllocator(prisma);
-
-      const result = await allocator.allocateSubnet();
-
-      expect(result.subnet).toBe('172.30.0.0/24');
-      expect(result.gateway).toBe('172.30.0.1');
-    });
-
-    it('skips subnets already stored in InfraResource.metadata', async () => {
-      // Slots 0, 1 are taken; should return slot 2
-      const prisma = makeMockPrisma({
-        infraResourceFindMany: [
-          { metadata: { subnet: '172.30.0.0/24', gateway: '172.30.0.1' } },
-          { metadata: { subnet: '172.30.1.0/24', gateway: '172.30.1.1' } },
-        ],
-      });
-      const allocator = new EgressNetworkAllocator(prisma);
-
-      const result = await allocator.allocateSubnet();
-
-      expect(result.subnet).toBe('172.30.2.0/24');
-      expect(result.gateway).toBe('172.30.2.1');
-    });
-
-    it('skips subnets in use by Docker when Docker is connected', async () => {
-      const { default: DockerService } = await import('../services/docker');
-      vi.mocked(DockerService.getInstance).mockReturnValueOnce({
-        isConnected: vi.fn().mockReturnValue(true),
-        listNetworks: vi.fn().mockResolvedValue([
-          { ipam: { config: [{ subnet: '172.30.0.0/24' }] } },
-          { ipam: { config: [{ subnet: '172.30.1.0/24' }] } },
-        ]),
-      } as any);
-
-      const prisma = makeMockPrisma();
-      const allocator = new EgressNetworkAllocator(prisma);
-
-      const result = await allocator.allocateSubnet();
-
-      expect(result.subnet).toBe('172.30.2.0/24');
-    });
-
-    it('ignores IPv6 entries in Docker network list', async () => {
-      const { default: DockerService } = await import('../services/docker');
-      vi.mocked(DockerService.getInstance).mockReturnValueOnce({
-        isConnected: vi.fn().mockReturnValue(true),
-        listNetworks: vi.fn().mockResolvedValue([
-          { ipam: { config: [{ subnet: 'fd00::/64' }] } },   // IPv6 - should be ignored
-          { ipam: { config: [{ subnet: '172.30.0.0/24' }] } }, // IPv4 - should be counted
-        ]),
-      } as any);
-
-      const prisma = makeMockPrisma();
-      const allocator = new EgressNetworkAllocator(prisma);
-
-      // IPv6 entry ignored, only 172.30.0.0/24 taken → next is 172.30.1.0/24
-      const result = await allocator.allocateSubnet();
-
-      expect(result.subnet).toBe('172.30.1.0/24');
-    });
-
-    it('throws when the pool is exhausted', async () => {
-      // Fill all 256 slots of 172.30.0.0/16
-      const allSubnets = Array.from({ length: 256 }, (_, i) => ({
-        metadata: { subnet: `172.30.${i}.0/24` },
-      }));
-      const prisma = makeMockPrisma({ infraResourceFindMany: allSubnets });
-      const allocator = new EgressNetworkAllocator(prisma);
-
-      await expect(allocator.allocateSubnet()).rejects.toThrow(/pool exhausted/i);
-    });
-
-    it('respects MINI_INFRA_EGRESS_POOL_CIDR env var', async () => {
-      process.env['MINI_INFRA_EGRESS_POOL_CIDR'] = '10.100.0.0/16';
-
-      const prisma = makeMockPrisma();
-      const allocator = new EgressNetworkAllocator(prisma);
-
-      const result = await allocator.allocateSubnet();
-
-      expect(result.subnet).toBe('10.100.0.0/24');
-      expect(result.gateway).toBe('10.100.0.1');
-    });
-
-    it('ignores InfraResource entries with no metadata.subnet', async () => {
-      const prisma = makeMockPrisma({
-        infraResourceFindMany: [
-          { metadata: null },
-          { metadata: {} },
-          { metadata: { someOtherField: 'value' } },
-        ],
-      });
-      const allocator = new EgressNetworkAllocator(prisma);
-
-      // All entries have no subnet, so slot 0 should be available
-      const result = await allocator.allocateSubnet();
-      expect(result.subnet).toBe('172.30.0.0/24');
-    });
-  });
-
   describe('allocateGatewayIp', () => {
     it('returns .2 in the subnet when no containers are connected', async () => {
       const { default: DockerService } = await import('../services/docker');

--- a/server/src/__tests__/environment-manager.test.ts
+++ b/server/src/__tests__/environment-manager.test.ts
@@ -44,11 +44,9 @@ vi.mock('../services/docker', () => ({
 }));
 
 // Mock EgressNetworkAllocator
-const mockAllocateSubnet = vi.fn().mockResolvedValue({ subnet: '172.30.0.0/24', gateway: '172.30.0.1' });
 vi.mock('../services/egress/egress-network-allocator', () => ({
   EgressNetworkAllocator: function() {
     return {
-      allocateSubnet: mockAllocateSubnet,
       allocateGatewayIp: vi.fn().mockResolvedValue('172.30.0.2'),
     };
   },
@@ -128,6 +126,9 @@ describe('EnvironmentManager', () => {
         getNetwork: vi.fn().mockReturnValue({
           connect: vi.fn().mockResolvedValue(undefined),
           disconnect: vi.fn().mockResolvedValue(undefined),
+          inspect: vi.fn().mockResolvedValue({
+            IPAM: { Config: [{ Subnet: '172.30.0.0/24', Gateway: '172.30.0.1' }] },
+          }),
         }),
       }),
     } as any;
@@ -141,7 +142,6 @@ describe('EnvironmentManager', () => {
       duration: 100,
     });
     mockReconcilerStopStack.mockResolvedValue({ success: true, stoppedContainers: 1 });
-    mockAllocateSubnet.mockResolvedValue({ subnet: '172.30.0.0/24', gateway: '172.30.0.1' });
 
     environmentManager = EnvironmentManager.getInstance(mockPrisma);
   });
@@ -332,10 +332,10 @@ describe('EnvironmentManager', () => {
       mockPrisma.environment.create.mockResolvedValue(createdEnvData as any);
       mockPrisma.environment.findUnique.mockResolvedValue(fetchedEnvData as any);
 
-      // Make egress subnet allocation throw — provisionEgressGateway swallows
-      // it, but the UserEvent should still finalise as `completed` (env is
-      // usable) with a warning entry in the logs. The HTTP response is unaffected.
-      mockAllocateSubnet.mockRejectedValueOnce(new Error('allocator unavailable'));
+      // Make an egress provisioning step throw — provisionEgressGateway swallows
+      // it, but the UserEvent should still finalise (env is usable) with a
+      // warning entry in the logs. The HTTP response is unaffected.
+      mockDockerExecutor.networkExists.mockRejectedValueOnce(new Error('docker unavailable'));
 
       const request = { name: 'test-env', type: 'nonproduction' as const };
 

--- a/server/src/services/egress/egress-network-allocator.ts
+++ b/server/src/services/egress/egress-network-allocator.ts
@@ -5,93 +5,6 @@ import { getLogger } from '../../lib/logger-factory';
 const log = getLogger('stacks', 'egress-network-allocator');
 
 /**
- * Default CIDR pool for egress gateway subnets.
- * Override with MINI_INFRA_EGRESS_POOL_CIDR env var (e.g. "10.100.0.0/16").
- * Per-environment subnets are allocated as /<hostBits>-sized slices, default /24.
- */
-const DEFAULT_POOL_CIDR = '172.30.0.0/16';
-const DEFAULT_SUBNET_MASK = 24;
-
-/**
- * Parse the pool CIDR from env, falling back to the default.
- * Returns { baseOctets: [a, b, c, d], poolMask, subnetMask }.
- */
-function getPoolConfig(): { base: number[]; poolMask: number; subnetMask: number } {
-  const raw = process.env['MINI_INFRA_EGRESS_POOL_CIDR'] ?? DEFAULT_POOL_CIDR;
-  const match = raw.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)\/(\d+)$/);
-  if (!match) {
-    log.warn({ raw }, 'MINI_INFRA_EGRESS_POOL_CIDR is malformed, using default');
-    return { base: [172, 30, 0, 0], poolMask: 16, subnetMask: DEFAULT_SUBNET_MASK };
-  }
-  const base = [
-    parseInt(match[1], 10),
-    parseInt(match[2], 10),
-    parseInt(match[3], 10),
-    parseInt(match[4], 10),
-  ];
-  const poolMask = parseInt(match[5], 10);
-  const subnetMask = DEFAULT_SUBNET_MASK;
-  if (poolMask > subnetMask) {
-    log.warn({ poolMask, subnetMask }, 'Pool mask is larger than subnet mask, using default pool');
-    return { base: [172, 30, 0, 0], poolMask: 16, subnetMask: DEFAULT_SUBNET_MASK };
-  }
-  return { base, poolMask, subnetMask };
-}
-
-/**
- * Convert a /24 subnet index to the corresponding CIDR network address string.
- * For pool 172.30.0.0/16 with /24 subnets: index 0 → "172.30.0.0/24", index 1 → "172.30.1.0/24", etc.
- *
- * Subnets are always /24, so the 4th octet of the network address is always 0.
- * The index selects successive /24 blocks starting from the pool base address.
- */
-function indexToSubnet(index: number, base: number[], subnetMask: number): string {
-  // Convert the base address to a 32-bit integer
-  const baseInt = ((base[0] << 24) | (base[1] << 16) | (base[2] << 8) | base[3]) >>> 0;
-  // Each /24 block is 256 addresses
-  const blockSize = 1 << (32 - subnetMask);
-  const subnetInt = (baseInt + index * blockSize) >>> 0;
-  const o0 = (subnetInt >>> 24) & 0xff;
-  const o1 = (subnetInt >>> 16) & 0xff;
-  const o2 = (subnetInt >>> 8) & 0xff;
-  const o3 = subnetInt & 0xff;
-  return `${o0}.${o1}.${o2}.${o3}/${subnetMask}`;
-}
-
-/**
- * Derive the gateway IP from a subnet CIDR.
- * By convention the gateway occupies .1 in the subnet network address.
- * e.g. "172.30.5.0/24" → "172.30.5.1"
- */
-function subnetToGatewayIp(subnet: string): string {
-  const cidr = subnet.split('/')[0];
-  const parts = cidr.split('.').map(Number);
-  parts[3] = 1;
-  return parts.join('.');
-}
-
-/**
- * The egress gateway container IP — second host address (.2) in the subnet.
- * e.g. "172.30.5.0/24" → "172.30.5.2"
- */
-function subnetToGatewayContainerIp(subnet: string): string {
-  const cidr = subnet.split('/')[0];
-  const parts = cidr.split('.').map(Number);
-  parts[3] = 2;
-  return parts.join('.');
-}
-
-/**
- * Determine how many /24 slots exist in a pool of size poolMask bits.
- * For /16 → 256 subnets (x.y.0.0 to x.y.255.0); for /8 → 65536.
- */
-function poolSlotCount(poolMask: number, subnetMask: number): number {
-  const bits = subnetMask - poolMask;
-  if (bits <= 0) return 1;
-  return Math.min(1 << bits, 65536); // Cap at 65536 to avoid absurd loops
-}
-
-/**
  * Parse an IPv4 CIDR subnet string to its network address as an array of 4 octets.
  * Returns null if invalid or IPv6.
  */
@@ -104,82 +17,17 @@ function parseCidrNetworkAddress(cidr: string): number[] | null {
 }
 
 /**
- * EgressNetworkAllocator picks deterministic, non-conflicting /24 subnets
- * and gateway IPs from the egress pool for the per-env egress network
- * (where the egress-gateway container and managed app containers live).
+ * EgressNetworkAllocator picks the gateway container IP for the per-env egress
+ * network (where the egress-gateway container and managed app containers live).
+ *
+ * The network's subnet is chosen by Docker's IPAM at network-create time — the
+ * allocator does not prescribe it (delegating to Docker is what keeps the
+ * subnet from overlapping other networks on a shared host). The allocator's
+ * only job is to pick the gateway container's host address within whatever
+ * subnet Docker assigned.
  */
 export class EgressNetworkAllocator {
   constructor(private readonly prisma: PrismaClient) {}
-
-  /**
-   * Picks the lowest unused /24 from the configured pool.
-   * - Pool default: 172.30.0.0/16, allocated as 172.30.<x>.0/24 for x in [0..255].
-   * - Excludes subnets already stored in EnvironmentNetwork.options.subnet.
-   * - Excludes subnets in use by existing Docker networks (cross-check via DockerService).
-   *
-   * Returns { subnet, gateway } where gateway is the .1 address (the bridge gateway).
-   * The egress container itself will be allocated .2 separately via allocateGatewayIp().
-   */
-  async allocateSubnet(): Promise<{ subnet: string; gateway: string }> {
-    const { base, poolMask, subnetMask } = getPoolConfig();
-    const totalSlots = poolSlotCount(poolMask, subnetMask);
-
-    // Collect subnets already in use from the DB.
-    // Subnets are persisted on InfraResource.metadata.subnet for the per-env
-    // egress network. The Docker scan below catches anything else that lives
-    // in the pool (e.g. an applications network deployed elsewhere).
-    const dbResources = await this.prisma.infraResource.findMany({
-      where: { type: 'docker-network', purpose: 'egress', scope: 'environment' },
-      select: { metadata: true },
-    });
-
-    const usedFromDb = new Set<string>();
-    for (const r of dbResources) {
-      const meta = r.metadata as Record<string, unknown> | null;
-      const subnet = meta?.['subnet'];
-      if (typeof subnet === 'string') {
-        // Normalise to just the network address for comparison
-        const addr = parseCidrNetworkAddress(subnet);
-        if (addr) usedFromDb.add(addr.join('.'));
-      }
-    }
-
-    // Collect subnets in use by Docker (cross-check via DockerService)
-    const usedFromDocker = new Set<string>();
-    try {
-      const docker = DockerService.getInstance();
-      if (docker.isConnected()) {
-        const networks = await docker.listNetworks();
-        for (const net of networks) {
-          for (const cfg of net.ipam?.config ?? []) {
-            if (!cfg.subnet) continue;
-            const addr = parseCidrNetworkAddress(cfg.subnet);
-            if (addr) usedFromDocker.add(addr.join('.'));
-          }
-        }
-      }
-    } catch (err) {
-      log.warn({ error: err instanceof Error ? err.message : String(err) }, 'Could not query Docker networks for subnet conflict check; proceeding with DB-only check');
-    }
-
-    // Pick the lowest unused slot
-    for (let i = 0; i < totalSlots; i++) {
-      const candidate = indexToSubnet(i, base, subnetMask);
-      const addr = parseCidrNetworkAddress(candidate);
-      if (!addr) continue;
-      const addrStr = addr.join('.');
-      if (usedFromDb.has(addrStr) || usedFromDocker.has(addrStr)) continue;
-
-      const gateway = subnetToGatewayIp(candidate);
-      log.info({ subnet: candidate, gateway, slot: i }, 'Allocated egress subnet');
-      return { subnet: candidate, gateway };
-    }
-
-    throw new Error(
-      `Egress subnet pool exhausted: all ${totalSlots} slots in the pool are in use. ` +
-      `Override MINI_INFRA_EGRESS_POOL_CIDR to use a larger pool.`
-    );
-  }
 
   /**
    * For the per-env egress network already created with a known subnet, pick
@@ -252,13 +100,4 @@ export class EgressNetworkAllocator {
       `Egress gateway IP pool exhausted for network "${networkName}" subnet "${subnet}": all host addresses are in use`
     );
   }
-}
-
-/**
- * Helper: derive the egress container IP from a known subnet.
- * This is the .2 address — used when creating the gateway stack service.
- * Callers should prefer allocateGatewayIp() for correctness; this is for testing.
- */
-export function egressContainerIpFromSubnet(subnet: string): string {
-  return subnetToGatewayContainerIp(subnet);
 }

--- a/server/src/services/environment/environment-manager.ts
+++ b/server/src/services/environment/environment-manager.ts
@@ -601,38 +601,66 @@ export class EnvironmentManager {
       await executor.initialize();
       const allocator = new EgressNetworkAllocator(this.prisma);
 
-      // Step 1: Determine subnet. If the egress network already exists (e.g.
-      // from a prior failed attempt, or external creation), use its subnet so
-      // we stay consistent with reality. Otherwise allocate a fresh /24 from
-      // the pool.
+      // Step 1: Create the egress Docker network if it doesn't exist yet,
+      // letting Docker's IPAM assign the subnet. We deliberately don't prescribe
+      // a subnet — a hardcoded pool collides with whatever other networks
+      // already exist on the host, whereas Docker never double-allocates within
+      // a daemon and skips ranges that overlap host routes. Creating it up-front
+      // (before the egress-gateway stack apply) lets mini-infra-server join
+      // (Step 3b) and lets us pick a non-colliding gateway IP (Step 3c) before
+      // any container races onto the network.
+      const networkAlreadyExists = await executor.networkExists(egressNetworkName);
+      if (!networkAlreadyExists) {
+        try {
+          await executor.createNetwork(egressNetworkName, '', {
+            driver: 'bridge',
+            labels: {
+              'mini-infra.infra-resource': 'true',
+              'mini-infra.resource-purpose': 'egress',
+              'mini-infra.environment': environmentId,
+            },
+          });
+        } catch (netErr) {
+          const msg = netErr instanceof Error ? netErr.message : String(netErr);
+          this.logger.error({ environmentId, err: msg }, 'Failed to create egress network for env');
+          await this.userEventService.appendLogs(userEventId, `[${new Date().toISOString()}] WARNING: egress network create failed: ${msg}`);
+          // Fall through — the network may already exist (race / prior run); the
+          // inspect below is the source of truth and returns if it's truly absent.
+        }
+      }
+
+      // Step 2: Read back the subnet + bridge gateway Docker assigned (the same
+      // path serves an already-existing network) and record them on the egress
+      // InfraResource. The record is a cache of Docker's truth, refreshed from
+      // inspect — never a value we feed back into network creation. Downstream
+      // consumers and allocateGatewayIp's fallback read the subnet from here.
       let subnet: string;
       let gateway: string;
-      const networkAlreadyExists = await executor.networkExists(egressNetworkName);
-      if (networkAlreadyExists) {
+      try {
         const dockerClient = executor.getDockerClient();
         const inspect = await dockerClient.getNetwork(egressNetworkName).inspect();
         const ipamCfg = inspect.IPAM?.Config?.[0];
         if (!ipamCfg?.Subnet) {
-          throw new Error(`Existing network ${egressNetworkName} has no IPAM subnet`);
+          throw new Error(`Egress network ${egressNetworkName} has no IPAM subnet`);
         }
         subnet = ipamCfg.Subnet;
         const subnetOctets = subnet.split('/')[0].split('.');
         gateway = ipamCfg.Gateway ?? `${subnetOctets.slice(0, 3).join('.')}.1`;
-        this.logger.info({ environmentId, subnet, gateway, egressNetworkName }, 'Reusing existing egress network subnet');
-      } else {
-        const allocated = await allocator.allocateSubnet();
-        subnet = allocated.subnet;
-        gateway = allocated.gateway;
+        this.logger.info({ environmentId, subnet, gateway, egressNetworkName }, 'Recorded egress network subnet from Docker');
+        await this.userEventService.appendLogs(userEventId, `[${new Date().toISOString()}] Egress network ${egressNetworkName} ready (subnet ${subnet})`);
+      } catch (inspectErr) {
+        const msg = inspectErr instanceof Error ? inspectErr.message : String(inspectErr);
+        this.logger.error({ environmentId, egressNetworkName, err: msg }, 'Failed to inspect egress network for subnet');
+        await this.userEventService.appendLogs(userEventId, `[${new Date().toISOString()}] WARNING: could not read egress network subnet: ${msg}`);
+        return;
       }
 
       // Note: egressGatewayIp is allocated after the network exists and the
       // mini-infra-server has joined, so we can pick the first IP that isn't
       // already taken. See "Step 3c" below.
 
-      // Step 2: Pre-create the InfraResource record with the subnet in metadata
-      // so that when the egress-gateway stack runs reconcileOutputs it reuses
-      // this subnet for the egress network. Use upsert-by-findFirst since
-      // SQLite NULL uniqueness prevents true upsert.
+      // Record the subnet + gateway on the egress InfraResource. Use
+      // upsert-by-findFirst since SQLite NULL uniqueness prevents true upsert.
       const existingResource = await this.prisma.infraResource.findFirst({
         where: { type: 'docker-network', purpose: 'egress', scope: 'environment', environmentId },
       });
@@ -655,30 +683,6 @@ export class EnvironmentManager {
             metadata: { subnet, gateway } as Prisma.InputJsonValue,
           },
         });
-      }
-
-      // Step 3a: Create the egress Docker network up-front with the allocated
-      // subnet. We do this before the egress-gateway stack apply so that
-      // mini-infra-server can join (Step 3b) and we can pick a non-colliding
-      // gateway IP (Step 3c) before any container races onto the network.
-      if (!networkAlreadyExists) {
-        try {
-          await executor.createNetwork(egressNetworkName, '', {
-            driver: 'bridge',
-            labels: {
-              'mini-infra.infra-resource': 'true',
-              'mini-infra.resource-purpose': 'egress',
-              'mini-infra.environment': environmentId,
-            },
-            ipam: { subnet, gateway },
-          });
-          await this.userEventService.appendLogs(userEventId, `[${new Date().toISOString()}] Egress network ${egressNetworkName} created (subnet ${subnet})`);
-        } catch (netErr) {
-          const msg = netErr instanceof Error ? netErr.message : String(netErr);
-          this.logger.error({ environmentId, err: msg }, 'Failed to create egress network for env');
-          await this.userEventService.appendLogs(userEventId, `[${new Date().toISOString()}] WARNING: egress network create failed: ${msg}`);
-          // Continue — stack apply may still succeed if something else creates the network
-        }
       }
 
       // Step 3b: Connect the mini-infra-server container itself to this env's

--- a/server/src/services/stacks/stack-infra-resource-manager.ts
+++ b/server/src/services/stacks/stack-infra-resource-manager.ts
@@ -53,34 +53,13 @@ export class StackInfraResourceManager {
           labels['mini-infra.environment'] = stack.environmentId;
         }
 
-        // For environment-scoped egress networks, use the subnet pre-allocated
-        // by EgressNetworkAllocator and persisted on InfraResource.metadata.subnet.
-        // This gives the egress gateway a stable, known network segment.
-        let ipamConfig: { subnet: string; gateway?: string } | undefined;
-        if (output.purpose === 'egress' && stack.environmentId) {
-          // Check for an existing InfraResource record that may carry a pre-allocated subnet
-          const existingResource = await this.prisma.infraResource.findFirst({
-            where: {
-              type: 'docker-network',
-              purpose: 'egress',
-              scope: 'environment',
-              environmentId: stack.environmentId,
-            },
-            select: { metadata: true },
-          });
-          const meta = existingResource?.metadata as Record<string, unknown> | null;
-          const subnet = meta?.['subnet'];
-          const gateway = meta?.['gateway'];
-          if (typeof subnet === 'string') {
-            ipamConfig = {
-              subnet,
-              ...(typeof gateway === 'string' ? { gateway } : {}),
-            };
-            log.info({ network: name, subnet, gateway }, 'Using pre-allocated subnet for egress network');
-          }
-        }
-
-        await this.dockerExecutor.createNetwork(name, '', { driver: 'bridge', labels, ipam: ipamConfig });
+        // Every network — egress included — lets Docker's IPAM assign the
+        // subnet. The egress network is normally created up-front during
+        // environment provisioning (see EnvironmentManager.provisionEgressGateway),
+        // so this path only runs as a fallback when it's missing; either way we
+        // don't prescribe a subnet, which is what keeps it from overlapping
+        // other networks on a shared host.
+        await this.dockerExecutor.createNetwork(name, '', { driver: 'bridge', labels });
       }
 
       // Use findFirst + create/update instead of upsert because host-scoped resources


### PR DESCRIPTION
## Summary
- The per-environment egress network was the only Mini Infra network created with a self-chosen subnet (a hardcoded `172.30.0.0/16` pool). On a shared Docker host that pool collides with other Compose projects, and the allocator's exact-match-only overlap check kept handing Docker `/24`s inside an occupied range → `Pool overlaps with other one on this address space` → egress network never created → HAProxy fails with `network <env>-egress not found`.
- This makes the egress network behave like every other network: create it with **no IPAM config**, let Docker's IPAM assign a non-overlapping subnet, then **inspect and record** the subnet + gateway Docker chose on the egress `InfraResource`. `allocateGatewayIp()` (gateway static IP from live inspect) is unchanged.
- Removes `allocateSubnet()`, the `MINI_INFRA_EGRESS_POOL_CIDR` pool config, and the egress IPAM special-case in the stack reconciler.

## Changes
- `environment-manager`: `provisionEgressGateway` creates the network without a subnet, reads it back via inspect, persists subnet+gateway to metadata.
- `stack-infra-resource-manager`: drop the egress IPAM replay — egress networks are created like every other network.
- `egress-network-allocator`: trimmed to `allocateGatewayIp()` + helpers; pool logic removed.
- Tests updated for the inspect-based flow.

## Test plan
- [x] `pnpm build:lib` + server `tsc` clean
- [x] `pnpm --filter mini-infra-server test` — 2336 tests pass (incl. updated `environment-manager` provisioning tests)
- [x] `pnpm --filter mini-infra-server lint` clean
- [x] Live smoke in dev: deleted + recreated the `local` env → `local-egress` created on a **Docker-assigned** `172.24.0.0/16` (not the old pool), gateway deployed at its static IP, `egress-gateway` stack `synced`, **zero "Pool overlaps" events**.

Closes MINI-64