### PR TITLE
fix(monitoring): address Prometheus/Loki by the reconciler's project name

### DIFF
--- a/server/src/__tests__/stack-template-engine.test.ts
+++ b/server/src/__tests__/stack-template-engine.test.ts
@@ -1,5 +1,6 @@
 import {
   buildTemplateContext,
+  getStackProjectName,
   resolveTemplate,
   resolveStackConfigFiles,
   TemplateContext,
@@ -151,5 +152,43 @@ describe('resolveStackConfigFiles', () => {
     // Non-content fields unchanged
     expect(resolved[0].volumeName).toBe('config');
     expect(resolved[0].path).toBe('/etc/loki/config.yaml');
+  });
+});
+
+describe('getStackProjectName', () => {
+  it('prefixes host-scoped stacks with mini-infra-', () => {
+    expect(getStackProjectName({ name: 'monitoring', environment: null })).toBe('mini-infra-monitoring');
+    expect(getStackProjectName({ name: 'nats' })).toBe('mini-infra-nats');
+  });
+
+  it('prefixes environment-scoped stacks with the environment name', () => {
+    expect(getStackProjectName({ name: 'web', environment: { name: 'prod' } })).toBe('prod-web');
+  });
+
+  it('matches the container/network names the monitoring proxy + network-join address', () => {
+    // Drift guard: routes/monitoring.ts reaches Prometheus/Loki by container
+    // name and monitoring-service.ts joins the network by name. Both derive
+    // from getStackProjectName, so they must equal what buildTemplateContext
+    // (i.e. the reconciler) actually creates — otherwise metrics/logs silently
+    // break even though the stack is healthy.
+    const ctx = buildTemplateContext(
+      {
+        name: 'monitoring',
+        networks: [{ name: 'monitoring_network' }],
+        volumes: [{ name: 'prometheus_data' }],
+      },
+      [
+        { serviceName: 'prometheus', dockerImage: 'prom/prometheus', dockerTag: 'v3.3.0', containerConfig: {} },
+        { serviceName: 'loki', dockerImage: 'grafana/loki', dockerTag: '2.9.0', containerConfig: {} },
+      ],
+      {} // host-scoped: no environment
+    );
+    const project = getStackProjectName({ name: 'monitoring', environment: null });
+    expect(ctx.services.prometheus.containerName).toBe(`${project}-prometheus`);
+    expect(ctx.services.loki.containerName).toBe(`${project}-loki`);
+    expect(ctx.networks.monitoring_network).toBe(`${project}_monitoring_network`);
+    // Pin the concrete values so a future change to the naming scheme trips loudly.
+    expect(ctx.services.prometheus.containerName).toBe('mini-infra-monitoring-prometheus');
+    expect(ctx.networks.monitoring_network).toBe('mini-infra-monitoring_monitoring_network');
   });
 });

--- a/server/src/routes/monitoring.ts
+++ b/server/src/routes/monitoring.ts
@@ -7,15 +7,20 @@ import { MonitoringStatusResponse } from '@mini-infra/types';
 import { DockerExecutorService } from '../services/docker-executor';
 import { StackReconciler } from '../services/stacks/stack-reconciler';
 import { serializeStack, mapContainerStatus, isDockerConnectionError } from '../services/stacks/utils';
+import { getStackProjectName } from '../services/stacks/template-engine';
 
 const router = Router();
 const logger = getLogger("platform", "monitoring");
 
-// When the server runs inside Docker, use container names on the shared network.
+// When the server runs inside Docker, reach Prometheus/Loki by their container
+// names on the shared monitoring network. The names must match exactly what the
+// stack reconciler creates for the host-scoped `monitoring` stack — project
+// `mini-infra-monitoring`, so containers `mini-infra-monitoring-{prometheus,loki}`.
 // When running on the host, use localhost with the published ports.
+const MONITORING_PROJECT = getStackProjectName({ name: 'monitoring', environment: null });
 const inDocker = existsSync('/.dockerenv');
