### PR TITLE
fix(images): use Bearer-token auth for GHCR/non-Hub registries in image validation

### DIFF
--- a/client/src/hooks/use-detect-image-ports.ts
+++ b/client/src/hooks/use-detect-image-ports.ts
@@ -48,7 +48,7 @@ async function validateImage({
   if (res.status === 404) {
     return { status: "not-found", message };
   }
-  if (res.status === 502 && /authentication/i.test(message)) {
+  if (res.status === 401 || res.status === 403) {
     return { status: "auth-required", message };
   }
   return { status: "error", message };

--- a/server/src/__tests__/image-inspect.test.ts
+++ b/server/src/__tests__/image-inspect.test.ts
@@ -71,11 +71,27 @@ describe("ImageInspectService", () => {
       expect(decodeURIComponent(mockFetch.mock.calls[0][0])).toContain("repository:myuser/myapp");
     });
 
-    it("returns exposed ports from GHCR with credentials", async () => {
+    it("returns exposed ports from GHCR with credentials, exchanging Basic creds for a Bearer token", async () => {
       const creds = { username: "user", password: "pat-token" };
       service = new ImageInspectService(creds);
 
-      // GHCR manifest (no separate token exchange needed with Basic auth)
+      // GHCR challenges anonymous /v2/ probes with a Bearer realm
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        headers: {
+          get: (name: string) =>
+            name.toLowerCase() === "www-authenticate"
+              ? 'Bearer realm="https://ghcr.io/token",service="ghcr.io"'
+              : null,
+        },
+      });
+      // Token exchange using the supplied Basic credentials
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ token: "ghcr-bearer-token" }),
+      });
+      // GHCR manifest, fetched with the exchanged Bearer token
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
@@ -95,8 +111,42 @@ describe("ImageInspectService", () => {
       const ports = await service.getExposedPorts("ghcr.io/owner/repo", "latest");
 
       expect(ports).toEqual([8080]);
-      // Verify Basic auth header was sent
-      const manifestCall = mockFetch.mock.calls[0];
+      // Verify the token exchange used the Basic credentials...
+      const tokenCall = mockFetch.mock.calls[1];
+      expect(tokenCall[1].headers.Authorization).toMatch(/^Basic /);
+      // ...and the manifest fetch used the exchanged Bearer token
+      const manifestCall = mockFetch.mock.calls[2];
+      expect(manifestCall[1].headers.Authorization).toBe("Bearer ghcr-bearer-token");
+    });
+
+    it("falls back to Basic auth against GHCR when no Bearer challenge is issued", async () => {
+      const creds = { username: "user", password: "pat-token" };
+      service = new ImageInspectService(creds);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          config: { digest: "sha256:def456" },
+        }),
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          config: {
+            ExposedPorts: { "8080/tcp": {} },
+          },
+        }),
+      });
+
+      const ports = await service.getExposedPorts("ghcr.io/owner/repo", "latest");
+
+      expect(ports).toEqual([8080]);
+      const manifestCall = mockFetch.mock.calls[1];
       expect(manifestCall[1].headers.Authorization).toMatch(/^Basic /);
     });
 

--- a/server/src/__tests__/images-api.test.ts
+++ b/server/src/__tests__/images-api.test.ts
@@ -128,14 +128,14 @@ describe("GET /api/images/inspect-ports", () => {
     expect(res.status).toBe(404);
   });
 
