### PR TITLE
feat(egress): surface egress network on environment detail (Phase 2, MINI-65)

### DIFF
--- a/client/src/app/environments/[id]/page.tsx
+++ b/client/src/app/environments/[id]/page.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useParams, Link, Navigate } from "react-router-dom";
 import { Environment } from "@mini-infra/types";
 import { useEnvironment } from "@/hooks/use-environments";
-import { StacksList } from "@/components/environments";
+import { StacksList, EgressNetworkCard } from "@/components/environments";
 import { useUserStacks } from "@/hooks/use-applications";
 import { EnvironmentEditDialog } from "@/components/environments/environment-edit-dialog";
 import { EnvironmentDeleteDialog } from "@/components/environments/environment-delete-dialog";
@@ -311,6 +311,10 @@ export function EnvironmentDetailPage() {
             </CardContent>
           </Card>
         </div>
+      </div>
+
+      <div className="px-4 lg:px-6 max-w-full mb-6">
+        <EgressNetworkCard egressNetwork={environment.egressNetwork} />
       </div>
 
       <div className="px-4 lg:px-6 max-w-full">

--- a/client/src/components/environments/egress-network-card.tsx
+++ b/client/src/components/environments/egress-network-card.tsx
@@ -1,0 +1,97 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  IconNetwork,
+  IconCheck,
+  IconAlertTriangle,
+  IconBan,
+} from "@tabler/icons-react";
+import type { EgressNetworkInfo, EgressNetworkStatus } from "@mini-infra/types";
+
+interface EgressNetworkCardProps {
+  egressNetwork?: EgressNetworkInfo;
+  className?: string;
+}
+
+const STATUS_META: Record<
+  EgressNetworkStatus,
+  { label: string; badgeClass: string; Icon: typeof IconCheck }
+> = {
+  present: {
+    label: "Healthy",
+    badgeClass:
+      "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300",
+    Icon: IconCheck,
+  },
+  error: {
+    label: "Network missing",
+    badgeClass: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300",
+    Icon: IconAlertTriangle,
+  },
+  missing: {
+    label: "Not provisioned",
+    badgeClass: "bg-muted text-muted-foreground",
+    Icon: IconBan,
+  },
+};
+
+function DetailRow({ label, value }: { label: string; value: string | null }) {
+  return (
+    <div className="flex items-center justify-between text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-medium font-mono text-xs">{value ?? "—"}</span>
+    </div>
+  );
+}
+
+export function EgressNetworkCard({
+  egressNetwork,
+  className,
+}: EgressNetworkCardProps) {
+  // The environment detail endpoint always populates this; guard for safety
+  // (e.g. a cached list entry rendered before detail resolves).
+  if (!egressNetwork) return null;
+
+  const meta = STATUS_META[egressNetwork.status];
+  const StatusIcon = meta.Icon;
+
+  return (
+    <Card className={className}>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <div>
+          <CardTitle className="text-sm font-medium">Egress Network</CardTitle>
+          <CardDescription className="text-xs">
+            Managed containers route outbound traffic through this network
+          </CardDescription>
+        </div>
+        <div className="flex items-center gap-2">
+          <IconNetwork className="h-4 w-4 text-muted-foreground" />
+          <Badge variant="outline" className={meta.badgeClass}>
+            <StatusIcon className="h-3 w-3 mr-1" />
+            {meta.label}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {egressNetwork.status === "missing" ? (
+          <p className="text-sm text-muted-foreground">
+            No egress network has been provisioned for this environment.
+          </p>
+        ) : (
+          <div className="space-y-2.5">
+            <DetailRow label="Network" value={egressNetwork.name} />
+            <DetailRow label="Subnet" value={egressNetwork.subnet} />
+            <DetailRow label="Bridge gateway" value={egressNetwork.bridgeGateway} />
+            <DetailRow label="Gateway IP" value={egressNetwork.gatewayContainerIp} />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/components/environments/index.ts
+++ b/client/src/components/environments/index.ts
@@ -4,6 +4,7 @@ export { EnvironmentEditDialog } from "./environment-edit-dialog";
 export { EnvironmentDeleteDialog } from "./environment-delete-dialog";
 export { EnvironmentFilters } from "./environment-filters";
 export { EnvironmentList } from "./environment-list";
+export { EgressNetworkCard } from "./egress-network-card";
 // Stack management components
 export { StacksList } from "./stacks-list";
 

--- a/lib/types/environments.ts
+++ b/lib/types/environments.ts
@@ -16,8 +16,39 @@ export interface Environment {
   networks: EnvironmentNetwork[];
   stackCount: number;
   systemStackCount: number;
+  /**
+   * The environment's egress network (subnet, gateway, health). Only populated
+   * on the single-environment detail response, not on list responses.
+   */
+  egressNetwork?: EgressNetworkInfo;
   createdAt: Date;
   updatedAt: Date;
+}
+
+/**
+ * Health of the per-environment egress network.
+ * - `present`: recorded and the Docker network is live.
+ * - `missing`: no egress network has been provisioned.
+ * - `error`: a subnet was recorded but the Docker network is gone (drift).
+ */
+export type EgressNetworkStatus = 'present' | 'missing' | 'error';
+
+/**
+ * The per-environment egress network as surfaced on the environment detail
+ * screen. The subnet is chosen by Docker's IPAM at provisioning time and
+ * recorded by the server; the values here are read back, not prescribed.
+ */
+export interface EgressNetworkInfo {
+  /** Docker network name, e.g. `local-egress`. */
+  name: string;
+  /** Subnet Docker assigned, e.g. `172.24.0.0/16`. Null if not recorded. */
+  subnet: string | null;
+  /** Bridge gateway address (`.1`), e.g. `172.24.0.1`. Null if not recorded. */
+  bridgeGateway: string | null;
+  /** Egress gateway container's static IP, e.g. `172.24.0.3`. Null if not allocated. */
+  gatewayContainerIp: string | null;
+  /** Derived health of the egress network. */
+  status: EgressNetworkStatus;
 }
 
 export interface EnvironmentNetwork {

--- a/server/src/__tests__/environment-manager.test.ts
+++ b/server/src/__tests__/environment-manager.test.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from "../generated/prisma/client";
 import { EnvironmentManager } from '../services/environment';
 import { DockerExecutorService } from '../services/docker-executor';
+import DockerService from '../services/docker';
 
 // Mock prisma module so docker-executor/index.ts doesn't try to resolve DATABASE_URL at import time
 vi.mock('../lib/prisma', () => ({ default: {} }));
@@ -397,6 +398,89 @@ describe('EnvironmentManager', () => {
       const result = await environmentManager.getEnvironmentById('non-existent');
 
       expect(result).toBeNull();
+    });
+
+    describe('egressNetwork', () => {
+      const baseEnv = {
+        id: 'env-1',
+        name: 'test-env',
+        type: 'nonproduction',
+        networkType: 'local',
+        networks: [],
+        egressGatewayIp: '172.24.0.3',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      it('reports status "missing" when no egress resource exists', async () => {
+        mockPrisma.environment.findUnique.mockResolvedValue({ ...baseEnv, egressGatewayIp: null } as any);
+        mockPrisma.infraResource.findFirst.mockResolvedValue(null);
+
+        const result = await environmentManager.getEnvironmentById('env-1');
+
+        expect(result!.egressNetwork).toEqual({
+          name: 'test-env-egress',
+          subnet: null,
+          bridgeGateway: null,
+          gatewayContainerIp: null,
+          status: 'missing',
+        });
+      });
+
+      it('reports status "present" with the recorded subnet when the Docker network is live', async () => {
+        mockPrisma.environment.findUnique.mockResolvedValue(baseEnv as any);
+        mockPrisma.infraResource.findFirst.mockResolvedValue({
+          metadata: { subnet: '172.24.0.0/16', gateway: '172.24.0.1' },
+        } as any);
+        const spy = vi.spyOn(DockerService, 'getInstance').mockReturnValue({
+          isConnected: () => true,
+          listNetworks: vi.fn().mockResolvedValue([{ name: 'test-env-egress' }]),
+        } as any);
+
+        const result = await environmentManager.getEnvironmentById('env-1');
+
+        expect(result!.egressNetwork).toEqual({
+          name: 'test-env-egress',
+          subnet: '172.24.0.0/16',
+          bridgeGateway: '172.24.0.1',
+          gatewayContainerIp: '172.24.0.3',
+          status: 'present',
+        });
+        spy.mockRestore();
+      });
+
+      it('reports status "error" when a subnet is recorded but the Docker network is gone', async () => {
+        mockPrisma.environment.findUnique.mockResolvedValue(baseEnv as any);
+        mockPrisma.infraResource.findFirst.mockResolvedValue({
+          metadata: { subnet: '172.24.0.0/16', gateway: '172.24.0.1' },
+        } as any);
+        const spy = vi.spyOn(DockerService, 'getInstance').mockReturnValue({
+          isConnected: () => true,
+          listNetworks: vi.fn().mockResolvedValue([{ name: 'some-other-network' }]),
+        } as any);
+
+        const result = await environmentManager.getEnvironmentById('env-1');
+
+        expect(result!.egressNetwork!.status).toBe('error');
+        expect(result!.egressNetwork!.subnet).toBe('172.24.0.0/16');
+        spy.mockRestore();
+      });
+
+      it('trusts the DB record (status "present") when Docker is unreachable', async () => {
+        mockPrisma.environment.findUnique.mockResolvedValue(baseEnv as any);
+        mockPrisma.infraResource.findFirst.mockResolvedValue({
+          metadata: { subnet: '172.24.0.0/16', gateway: '172.24.0.1' },
+        } as any);
+        const spy = vi.spyOn(DockerService, 'getInstance').mockReturnValue({
+          isConnected: () => false,
+          listNetworks: vi.fn(),
+        } as any);
+
+        const result = await environmentManager.getEnvironmentById('env-1');
+
+        expect(result!.egressNetwork!.status).toBe('present');
+        spy.mockRestore();
+      });
     });
   });
 

--- a/server/src/services/environment/environment-manager.ts
+++ b/server/src/services/environment/environment-manager.ts
@@ -5,6 +5,8 @@ import {
   EnvironmentType,
   EnvironmentNetworkType,
   EnvironmentNetwork,
+  EgressNetworkInfo,
+  EgressNetworkStatus,
   CreateEnvironmentRequest,
   UpdateEnvironmentRequest,
 } from '@mini-infra/types';
@@ -218,12 +220,74 @@ export class EnvironmentManager {
         return null;
       }
 
-      return this.mapPrismaToEnvironment(environment);
+      const mapped = this.mapPrismaToEnvironment(environment);
+      mapped.egressNetwork = await this.getEgressNetworkInfo(
+        environment.id,
+        environment.name,
+        environment.egressGatewayIp ?? null,
+      );
+      return mapped;
 
     } catch (error) {
       this.logger.error({ error, environmentId: id }, 'Failed to get environment by ID');
       throw error;
     }
+  }
+
+  /**
+   * Build the egress-network view for the environment detail screen. The subnet
+   * and bridge gateway are read from the egress InfraResource record (where
+   * provisioning persisted whatever Docker's IPAM assigned); the gateway
+   * container IP comes from Environment.egressGatewayIp. Status is derived by
+   * cross-checking the live Docker network — `present` when the record and the
+   * network both exist, `error` when a subnet was recorded but the network is
+   * gone, `missing` when no egress network was ever provisioned. The Docker
+   * check is best-effort: if the daemon is unreachable we trust the DB record
+   * rather than failing the read.
+   */
+  private async getEgressNetworkInfo(
+    environmentId: string,
+    environmentName: string,
+    egressGatewayIp: string | null,
+  ): Promise<EgressNetworkInfo> {
+    const name = `${environmentName}-egress`;
+
+    const resource = await this.prisma.infraResource.findFirst({
+      where: { type: 'docker-network', purpose: 'egress', scope: 'environment', environmentId },
+      select: { metadata: true },
+    });
+    const meta = (resource?.metadata as Record<string, unknown> | null) ?? null;
+    const subnet = typeof meta?.['subnet'] === 'string' ? (meta['subnet'] as string) : null;
+    const bridgeGateway = typeof meta?.['gateway'] === 'string' ? (meta['gateway'] as string) : null;
+
+    let status: EgressNetworkStatus;
+    if (!resource) {
+      status = 'missing';
+    } else {
+      let networkExists: boolean | null = null;
+      try {
+        const docker = DockerService.getInstance();
+        if (docker.isConnected()) {
+          const networks = await docker.listNetworks();
+          networkExists = networks.some(n => n.name === name);
+        }
+      } catch (err) {
+        this.logger.warn(
+          { error: err instanceof Error ? err.message : String(err), environmentId, name },
+          'Could not query Docker to derive egress network status; trusting DB record',
+        );
+      }
+      // networkExists === null → Docker unreachable; trust the record (present).
+      status = networkExists === false ? 'error' : 'present';
+    }
+
+    return {
+      name,
+      subnet,
+      bridgeGateway,
+      gatewayContainerIp: egressGatewayIp,
+      status,
+    };
   }
 
   public async getEnvironmentByName(name: string): Promise<Environment | null> {


### PR DESCRIPTION
## Summary
- Surfaces the per-environment egress network on the environment detail screen: subnet, bridge gateway, gateway container IP, and a derived health status (`present` / `error` / `missing`).
- Server: `getEnvironmentById` reads the recorded subnet/gateway from the egress `InfraResource` + `Environment.egressGatewayIp`, and derives status by a **best-effort** Docker network cross-check (falls back to the DB record when the daemon is unreachable, so the read never fails). The list endpoint is untouched — no per-env Docker calls.
- Shared `EgressNetworkInfo` / `EgressNetworkStatus` types in `@mini-infra/types`; `egressNetwork` is optional on `Environment` and only populated on the detail response.
- Client: new read-only `EgressNetworkCard` rendered between the detail cards and the stacks list.

Builds on Phase 1 (MINI-64), which records what Docker assigned.

## Test plan
- [x] `pnpm build:lib` + server `tsc` + client build clean
- [x] `pnpm --filter mini-infra-server test` — 2340 tests pass (incl. 4 new status-derivation cases: present/error/missing/docker-unreachable)
- [x] server lint + client lint clean
- [x] Live API: `GET /api/environments/:id` returns `egressNetwork` (subnet `172.23.0.0/16`, gateway `172.23.0.3`, status `present`); list endpoint omits it
- [x] Live UI: environment detail page renders the "Egress Network" panel with a Healthy badge and the correct values (screenshot verified)

Closes MINI-65