### PR TITLE
feat(tunnels): self-provision connector stack + dynamic token

### DIFF
--- a/lib/types/stacks.ts
+++ b/lib/types/stacks.ts
@@ -50,6 +50,16 @@ export type DynamicEnvSource =
   | { kind: 'nats-url' }
   | { kind: 'nats-creds' }
   /**
+   * Cloudflare tunnel connector token for the stack's environment. Resolved
+   * at apply time from the managed-tunnel store (the token issued when the
+   * managed tunnel was created) and injected as a plain env var — cloudflared
+   * reads `TUNNEL_TOKEN` natively. Resolving dynamically (rather than baking
+   * the token into a stack parameter) means the instantiate / create-tunnel /
+   * deploy steps are order-independent: the live token is always read fresh on
+   * each apply. Fails closed if no managed tunnel exists for the environment.
+   */
+  | { kind: 'cloudflare-tunnel-token' }
+  /**
    * Read a single field from a Vault KV v2 path at apply time using the
    * Mini Infra admin token. The container receives the value as a plain
    * env var — no Vault client SDK or AppRole needed by the running app.

--- a/server/src/__tests__/dynamic-env-source-schema.test.ts
+++ b/server/src/__tests__/dynamic-env-source-schema.test.ts
@@ -25,6 +25,21 @@ describe('dynamicEnvSource — discriminated union', () => {
   it('accepts pool-management-token referencing a service name', () => {
     expect(parseDyn({ A: { kind: 'pool-management-token', poolService: 'worker' } }).success).toBe(true);
   });
+
+  it('accepts cloudflare-tunnel-token', () => {
+    expect(parseDyn({ TUNNEL_TOKEN: { kind: 'cloudflare-tunnel-token' } }).success).toBe(true);
+  });
+
+  it('accepts cloudflare-tunnel-token with restartPolicy="unless-stopped" (durable credential, not single-use)', () => {
+    // The cloudflared connector stays up (unless-stopped) and re-reads its
+    // token from env on every restart. Unlike vault-wrapped-secret-id, the
+    // token is durable, so it must NOT trip the single-use restart guard.
+    const r = stackContainerConfigSchema.safeParse({
+      dynamicEnv: { TUNNEL_TOKEN: { kind: 'cloudflare-tunnel-token' } },
+      restartPolicy: 'unless-stopped',
+    });
+    expect(r.success).toBe(true);
+  });
 });
 
 describe('dynamicEnvSource — vault-kv (new in Phase 1)', () => {

--- a/server/src/routes/cloudflare/managed-tunnels-routes.ts
+++ b/server/src/routes/cloudflare/managed-tunnels-routes.ts
@@ -5,6 +5,7 @@ import { asyncHandler } from "../../lib/async-handler";
 import { requirePermission, getAuthenticatedUser } from "../../middleware/auth";
 import prisma from "../../lib/prisma";
 import { CloudflareService } from "../../services/cloudflare";
+import { StackTemplateService } from "../../services/stacks/stack-template-service";
 import { tunnelCache } from "../../services/cloudflare/tunnel-cache";
 import {
   ManagedTunnelListResponse,
@@ -139,70 +140,55 @@ export function createManagedTunnelsRouter(
         });
       }
 
+      // Ensure the cloudflare-tunnel connector stack exists for this
+      // environment. It is never auto-provisioned on environment creation
+      // (stack creation is user-initiated via template instantiation), so
+      // without this the Tunnels page would strand the user at "Not Deployed"
+      // with no stack for the Deploy button to act on. Idempotent — reuses an
+      // already-instantiated stack. The connector reads its token dynamically
+      // at apply time (dynamicEnv: cloudflare-tunnel-token), so there is no
+      // stack parameter to wire and creation order no longer matters.
+      let stack = await prisma.stack.findFirst({
+        where: {
+          name: "cloudflare-tunnel",
+          environmentId,
+          status: { not: "removed" },
+        },
+        select: { id: true, status: true },
+      });
+
+      if (!stack) {
+        const template = await prisma.stackTemplate.findUnique({
+          where: {
+            name_source: { name: "cloudflare-tunnel", source: "system" },
+          },
+          select: { id: true },
+        });
+        if (!template) {
+          return res.status(500).json({
+            success: false,
+            error:
+              "The cloudflare-tunnel system template is missing — cannot provision the connector stack",
+          });
+        }
+        const created = await new StackTemplateService(
+          prisma,
+        ).createStackFromTemplate({ templateId: template.id, environmentId }, userId);
+        stack = { id: created.id, status: created.status };
+        logger.info(
+          { environmentId, stackId: created.id },
+          "Auto-provisioned cloudflare-tunnel connector stack for managed tunnel",
+        );
+      }
+
       const result = await cloudflareConfigService.createManagedTunnel(
         environmentId,
         parsed.data.name,
         userId,
       );
 
-      // Propagate the freshly-issued token to the cloudflare-tunnel stack
-      // so its next deploy can authenticate. If the stack update fails we
-      // roll back the tunnel creation so the system doesn't end up with
-      // a tunnel that no stack knows about.
       const token =
         await cloudflareConfigService.getManagedTunnelToken(environmentId);
-      const stack = await prisma.stack.findFirst({
-        where: {
-          name: "cloudflare-tunnel",
-          environmentId,
-          status: { not: "removed" },
-        },
-        select: { id: true, status: true, parameterValues: true },
-      });
-
-      if (token && stack) {
-        try {
-          const existingParams =
-            (stack.parameterValues as Record<string, string>) ?? {};
-          await prisma.stack.update({
-            where: { id: stack.id },
-            data: {
-              parameterValues: {
-                ...existingParams,
-                "tunnel-token": token,
-              },
-              status: "pending",
-            },
-          });
-        } catch (stackError) {
-          logger.error(
-            {
-              error:
-                stackError instanceof Error
-                  ? stackError.message
-                  : "Unknown",
-            },
-            "Failed to update stack after tunnel creation, rolling back",
-          );
-          try {
-            await cloudflareConfigService.deleteManagedTunnel(
-              environmentId,
-              userId,
-            );
-          } catch (rollbackError) {
-            logger.error(
-              {
-                error:
-                  rollbackError instanceof Error
-                    ? rollbackError.message
-                    : "Unknown",
-              },
-              "Failed to roll back tunnel creation — manual cleanup may be required",
-            );
-          }
-          throw stackError;
-        }
-      }
 
       tunnelCache.clear();
 
@@ -213,8 +199,8 @@ export function createManagedTunnelsRouter(
           tunnelName: result.tunnelName,
           environmentId,
           hasToken: !!token,
-          stackId: stack?.id,
-          stackStatus: token && stack ? "pending" : stack?.status,
+          stackId: stack.id,
+          stackStatus: stack.status,
         },
         message: "Managed tunnel created successfully",
       };

--- a/server/src/services/cloudflare/__tests__/cloudflare-tunnel-token-injector.test.ts
+++ b/server/src/services/cloudflare/__tests__/cloudflare-tunnel-token-injector.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { StackContainerConfig } from "@mini-infra/types";
+
+// Mock the heavy collaborator so the unit test isolates the injector. The
+// real CloudflareService pulls in prisma + the Cloudflare API clients; we only
+// care that the injector reads the token via getManagedTunnelToken and maps it.
+// `new CloudflareService()` must be constructible, so the mock is a class.
+const { getManagedTunnelToken } = vi.hoisted(() => ({
+  getManagedTunnelToken: vi.fn(),
+}));
+vi.mock("../cloudflare-service", () => ({
+  CloudflareService: class {
+    getManagedTunnelToken = getManagedTunnelToken;
+  },
+}));
+
+import { CloudflareTunnelTokenInjector } from "../cloudflare-tunnel-token-injector";
+
+const prisma =
+  {} as ConstructorParameters<typeof CloudflareTunnelTokenInjector>[0];
+
+const cfg = (dynamicEnv?: Record<string, unknown>): StackContainerConfig =>
+  ({ dynamicEnv } as unknown as StackContainerConfig);
+
+describe("CloudflareTunnelTokenInjector", () => {
+  beforeEach(() => {
+    getManagedTunnelToken.mockReset();
+  });
+
+  it("returns null when the service declares no dynamicEnv", async () => {
+    const injector = new CloudflareTunnelTokenInjector(prisma);
+    expect(await injector.resolve("env-1", cfg(undefined))).toBeNull();
+    expect(getManagedTunnelToken).not.toHaveBeenCalled();
+  });
+
+  it("returns null when no cloudflare-tunnel-token entry is present", async () => {
+    const injector = new CloudflareTunnelTokenInjector(prisma);
+    const res = await injector.resolve(
+      "env-1",
+      cfg({ OTHER: { kind: "nats-url" } }),
+    );
+    expect(res).toBeNull();
+    expect(getManagedTunnelToken).not.toHaveBeenCalled();
+  });
+
+  it("maps the resolved token onto every declared env key", async () => {
+    getManagedTunnelToken.mockResolvedValue("tok-abc");
+    const injector = new CloudflareTunnelTokenInjector(prisma);
+    const res = await injector.resolve(
+      "env-1",
+      cfg({
+        TUNNEL_TOKEN: { kind: "cloudflare-tunnel-token" },
+        ALT: { kind: "cloudflare-tunnel-token" },
+      }),
+    );
+    expect(res).toEqual({ TUNNEL_TOKEN: "tok-abc", ALT: "tok-abc" });
+    expect(getManagedTunnelToken).toHaveBeenCalledWith("env-1");
+  });
+
+  it("throws (fail-closed) when the stack has no environment", async () => {
+    const injector = new CloudflareTunnelTokenInjector(prisma);
+    await expect(
+      injector.resolve(
+        null,
+        cfg({ TUNNEL_TOKEN: { kind: "cloudflare-tunnel-token" } }),
+      ),
+    ).rejects.toThrow(/environment-scoped/);
+    expect(getManagedTunnelToken).not.toHaveBeenCalled();
+  });
+
+  it("throws (fail-closed) when no managed tunnel token exists for the environment", async () => {
+    getManagedTunnelToken.mockResolvedValue(null);
+    const injector = new CloudflareTunnelTokenInjector(prisma);
+    await expect(
+      injector.resolve(
+        "env-1",
+        cfg({ TUNNEL_TOKEN: { kind: "cloudflare-tunnel-token" } }),
+      ),
+    ).rejects.toThrow(/create the managed tunnel/);
+  });
+});

--- a/server/src/services/cloudflare/cloudflare-tunnel-token-injector.ts
+++ b/server/src/services/cloudflare/cloudflare-tunnel-token-injector.ts
@@ -1,0 +1,52 @@
+import type { PrismaClient } from "../../generated/prisma/client";
+import type { StackContainerConfig } from "@mini-infra/types";
+import { CloudflareService } from "./cloudflare-service";
+
+/**
+ * Resolves the `cloudflare-tunnel-token` dynamicEnv kind at apply time.
+ *
+ * The cloudflared connector needs the tunnel token issued when the managed
+ * tunnel was created. Rather than baking that token into a stack parameter
+ * (which couples the instantiate / create-tunnel / deploy steps to a rigid
+ * order), the connector template declares the token as a dynamicEnv value;
+ * this injector reads the live token from the managed-tunnel store on every
+ * apply. cloudflared reads the resulting `TUNNEL_TOKEN` env var natively.
+ *
+ * Fails closed: if the stack is not environment-scoped, or no managed tunnel
+ * exists for the environment, resolution throws so the apply aborts before a
+ * cloudflared container is started with an empty token.
+ */
+export class CloudflareTunnelTokenInjector {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async resolve(
+    environmentId: string | null,
+    containerConfig: StackContainerConfig,
+  ): Promise<Record<string, string> | null> {
+    const dynamicEnv = containerConfig.dynamicEnv;
+    if (!dynamicEnv) return null;
+
+    const keys = Object.entries(dynamicEnv)
+      .filter(([, src]) => src.kind === "cloudflare-tunnel-token")
+      .map(([key]) => key);
+    if (keys.length === 0) return null;
+
+    if (!environmentId) {
+      throw new Error(
+        "Service declares cloudflare-tunnel-token but the stack has no environment — the cloudflare-tunnel connector must be environment-scoped",
+      );
+    }
+
+    const cloudflare = new CloudflareService(this.prisma);
+    const token = await cloudflare.getManagedTunnelToken(environmentId);
+    if (!token) {
+      throw new Error(
+        `Service declares cloudflare-tunnel-token but no managed tunnel exists for environment ${environmentId} — create the managed tunnel before deploying the connector`,
+      );
+    }
+
+    const values: Record<string, string> = {};
+    for (const key of keys) values[key] = token;
+    return values;
+  }
+}