-  it("returns 502 when auth fails", async () => {
+  it("returns 401 when auth fails", async () => {
     mockGetExposedPorts.mockRejectedValue(new Error("Authentication failed"));
 
     const res = await request(app)
       .get("/api/images/inspect-ports")
       .query({ image: "private/image", tag: "latest" });
 
-    expect(res.status).toBe(502);
+    expect(res.status).toBe(401);
   });
 
   it("returns empty ports array when image has no EXPOSE", async () => {

--- a/server/src/__tests__/registry-auth.test.ts
+++ b/server/src/__tests__/registry-auth.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getRegistryAuthHeader } from "../services/registry-auth";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function headersWithWwwAuthenticate(value: string | null) {
+  return {
+    get: (name: string) =>
+      name.toLowerCase() === "www-authenticate" ? value : null,
+  };
+}
+
+describe("getRegistryAuthHeader", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null when no credentials are supplied", async () => {
+    const result = await getRegistryAuthHeader("ghcr.io", "owner/repo");
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("exchanges Basic credentials for a Bearer token when the registry issues a challenge (GHCR)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: headersWithWwwAuthenticate(
+        'Bearer realm="https://ghcr.io/token",service="ghcr.io"',
+      ),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ token: "exchanged-bearer-token" }),
+    });
+
+    const result = await getRegistryAuthHeader(
+      "ghcr.io",
+      "owner/repo",
+      "user",
+      "pat-token",
+    );
+
+    expect(result).toBe("Bearer exchanged-bearer-token");
+
+    const [probeUrl] = mockFetch.mock.calls[0];
+    expect(probeUrl).toBe("https://ghcr.io/v2/");
+
+    const [tokenUrl, tokenInit] = mockFetch.mock.calls[1];
+    expect(tokenUrl).toContain("https://ghcr.io/token?");
+    expect(tokenUrl).toContain("service=ghcr.io");
+    expect(decodeURIComponent(tokenUrl)).toContain("repository:owner/repo:pull");
+    expect(tokenInit.headers.Authorization).toBe(
+      `Basic ${Buffer.from("user:pat-token").toString("base64")}`,
+    );
+  });
+
+  it("supports access_token as an alternative token field", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: headersWithWwwAuthenticate(
+        'Bearer realm="https://example.com/token",service="example.com"',
+      ),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: "alt-token" }),
+    });
+
+    const result = await getRegistryAuthHeader(
+      "example.com",
+      "owner/repo",
+      "user",
+      "pass",
+    );
+
+    expect(result).toBe("Bearer alt-token");
+  });
+
+  it("falls back to Basic auth when the registry issues no Bearer challenge", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: headersWithWwwAuthenticate(null),
+    });
+
+    const result = await getRegistryAuthHeader(
+      "private-registry.example.com",
+      "owner/repo",
+      "user",
+      "pass",
+    );
+
+    expect(result).toBe(
+      `Basic ${Buffer.from("user:pass").toString("base64")}`,
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to Basic auth when the token exchange fails", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: headersWithWwwAuthenticate(
+        'Bearer realm="https://ghcr.io/token",service="ghcr.io"',
+      ),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    });
+
+    const result = await getRegistryAuthHeader(
+      "ghcr.io",
+      "owner/repo",
+      "user",
+      "pat-token",
+    );
+
+    expect(result).toBe(
+      `Basic ${Buffer.from("user:pat-token").toString("base64")}`,
+    );
+  });
+
+  it("falls back to Basic auth when the challenge probe throws", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network error"));
+
+    const result = await getRegistryAuthHeader(
+      "ghcr.io",
+      "owner/repo",
+      "user",
+      "pat-token",
+    );
+
+    expect(result).toBe(
+      `Basic ${Buffer.from("user:pat-token").toString("base64")}`,
+    );
+  });
+
+  it("probes over plain HTTP for localhost registries", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: headersWithWwwAuthenticate(null),
+    });
+
+    await getRegistryAuthHeader("localhost:5000", "owner/repo", "user", "pass");
+
+    expect(mockFetch.mock.calls[0][0]).toBe("http://localhost:5000/v2/");
+  });
+});

--- a/server/src/routes/images.ts
+++ b/server/src/routes/images.ts
@@ -56,7 +56,7 @@ export default function createImagesRouter(
           return res.status(404).json({ success: false, error: message });
         }
         if (message.includes("Authentication")) {
-          return res.status(502).json({ success: false, error: message });
+          return res.status(401).json({ success: false, error: message });
         }
         res.status(502).json({ success: false, error: "Failed to inspect image" });
       }

--- a/server/src/services/docker-executor/registry-manager.ts
+++ b/server/src/services/docker-executor/registry-manager.ts
@@ -1,6 +1,7 @@
 import Docker from "dockerode";
 import { getLogger } from "../../lib/logger-factory";
 import { RegistryCredentialService } from "../registry-credential";
