### PR TITLE
fix(stacks): re-attach server to managed infra networks on boot (MINI-68)

### DIFF
--- a/server/src/__tests__/self-network-reattach.test.ts
+++ b/server/src/__tests__/self-network-reattach.test.ts
@@ -1,0 +1,80 @@
+import {
+  reattachSelfToManagedNetworks,
+  connectSelfToNetwork,
+} from '../services/stacks/self-network-reattach';
+
+vi.mock('../services/self-update', () => ({
+  getOwnContainerId: vi.fn(() => 'self-id'),
+}));
+
+function makeExecutor(connectImpl?: () => Promise<void>) {
+  const connect = vi.fn(connectImpl ?? (() => Promise.resolve()));
+  const getNetwork = vi.fn(() => ({ connect }));
+  const executor = { getDockerClient: () => ({ getNetwork }) } as any;
+  return { executor, getNetwork, connect };
+}
+
+const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() } as any;
+
+describe('reattachSelfToManagedNetworks', () => {
+  it('re-attaches only to docker-network resources whose stack declares joinSelf', async () => {
+    const { executor, getNetwork, connect } = makeExecutor();
+    const prisma = {
+      infraResource: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            name: 'mini-infra-vault',
+            purpose: 'vault',
+            stack: { resourceOutputs: [{ type: 'docker-network', purpose: 'vault', joinSelf: true }] },
+          },
+          {
+            name: 'mini-infra-database',
+            purpose: 'database',
+            stack: { resourceOutputs: [{ type: 'docker-network', purpose: 'database', joinSelf: false }] },
+          },
+          { name: 'orphan-egress', purpose: 'egress', stack: null },
+        ]),
+      },
+    } as any;
+
+    await reattachSelfToManagedNetworks(executor, prisma, log);
+
+    expect(getNetwork).toHaveBeenCalledTimes(1);
+    expect(getNetwork).toHaveBeenCalledWith('mini-infra-vault');
+    expect(connect).toHaveBeenCalledWith({ Container: 'self-id' });
+  });
+
+  it('skips entirely when not running in Docker', async () => {
+    const { getOwnContainerId } = await import('../services/self-update');
+    (getOwnContainerId as any).mockReturnValueOnce(null);
+    const { executor, getNetwork } = makeExecutor();
+    const prisma = { infraResource: { findMany: vi.fn() } } as any;
+
+    await reattachSelfToManagedNetworks(executor, prisma, log);
+
+    expect(prisma.infraResource.findMany).not.toHaveBeenCalled();
+    expect(getNetwork).not.toHaveBeenCalled();
+  });
+});
+
+describe('connectSelfToNetwork', () => {
+  it('returns true on a fresh attach', async () => {
+    const { executor } = makeExecutor();
+    expect(await connectSelfToNetwork(executor, 'self-id', 'net', log)).toBe(true);
+  });
+
+  it('treats an already-connected 403 as a no-op (false) without throwing', async () => {
+    const { executor } = makeExecutor(() =>
+      Promise.reject(Object.assign(new Error('endpoint already exists'), { statusCode: 403 })),
+    );
+    expect(await connectSelfToNetwork(executor, 'self-id', 'net', log)).toBe(false);
+  });
+
+  it('warns and returns false on a genuine failure', async () => {
+    const warn = vi.fn();
+    const localLog = { info: vi.fn(), warn, debug: vi.fn() } as any;
+    const { executor } = makeExecutor(() => Promise.reject(new Error('boom')));
+    expect(await connectSelfToNetwork(executor, 'self-id', 'net', localLog)).toBe(false);
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -66,6 +66,7 @@ import { DockerExecutorService } from "./services/docker-executor";
 import { loadOrCreateInternalAuthSecret } from "./lib/security-config";
 import { syncBuiltinStacks } from "./services/stacks/builtin-stack-sync";
 import { runBuiltinVaultReconcile, BUNDLES_DRIVE_BUILTIN } from "./services/stacks/builtin-vault-reconcile";
+import { reattachSelfToManagedNetworks } from "./services/stacks/self-network-reattach";
 import { MonitoringService } from "./services/monitoring";
 import { cleanupOrphanedSidecars, finalizeLastUpdate } from "./services/self-update";
 import { setupHAProxyCrashLoopWatcher } from "./services/haproxy/haproxy-crash-loop-watcher";
@@ -163,6 +164,26 @@ const initializeServices = async () => {
     await dockerService.initialize();
     console.log("[STARTUP] ✓ Docker service initialized");
 
+    // Re-attach the server container to its managed infra networks (vault, nats,
+    // dataplane, database, and each env's egress network — every `joinSelf`
+    // infra-resource network). These are joined at stack-apply time, but a
+    // container recreate (e.g. `docker compose up -d`) wipes them and the
+    // already-synced host stacks don't re-apply on boot, so the server would
+    // otherwise be unable to reach Vault/NATS/managed DBs. Best-effort — never
+    // blocks boot. Runs inline now (Docker connected at boot on a configured
+    // host) and again from the onConnect callback below (covers the degraded
+    // worktree case where Docker connects only after the seeder posts the host).
+    const reattachInfraNetworks = async () => {
+      try {
+        const exec = new DockerExecutorService();
+        await exec.initialize();
+        await reattachSelfToManagedNetworks(exec, prisma, logger);
+      } catch (err) {
+        logger.warn({ err }, "Re-attaching to managed infra networks failed (non-fatal)");
+      }
+    };
+    await reattachInfraNetworks();
+
     // Re-provision sidecars after Docker reconnects. On a fresh-boot worktree
     // the DB has no docker host yet, so initialize() lands in degraded mode
     // and the inline ensureXxx calls below fail. Once the seeder posts the
@@ -171,6 +192,9 @@ const initializeServices = async () => {
     // Both ensureXxx are idempotent — safe if they already succeeded inline.
     dockerService.onConnect(async () => {
       logger.info("Docker connected, re-provisioning sidecars");
+      // Re-attach to managed infra networks first so Vault/NATS are reachable
+      // for the fw-agent bootstrap (and everything else) below.
+      await reattachInfraNetworks();
       try {
         // ALT-27: fw-agent is now a host-scope stack. The bootstrap is
         // idempotent — if the stack is already applied this is a couple

--- a/server/src/services/stacks/self-network-reattach.ts
+++ b/server/src/services/stacks/self-network-reattach.ts
@@ -1,0 +1,86 @@
+import type { PrismaClient } from '../../generated/prisma/client';
+import type { Logger } from 'pino';
+import type { StackResourceOutput } from '@mini-infra/types';
+import type { DockerExecutorService } from '../docker-executor';
+
+/**
+ * Connect the mini-infra container itself to a Docker network by name.
+ *
+ * Idempotent: Docker returns "already exists" / a 403 when the container is
+ * already attached — those are treated as success (returns false = "no change").
+ * Returns true only when a fresh attachment was made.
+ */
+export async function connectSelfToNetwork(
+  dockerExecutor: DockerExecutorService,
+  selfId: string,
+  netName: string,
+  log: Logger,
+): Promise<boolean> {
+  try {
+    const docker = dockerExecutor.getDockerClient();
+    await docker.getNetwork(netName).connect({ Container: selfId });
+    return true;
+  } catch (err) {
+    const e = err as { message?: string; statusMessage?: string; statusCode?: number };
+    const msg = e?.message || e?.statusMessage || '';
+    if (msg.includes('already exists') || msg.includes('already in network') || e?.statusCode === 403) {
+      // Already attached — nothing to do.
+      return false;
+    }
+    log.warn({ network: netName, error: msg }, 'Failed to connect self to network');
+    return false;
+  }
+}
+
+/**
+ * Re-attach the mini-infra container to every managed infra network it is meant
+ * to be on — i.e. every `docker-network` InfraResource whose owning stack
+ * declared `joinSelf: true` for that purpose (vault, nats, dataplane, database,
+ * and each environment's egress network).
+ *
+ * These attachments are normally made during stack apply
+ * (`StackInfraResourceManager.joinSelfToOutputNetworks`). A container recreate
+ * (e.g. a `docker compose up -d` redeploy) wipes them, and the host stacks are
+ * already `synced` so they never re-apply — leaving the server unable to reach
+ * Vault/NATS/managed DBs. Running this on boot restores those attachments.
+ *
+ * Best-effort and idempotent: never throws; per-network failures are logged and
+ * skipped so one bad network can't block the rest (or boot).
+ */
+export async function reattachSelfToManagedNetworks(
+  dockerExecutor: DockerExecutorService,
+  prisma: PrismaClient,
+  log: Logger,
+): Promise<void> {
+  const { getOwnContainerId } = await import('../self-update');
+  const selfId = getOwnContainerId();
+  if (!selfId) {
+    log.debug('Not running in Docker, skipping managed-network re-attach');
+    return;
+  }
+
+  const resources = await prisma.infraResource.findMany({
+    where: { type: 'docker-network' },
+    select: {
+      name: true,
+      purpose: true,
+      stack: { select: { resourceOutputs: true } },
+    },
+  });
+
+  let joined = 0;
+  for (const r of resources) {
+    const outputs = (r.stack?.resourceOutputs as StackResourceOutput[] | null) ?? [];
+    const match = outputs.find(o => o.type === 'docker-network' && o.purpose === r.purpose);
+    if (!match?.joinSelf) continue;
+
+    if (await connectSelfToNetwork(dockerExecutor, selfId, r.name, log)) {
+      joined++;
+      log.info({ network: r.name, purpose: r.purpose }, 'Re-attached mini-infra to managed network on boot');
+    }
+  }
+
+  if (joined > 0) {
+    log.info({ count: joined }, 'Re-attached mini-infra to managed infra networks on boot');
+  }
+}

--- a/server/src/services/stacks/stack-infra-resource-manager.ts
+++ b/server/src/services/stacks/stack-infra-resource-manager.ts
@@ -7,6 +7,7 @@ import type {
 } from '@mini-infra/types';
 import type { DockerExecutorService } from '../docker-executor';
 import type { StackContainerManager } from './stack-container-manager';
+import { connectSelfToNetwork } from './self-network-reattach';
 
 /**
  * Manages Docker networks and InfraResource records that back a stack's
@@ -196,26 +197,14 @@ export class StackInfraResourceManager {
       return;
     }
 
-    const docker = this.dockerExecutor.getDockerClient();
-
     for (const output of resourceOutputs) {
       if (!output.joinSelf || output.type !== 'docker-network') continue;
 
       const netName = outputNetworkMap.get(output.purpose);
       if (!netName) continue;
 
-      try {
-        const network = docker.getNetwork(netName);
-        await network.connect({ Container: selfId });
+      if (await connectSelfToNetwork(this.dockerExecutor, selfId, netName, log)) {
         log.info({ network: netName, purpose: output.purpose }, 'Mini-infra joined infra resource network (joinSelf)');
-      } catch (err) {
-        const e = err as { message?: string; statusMessage?: string; statusCode?: number };
-        const msg = e?.message || e?.statusMessage || '';
-        if (!msg.includes('already exists') && e?.statusCode !== 403) {
-          log.warn({ network: netName, purpose: output.purpose, error: msg }, 'Failed to join self to infra resource network');
-        } else {
-          log.debug({ network: netName }, 'Already connected to infra resource network');
-        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- The server joins its managed infra networks (`vault`, `nats`, `dataplane`, `database`, each env's egress — every `joinSelf: true` network) only at **stack apply** time. A container recreate (`docker compose up -d` redeploy) wipes those runtime attachments, and the already-`synced` host stacks never re-apply on boot — so the server can't reach Vault/NATS/DBs, `/api/vault/status` shows `reachable: false`, and provisioning fails with a misleading "Operator passphrase must be unlocked". Recovery required a manual `docker network connect` (hit live on a v1.10.0 prod redeploy).
- Adds a boot-time reconcile: for every `docker-network` InfraResource whose stack declares `joinSelf`, re-attach the server container. The connect-self logic is extracted into `connectSelfToNetwork` and **reused** by both the apply-time `joinSelfToOutputNetworks` and the new boot-time `reattachSelfToManagedNetworks` (single idempotent path).
- Runs inline after Docker init **and** from `onConnect` (degraded-worktree case), mirroring the existing sidecar re-provision pattern. Best-effort — never blocks boot.

## Changes
- New `server/src/services/stacks/self-network-reattach.ts` (`connectSelfToNetwork` + `reattachSelfToManagedNetworks`).
- `stack-infra-resource-manager.ts`: `joinSelfToOutputNetworks` now uses the shared `connectSelfToNetwork`.
- `server.ts`: calls the reconcile on boot (inline + onConnect).
- Unit tests for the new module.

## Test plan
- [x] `pnpm build:lib` + server `tsc` clean
- [x] `pnpm --filter mini-infra-server test` — 2345 pass (incl. 5 new)
- [x] server lint clean
- [x] **Live smoke** (dev): `docker network disconnect mini-infra-vault <server>` → Vault `reachable: false`; `docker restart <server>` → boot re-attaches → `reachable: true`, with log `Re-attached mini-infra to managed network on boot | network=mini-infra-vault purpose=vault`. No manual `docker network connect` needed.

Closes MINI-68