-const PROMETHEUS_URL = inDocker ? 'http://monitoring-prometheus:9090' : 'http://localhost:9090';
-const LOKI_URL = inDocker ? 'http://monitoring-loki:3100' : 'http://localhost:3100';
+const PROMETHEUS_URL = inDocker ? `http://${MONITORING_PROJECT}-prometheus:9090` : 'http://localhost:9090';
+const LOKI_URL = inDocker ? `http://${MONITORING_PROJECT}-loki:3100` : 'http://localhost:3100';
 
 async function getMonitoringStack() {
   return prisma.stack.findFirst({

--- a/server/src/services/monitoring/monitoring-service.ts
+++ b/server/src/services/monitoring/monitoring-service.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from 'fs';
 import { hostname } from 'os';
 import Docker from 'dockerode';
 import { DockerExecutorService } from '../docker-executor';
+import { getStackProjectName } from '../stacks/template-engine';
 import { getLogger } from '../../lib/logger-factory';
 import {
   IApplicationService,
@@ -83,7 +84,11 @@ export class MonitoringService implements IApplicationService {
     ]
   };
 
-  constructor(projectName: string = 'monitoring') {
+  // Default must match the reconciler's project name for the host-scoped
+  // `monitoring` stack (`mini-infra-monitoring`) so the app joins the right
+  // network (`mini-infra-monitoring_monitoring_network`) and the Prometheus/Loki
+  // URLs resolve to the actual `mini-infra-monitoring-*` containers.
+  constructor(projectName: string = getStackProjectName({ name: 'monitoring', environment: null })) {
     this.dockerExecutor = new DockerExecutorService();
     this.projectName = projectName;
     this.telegrafContainerName = `${this.projectName}-telegraf`;

--- a/server/src/services/stacks/stack-reconciler.ts
+++ b/server/src/services/stacks/stack-reconciler.ts
@@ -23,6 +23,7 @@ import { DockerExecutorService } from '../docker-executor';
 import { StackContainerManager } from './stack-container-manager';
 import { StackRoutingManager, type StackRoutingContext } from './stack-routing-manager';
 import { StackResourceReconciler } from './stack-resource-reconciler';
+import { getStackProjectName } from './template-engine';
 import { getLogger } from '../../lib/logger-factory';
 import { withOperation } from '../../lib/logging-context';
 import {
@@ -125,7 +126,7 @@ export class StackReconciler {
     });
 
     try {
-      const projectName = stack.environment ? `${stack.environment.name}-${stack.name}` : `mini-infra-${stack.name}`;
+      const projectName = getStackProjectName(stack);
 
       // Build template context with parameters and resolve service definitions
       const params = mergeParameterValues(
@@ -487,7 +488,7 @@ export class StackReconciler {
     });
 
     try {
-      const projectName = stack.environment ? `${stack.environment.name}-${stack.name}` : `mini-infra-${stack.name}`;
+      const projectName = getStackProjectName(stack);
       const params = mergeParameterValues(
         (stack.parameters as unknown as StackParameterDefinition[]) ?? [],
         (stack.parameterValues as unknown as Record<string, StackParameterValue>) ?? {}
@@ -983,7 +984,7 @@ export class StackReconciler {
       include: { services: true, environment: true },
     });
 
-    const projectName = stack.environment ? `${stack.environment.name}-${stack.name}` : `mini-infra-${stack.name}`;
+    const projectName = getStackProjectName(stack);
     // Include any synthesised default network so destroy reaps it as well.
     const networks = synthesiseDefaultNetworkIfNeeded(
       (stack.networks as unknown as StackNetwork[]) ?? [],

--- a/server/src/services/stacks/template-engine.ts
+++ b/server/src/services/stacks/template-engine.ts
@@ -59,6 +59,27 @@ export interface BuildTemplateContextOptions {
   inputs?: Record<string, string>;
 }
 
+/**
+ * Compute the docker-compose-style project name that prefixes every resource a
+ * stack owns: containers (`<project>-<service>`), networks (`<project>_<net>`)
+ * and volumes (`<project>_<vol>`). Host-scoped stacks use `mini-infra-<name>`;
+ * environment-scoped stacks use `<environment>-<name>`.
+ *
+ * This is the single source of truth for stack resource naming. Anything that
+ * needs to address a stack's containers or networks by name (e.g. the
+ * monitoring proxy reaching Prometheus/Loki, or the app joining the monitoring
+ * network) must derive the name from here so it cannot drift from what the
+ * reconciler actually creates.
+ */
+export function getStackProjectName(stack: {
+  name: string;
+  environment?: { name: string } | null;
+}): string {
+  return stack.environment
+    ? `${stack.environment.name}-${stack.name}`
+    : `mini-infra-${stack.name}`;
+}
+
 export function buildTemplateContext(
   stack: { name: string; networks: StackNetwork[]; volumes: StackVolume[] },
   services: {
@@ -70,7 +91,7 @@ export function buildTemplateContext(
   options: BuildTemplateContextOptions = {}
 ): TemplateContext {
   const { stackId, environment, params, inputs } = options;
-  const projectName = environment ? `${environment.name}-${stack.name}` : `mini-infra-${stack.name}`;
+  const projectName = getStackProjectName({ name: stack.name, environment });
 
   const svcMap: Record<string, { containerName: string; image: string }> = {};
   const envMap: Record<string, string> = {};


### PR DESCRIPTION
## Problem

In production, **Container Metrics and Logs render blank even when the monitoring stack is healthy and running.** Deploying/redeploying the stack from the Host page doesn't help.

## Root cause — a name mismatch between who *creates* the resources and who *addresses* them

The monitoring stack is deployed through the **stack reconciler**, which names every host-scoped stack's resources with the project prefix `mini-infra-<stackname>`. For the `monitoring` stack that's `mini-infra-monitoring`, so the real resources are:

- containers `mini-infra-monitoring-prometheus` / `mini-infra-monitoring-loki`
- network `mini-infra-monitoring_monitoring_network`

But two places hardcoded the **old `monitoring`-prefixed names** (leftover from the legacy `MonitoringService`-managed deploy path):

1. `routes/monitoring.ts` proxied to `http://monitoring-prometheus:9090` / `http://monitoring-loki:3100` — hostnames that resolve to nothing → every query 503s.
2. `MonitoringService` defaulted its project name to `monitoring`, so `ensureAppConnectedToMonitoringNetwork()` joined `monitoring_monitoring_network` — a stale/empty network — instead of `mini-infra-monitoring_monitoring_network` where the containers actually live.

Net effect: the app joins an empty network and can't resolve Prometheus/Loki, so the UI stays blank despite a green stack.

Confirmed on a live prod host: containers are `mini-infra-monitoring-*`, and both a stale `monitoring_monitoring_network` and the real `mini-infra-monitoring_monitoring_network` exist side by side.

## Fix

Extract the project-name logic into a single source of truth — `getStackProjectName()` in `template-engine.ts` — and use it everywhere a stack's resources are addressed by name:

- the **reconciler** that *creates* the resources (replaces 3 inline copies + the one in `buildTemplateContext`),
- the **monitoring proxy** (`routes/monitoring.ts`),
- the **monitoring network-join** (`MonitoringService` default project name).

The addresser can no longer drift from the creator. A drift-guard test pins the monitoring container/network names to exactly what `buildTemplateContext` produces.

## Testing

- `pnpm --filter mini-infra-server build` — clean typecheck.
- `pnpm --filter mini-infra-server exec vitest run` on `stack-template-engine`, `stack-reconciler-apply`, `stack-reconciler-plan`, `stack-template-environment` — all pass (49 tests, incl. 3 new).
- After deploy, prod confirmation: the app container resolves `mini-infra-monitoring-prometheus` on the shared network and the Metrics/Logs pages populate.

## Notes / follow-ups (out of scope)

- **Lint could not be run** — `eslint` in this checkout crashes at startup with `Cannot find module 'ajv/lib/refs/json-schema-draft-04.json'` (ajv resolves to v8 but eslint's bundled shim expects v6's layout). It fails identically on untouched files, so it's a pre-existing repo-wide toolchain issue, not from this change. Worth a separate `pnpm` override fix.
- The stale `monitoring_monitoring_network` left on existing prod hosts is harmless and can be pruned with `docker network rm monitoring_monitoring_network` once nothing is attached.
- `deployment/monitoring/docker-compose.yaml` (reference only) uses yet another naming (`mini-infra-prometheus`); left untouched here since it isn't the product deploy path, but it's inconsistent and worth reconciling separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)