### PR TITLE
chore(deps): add 5-day dependency cooldown across pnpm, npm, and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,71 @@
+# Dependabot version updates with a 5-day cooldown (supply-chain defence).
+#
+# Dependabot won't open a version-update PR until the target version has been
+# published for at least 5 days, mirroring the install-layer cooldown in
+# pnpm-workspace.yaml (minimumReleaseAge) and each package's .npmrc
+# (min-release-age). IMPORTANT: cooldown applies to *version* updates only —
+# Dependabot security updates are intentionally exempt so vulnerability fixes
+# can still land fast.
+#
+# Grouping rolls minor/patch bumps into a single PR per area to cut noise;
+# majors still come through as individual PRs so they can be reviewed on their own.
+version: 2
+updates:
+  # pnpm workspace: root + client / server / lib / acme (via pnpm-lock.yaml).
+  - package-ecosystem: npm
+    directories:
+      - "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 5
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      workspace-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Standalone npm packages — each has its own package-lock.json.
+  - package-ecosystem: npm
+    directories:
+      - "/agent-sidecar"
+      - "/update-sidecar"
+      - "/pg-az-backup"
+      - "/deployment/development"
+      - "/claude-shell"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 5
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      sidecar-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used by .github/workflows/*.
+  - package-ecosystem: github-actions
+    directories:
+      - "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/agent-sidecar/.npmrc
+++ b/agent-sidecar/.npmrc
@@ -1,0 +1,9 @@
+# Dependency cooldown (supply-chain defence): npm refuses to resolve any
+# version published less than 5 days ago. This gates `npm install`/`npm update`
+# (picking a new version); `npm ci` is unaffected since it installs the
+# lockfile exactly, so container builds stay reproducible.
+#
+# Requires npm >= 11.10.0, which added the `min-release-age` setting. On older
+# npm (this repo's system npm was 11.8.0) the key is ignored — i.e. inert, not
+# an error. Run dependency bumps with npm >= 11.10.0 for the cooldown to apply.
+min-release-age=5

--- a/claude-shell/.npmrc
+++ b/claude-shell/.npmrc
@@ -1,0 +1,9 @@
+# Dependency cooldown (supply-chain defence): npm refuses to resolve any
+# version published less than 5 days ago. This gates `npm install`/`npm update`
+# (picking a new version); `npm ci` is unaffected since it installs the
+# lockfile exactly, so container builds stay reproducible.
+#
+# Requires npm >= 11.10.0, which added the `min-release-age` setting. On older
+# npm (this repo's system npm was 11.8.0) the key is ignored — i.e. inert, not
+# an error. Run dependency bumps with npm >= 11.10.0 for the cooldown to apply.
+min-release-age=5

--- a/deployment/development/.npmrc
+++ b/deployment/development/.npmrc
@@ -1,0 +1,9 @@
+# Dependency cooldown (supply-chain defence): npm refuses to resolve any
+# version published less than 5 days ago. This gates `npm install`/`npm update`
+# (picking a new version); `npm ci` is unaffected since it installs the
+# lockfile exactly.
+#
+# Requires npm >= 11.10.0, which added the `min-release-age` setting. On older
+# npm (this repo's system npm was 11.8.0) the key is ignored — i.e. inert, not
+# an error. Run dependency bumps with npm >= 11.10.0 for the cooldown to apply.
+min-release-age=5

--- a/pg-az-backup/.npmrc
+++ b/pg-az-backup/.npmrc
@@ -1,0 +1,13 @@
+# Dependency cooldown (supply-chain defence): npm refuses to resolve any
+# version published less than 5 days ago.
+#
+# NOTE: this package's Dockerfile builds with `npm install --no-package-lock`,
+# which resolves versions fresh — so the cooldown applies at *build* time here
+# (it picks the newest version that is already >= 5 days old). That's the
+# intended behaviour; it keeps brand-new, potentially-compromised releases out
+# of the image.
+#
+# Requires npm >= 11.10.0, which added the `min-release-age` setting. On older
+# npm the key is ignored — i.e. inert, not an error — so builds keep working;
+# the cooldown simply doesn't take effect until the build's npm is new enough.
+min-release-age=5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,16 @@ packages:
   - lib
   - acme
 
+# Dependency cooldown (supply-chain defence): pnpm refuses to install any
+# version published less than 5 days ago, including transitive deps. Most
+# compromised releases are flagged and yanked within hours, so the delay
+# filters smash-and-grab attacks at the install layer. 7200 minutes = 5 days.
+# Added in pnpm 10.16; we run 10.32. Workspace-linked packages (workspace:)
+# are never fetched from the registry, so the cooldown doesn't apply to them.
+# To always-allow a trusted package despite the cooldown, add it under
+# minimumReleaseAgeExclude (by name; supports globs, e.g. '@mini-infra/*').
+minimumReleaseAge: 7200
+
 # Transitive dependency version pins. These were previously in the root
 # package.json `overrides` field under npm.
 overrides:

--- a/update-sidecar/.npmrc
+++ b/update-sidecar/.npmrc
@@ -1,0 +1,9 @@
+# Dependency cooldown (supply-chain defence): npm refuses to resolve any
+# version published less than 5 days ago. This gates `npm install`/`npm update`
+# (picking a new version); `npm ci` is unaffected since it installs the
+# lockfile exactly, so container builds stay reproducible.
+#
+# Requires npm >= 11.10.0, which added the `min-release-age` setting. On older
+# npm (this repo's system npm was 11.8.0) the key is ignored — i.e. inert, not
+# an error. Run dependency bumps with npm >= 11.10.0 for the cooldown to apply.
+min-release-age=5


### PR DESCRIPTION
## What

Adds a **5-day "minimum release age" cooldown** so we never install a dependency version that was published less than 5 days ago. This is a cheap, high-leverage supply-chain defence — most compromised package versions are flagged and yanked within hours, so a few days' delay filters out smash-and-grab attacks at the install layer.

Two layers are gated:

| Layer | Setting | Covers |
|---|---|---|
| pnpm (`pnpm-workspace.yaml`) | `minimumReleaseAge: 7200` (min = 5 days) | Workspace: root + `client`/`server`/`lib`/`acme`, incl. transitive deps |
| npm (`.npmrc` × 5) | `min-release-age=5` (days) | `agent-sidecar`, `update-sidecar`, `pg-az-backup`, `deployment/development`, `claude-shell` |
| Dependabot (`.github/dependabot.yml`) | `cooldown.default-days: 5` | Update **PRs** for npm workspace + 5 sidecars + GitHub Actions |

## ⚠️ Prerequisite for the npm sidecars

`min-release-age` requires **npm ≥ 11.10.0** (the system npm here was 11.8.0). On older npm the key is **ignored — inert, not an error** — so the sidecars build fine but are *unprotected* until npm is bumped. Run dependency bumps with npm ≥ 11.10.0 (`npm i -g npm@latest`). pnpm 10.32 supports `minimumReleaseAge` natively, and Dependabot's cooldown runs server-side, so those two are live immediately.

## Behaviour notes

- **Security fixes still land fast** — Dependabot cooldown applies to *version* updates only; security updates are exempt by design.
- **Builds stay reproducible** — `npm ci` (agent-sidecar, update-sidecar) installs the lockfile exactly, so cooldown doesn't touch it. Only `pg-az-backup` (`npm install --no-package-lock`) resolves fresh, where the cooldown is a bonus.
- **New behaviour:** Dependabot was previously security-only (no config file). This enables grouped weekly **version-update** PRs (minor/patch grouped per area; majors individual).

## Test plan

- [x] YAML validates for `pnpm-workspace.yaml` and `.github/dependabot.yml`
- [x] `minimumReleaseAge: 7200` confirmed = 5 days
- [ ] After merge: confirm GitHub parses `dependabot.yml` (Insights → Dependency graph → Dependabot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)