### PR TITLE
fix(applications): use PATCH instead of PUT when saving application metadata

### DIFF
--- a/client/src/app/applications/[id]/configuration/page.tsx
+++ b/client/src/app/applications/[id]/configuration/page.tsx
@@ -332,7 +332,21 @@ export default function ApplicationConfigurationTab() {
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>Service Type</FormLabel>
-                    <Select onValueChange={field.onChange} value={field.value}>
+                    <Select
+                      onValueChange={(value) => {
+                        field.onChange(value);
+                        // Routing (HAProxy zero-downtime blue-green) only applies to
+                        // StatelessWeb — mirrors ServiceTypeStep's reset in the create
+                        // wizard so a leftover "enabled" flag can't smuggle a routing
+                        // config onto a Stateful service.
+                        form.setValue(
+                          "enableRouting",
+                          value === "StatelessWeb",
+                          { shouldValidate: true },
+                        );
+                      }}
+                      value={field.value}
+                    >
                       <FormControl>
                         <SelectTrigger>
                           <SelectValue placeholder="Select type" />

--- a/client/src/hooks/use-applications.ts
+++ b/client/src/hooks/use-applications.ts
@@ -163,7 +163,7 @@ async function updateTemplateMetadata(
   correlationId: string,
 ): Promise<void> {
   const response = await fetch(`/api/stack-templates/${templateId}`, {
-    method: "PUT",
+    method: "PATCH",
     credentials: "include",
     headers: {
       "Content-Type": "application/json",

--- a/client/src/lib/application-schemas.ts
+++ b/client/src/lib/application-schemas.ts
@@ -31,14 +31,26 @@ export const healthCheckSchema = z.object({
   startPeriod: z.number().int().min(0),
 });
 
-// Field-level routing validation is intentionally lenient on `hostname`: a
-// non-routed service (e.g. Stateful) keeps a leftover `routing` object with an
-// empty hostname, and it must not fail validation. The "hostname is required
-// when routing is enabled" rule is enforced by `requireRoutingHostnameWhenEnabled`
-// on the final create/edit schemas, so the error only fires (and only surfaces)
-// when the routing step is actually in play.
+// Matches the full-hostname format enforced elsewhere for HAProxy routes
+// (see client/src/components/haproxy/add-route-dialog.tsx).
+const HOSTNAME_REGEX = /^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
+// Field-level routing validation is intentionally lenient on `hostname` only
+// with respect to emptiness: a non-routed service (e.g. Stateful) keeps a
+// leftover `routing` object with an empty hostname, and that must not fail
+// validation. The "hostname is required when routing is enabled" rule is
+// enforced by `requireRoutingHostnameWhenEnabled` on the final create/edit
+// schemas, so that error only fires (and only surfaces) when the routing step
+// is actually in play. A non-empty hostname must still be a valid DNS name —
+// this is what a real Cloudflare DNS record / ACME certificate gets issued
+// for, so garbage input here fails silently much further downstream instead.
 export const routingSchema = z.object({
-  hostname: z.string(),
+  hostname: z
+    .string()
+    .refine(
+      (value) => value.length === 0 || HOSTNAME_REGEX.test(value),
+      "Must be a valid hostname (e.g. app.example.com)",
+    ),
   listeningPort: z.number().int().min(1).max(65535),
   enableSsl: z.boolean().optional(),
   enableTunnel: z.boolean().optional(),

--- a/server/src/__tests__/stack-templates-delete-route.integration.test.ts
+++ b/server/src/__tests__/stack-templates-delete-route.integration.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Integration test for DELETE /api/stack-templates/:templateId.
+ *
+ * deleteTemplate() used to only remove DB rows (the StackTemplate and any
+ * linked Stack records) with no teardown of the real Docker containers,
+ * networks, or volumes a deployed stack owns — orphaning them with no UI
+ * path left to find or clean up. The route now blocks the delete while any
+ * linked stack is still deployed (not `undeployed` and not yet `removed`),
+ * pointing the caller at the existing stack-destroy flow (the "Stop" button)
+ * instead of silently leaking resources.
+ */
+
+import supertest from 'supertest';
+import express, { type Request, type Response, type NextFunction } from 'express';
+import { describe, it, expect } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { testPrisma } from './integration-test-helpers';
+
+vi.mock('../middleware/auth', () => ({
+  requirePermission: () => (req: Request, _res: Response, next: NextFunction) => {
+    (req as Request & { user?: { id: string } }).user = { id: 'session-user' };
+    next();
+  },
+}));
+
+vi.mock('../lib/prisma', () => ({ default: testPrisma }));
+
+import stackTemplateRouter from '../routes/stack-templates';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/stack-templates', stackTemplateRouter);
+  return app;
+}
+
+async function createTemplateWithStack(opts: {
+  stackStatus: string;
+  removedAt?: Date | null;
+}): Promise<{ templateId: string; stackId: string }> {
+  const templateId = createId();
+  await testPrisma.stackTemplate.create({
+    data: {
+      id: templateId,
+      name: `delete-test-${templateId.slice(0, 6)}`,
+      displayName: 'Delete Test',
+      source: 'user',
+      scope: 'host',
+    },
+  });
+
+  const stackId = createId();
+  await testPrisma.stack.create({
+    data: {
+      id: stackId,
+      name: `delete-test-stack-${stackId.slice(0, 6)}`,
+      networks: [],
+      volumes: [],
+      templateId,
+      templateVersion: 1,
+      status: opts.stackStatus as never,
+      removedAt: opts.removedAt ?? null,
+    },
+  });
+
+  return { templateId, stackId };
+}
+
+describe('DELETE /api/stack-templates/:templateId — deployed-stack guard', () => {
+  it('rejects with 409 when a linked stack is still deployed', async () => {
+    const { templateId } = await createTemplateWithStack({ stackStatus: 'synced' });
+
+    const res = await supertest(buildApp()).delete(`/api/stack-templates/${templateId}`);
+
+    expect(res.status).toBe(409);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toMatch(/still deployed/i);
+
+    const stillThere = await testPrisma.stackTemplate.findUnique({ where: { id: templateId } });
+    expect(stillThere).not.toBeNull();
+  });
+
+  it('allows delete once the linked stack has been destroyed (removedAt set)', async () => {
+    const { templateId, stackId } = await createTemplateWithStack({
+      stackStatus: 'synced',
+      removedAt: new Date(0),
+    });
+
+    const res = await supertest(buildApp()).delete(`/api/stack-templates/${templateId}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const gone = await testPrisma.stackTemplate.findUnique({ where: { id: templateId } });
+    expect(gone).toBeNull();
+    const stackGone = await testPrisma.stack.findUnique({ where: { id: stackId } });
+    expect(stackGone).toBeNull();
+  });
+
+  it('allows delete when the linked stack was never deployed (undeployed)', async () => {
+    const { templateId } = await createTemplateWithStack({ stackStatus: 'undeployed' });
+
+    const res = await supertest(buildApp()).delete(`/api/stack-templates/${templateId}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const gone = await testPrisma.stackTemplate.findUnique({ where: { id: templateId } });
+    expect(gone).toBeNull();
+  });
+});

--- a/server/src/services/stacks/stack-template-service.ts
+++ b/server/src/services/stacks/stack-template-service.ts
@@ -439,13 +439,28 @@ export class StackTemplateService {
   async deleteTemplate(templateId: string): Promise<void> {
     const template = await this.prisma.stackTemplate.findUnique({
       where: { id: templateId },
-      include: { stacks: { select: { id: true, removedAt: true } } },
+      include: { stacks: { select: { id: true, name: true, status: true, removedAt: true } } },
     });
     if (!template) {
       throw new TemplateError("Template not found", 404);
     }
     if (template.source === "system") {
       throw new TemplateError("Cannot delete system templates", 403);
+    }
+
+    // A deployed stack has real Docker containers/networks/volumes that this
+    // delete only removes DB rows for — destroying the template out from
+    // under it would orphan those resources with no UI path left to find or
+    // clean them up. Require the stack to be torn down (POST
+    // /stacks/:id/destroy) or never deployed before the template can go.
+    const deployedStack = template.stacks.find(
+      (stack) => stack.removedAt === null && stack.status !== "undeployed",
+    );
+    if (deployedStack) {
+      throw new TemplateError(
+        `Cannot delete: stack "${deployedStack.name}" is still deployed. Stop it first.`,
+        409
+      );
     }
 
     await this.prisma.$transaction([


### PR DESCRIPTION
## Summary
- Every "Save Changes" on an Application's Configuration tab has 404'd since the applications feature launched — the client always `PUT`s to `/api/stack-templates/:id` for the metadata update step, but the server has only ever registered a `PATCH` route there (`server/src/routes/stack-templates.ts:145`).
- Fixes the one-line HTTP method mismatch in `client/src/hooks/use-applications.ts`. The sibling Stack Templates page (`use-stack-templates.ts`) already used `PATCH` correctly against the same endpoint — this brings the Applications hook in line.
- Found while reproducing a report that saving an application after connecting it to a database/container's network fails. Root cause is not specific to that new feature — it's the pre-existing metadata-update step that runs on every save regardless of what changed.

**Follow-up (found during a post-fix smoke test of the same screen):**
- **Routing hostname had no format validation** — spaces/symbols were silently accepted and persisted, which would fail downstream DNS/TLS provisioning. `routingSchema.hostname` now validates against the same hostname regex already used for HAProxy routes (`client/src/lib/application-schemas.ts`).
- **Switching Service Type to Stateful didn't reset `enableRouting`** — a StatelessWeb-only HAProxy routing config (hostname/TLS/DNS) could get saved on a Stateful service. The edit form's Service Type selector now resets `enableRouting` on change, mirroring the create wizard's `ServiceTypeStep`, which already did this correctly (`client/src/app/applications/[id]/configuration/page.tsx`).
- **Deleting an application only removed DB rows** — any real running container/network/volume for a still-deployed stack was silently orphaned, with no UI path left to find or clean it up. `deleteTemplate()` now blocks with a 409 while a linked stack is still deployed, directing the user to Stop it first (which already runs the correct destroy pipeline) (`server/src/services/stacks/stack-template-service.ts`).

## Test plan
- [x] `tsc --noEmit` passes
- [x] Production frontend build (`pnpm --filter mini-infra-client build`) succeeds
- [x] Full server test suite passes (2379 tests, including 3 new tests for the delete guard)
- [x] Reproduced the original 404 live on production before the fix; confirmed fixed live in a rebuilt dev worktree (container-connection save now returns `200`s throughout, `joinNetworks` persists correctly)
- [x] Smoke-tested the whole Configuration screen (env vars, volumes, health check, ports, advanced, connect-to-container, routing, cancel, required-field validation) — surfaced the three follow-up issues above
- [x] Verified each follow-up fix live: invalid hostname now blocked inline ("Must be a valid hostname..."), Routing card disappears and no routing config persists after switching to Stateful, and Delete is blocked with a clear error until the stack is Stopped first (then Delete succeeds with no orphaned container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