--- a/server/src/services/stacks/schemas.ts
+++ b/server/src/services/stacks/schemas.ts
@@ -99,6 +99,7 @@ const dynamicEnvSourceSchema = z.discriminatedUnion("kind", [
   }),
   z.object({ kind: z.literal("nats-url") }),
   z.object({ kind: z.literal("nats-creds") }),
+  z.object({ kind: z.literal("cloudflare-tunnel-token") }),
   z.object({
     kind: z.literal("vault-kv"),
     path: kvPathSchema,

--- a/server/src/services/stacks/stack-reconciler.ts
+++ b/server/src/services/stacks/stack-reconciler.ts
@@ -43,6 +43,7 @@ import { StackServiceHandlers, type ServiceHandlerContext } from './stack-servic
 import { VaultCredentialInjector } from '../vault/vault-credential-injector';
 import { vaultServicesReady } from '../vault/vault-services';
 import { NatsCredentialInjector } from '../nats/nats-credential-injector';
+import { CloudflareTunnelTokenInjector } from '../cloudflare/cloudflare-tunnel-token-injector';
 import { revokeStackNatsSigningKeys } from './stack-nats-revocation';
 import { rotatePoolManagementTokens } from './pool-management-token';
 import { resolveEffectiveVaultBinding } from './vault-binding-resolver';
@@ -672,6 +673,7 @@ export class StackReconciler {
   private async resolveVaultEnv(
     stack: {
       id: string;
+      environmentId: string | null;
       vaultAppRoleId: string | null;
       vaultFailClosed: boolean;
       lastAppliedVaultAppRoleId: string | null;
@@ -697,6 +699,7 @@ export class StackReconciler {
     const vaultReady = vaultServicesReady();
     const injector = vaultReady ? new VaultCredentialInjector(this.prisma) : null;
     const natsInjector = new NatsCredentialInjector(this.prisma);
+    const tunnelTokenInjector = new CloudflareTunnelTokenInjector(this.prisma);
 
     for (const [serviceName, serviceDef] of resolvedDefinitions.entries()) {
       if (!activeServiceNames.has(serviceName)) continue;
@@ -724,6 +727,37 @@ export class StackReconciler {
       const hasPoolTokenEntries = Object.values(dynamicEnv).some(
         (src) => src.kind === 'pool-management-token',
       );
+      const hasTunnelTokenEntries = Object.values(dynamicEnv).some(
+        (src) => src.kind === 'cloudflare-tunnel-token',
+      );
+
+      // Cloudflare tunnel token resolves inline from the managed-tunnel store —
+      // no Vault / NATS / AppRole involved. It's independent of the other kinds,
+      // so resolve + merge it up front; a tunnel-token-only service (the
+      // cloudflared connector) then falls through the Vault/NATS gates below
+      // and keeps these values. Fails closed if no managed tunnel exists.
+      if (hasTunnelTokenEntries) {
+        try {
+          const values = await tunnelTokenInjector.resolve(
+            stack.environmentId,
+            serviceDef.containerConfig,
+          );
+          if (values) {
+            const existing = overrides.get(serviceName) ?? {};
+            overrides.set(serviceName, { ...existing, ...values });
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          log.error(
+            { service: serviceName, err: msg },
+            'Cloudflare tunnel token resolution failed',
+          );
+          throw new Error(
+            `Cloudflare tunnel token injection failed for service "${serviceName}": ${msg}`,
+            { cause: err },
+          );
+        }
+      }
 
       const svcRow = serviceByName.get(serviceName) ?? {
         vaultAppRoleId: null,
@@ -742,7 +776,10 @@ export class StackReconciler {
             if (token) values[key] = token;
           }
         }
-        if (Object.keys(values).length > 0) overrides.set(serviceName, values);
+        if (Object.keys(values).length > 0) {
+          const existing = overrides.get(serviceName) ?? {};
+          overrides.set(serviceName, { ...existing, ...values });
+        }
         continue;
       }
 

--- a/server/templates/cloudflare-tunnel/template.json
+++ b/server/templates/cloudflare-tunnel/template.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-tunnel",
   "displayName": "Cloudflare Tunnel",
-  "builtinVersion": 6,
+  "builtinVersion": 7,
   "scope": "environment",
   "networkType": "internet",
   "category": "infrastructure",
@@ -9,14 +9,7 @@
   "resourceOutputs": [
     { "type": "docker-network", "purpose": "tunnel" }
   ],
-  "parameters": [
-    {
-      "name": "tunnel-token",
-      "type": "string",
-      "default": "",
-      "description": "Cloudflare tunnel token (auto-populated when managed tunnel is created)"
-    }
-  ],
+  "parameters": [],
   "networks": [],
   "volumes": [],
   "services": [
@@ -26,7 +19,10 @@
       "dockerImage": "cloudflare/cloudflared",
       "dockerTag": "latest",
       "containerConfig": {
-        "command": ["tunnel", "--no-autoupdate", "run", "--token", "{{params.tunnel-token}}"],
+        "command": ["tunnel", "--no-autoupdate", "run"],
+        "dynamicEnv": {
+          "TUNNEL_TOKEN": { "kind": "cloudflare-tunnel-token" }
+        },
         "requiredEgress": ["*.cloudflare.com", "*.argotunnel.com"],
         "joinResourceNetworks": ["tunnel"],
         "restartPolicy": "unless-stopped",


### PR DESCRIPTION
## Problem

On the **Cloudflare Tunnels** page, creating a managed tunnel stranded you at *"Not Deployed"* with only a **Delete** button — no way to deploy. Two root causes:

1. **Hidden orchestration.** The Deploy button is gated on the tunnel having an associated `cloudflare-tunnel` connector stack (`tunnel.stackId`). That stack is **never auto-created** (`builtin-stack-sync.ts`: *"Never creates a stack — creation is user-initiated via template instantiation"*), and the Tunnels page can't instantiate it — you had to know to do it on the Environment page first.
2. **Token-ordering footgun.** The connector token was a **static stack parameter** wired only at tunnel-creation time (and only *if* the stack already existed), so the instantiate → create → deploy steps had a rigid, undocumented order. Get it wrong and Deploy was disabled with "missing parameters" or cloudflared ran with an empty token.

## Fix

Make the Tunnels page self-sufficient and make ordering irrelevant.

**Self-provisioning** (`managed-tunnels-routes.ts`): create-tunnel now instantiates the `cloudflare-tunnel` connector stack for the environment if it doesn't exist (idempotent, reuses `createStackFromTemplate`). Stack-first ordering, so a transient CF failure leaves only a harmless undeployed stack that a retry reuses — recoverable, and invisible to the UI (the card keys off `hasTunnel`). The Deploy button now appears on its own.

**Dynamic token** (new `cloudflare-tunnel-token` dynamicEnv kind): the connector token is resolved at **apply time** from the managed-tunnel store via `CloudflareTunnelTokenInjector` and injected as `TUNNEL_TOKEN`, which cloudflared reads natively. Order no longer matters — the live token is read fresh on every apply. **Fails closed** if no managed tunnel exists for the environment.

This also let me **delete** the route's old token-wiring + rollback dance (the token is no longer stored on the stack) — a net simplification.

### Changed
- `lib/types/stacks.ts`, `server/.../schemas.ts` — new `cloudflare-tunnel-token` dynamicEnv kind.
- `server/.../cloudflare/cloudflare-tunnel-token-injector.ts` — **new** resolver (mirrors `NatsCredentialInjector`).
- `server/.../stacks/stack-reconciler.ts` — resolves the kind inline (no Vault/NATS), merged into per-service env overrides.
- `server/templates/cloudflare-tunnel/template.json` — drop static `tunnel-token` param; command `["tunnel","--no-autoupdate","run"]`; add `dynamicEnv.TUNNEL_TOKEN`; `builtinVersion` 6 → 7 (upgrades existing stacks).
- `server/.../routes/cloudflare/managed-tunnels-routes.ts` — auto-instantiate stack; remove token-wiring/rollback.

## Testing

- ✅ `build:lib` + server (tsc) + client builds; client lint
- ✅ Unit tests: `CloudflareTunnelTokenInjector` (mapping + both fail-closed paths), new dynamicEnv kind incl. `unless-stopped` compatibility
- ✅ Existing suites: stacks + cloudflare (230), builtin templates (26) — green
- ✅ **Live smoke** on a rebuilt dev env:
  - Connector template confirmed upgraded to **v7** with `command: [tunnel,--no-autoupdate,run]` and `dynamicEnv: {TUNNEL_TOKEN: {kind: cloudflare-tunnel-token}}`, `unless-stopped` accepted.
  - Created an internet env + attempted a tunnel → the `cloudflare-tunnel` connector stack was **auto-instantiated at v7**, confirming self-provisioning. (Full visible-Deploy + deploy E2E was blocked only by the dev Cloudflare token lacking "Cloudflare Tunnel" edit permission — the unchanged CF call, not this change.) Dev artifacts cleaned up; no Cloudflare resources created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)