### PR TITLE
fix(tunnels): make cloudflared connector healthcheck work on distroless image

### DIFF
--- a/server/src/__tests__/cloudflare-tunnel-template-load.test.ts
+++ b/server/src/__tests__/cloudflare-tunnel-template-load.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression tests for the built-in `cloudflare-tunnel` connector template.
+ *
+ * The `cloudflare/cloudflared` image is fully distroless: its only executable
+ * is `/usr/local/bin/cloudflared` — there is no `/bin/sh`, no `wget`, no
+ * `curl`. An earlier revision shipped a healthcheck of the form
+ *   ["CMD-SHELL", "wget --spider -q http://localhost:2000/ready || exit 1"]
+ * which could never pass against that image because:
+ *   1. CMD-SHELL wraps the command in `/bin/sh -c`, and there is no shell.
+ *   2. `wget` is not present.
+ *   3. cloudflared binds its metrics/`/ready` server to a *random* port unless
+ *      `--metrics` / `$TUNNEL_METRICS` pins it — never port 2000.
+ * The stack therefore sat in `error` ("Healthcheck timeout") even though the
+ * tunnel itself was connected and healthy.
+ *
+ * The fix pins the metrics server to a fixed loopback port via the
+ * `TUNNEL_METRICS` env var (read by both the `run` process and the probe) and
+ * uses cloudflared's own exec-form `tunnel ready` subcommand as the
+ * healthcheck. These tests pin that shape so it cannot regress back to a
+ * shell/wget probe the image cannot execute.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as path from 'path';
+import { loadTemplateFromDirectory } from '../services/stacks/template-file-loader';
+
+const TEMPLATES_DIR = path.resolve(process.cwd(), 'templates');
+
+function loadTunnel() {
+  return loadTemplateFromDirectory(path.join(TEMPLATES_DIR, 'cloudflare-tunnel'));
+}
+
+describe('cloudflare-tunnel template.json', () => {
+  it('parses successfully via loadTemplateFromDirectory', () => {
+    expect(() => loadTunnel()).not.toThrow();
+  });
+
+  it('has a single cloudflared service', () => {
+    const loaded = loadTunnel();
+    expect(loaded.definition.services).toHaveLength(1);
+    expect(loaded.definition.services[0].serviceName).toBe('cloudflared');
+  });
+
+  it('pins the cloudflared metrics server to a fixed loopback port via TUNNEL_METRICS', () => {
+    const svc = loadTunnel().definition.services[0];
+    // Without this, cloudflared binds /ready to a random port and the
+    // healthcheck (and any operator probe) can never find it.
+    expect(svc.containerConfig.env?.TUNNEL_METRICS).toBe('127.0.0.1:2000');
+  });
+
+  it('keeps the static TUNNEL_METRICS env disjoint from the dynamic TUNNEL_TOKEN', () => {
+    const svc = loadTunnel().definition.services[0];
+    const staticKeys = Object.keys(svc.containerConfig.env ?? {});
+    const dynamicKeys = Object.keys(svc.containerConfig.dynamicEnv ?? {});
+    expect(staticKeys).toContain('TUNNEL_METRICS');
+    expect(dynamicKeys).toContain('TUNNEL_TOKEN');
+    expect(staticKeys.filter((k) => dynamicKeys.includes(k))).toEqual([]);
+  });
+
+  it('uses the distroless-safe exec-form `cloudflared tunnel ready` healthcheck', () => {
+    const svc = loadTunnel().definition.services[0];
+    const test = svc.containerConfig.healthcheck?.test;
+    // Exec form (no shell) using the only binary present in the image.
+    expect(test).toEqual(['CMD', 'cloudflared', 'tunnel', 'ready']);
+  });
+
+  it('does not use a shell-form healthcheck or external probe binaries', () => {
+    const svc = loadTunnel().definition.services[0];
+    const test = svc.containerConfig.healthcheck?.test ?? [];
+    // The cloudflared image is distroless — guard against reintroducing a
+    // CMD-SHELL/wget/curl probe that the image cannot run.
+    expect(test[0]).not.toBe('CMD-SHELL');
+    expect(test.join(' ')).not.toMatch(/\b(wget|curl)\b/);
+  });
+});

