### PR TITLE
fix(environments): stop env delete dialog crashing on blocking dependencies (MINI-67)

### DIFF
--- a/client/src/components/environments/environment-delete-dialog.tsx
+++ b/client/src/components/environments/environment-delete-dialog.tsx
@@ -15,7 +15,7 @@ import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { toast } from "sonner";
-import { IconLoader2, IconAlertTriangle, IconNetwork, IconStack2, IconLayoutNavbar, IconServer, IconTemplate } from "@tabler/icons-react";
+import { IconLoader2, IconAlertTriangle, IconNetwork, IconStack2, IconLayoutNavbar, IconServer } from "@tabler/icons-react";
 
 interface EnvironmentDeleteDialogProps {
   open: boolean;
@@ -113,10 +113,8 @@ export function EnvironmentDeleteDialog({
                 <div className="font-medium mb-2">Cannot delete — remove these resources first:</div>
                 <div className="space-y-1.5 text-sm">
                   <DependencyList icon={IconStack2} label="Stacks" items={deleteCheck.data!.dependencies.stacks} />
-                  <DependencyList icon={IconServer} label="Deployment Configs" items={deleteCheck.data!.dependencies.deploymentConfigurations} />
                   <DependencyList icon={IconLayoutNavbar} label="HAProxy Frontends" items={deleteCheck.data!.dependencies.haproxyFrontends} />
                   <DependencyList icon={IconServer} label="HAProxy Backends" items={deleteCheck.data!.dependencies.haproxyBackends} />
-                  <DependencyList icon={IconTemplate} label="Stack Templates" items={deleteCheck.data!.dependencies.stackTemplates} />
                 </div>
               </AlertDescription>
             </Alert>
@@ -213,7 +211,7 @@ function DependencyList({
   label: string;
   items: EnvironmentDependencyItem[];
 }) {
-  if (items.length === 0) return null;
+  if (!items || items.length === 0) return null;
   return (
     <div className="flex items-start gap-1.5">
       <Icon className="h-3.5 w-3.5 mt-0.5 shrink-0" />

--- a/lib/types/environments.ts
+++ b/lib/types/environments.ts
@@ -130,9 +130,7 @@ export interface EnvironmentDeleteCheck {
   canDelete: boolean;
   dependencies: {
     stacks: EnvironmentDependencyItem[];
-    deploymentConfigurations: EnvironmentDependencyItem[];
     haproxyFrontends: EnvironmentDependencyItem[];
     haproxyBackends: EnvironmentDependencyItem[];
-    stackTemplates: EnvironmentDependencyItem[];
   };
 }


### PR DESCRIPTION
## Summary
- The environment delete dialog crashed with `undefined is not an object (evaluating 'n.length')` whenever it opened on an environment that can't be deleted (`canDelete: false`).
- Root cause: `EnvironmentDeleteCheck.dependencies` declared **5** arrays, but `GET /:id/delete-check` only returns **3** (`stacks`, `haproxyFrontends`, `haproxyBackends`). The dialog's `DependencyList` did `items.length` on the two phantom fields — `deploymentConfigurations` (no backing model) and `stackTemplates` (real, but the route never reported it) — and threw.
- Fix: align the type + dialog to the 3 arrays the server actually returns, and harden `DependencyList` against an undefined `items` array. **No change to deletion behaviour or `canDelete`.**

## Test plan
- [x] `pnpm build:lib`, `pnpm --filter mini-infra-client build`, `pnpm --filter mini-infra-server build` all clean (tsc verifies the dialog only references existing fields)
- [ ] CI lint (local eslint install is broken — `ajv` module missing — so relying on CI's clean env for the authoritative lint)
- Manual repro: opening the delete dialog on an env with blocking system stacks no longer crashes (this was hitting a live production instance).

Closes MINI-67