### PR TITLE
feat(applications): connect an app to a database/container's network

### DIFF
--- a/client/src/__tests__/application-schemas.test.ts
+++ b/client/src/__tests__/application-schemas.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import {
+  createApplicationFormSchema,
+  createApplicationDefaults,
+  type CreateApplicationFormData,
+} from "@/lib/application-schemas";
+
+function baseStateful(
+  overrides: Partial<CreateApplicationFormData> = {},
+): CreateApplicationFormData {
+  return {
+    ...createApplicationDefaults,
+    displayName: "My App",
+    environmentId: "env-1",
+    serviceType: "Stateful",
+    serviceName: "stateful",
+    dockerImage: "redis",
+    dockerTag: "alpine",
+    // A Stateful service isn't routed, but the form keeps the default routing
+    // object around with an empty hostname — this must NOT block validation.
+    enableRouting: false,
+    routing: { hostname: "", listeningPort: 6379 },
+    ...overrides,
+  };
+}
+
+describe("createApplicationFormSchema — routing gating", () => {
+  it("accepts a Stateful app with routing disabled and an empty leftover hostname (regression: was a silent submit block)", () => {
+    const result = createApplicationFormSchema.safeParse(baseStateful());
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a routed app with an empty hostname, on routing.hostname", () => {
+    const result = createApplicationFormSchema.safeParse(
+      baseStateful({
+        serviceType: "StatelessWeb",
+        serviceName: "web",
+        enableRouting: true,
+        routing: { hostname: "", listeningPort: 8080 },
+      }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join("."));
+      expect(paths).toContain("routing.hostname");
+    }
+  });
+
+  it("accepts a routed app once a hostname is provided", () => {
+    const result = createApplicationFormSchema.safeParse(
+      baseStateful({
+        serviceType: "StatelessWeb",
+        serviceName: "web",
+        enableRouting: true,
+        routing: { hostname: "app.example.com", listeningPort: 8080 },
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("createApplicationFormSchema — linkedContainers", () => {
+  it("accepts a link with a network name (containerName optional)", () => {
+    const result = createApplicationFormSchema.safeParse(
+      baseStateful({
+        linkedContainers: [
+          { containerName: "some-postgres", networkName: "local-database" },
+          { networkName: "local-database-2" },
+        ],
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a link with an empty network name", () => {
+    const result = createApplicationFormSchema.safeParse(
+      baseStateful({
+        linkedContainers: [{ containerName: "some-postgres", networkName: "" }],
+      }),
+    );
+    expect(result.success).toBe(false);
+  });
+});

--- a/client/src/app/applications/[id]/configuration/page.tsx
+++ b/client/src/app/applications/[id]/configuration/page.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/lib/application-schemas";
 import { ConfigurationCard } from "../../components/configuration-card";
 import { RoutingCard } from "../../components/routing-card";
+import { ConnectToContainersField } from "../../components/connect-to-containers-field";
 import type { ApplicationDetailContext } from "../layout";
 
 type ApplicationData = ApplicationDetailContext["template"];
@@ -69,6 +70,18 @@ function buildDefaultValues(
   const hasRouting = !!service.routing;
   const hc = service.containerConfig?.healthcheck;
 
+  // Derive "connect to container" links from the persisted joinNetworks,
+  // excluding the app's own stack network(s) — those are managed here, not
+  // user-chosen links. containerName isn't recoverable from joinNetworks, so
+  // it's left undefined and re-derived from live network membership in the UI.
+  const ownedNetworkNames = new Set<string>([
+    ...(version?.networks ?? []).map((n) => n.name),
+    `${application.name}-net`,
+  ]);
+  const linkedContainers = (service.containerConfig?.joinNetworks ?? [])
+    .filter((netName) => !ownedNetworkNames.has(netName))
+    .map((networkName) => ({ networkName }));
+
   return {
     displayName: application.displayName,
     description: application.description ?? "",
@@ -82,6 +95,7 @@ function buildDefaultValues(
     ports,
     envVars,
     volumeMounts,
+    linkedContainers,
     enableRouting: hasRouting,
     routing:
       hasRouting && service.routing
@@ -201,6 +215,16 @@ export default function ApplicationConfigurationTab() {
         ? existingVersion.networks
         : [{ name: `${templateName}-net` }];
 
+    // joinNetworks = the app's own stack network(s) + any user-selected
+    // linked-container networks. Deduped so a link that happens to name the
+    // owned network can't produce a duplicate.
+    const joinNetworks = Array.from(
+      new Set([
+        ...networks.map((n) => n.name),
+        ...formData.linkedContainers.map((l) => l.networkName),
+      ]),
+    );
+
     try {
       await updateApplication.mutateAsync({
         templateId,
@@ -221,7 +245,7 @@ export default function ApplicationConfigurationTab() {
                 env: Object.keys(env).length > 0 ? env : undefined,
                 ports: ports.length > 0 ? ports : undefined,
                 mounts: mounts.length > 0 ? mounts : undefined,
-                joinNetworks: networks.map((n) => n.name),
+                joinNetworks,
                 restartPolicy: formData.restartPolicy,
                 healthcheck,
               },
@@ -361,6 +385,17 @@ export default function ApplicationConfigurationTab() {
           </Card>
 
           <ConfigurationCard />
+
+          <FormField
+            control={form.control}
+            name="linkedContainers"
+            render={({ field }) => (
+              <ConnectToContainersField
+                value={field.value}
+                onChange={field.onChange}
+              />
+            )}
+          />
 
           {(serviceType === "StatelessWeb" || enableRouting) && (
             <RoutingCard networkType={networkType} showEnableToggle />

--- a/client/src/app/applications/adopt/page.tsx
+++ b/client/src/app/applications/adopt/page.tsx
@@ -43,6 +43,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { linkedContainerSchema } from "@/lib/application-schemas";
+import { ConnectToContainersField } from "../components/connect-to-containers-field";
 
 // ---- Zod Schema ----
 
@@ -54,6 +56,7 @@ const adoptFormSchema = z.object({
   listeningPort: z.number().int().min(1).max(65535),
   hostname: z.string().min(1, "Hostname is required").max(253),
   healthCheckEndpoint: z.string().max(500).optional(),
+  linkedContainers: z.array(linkedContainerSchema),
 });
 
 type AdoptFormData = z.infer<typeof adoptFormSchema>;
@@ -66,6 +69,7 @@ const defaultValues: AdoptFormData = {
   listeningPort: 3000,
   hostname: "",
   healthCheckEndpoint: "/api/health",
+  linkedContainers: [],
 };
 
 export default function AdoptContainerPage() {
@@ -155,6 +159,12 @@ export default function AdoptContainerPage() {
         : {}),
     };
 
+    // Networks the adopted container should join to reach linked containers
+    // (e.g. a database). Applied to the existing container at deploy time.
+    const joinNetworks = Array.from(
+      new Set(data.linkedContainers.map((l) => l.networkName)),
+    );
+
     try {
       await createApplication.mutateAsync({
         name: templateName,
@@ -174,7 +184,8 @@ export default function AdoptContainerPage() {
             serviceType: "AdoptedWeb" as StackServiceType,
             dockerImage: "adopted",
             dockerTag: "n/a",
-            containerConfig: {},
+            containerConfig:
+              joinNetworks.length > 0 ? { joinNetworks } : {},
             dependsOn: [],
             order: 0,
             routing,
@@ -456,6 +467,20 @@ export default function AdoptContainerPage() {
                   />
                 </CardContent>
               </Card>
+            )}
+
+            {/* Connect to a database / another container */}
+            {selectedContainerName && (
+              <FormField
+                control={form.control}
+                name="linkedContainers"
+                render={({ field }) => (
+                  <ConnectToContainersField
+                    value={field.value}
+                    onChange={field.onChange}
+                  />
+                )}
+              />
             )}
 
             {/* Submit */}

--- a/client/src/app/applications/components/connect-to-containers-field.tsx
+++ b/client/src/app/applications/components/connect-to-containers-field.tsx
@@ -1,0 +1,358 @@
+import { useMemo, useState } from "react";
+import {
+  IconAlertTriangle,
+  IconPlus,
+  IconTrash,
+  IconPlugConnected,
+} from "@tabler/icons-react";
+import type { ContainerInfo, DockerNetwork } from "@mini-infra/types";
+import { useContainers } from "@/hooks/useContainers";
+import { useNetworks } from "@/hooks/use-networks";
+import type { LinkedContainer } from "@/lib/application-schemas";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface ConnectToContainersFieldProps {
+  value: LinkedContainer[];
+  onChange: (next: LinkedContainer[]) => void;
+}
+
+/**
+ * Networks we never offer as an app-to-container link target:
+ *  - the default `bridge` network (containers can't resolve each other by name)
+ *  - `host` / `none` pseudo-networks (no shared bridge to join)
+ *  - `null`/`host`-driver networks the daemon can't use for name DNS
+ * Everything else is a user-defined bridge/overlay where Docker DNS lets the
+ * app reach the target by its container name.
+ */
+function isUsableLinkNetwork(net: DockerNetwork): boolean {
+  if (net.driver === "host" || net.driver === "null") return false;
+  if (net.name === "host" || net.name === "none") return false;
+  if (net.name === "bridge" && net.driver === "bridge") return false;
+  return true;
+}
+
+/** Networks (usable for linking) that the given container is attached to. */
+function candidateNetworksFor(
+  containerName: string,
+  networks: DockerNetwork[],
+): DockerNetwork[] {
+  return networks.filter(
+    (net) =>
+      isUsableLinkNetwork(net) &&
+      net.containers.some((c) => c.name === containerName),
+  );
+}
+
+/** The target container's IPv4 on a specific network, if known. */
+function ipOnNetwork(
+  containerName: string,
+  networkName: string,
+  networks: DockerNetwork[],
+): string | undefined {
+  const net = networks.find((n) => n.name === networkName);
+  const entry = net?.containers.find((c) => c.name === containerName);
+  const ip = entry?.ipv4Address;
+  // Docker returns CIDR form (e.g. "172.20.0.3/16"); trim the mask for display.
+  return ip ? ip.split("/")[0] : undefined;
+}
+
+/** Human-readable exposed ports for the read-only "connect here" hint. */
+function portSummary(container: ContainerInfo | undefined): string {
+  if (!container || container.ports.length === 0) return "no exposed ports";
+  const seen = new Set<string>();
+  const parts: string[] = [];
+  for (const p of container.ports) {
+    const label = `${p.private}/${p.type}`;
+    if (!seen.has(label)) {
+      seen.add(label);
+      parts.push(label);
+    }
+  }
+  return parts.join(", ");
+}
+
+export function ConnectToContainersField({
+  value,
+  onChange,
+}: ConnectToContainersFieldProps) {
+  const { data: containersData, isLoading: containersLoading } = useContainers({
+    queryParams: { limit: 200 },
+  });
+  const { data: networksData } = useNetworks();
+
+  const containers = useMemo(
+    () => containersData?.containers ?? [],
+    [containersData],
+  );
+  const networks = useMemo(() => networksData?.networks ?? [], [networksData]);
+
+  const containerByName = useMemo(() => {
+    const map = new Map<string, ContainerInfo>();
+    for (const c of containers) map.set(c.name, c);
+    return map;
+  }, [containers]);
+
+  // In-progress selection for the "add a link" row.
+  const [pendingContainer, setPendingContainer] = useState("");
+  const [pendingNetwork, setPendingNetwork] = useState("");
+
+  // The durable unit of a link is its network — dedupe/exclude on that.
+  const linkedNetworks = useMemo(
+    () => new Set(value.map((l) => l.networkName)),
+    [value],
+  );
+
+  // Usable networks for a pending container that aren't already linked.
+  const freshCandidatesFor = useMemo(
+    () => (containerName: string) =>
+      candidateNetworksFor(containerName, networks).filter(
+        (net) => !linkedNetworks.has(net.name),
+      ),
+    [networks, linkedNetworks],
+  );
+
+  // Containers offered by the picker: those with at least one usable network
+  // not already linked (otherwise selecting them adds nothing).
+  const selectableContainers = useMemo(
+    () => containers.filter((c) => freshCandidatesFor(c.name).length > 0),
+    [containers, freshCandidatesFor],
+  );
+
+  const pendingCandidates = useMemo(
+    () => (pendingContainer ? freshCandidatesFor(pendingContainer) : []),
+    [pendingContainer, freshCandidatesFor],
+  );
+
+  // The chosen container exists but has no joinable network left — surfaced as
+  // guidance, not an error.
+  const pendingUnreachable = !!pendingContainer && pendingCandidates.length === 0;
+
+  const effectivePendingNetwork =
+    pendingNetwork ||
+    (pendingCandidates.length === 1 ? pendingCandidates[0].name : "");
+
+  const handlePickContainer = (name: string) => {
+    setPendingContainer(name);
+    const candidates = freshCandidatesFor(name);
+    // Auto-select when there's exactly one usable network.
+    setPendingNetwork(candidates.length === 1 ? candidates[0].name : "");
+  };
+
+  const handleAdd = () => {
+    if (!pendingContainer || !effectivePendingNetwork) return;
+    onChange([
+      ...value,
+      { containerName: pendingContainer, networkName: effectivePendingNetwork },
+    ]);
+    setPendingContainer("");
+    setPendingNetwork("");
+  };
+
+  const handleRemove = (index: number) => {
+    onChange(value.filter((_, i) => i !== index));
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <IconPlugConnected className="h-5 w-5" />
+          Connect to a database or container
+        </CardTitle>
+        <CardDescription>
+          Optionally attach this application to another running container&apos;s
+          network — for example a database — so it can reach it by name. This is
+          optional; leave it empty if the app doesn&apos;t need to talk to
+          another container.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Existing links (durable unit = network; container label is best-effort) */}
+        {value.length > 0 && (
+          <div className="space-y-2">
+            {value.map((link, index) => {
+              const net = networks.find((n) => n.name === link.networkName);
+              const members = net?.containers ?? [];
+              // Prefer the stored container; else infer from the sole member.
+              const target =
+                link.containerName ??
+                (members.length === 1 ? members[0].name : undefined);
+              const container = target
+                ? containerByName.get(target)
+                : undefined;
+              const ip = target
+                ? ipOnNetwork(target, link.networkName, networks)
+                : undefined;
+              return (
+                <div
+                  key={`${link.networkName}:${link.containerName ?? ""}:${index}`}
+                  className="flex items-start justify-between gap-3 rounded-md border p-3"
+                >
+                  <div className="min-w-0 space-y-1 text-sm">
+                    <p className="font-medium">
+                      Joins network{" "}
+                      <code className="rounded bg-muted px-1 py-0.5">
+                        {link.networkName}
+                      </code>
+                    </p>
+                    {target ? (
+                      <p className="text-muted-foreground">
+                        Reach it at{" "}
+                        <code className="rounded bg-muted px-1 py-0.5">
+                          {target}
+                        </code>
+                        {ip ? ` (${ip})` : ""}
+                        {container ? ` — ports: ${portSummary(container)}` : ""}
+                        .
+                      </p>
+                    ) : (
+                      <p className="text-muted-foreground">
+                        {members.length > 0
+                          ? `Containers on this network: ${members
+                              .map((m) => m.name)
+                              .join(", ")}.`
+                          : "No containers are currently attached to this network."}
+                      </p>
+                    )}
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleRemove(index)}
+                    aria-label={`Remove connection to ${link.networkName}`}
+                  >
+                    <IconTrash className="h-4 w-4" />
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Add-a-link row */}
+        <div className="space-y-3 rounded-md border border-dashed p-3">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Container</label>
+              <Select
+                value={pendingContainer}
+                onValueChange={handlePickContainer}
+                disabled={containersLoading}
+              >
+                <SelectTrigger>
+                  <SelectValue
+                    placeholder={
+                      containersLoading
+                        ? "Loading containers..."
+                        : "Select a container"
+                    }
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {selectableContainers.map((c) => (
+                    <SelectItem key={c.id} value={c.name}>
+                      <span className="flex items-center gap-2">
+                        <span className="font-medium">{c.name}</span>
+                        <span className="text-xs text-muted-foreground">
+                          {c.image}
+                          {c.imageTag ? `:${c.imageTag}` : ""}
+                        </span>
+                      </span>
+                    </SelectItem>
+                  ))}
+                  {!containersLoading && selectableContainers.length === 0 && (
+                    <div className="px-2 py-4 text-center text-sm text-muted-foreground">
+                      No connectable containers found.
+                    </div>
+                  )}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Network picker: only when the container is on >1 usable network */}
+            {pendingCandidates.length > 1 && (
+              <div className="space-y-1">
+                <label className="text-sm font-medium">Network</label>
+                <Select value={pendingNetwork} onValueChange={setPendingNetwork}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Choose which network" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {pendingCandidates.map((net) => (
+                      <SelectItem key={net.id} value={net.name}>
+                        {net.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+          </div>
+
+          {pendingUnreachable && (
+            <div className="flex items-start gap-2 rounded-md border border-amber-500/50 bg-amber-500/10 p-2 text-sm text-amber-700 dark:text-amber-300">
+              <IconAlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                This container isn&apos;t on any user-defined network the app can
+                join (it may only be on the default bridge, where containers
+                can&apos;t resolve each other by name). Attach it to a
+                user-defined network, or expose a published host port and connect
+                via the host instead.
+              </span>
+            </div>
+          )}
+
+          {pendingContainer &&
+            !pendingUnreachable &&
+            effectivePendingNetwork && (
+              <p className="text-sm text-muted-foreground">
+                Your app will join{" "}
+                <code className="rounded bg-muted px-1 py-0.5">
+                  {effectivePendingNetwork}
+                </code>{" "}
+                and reach this container at{" "}
+                <code className="rounded bg-muted px-1 py-0.5">
+                  {pendingContainer}
+                </code>
+                {(() => {
+                  const ip = ipOnNetwork(
+                    pendingContainer,
+                    effectivePendingNetwork,
+                    networks,
+                  );
+                  return ip ? ` (${ip})` : "";
+                })()}{" "}
+                — ports: {portSummary(containerByName.get(pendingContainer))}.
+              </p>
+            )}
+
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleAdd}
+            disabled={!pendingContainer || !effectivePendingNetwork}
+          >
+            <IconPlus className="mr-1 h-4 w-4" />
+            Add connection
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/app/applications/new/page.tsx
+++ b/client/src/app/applications/new/page.tsx
@@ -27,6 +27,7 @@ import { ServiceTypeStep } from "./components/service-type-step";
 import { ImageStep } from "./components/image-step";
 import { ConfigurationStep } from "./components/configuration-step";
 import { RoutingStep } from "./components/routing-step";
+import { ConnectToContainersField } from "../components/connect-to-containers-field";
 
 export default function NewApplicationPage() {
   const navigate = useNavigate();
@@ -189,6 +190,11 @@ export default function NewApplicationPage() {
         ? [{ type: "docker-network", purpose: "applications" }]
         : undefined;
 
+    // Networks the app must join to reach linked containers (e.g. a database).
+    const joinNetworks = Array.from(
+      new Set(data.linkedContainers.map((l) => l.networkName)),
+    );
+
     try {
       await createApplication.mutateAsync({
         name: templateName,
@@ -209,6 +215,7 @@ export default function NewApplicationPage() {
               env: Object.keys(env).length > 0 ? env : undefined,
               ports: ports.length > 0 ? ports : undefined,
               mounts: mounts.length > 0 ? mounts : undefined,
+              joinNetworks: joinNetworks.length > 0 ? joinNetworks : undefined,
               restartPolicy: data.restartPolicy,
               healthcheck,
             },
@@ -272,6 +279,19 @@ export default function NewApplicationPage() {
             )}
 
             {canShowConfig && <ConfigurationStep />}
+
+            {canShowConfig && (
+              <FormField
+                control={form.control}
+                name="linkedContainers"
+                render={({ field }) => (
+                  <ConnectToContainersField
+                    value={field.value}
+                    onChange={field.onChange}
+                  />
+                )}
+              />
+            )}
 
             {canShowRouting && (
               <RoutingStep

--- a/client/src/lib/application-schemas.ts
+++ b/client/src/lib/application-schemas.ts
@@ -31,12 +31,34 @@ export const healthCheckSchema = z.object({
   startPeriod: z.number().int().min(0),
 });
 
+// Field-level routing validation is intentionally lenient on `hostname`: a
+// non-routed service (e.g. Stateful) keeps a leftover `routing` object with an
+// empty hostname, and it must not fail validation. The "hostname is required
+// when routing is enabled" rule is enforced by `requireRoutingHostnameWhenEnabled`
+// on the final create/edit schemas, so the error only fires (and only surfaces)
+// when the routing step is actually in play.
 export const routingSchema = z.object({
-  hostname: z.string().min(1, "Hostname is required"),
+  hostname: z.string(),
   listeningPort: z.number().int().min(1).max(65535),
   enableSsl: z.boolean().optional(),
   enableTunnel: z.boolean().optional(),
 });
+
+/**
+ * A link from this application's container to another container it needs to
+ * reach over the Docker network (e.g. a database). The durable, round-tripped
+ * unit is the `networkName` (folded into `containerConfig.joinNetworks`). The
+ * `containerName` is a best-effort label captured when the user picks a
+ * container — it powers the read-only host hint but can't be recovered from
+ * `joinNetworks` alone, so it's optional (re-derived from live network
+ * membership when an application is re-opened for editing).
+ */
+export const linkedContainerSchema = z.object({
+  containerName: z.string().optional(),
+  networkName: z.string().min(1, "Network is required"),
+});
+
+export type LinkedContainer = z.infer<typeof linkedContainerSchema>;
 
 export const serviceNameSchema = z
   .string()
@@ -53,6 +75,7 @@ export const applicationConfigBaseSchema = z.object({
   ports: z.array(portMappingSchema),
   envVars: z.array(envVarSchema),
   volumeMounts: z.array(volumeMountSchema),
+  linkedContainers: z.array(linkedContainerSchema),
   enableHealthCheck: z.boolean(),
   healthCheck: healthCheckSchema.optional(),
   restartPolicy: z.enum(RESTART_POLICIES),
@@ -71,6 +94,28 @@ export type ApplicationRoutingData = z.infer<
   typeof applicationRoutingBaseSchema
 >;
 
+/**
+ * Require a hostname only when routing is enabled. Applied as a superRefine on
+ * the final create/edit schemas (not the mergeable base, which must stay a
+ * ZodObject). The issue path targets `routing.hostname` so the RoutingCard's
+ * field-level message still renders it.
+ */
+function requireRoutingHostnameWhenEnabled(
+  data: { enableRouting: boolean; routing?: { hostname?: string } },
+  ctx: z.RefinementCtx,
+): void {
+  if (
+    data.enableRouting &&
+    (!data.routing || data.routing.hostname?.trim().length === 0 || !data.routing.hostname)
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["routing", "hostname"],
+      message: "Hostname is required",
+    });
+  }
+}
+
 // ---- Create form schema (includes deploy + health check options) ----
 
 export const createApplicationFormSchema = z
@@ -84,7 +129,8 @@ export const createApplicationFormSchema = z
     deployImmediately: z.boolean(),
   })
   .merge(applicationConfigBaseSchema)
-  .merge(applicationRoutingBaseSchema);
+  .merge(applicationRoutingBaseSchema)
+  .superRefine(requireRoutingHostnameWhenEnabled);
 
 export type CreateApplicationFormData = z.infer<
   typeof createApplicationFormSchema
@@ -100,6 +146,7 @@ export const createApplicationDefaults: CreateApplicationFormData = {
   ports: [],
   envVars: [],
   volumeMounts: [],
+  linkedContainers: [],
   enableRouting: true,
   routing: { hostname: "", listeningPort: 8080 },
   restartPolicy: "unless-stopped",
@@ -126,7 +173,8 @@ export const editApplicationFormSchema = z
     dockerTag: z.string().min(1, "Tag is required"),
   })
   .merge(applicationConfigBaseSchema)
-  .merge(applicationRoutingBaseSchema);
+  .merge(applicationRoutingBaseSchema)
+  .superRefine(requireRoutingHostnameWhenEnabled);
 
 export type EditApplicationFormData = z.infer<typeof editApplicationFormSchema>;
 
@@ -140,6 +188,7 @@ export const editApplicationDefaults: EditApplicationFormData = {
   ports: [],
   envVars: [],
   volumeMounts: [],
+  linkedContainers: [],
   enableRouting: false,
   routing: undefined,
   restartPolicy: "unless-stopped",

--- a/server/src/__tests__/stack-definition-hash.test.ts
+++ b/server/src/__tests__/stack-definition-hash.test.ts
@@ -106,4 +106,51 @@ describe('computeDefinitionHash', () => {
     const hash = computeDefinitionHash(makeService());
     expect(hash).toMatch(/^sha256:[a-f0-9]{64}$/);
   });
+
+  describe('AdoptedWeb', () => {
+    function makeAdopted(
+      overrides: Partial<StackServiceDefinition> = {},
+    ): StackServiceDefinition {
+      return {
+        serviceName: 'legacy-web',
+        serviceType: 'AdoptedWeb',
+        dockerImage: 'adopted',
+        dockerTag: 'n/a',
+        containerConfig: {},
+        dependsOn: [],
+        order: 0,
+        routing: { hostname: 'legacy.example.com', listeningPort: 8080 },
+        adoptedContainer: { containerName: 'legacy', listeningPort: 8080 },
+        ...overrides,
+      };
+    }
+
+    it('is stable for an adopted service with no linked networks', () => {
+      // Existing adopted services (no join fields) must keep a consistent hash
+      // so widening the canonical never marks them as drifted.
+      expect(computeDefinitionHash(makeAdopted())).toBe(
+        computeDefinitionHash(makeAdopted()),
+      );
+    });
+
+    it('changes hash when a linked-container network is added', () => {
+      const before = makeAdopted();
+      const after = makeAdopted({
+        containerConfig: { joinNetworks: ['db_default'] },
+      });
+      expect(computeDefinitionHash(before)).not.toBe(
+        computeDefinitionHash(after),
+      );
+    });
+
+    it('changes hash when the linked network set changes', () => {
+      const a = makeAdopted({
+        containerConfig: { joinNetworks: ['db_default'] },
+      });
+      const b = makeAdopted({
+        containerConfig: { joinNetworks: ['other_default'] },
+      });
+      expect(computeDefinitionHash(a)).not.toBe(computeDefinitionHash(b));
+    });
+  });
 });

--- a/server/src/__tests__/stack-templates-create-route.integration.test.ts
+++ b/server/src/__tests__/stack-templates-create-route.integration.test.ts
@@ -1,0 +1,95 @@
+/**
+ * HTTP regression test for POST /api/stack-templates — containerConfig.joinNetworks.
+ *
+ * The "connect to a database/container" feature on the application forms folds
+ * the user's linked-container selections into `containerConfig.joinNetworks`,
+ * which the create route must persist verbatim so the app joins those networks
+ * at apply time. Per server/CLAUDE.md, a field-persistence contract like this is
+ * tested through the real HTTP route (not a direct Prisma insert) so a future
+ * Zod-strip on the create path can't silently drop it — exactly the class of bug
+ * that hit `vaultAppRoleRef`.
+ */
+
+import supertest from 'supertest';
+import express, { type Request, type Response, type NextFunction } from 'express';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { testPrisma } from './integration-test-helpers';
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+
+vi.mock('../middleware/auth', () => ({
+  requirePermission: () => (req: Request, _res: Response, next: NextFunction) => {
+    (req as Request & { user?: { id: string } }).user = { id: 'session-user' };
+    next();
+  },
+}));
+
+vi.mock('../lib/prisma', () => ({ default: testPrisma }));
+
+import stackTemplateRouter from '../routes/stack-templates';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/stack-templates', stackTemplateRouter);
+  return app;
+}
+
+const baseService = {
+  serviceName: 'web',
+  serviceType: 'Stateful',
+  dockerImage: 'nginx',
+  dockerTag: 'latest',
+  containerConfig: {},
+  dependsOn: [],
+  order: 0,
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('POST /api/stack-templates — containerConfig.joinNetworks persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('persists containerConfig.joinNetworks on the v0 draft service row', async () => {
+    const suffix = createId().slice(0, 6);
+    const createBody = {
+      name: `join-net-${suffix}`,
+      displayName: 'Join Networks Test',
+      scope: 'environment',
+      networks: [],
+      volumes: [],
+      services: [
+        {
+          ...baseService,
+          containerConfig: { joinNetworks: ['some-db_default'] },
+        },
+      ],
+    };
+
+    const res = await supertest(buildApp())
+      .post('/api/stack-templates')
+      .send(createBody);
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+
+    const templateId = res.body.data.id as string;
+    const tmpl = await testPrisma.stackTemplate.findUnique({
+      where: { id: templateId },
+    });
+    const versionId = tmpl?.draftVersionId ?? tmpl?.currentVersionId;
+    expect(versionId).toBeTruthy();
+
+    const row = await testPrisma.stackTemplateService.findFirst({
+      where: { versionId: versionId! },
+    });
+    expect(row).not.toBeNull();
+    const containerConfig = row!.containerConfig as { joinNetworks?: string[] };
+    expect(containerConfig.joinNetworks).toEqual(['some-db_default']);
+  });
+});

--- a/server/src/services/stacks/definition-hash.ts
+++ b/server/src/services/stacks/definition-hash.ts
@@ -82,11 +82,19 @@ export function computeDefinitionHash(
   let canonical: unknown;
 
   if (service.serviceType === 'AdoptedWeb') {
-    // AdoptedWeb services don't manage the container — hash only the adoption ref and routing
+    // AdoptedWeb services don't manage the container itself — but we do attach
+    // it to networks at apply time, so hash the adoption ref, routing, and the
+    // network-join fields. Including joinNetworks/joinResourceNetworks means
+    // adding or removing a linked-container connection triggers a recreate that
+    // re-runs the attach. Both sides of the drift comparison are re-hashed live
+    // (see stack-plan-computer), so widening this canonical is safe for
+    // existing adopted services whose join fields are simply absent.
     canonical = {
       serviceType: 'AdoptedWeb',
       adoptedContainer: service.adoptedContainer ?? null,
       routing: service.routing ?? null,
+      joinNetworks: service.containerConfig?.joinNetworks ?? null,
+      joinResourceNetworks: service.containerConfig?.joinResourceNetworks ?? null,
     };
   } else {
     const configFiles = resolvedConfigFiles ?? service.configFiles ?? [];

--- a/server/src/services/stacks/stack-service-handlers.ts
+++ b/server/src/services/stacks/stack-service-handlers.ts
@@ -296,6 +296,10 @@ export class StackServiceHandlers {
           await this.infraManager.joinResourceNetworks(target.Id, serviceDef, infraNetworkMap, log);
         }
 
+        // Attach the adopted container to any user-selected external networks
+        // (e.g. a database it needs to reach). Best-effort, like the create path.
+        await this.joinJoinNetworks(target.Id, action.serviceName, serviceDef, log);
+
         const routingCtx: StackRoutingContext = {
           serviceName: action.serviceName,
           containerId: target.Id,


### PR DESCRIPTION
## What & why

Deploying an application often means it needs to reach a database (or another container) that lives on a **user-defined Docker network** — but the application forms gave no way to opt into that network, so the app landed with no connectivity to it. This adds a **"Connect to a database or container"** picker to the **new**, **edit**, and **adopt** application forms.

You pick a running container; the field resolves the shared user-defined network it sits on and folds that network name into the service's `containerConfig.joinNetworks`, so the app joins it at apply time and can reach the target **by name**. Default `bridge` / `host` / `none` are excluded (containers can't resolve each other by name there). A read-only hint surfaces the target's container name, IP, and exposed ports — you wire your own connection env vars from that (no credentials injected).

This reuses the existing `joinNetworks` apply mechanism end-to-end, so there's **no new server endpoint** and **no migration** — it's mostly a shared component plus payload wiring.

## How it works

- **`ConnectToContainersField`** (new shared component) is built on the existing `useContainers()` + `useNetworks()` hooks. It cross-references network membership client-side to list a container's joinable networks:
  - exactly one usable network → auto-selected;
  - several → a small "which network" picker appears;
  - none (bridge-only) → an inline warning suggesting a published host port instead.
- **New form** folds `linkedContainers[].networkName` into `containerConfig.joinNetworks`.
- **Edit form** round-trips with no new persisted field: on load it derives links from `joinNetworks` minus the app's own stack network; on save it recombines them.
- **Adopt form** needed two small, safe server changes to not be a no-op:
  - `applyAdoptedWeb` now also honours literal `joinNetworks` (it previously only did `joinResourceNetworks`);
  - the AdoptedWeb definition hash now includes the network-join fields so a link edit triggers a recreate. This is safe: the plan computer re-hashes **both** desired and snapshot live (`stack-plan-computer.ts`), so existing adopted apps whose join fields are simply absent are not marked drifted.

## Bonus fix (pre-existing bug found during smoke testing)

Creating a **Stateful** application via `/applications/new` was silently blocked: the form keeps a default `routing` object with an empty hostname, and the schema validated it even when routing was disabled (`routingSchema.hostname.min(1)`). Because no routing step renders for Stateful services, the validation error never surfaced — the submit button just did nothing. Hostname is now only required when routing is enabled (shared `superRefine` on the final create/edit schemas; field-level check loosened). This unblocks the primary use case for this feature (a Stateful app connecting to a DB).

## Testing

- **Unit / integration (added):**
  - HTTP field-persistence regression — `containerConfig.joinNetworks` survives the `POST /api/stack-templates` create path (guards against a `vaultAppRoleRef`-style Zod strip).
  - AdoptedWeb definition-hash cases — stable when absent, changes on link add/change.
  - Application-schema validation — Stateful-with-empty-routing passes, routed-with-empty-hostname fails on `routing.hostname`, `linkedContainers` accepts optional container name / rejects empty network.
- **Full suites:** client 110 passed, server 2376 passed. `pnpm build:all` green.
- **Manual smoke test (dev worktree):** deployed a Postgres stack, created a Stateful app in the same environment and linked it to the Postgres container via the new picker, deployed. Verified the app container joined `local-database` and that `getent hosts <postgres-container>` from inside the app resolves to the DB's IP on that network — i.e. the app can reach the database by name.

## Files

- `client/src/app/applications/components/connect-to-containers-field.tsx` — new shared field.
- `client/src/lib/application-schemas.ts` — `linkedContainers` field + routing-required-when-enabled fix.
- `client/src/app/applications/new/page.tsx`, `[id]/configuration/page.tsx`, `adopt/page.tsx` — render + payload wiring.
- `server/src/services/stacks/stack-service-handlers.ts`, `definition-hash.ts` — AdoptedWeb `joinNetworks` support.
- Tests: `client/src/__tests__/application-schemas.test.ts`, `server/src/__tests__/stack-templates-create-route.integration.test.ts`, `server/src/__tests__/stack-definition-hash.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
