### PR TITLE
fix(self-backup): add missing storage location selector

### DIFF
--- a/client/src/app/settings/self-backup/page.tsx
+++ b/client/src/app/settings/self-backup/page.tsx
@@ -88,6 +88,7 @@ import {
   useStorageLocationsList,
   useStorageSettings,
 } from "@/hooks/use-storage-settings";
+import { StorageLocationSelector } from "@/components/storage/StorageLocationSelector";
 import { useFormattedDateTime } from "@/hooks/use-formatted-date";
 import { useUserPreferences, useTimezones } from "@/hooks/use-user-preferences";
 import { formatBytes, formatDuration, cn } from "@/lib/utils";
@@ -410,6 +411,36 @@ export default function SelfBackupSettingsPage() {
                         </Button>
                       ))}
                     </div>
+                  </FormItem>
+                )}
+              />
+
+              {/* Storage Location */}
+              <FormField
+                control={form.control}
+                name="storageLocationId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Storage Location</FormLabel>
+                    <FormControl>
+                      <StorageLocationSelector
+                        provider={activeProviderId}
+                        value={field.value}
+                        onChange={field.onChange}
+                        disabled={!isStorageConnected}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Where database backups are stored. Configured on the{" "}
+                      <Link
+                        to="/connectivity-storage"
+                        className="underline underline-offset-2"
+                      >
+                        Storage
+                      </Link>{" "}
+                      page.
+                    </FormDescription>
+                    <FormMessage />
                   </FormItem>
                 )}
               />


### PR DESCRIPTION
## Problem

On the **Self-Backup Settings** page (`/settings-self-backup`), setting up a backup is impossible:

- **Save Configuration** is greyed out, and even when dirtied it silently does nothing.
- **Backup Now** is permanently disabled.
- Toggling **Scheduled Backups** off then on fails with `400 Bad Request` → toast *"Failed to enable self-backup: Bad Request"*.

### Root cause

The form requires a `storageLocationId` (enforced by both the client Zod schema and the server route), but **the form never rendered a control to set it** — only *Backup Schedule* and *Timezone* were shown. So `storageLocationId` stays empty, which cascades into all three symptoms:

| Symptom | Cause |
|---|---|
| Backup Now disabled | `!config?.storageLocationId` |
| Save silently no-ops | `form.handleSubmit` fails Zod `storageLocationId` validation; there was no `FormField`/`FormMessage` for it, so the error was invisible |
| Enable toggle → 400 | server `/enable` rejects with *"Backup schedule not configured"* when `storage_location_id` is blank |

Confirmed against a live instance — the API returns `"storageLocationId": ""` with `"isRegistered": false`, so scheduled self-backup was never actually running despite `enabled: true`.

### Why it regressed

The pluggable-storage refactor (#327) renamed `azureContainerName` → `storageLocationId`, introduced the reusable `StorageLocationSelector`, and wired it into the `/connectivity-storage` page and the **postgres backup modal** — but the **self-backup settings page was missed**. It kept the loader hook (`useStorageLocationsList`, used only for `isLoading`) but no selector was ever rendered.

## Fix

Add a `StorageLocationSelector` `FormField` to the self-backup form, mirroring the existing usage in `backup-configuration-modal.tsx`. This lets users pick where backups are stored, satisfies the schema, un-disables both buttons, surfaces validation via `FormMessage`, and lets the enable toggle succeed.

## Testing

- ✅ `pnpm build:lib` + `pnpm --filter mini-infra-client build` (typecheck + production build)
- ✅ `pnpm --filter mini-infra-client lint`
- Live smoke pending — dev env was still warming when the PR was opened; the change reuses a pattern already proven on two other pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)