+import { getRegistryAuthHeader } from "../registry-auth";
 import type { DockerRegistryTestOptions, DockerRegistryTestResult } from "./types";
 
 /**
@@ -324,7 +325,7 @@ export class RegistryManager {
       const imageParts = this.parseImageName(options.image);
 
       // Get authentication token (handles both Basic auth and OAuth2 token flow)
-      const authHeader = await this.getRegistryAuthHeader(
+      const authHeader = await getRegistryAuthHeader(
         imageParts.registry,
         imageParts.repository,
         options.registryUsername,
@@ -438,87 +439,6 @@ export class RegistryManager {
           errorCode,
         },
       };
-    }
-  }
-
-  /**
-   * Get authentication header for Docker registry
-   * Handles both Basic auth and OAuth2 token flow
-   */
-  private async getRegistryAuthHeader(
-    registry: string,
-    repository: string,
-    username?: string,
-    password?: string,
-  ): Promise<string | null> {
-    if (!username || !password) {
-      return null;
-    }
-
-    try {
-      // First, try to get authentication challenge from registry
-      const testUrl = `https://${registry}/v2/`;
-      const testResponse = await fetch(testUrl, { method: "GET" });
-
-      // Check if registry requires token authentication
-      const wwwAuthenticate = testResponse.headers.get("www-authenticate");
-
-      if (wwwAuthenticate && wwwAuthenticate.includes("Bearer")) {
-        // Extract realm and service from WWW-Authenticate header
-        const realmMatch = wwwAuthenticate.match(/realm="([^"]+)"/);
-        const serviceMatch = wwwAuthenticate.match(/service="([^"]+)"/);
-
-        if (realmMatch) {
-          const realm = realmMatch[1];
-          const service = serviceMatch ? serviceMatch[1] : registry;
-
-          // Build token URL
-          const tokenUrl = new URL(realm);
-          tokenUrl.searchParams.set("service", service);
-          tokenUrl.searchParams.set("scope", `repository:${repository}:pull`);
-
-          // Request token with Basic auth
-          const authString = Buffer.from(`${username}:${password}`).toString("base64");
-          const tokenResponse = await fetch(tokenUrl.toString(), {
-            headers: {
-              Authorization: `Basic ${authString}`,
-            },
-          });
-
-          if (tokenResponse.ok) {
-            const tokenData = await tokenResponse.json();
-            if (tokenData.token) {
-              getLogger("docker", "registry-manager").debug(
-                { registry, repository },
-                "Successfully obtained OAuth2 token for registry",
-              );
-              return `Bearer ${tokenData.token}`;
-            } else if (tokenData.access_token) {
-              return `Bearer ${tokenData.access_token}`;
-            }
-          }
-        }
-      }
-
-      // Fall back to Basic authentication
-      getLogger("docker", "registry-manager").debug(
-        { registry },
-        "Using Basic authentication for registry",
-      );
-      const authString = Buffer.from(`${username}:${password}`).toString("base64");
-      return `Basic ${authString}`;
-    } catch (error) {
-      getLogger("docker", "registry-manager").warn(
-        {
-          error: error instanceof Error ? error.message : String(error),
-          registry,
-        },
-        "Failed to get registry auth header, falling back to Basic auth",
-      );
-
-      // Fall back to Basic auth on any error
-      const authString = Buffer.from(`${username}:${password}`).toString("base64");
-      return `Basic ${authString}`;
     }
   }
 

--- a/server/src/services/image-inspect.ts
+++ b/server/src/services/image-inspect.ts
@@ -1,4 +1,5 @@
 import { getLogger } from "../lib/logger-factory";
+import { getRegistryAuthHeader } from "./registry-auth";
 
 const logger = getLogger("docker", "image-inspect");
 
@@ -153,14 +154,12 @@ export class ImageInspectService {
       return this.getDockerHubToken(ref.repository);
     }
 