--- a/server/templates/cloudflare-tunnel/template.json
+++ b/server/templates/cloudflare-tunnel/template.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-tunnel",
   "displayName": "Cloudflare Tunnel",
-  "builtinVersion": 7,
+  "builtinVersion": 8,
   "scope": "environment",
   "networkType": "internet",
   "category": "infrastructure",
@@ -20,6 +20,9 @@
       "dockerTag": "latest",
       "containerConfig": {
         "command": ["tunnel", "--no-autoupdate", "run"],
+        "env": {
+          "TUNNEL_METRICS": "127.0.0.1:2000"
+        },
         "dynamicEnv": {
           "TUNNEL_TOKEN": { "kind": "cloudflare-tunnel-token" }
         },
@@ -27,7 +30,7 @@
         "joinResourceNetworks": ["tunnel"],
         "restartPolicy": "unless-stopped",
         "healthcheck": {
-          "test": ["CMD-SHELL", "wget --spider -q http://localhost:2000/ready || exit 1"],
+          "test": ["CMD", "cloudflared", "tunnel", "ready"],
           "interval": 30,
           "timeout": 5,
           "retries": 3,


### PR DESCRIPTION
## Problem

The `cloudflare-tunnel` managed connector stack shows **Error** on `/tunnels` even though the tunnel itself is fully healthy. Observed in dev: the **Managed Tunnels** card reports `Error` while the **Cloudflare Tunnels** panel (sourced from the Cloudflare API) shows the same tunnel `healthy` with 4 active connections.

The stack's `lastFailureReason` is `cloudflared: Healthcheck timeout` — purely a healthcheck problem, not a connectivity one.

## Root cause

The connector template shipped a healthcheck the `cloudflare/cloudflared` image **can never satisfy**:

```json
["CMD-SHELL", "wget --spider -q http://localhost:2000/ready || exit 1"]
```

The image is **distroless** — its only executable is `/usr/local/bin/cloudflared` (verified: entrypoint `["cloudflared","--no-autoupdate"]`, user `65532`, nothing else on the filesystem). So the probe failed three ways over:

1. `CMD-SHELL` wraps the command in `/bin/sh -c` — there is no `/bin/sh`.
2. `wget` is not in the image.
3. cloudflared binds its `/ready` metrics server to a **random** port (e.g. `[::]:20241`), never `2000`, unless `--metrics`/`$TUNNEL_METRICS` pins it.

Docker's healthcheck therefore never reached `healthy`; `waitForHealthy()` timed out at 60s and the reconciler marked the stack `error`.

## Fix

- Pin the metrics server to a fixed loopback port via **`TUNNEL_METRICS=127.0.0.1:2000`**. cloudflared reads this env for both the long-running `run` process and the probe, so the port is defined once (DRY).
- Replace the probe with cloudflared's own exec-form **`["CMD", "cloudflared", "tunnel", "ready"]`** subcommand — purpose-built as a container readiness probe, needs no shell or external binaries, and uses the only executable present.
- Bump **`builtinVersion` 7 → 8** so `builtin-stack-sync` re-seeds the corrected definition onto already-deployed connector stacks.

Verified each piece against the real `cloudflare/cloudflared:latest` image: the distroless filesystem, that `tunnel ready` resolves and reads `$TUNNEL_METRICS` from the environment, and that the static `env` / dynamic `TUNNEL_TOKEN` keys stay disjoint per the schema refine.

## Deploying to an existing instance

After this ships and the app restarts, the connector stack auto-moves to `pending` (re-seeded at boot). **Redeploy the tunnel** (Deploy button on `/tunnels`, or re-apply the `cloudflare-tunnel` stack) to recreate the cloudflared container with the passing healthcheck → `synced`.

## Tests

- New `server/src/__tests__/cloudflare-tunnel-template-load.test.ts` pins the distroless-safe healthcheck shape and the `TUNNEL_METRICS` env so it can't regress to a shell/wget probe.
- Server build + existing template-loader/schema tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)