-    if (this.credentials) {
-      const encoded = Buffer.from(
-        `${this.credentials.username}:${this.credentials.password}`,
-      ).toString("base64");
-      return `Basic ${encoded}`;
-    }
-
-    return null;
+    return getRegistryAuthHeader(
+      ref.registry,
+      ref.repository,
+      this.credentials?.username,
+      this.credentials?.password,
+    );
   }
 
   private async getDockerHubToken(repository: string): Promise<string> {

--- a/server/src/services/registry-auth.ts
+++ b/server/src/services/registry-auth.ts
@@ -1,0 +1,75 @@
+import { getLogger } from "../lib/logger-factory";
+
+const logger = getLogger("docker", "registry-auth");
+
+/**
+ * Resolve an Authorization header for a container registry's v2 API.
+ *
+ * Probes the registry for a Bearer-token challenge (WWW-Authenticate) and
+ * exchanges it for a token, falling back to Basic auth if no challenge is
+ * present or the exchange fails. Registries like GHCR reject raw Basic auth
+ * on manifest/blob endpoints and require this token dance even when the
+ * supplied credentials are valid.
+ */
+export async function getRegistryAuthHeader(
+  registry: string,
+  repository: string,
+  username?: string,
+  password?: string,
+): Promise<string | null> {
+  if (!username || !password) {
+    return null;
+  }
+
+  const basicAuth = `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;
+
+  try {
+    const registryBase = registry.startsWith("localhost")
+      ? `http://${registry}`
+      : `https://${registry}`;
+    const testResponse = await fetch(`${registryBase}/v2/`, { method: "GET" });
+
+    const wwwAuthenticate = testResponse.headers.get("www-authenticate");
+
+    if (wwwAuthenticate && wwwAuthenticate.includes("Bearer")) {
+      const realmMatch = wwwAuthenticate.match(/realm="([^"]+)"/);
+      const serviceMatch = wwwAuthenticate.match(/service="([^"]+)"/);
+
+      if (realmMatch) {
+        const realm = realmMatch[1];
+        const service = serviceMatch ? serviceMatch[1] : registry;
+
+        const tokenUrl = new URL(realm);
+        tokenUrl.searchParams.set("service", service);
+        tokenUrl.searchParams.set("scope", `repository:${repository}:pull`);
+
+        const tokenResponse = await fetch(tokenUrl.toString(), {
+          headers: { Authorization: basicAuth },
+        });
+
+        if (tokenResponse.ok) {
+          const tokenData = await tokenResponse.json();
+          if (tokenData.token) {
+            logger.debug({ registry, repository }, "Obtained OAuth2 token for registry");
+            return `Bearer ${tokenData.token}`;
+          } else if (tokenData.access_token) {
+            return `Bearer ${tokenData.access_token}`;
+          }
+        }
+      }
+    }
+
+    logger.debug({ registry }, "Using Basic authentication for registry");
+    return basicAuth;
+  } catch (error) {
+    logger.warn(
+      {
+        error: error instanceof Error ? error.message : String(error),
+        registry,
+      },
+      "Failed to probe registry auth challenge, falling back to Basic auth",
+    );
+
+    return basicAuth;
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes a bug where validating a new application's container image against `ghcr.io` (and any other WWW-Authenticate-challenging registry) always returned "Authentication required" / a `502`, even with correct registry credentials configured.
- Root cause: `ImageInspectService` (used by the "Validate" button on the New Application page) sent raw `Basic` auth directly to the registry's manifest/blob endpoints. GHCR rejects that and requires the standard OAuth2-style flow: probe `/v2/` for a `WWW-Authenticate: Bearer` challenge, then exchange Basic credentials for a Bearer token at the realm URL. `DockerExecutorService`'s pull path already implemented this correctly, but `ImageInspectService` had its own, incomplete copy.
- Confirmed live against the real `ghcr.io` API: a raw `Basic` auth request against the manifest endpoint returns `401`, and `/v2/` does return the expected `WWW-Authenticate: Bearer realm="https://ghcr.io/token",service="ghcr.io"` challenge.

## Changes
- New `server/src/services/registry-auth.ts`: shared `getRegistryAuthHeader()` extracted from `docker-executor/registry-manager.ts`'s private method, implementing the WWW-Authenticate probe → Bearer token exchange → Basic fallback.
- `registry-manager.ts` and `image-inspect.ts` both now use this shared implementation instead of duplicating (`image-inspect.ts` previously just base64-encoded credentials and sent `Basic` unconditionally for non-Docker-Hub registries).
- `routes/images.ts`: auth failures now return `401` instead of a generic `502` disguised via message-string matching.
- `client/src/hooks/use-detect-image-ports.ts`: now checks `res.status === 401 || 403` instead of `502 && /authentication/i.test(message)`.
- Fixed an existing GHCR test in `image-inspect.test.ts` that had encoded the buggy "no token exchange needed" behavior as expected; added a fallback-to-Basic test; added a new `registry-auth.test.ts` covering the shared module directly.

## Test plan
- [x] `pnpm --filter mini-infra-server test` — full suite (2369 tests) passes
- [x] `pnpm --filter mini-infra-server exec tsc --noEmit` / `pnpm --filter mini-infra-client exec tsc --noEmit` — clean
- [x] `pnpm build:server` / `pnpm --filter mini-infra-client build` — clean
- [x] Reproduced the original bug live via Playwright against a running instance, then verified in a rebuilt worktree dev instance that the failure now surfaces as a clean `401` (previously a `502`)
- [ ] End-to-end validation with real `ghcr.io` credentials against a private image (author will test with their own PAT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)