### PR TITLE
fix(postgres,onboarding): fix 404s and no-op cache invalidations surfaced by the contract migration

### DIFF
--- a/client/src/components/postgres-server/server-modal.tsx
+++ b/client/src/components/postgres-server/server-modal.tsx
@@ -3,7 +3,7 @@ import { useForm, useWatch } from "react-hook-form";
 import { useQuery } from "@tanstack/react-query";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import type { PostgresServerInfo } from "@mini-infra/types";
+import type { ContainerInfo, PostgresServerInfo } from "@mini-infra/types";
 import { POSTGRES_SSL_MODES, ApiRoute, queryKeys } from "@mini-infra/types";
 import { toast } from "sonner";
 import {
@@ -98,10 +98,10 @@ export function ServerModal({ open, onOpenChange, mode, serverId, serverData, in
   const testConnectionMutation = useTestServerConnection();
 
   // Fetch PostgreSQL containers for linking
-  const { data: postgresContainers } = useQuery<Array<{ id: string; name: string; image: string; imageTag: string }>>({
+  const { data: postgresContainers } = useQuery<ContainerInfo[]>({
     queryKey: queryKeys.containers.postgres,
     queryFn: async () => {
-      const data = await apiFetch<Array<{ id: string; name: string; image: string; imageTag: string }> | undefined>(
+      const data = await apiFetch<ContainerInfo[] | undefined>(
         ApiRoute.containers.postgres(),
         { correlationIdPrefix: "postgres-containers" },
       );

--- a/client/src/hooks/use-managed-database-users.ts
+++ b/client/src/hooks/use-managed-database-users.ts
@@ -71,15 +71,14 @@ async function changeUserPassword(
   userId: string,
   request: ChangeUserPasswordRequest,
 ): Promise<ManagedDatabaseUserResponse> {
-  // NOTE: pre-existing behavior — this sends PUT, but the server route for
-  // this endpoint (server/src/routes/postgres-server/users.ts) is registered
-  // as `router.post("/:userId/password", ...)`. This mismatch predates this
-  // migration (not introduced or fixed here); see the Phase 4 migration
-  // report for detail.
+  // The server route (server/src/routes/postgres-server/users.ts) is
+  // registered as `router.post("/:userId/password", ...)` and the registry
+  // documents `ApiRoute.postgresServer.userPassword` as POST — so this must
+  // use POST, not PUT (a PUT hit no registered route and 404'd).
   return apiFetch<ManagedDatabaseUserResponse>(
     ApiRoute.postgresServer.userPassword(serverId, userId),
     {
-      method: "PUT",
+      method: "POST",
       body: request,
       correlationIdPrefix: "managed-database-user",
       unwrap: false,

--- a/client/src/hooks/use-onboarding.ts
+++ b/client/src/hooks/use-onboarding.ts
@@ -40,15 +40,12 @@ export function useCompleteOnboarding() {
       queryClient.invalidateQueries({
         queryKey: queryKeys.settings.systemSettings,
       });
-      // These two invalidation targets don't match any live query key
-      // anywhere in the app today — self-backup config is actually cached
-      // under "self-backup-config" (use-self-backup.ts) and TLS settings
-      // under ["settings","tls"] (use-tls-settings.ts). Pre-existing no-op
-      // bugs, preserved via documented "Legacy" registry entries rather than
-      // silently repointed — see queryKeys.selfBackup.configLegacy /
-      // queryKeys.settings.tlsSettingsLegacy in lib/types/query-keys.ts.
-      queryClient.invalidateQueries({ queryKey: queryKeys.selfBackup.configLegacy });
-      queryClient.invalidateQueries({ queryKey: queryKeys.settings.tlsSettingsLegacy });
+      // Refresh the self-backup config (cached under "self-backup-config" in
+      // use-self-backup.ts) and the TLS settings form (cached under
+      // ["settings","tls"] in use-tls-settings.ts) so onboarding-completion
+      // changes show up without waiting for a natural refetch.
+      queryClient.invalidateQueries({ queryKey: queryKeys.selfBackup.config });
+      queryClient.invalidateQueries({ queryKey: queryKeys.settings.tlsSettings });
     },
   });
 

--- a/client/src/hooks/use-postgres-backup-configs.ts
+++ b/client/src/hooks/use-postgres-backup-configs.ts
@@ -238,7 +238,7 @@ export function useQuickSetupPostgresBackup() {
   return useMutation({
     mutationFn: (request: QuickBackupSetupRequest) =>
       quickSetupPostgresBackup(request),
-    onSuccess: (response) => {
+    onSuccess: (response, request) => {
       const databaseId = response.data.databaseId;
       // Invalidate and refetch backup configuration for this database
       queryClient.invalidateQueries({
@@ -246,12 +246,14 @@ export function useQuickSetupPostgresBackup() {
       });
       // Also invalidate databases list as it might show backup configuration status
       queryClient.invalidateQueries({ queryKey: queryKeys.postgresDatabases.all });
-      // Invalidate managed databases list for the server
-      // NOTE: pre-existing invalidation target with no matching query anywhere
-      // in the app (likely a latent no-op bug predating this migration) —
-      // preserved as-is rather than silently repointed.
+      // Refetch the managed-databases list for this server and the single
+      // managed-database detail so the newly-configured backup shows up (both
+      // surfaces render backup-configuration status).
       queryClient.invalidateQueries({
-        queryKey: queryKeys.postgresDatabases.managedDatabasesLegacy,
+        queryKey: queryKeys.postgresServer.databasesForServer(request.serverId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.postgresServer.database(databaseId),
       });
     },
   });

--- a/client/src/hooks/use-postgres-restore-operations.ts
+++ b/client/src/hooks/use-postgres-restore-operations.ts
@@ -95,19 +95,18 @@ async function fetchAvailableBackups(
   sortBy: "createdAt" | "sizeBytes" | "name" = "createdAt",
   sortOrder: "asc" | "desc" = "desc",
 ): Promise<BackupBrowserResponse> {
-  // NOTE: `ApiRoute.postgres.restoreBackupsForContainer` only accepts
-  // `containerName` (the real server route is
-  // `GET /api/postgres/restore/backups/:containerName` — no `:databaseId`
-  // segment). This call has appended an extra `/${databaseId}` path segment
-  // since before this migration, which doesn't match the registered route.
-  // Preserved as-is (pre-existing bug, not introduced by this migration) —
-  // see the Phase 4 migration report for the missing-ApiRoute-builder flag.
+  // The server route is `GET /api/postgres/restore/backups/:containerName`
+  // (no `:databaseId` path segment — appending one 404'd). Backups live in a
+  // container shared across databases and are keyed by a `<databaseId>/...`
+  // blob prefix, so we scope to the current database with a `databaseId`
+  // query param that the route filters on.
   const url = new URL(
-    `${ApiRoute.postgres.restoreBackupsForContainer(containerName)}/${databaseId}`,
+    ApiRoute.postgres.restoreBackupsForContainer(containerName),
     window.location.origin,
   );
 
   // Add query parameters
+  url.searchParams.set("databaseId", databaseId);
   url.searchParams.set("page", page.toString());
   url.searchParams.set("limit", limit.toString());
   url.searchParams.set("sortBy", sortBy);

--- a/client/src/hooks/useContainers.ts
+++ b/client/src/hooks/useContainers.ts
@@ -31,7 +31,6 @@ async function fetchContainers(
   if (queryParams.status) url.searchParams.set("status", queryParams.status);
   if (queryParams.name) url.searchParams.set("name", queryParams.name);
   if (queryParams.image) url.searchParams.set("image", queryParams.image);
-  if (queryParams.deploymentId) url.searchParams.set("deploymentId", queryParams.deploymentId);
   if (queryParams.deploymentManaged !== undefined) url.searchParams.set("deploymentManaged", queryParams.deploymentManaged.toString());
 
   return apiFetch<ContainerListResponse>(url.toString(), {
@@ -244,7 +243,6 @@ export function useContainerFilters(initialFilters: ContainerFilters = { status:
     sortOrder,
     page,
     limit,
-    deploymentId: filters.deploymentId,
     deploymentManaged: filters.deploymentManaged,
     filters,
   };

--- a/lib/types/containers.ts
+++ b/lib/types/containers.ts
@@ -57,7 +57,6 @@ export interface ContainerFilters {
   status?: string;
   name?: string;
   image?: string;
-  deploymentId?: string;
   deploymentManaged?: boolean; // Filter for containers managed by deployments
   /**
    * When true, restrict the list to containers labelled
@@ -74,7 +73,6 @@ export interface ContainerQueryParams {
   status?: string;
   name?: string;
   image?: string;
-  deploymentId?: string;
   deploymentManaged?: boolean;
   poolInstance?: boolean;
   filters?: ContainerFilters;
@@ -90,12 +88,6 @@ export interface ContainerListResponse {
   lastUpdated: string; // ISO string for JSON serialization
   page?: number;
   limit?: number;
-}
-
-export interface ContainerResponse {
-  success: boolean;
-  data: ContainerInfo;
-  message?: string;
 }
 
 export interface ContainerListApiResponse {
@@ -137,10 +129,6 @@ export interface ContainerCacheFlushResponse {
 // ====================
 
 export type ContainerAction = "start" | "stop" | "restart" | "remove";
-
-export interface ContainerActionRequest {
-  action: ContainerAction;
-}
 
 export interface ContainerActionResponse {
   success: boolean;

--- a/lib/types/query-keys.ts
+++ b/lib/types/query-keys.ts
@@ -278,12 +278,6 @@ export const queryKeys = {
       sortOrder?: string,
     ) => ["postgresDatabases", filters, page, limit, sortBy, sortOrder] as const,
     detail: (id: string) => ["postgresDatabase", id] as const,
-    /**
-     * Pre-existing invalidation target with no matching query anywhere in
-     * the app (likely a latent no-op bug predating this migration) —
-     * preserved as-is rather than silently repointed. See Phase 4 report.
-     */
-    managedDatabasesLegacy: ["managedDatabases"] as const,
   },
 
   postgresBackupConfig: {
@@ -354,14 +348,6 @@ export const queryKeys = {
     scheduleInfo: ["schedule-info"] as const,
     /** Bare root for the backup-history resource — broad-invalidates every `history(...)` variant regardless of filters. */
     historyAll: ["backup-history"] as const,
-    /**
-     * Pre-existing invalidation target with no matching query anywhere in
-     * the app (the real key is `config` = `["self-backup-config"]` above) —
-     * likely a latent no-op bug in `use-onboarding.ts`'s completion handler,
-     * predating this migration. Preserved as-is rather than silently
-     * repointed. See Phase 4 report.
-     */
-    configLegacy: ["selfBackupConfig"] as const,
     /** Paginated/filtered backup-history list query key (positional params mirror the server's query-string filters). */
     history: (
       status?: string,
@@ -396,14 +382,6 @@ export const queryKeys = {
     managedTunnel: (environmentId: string) => ["managed-tunnel", environmentId] as const,
     tailscaleSettings: ["tailscaleSettings"] as const,
     tlsSettings: ["settings", "tls"] as const,
-    /**
-     * Pre-existing invalidation target with no matching query anywhere in
-     * the app (the real key is `tlsSettings` = `["settings","tls"]` above) —
-     * likely a latent no-op bug in `use-onboarding.ts`'s completion handler,
-     * predating this migration. Preserved as-is rather than silently
-     * repointed. See Phase 4 report.
-     */
-    tlsSettingsLegacy: ["tlsSettings"] as const,
     storageSettings: ["storage", "settings"] as const,
   },
 

--- a/server/src/__tests__/postgres-server-users-route.test.ts
+++ b/server/src/__tests__/postgres-server-users-route.test.ts
@@ -1,0 +1,104 @@
+import request from "supertest";
+import express from "express";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — declared before any vi.mock() calls that reference them.
+// ---------------------------------------------------------------------------
+const { mockChangePassword, mockLogger, mockRequirePermission } = vi.hoisted(
+  () => ({
+    mockChangePassword: vi.fn().mockResolvedValue(undefined),
+    mockLogger: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+    mockRequirePermission: vi.fn(
+      () => (_req: any, _res: any, next: any) => next(),
+    ),
+  }),
+);
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+vi.mock("../lib/logger-factory", () => ({
+  getLogger: vi.fn(() => mockLogger),
+  clearLoggerCache: vi.fn(),
+}));
+
+vi.mock("../middleware/auth", () => ({
+  requirePermission: mockRequirePermission,
+  getCurrentUserId: () => "test-user-id",
+}));
+
+vi.mock("../services/postgres-server/user-manager", () => ({
+  default: {
+    changePassword: mockChangePassword,
+  },
+}));
+
+vi.mock("../services/postgres-server/grant-manager", () => ({
+  default: {
+    listGrantsForUser: vi.fn(),
+  },
+}));
+
+// Import the router AFTER the mocks are set up.
+import usersRouter from "../routes/postgres-server/users";
+
+// ---------------------------------------------------------------------------
+// Test app
+// ---------------------------------------------------------------------------
+const SERVER_ID = "server-123";
+const USER_ID = "user-456";
+const PASSWORD_PATH = `/api/postgres-server/servers/${SERVER_ID}/users/${USER_ID}/password`;
+
+describe("Postgres-server user password route", () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    // mergeParams:true on the router exposes :serverId to the handlers.
+    app.use("/api/postgres-server/servers/:serverId/users", usersRouter);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("accepts POST to change a user's password (regression: client must not send PUT)", async () => {
+    const res = await request(app)
+      .post(PASSWORD_PATH)
+      .send({ password: "new-secret-123" });
+
+    // The client previously sent PUT, which hit no registered route (404).
+    // The registered method is POST — it must reach the handler and succeed.
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ success: true });
+    expect(mockChangePassword).toHaveBeenCalledTimes(1);
+    expect(mockChangePassword).toHaveBeenCalledWith(
+      SERVER_ID,
+      "test-user-id",
+      USER_ID,
+      "new-secret-123",
+    );
+  });
+
+  it("does not register PUT on the password route (the original client bug 404'd)", async () => {
+    const res = await request(app)
+      .put(PASSWORD_PATH)
+      .send({ password: "new-secret-123" });
+
+    expect(res.status).toBe(404);
+    expect(mockChangePassword).not.toHaveBeenCalled();
+  });
+
+  it("validates that a password is supplied (POST with empty body → 400)", async () => {
+    const res = await request(app).post(PASSWORD_PATH).send({});
+
+    expect(res.status).toBe(400);
+    expect(mockChangePassword).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/routes/containers.schemas.ts
+++ b/server/src/routes/containers.schemas.ts
@@ -144,7 +144,6 @@ export const ContainerQuerySchema = z.object({
   status: z.string().optional(),
   name: z.string().optional(),
   image: z.string().optional(),
-  deploymentId: z.string().optional(),
 });
 
 export const ContainerListResponseSchema = z.object({

--- a/server/src/routes/postgres-restore.ts
+++ b/server/src/routes/postgres-restore.ts
@@ -272,13 +272,18 @@ function mapRestoreOperationToInfo(operation: Prisma.RestoreOperationGetPayload<
 }
 
 /**
- * List available backups from Azure Storage for all databases in a container
+ * List available backups from storage for a container. Backups are stored
+ * under a `<databaseId>/<file>` blob prefix in a container that is shared
+ * across databases, so pass `filterDatabaseId` to scope the results to a
+ * single database (used by the per-database restore page); omit it to list
+ * every database's backups in the container.
  */
 async function listAvailableBackupsInContainer(
   containerName: string,
   filter: BackupBrowserFilter,
   sort: BackupBrowserSortOptions,
   pagination: { page: number; limit: number },
+  filterDatabaseId?: string,
 ): Promise<{ items: BackupBrowserItem[]; totalCount: number }> {
   try {
     const storageBackend = await StorageService.getInstance(prisma).getActiveBackend();
@@ -288,6 +293,16 @@ async function listAvailableBackupsInContainer(
 
     for (const obj of list.objects) {
       if (!obj.name.endsWith(".dump") && !obj.name.endsWith(".sql")) {
+        continue;
+      }
+
+      // Extract database ID from the blob path (`<databaseId>/<file>`).
+      const pathParts = obj.name.split("/");
+      const blobDatabaseId = pathParts.length > 1 ? pathParts[0] : "unknown";
+
+      // Scope to a single database when requested — skip other databases'
+      // backups before doing any (potentially SAS-minting) URL resolution.
+      if (filterDatabaseId && blobDatabaseId !== filterDatabaseId) {
         continue;
       }
 
@@ -312,10 +327,6 @@ async function listAvailableBackupsInContainer(
         url = `${containerName}/${obj.name}`;
       }
 
-      // Extract database ID from blob path
-      const pathParts = obj.name.split("/");
-      const databaseId = pathParts.length > 1 ? pathParts[0] : "unknown";
-
       const item: BackupBrowserItem = {
         name: obj.name,
         url,
@@ -325,7 +336,7 @@ async function listAvailableBackupsInContainer(
         lastModified:
           obj.lastModified?.toISOString() || new Date().toISOString(),
         metadata: {
-          databaseName: databaseId,
+          databaseName: blobDatabaseId,
           contentType: obj.contentType,
           etag: obj.etag,
           ...obj.metadata,
@@ -859,6 +870,12 @@ router.get(
     const requestId = res.locals.requestId;
     const user = getAuthenticatedUser(req);
     const containerName = String(req.params.containerName);
+    // Optional: scope the listing to a single database. The restore page is
+    // per-database, so it passes `?databaseId=...`; omitting it lists every
+    // database's backups in the container.
+    const databaseId = req.query.databaseId
+      ? String(req.query.databaseId)
+      : undefined;
 
     if (!user?.id) {
       return res.status(401).json({
@@ -872,19 +889,20 @@ router.get(
 
     try {
       logger.debug(
-        { requestId, userId: user?.id, containerName },
+        { requestId, userId: user?.id, containerName, databaseId },
         "Browsing available backups in container",
       );
 
       // Parse query parameters
       const { pagination, filter, sort } = parseBackupBrowserQuery(req.query);
 
-      // List available backups from Azure Storage for all databases
+      // List available backups from storage (optionally scoped to one database)
       const { items, totalCount } = await listAvailableBackupsInContainer(
         containerName,
         filter,
         sort,
         pagination,
+        databaseId,
       );
 
       const response: BackupBrowserResponse = {


### PR DESCRIPTION
## Summary

Fixes 4 pre-existing bugs (2 user-facing 404s, 2 no-op cache invalidations) plus the low-risk tidy-ups that were flagged when the frontend↔backend contract migration (PR #475) surfaced them. Each bug was re-verified against current `main` (`8c32303`) before editing. The `*Legacy` query-key entries the migration parked as "documented no-ops" are now repointed or removed.

## Bugs fixed

### 1. Managed-Postgres user password change 404'd (user-facing) 🔴
The client sent `PUT` to `/api/postgres-server/servers/:serverId/users/:userId/password`, but the route is registered as `POST` (and the registry documents it as `POST`) — so the request hit no route and 404'd.
- **Fix:** `client/src/hooks/use-managed-database-users.ts` — `changeUserPassword` now sends `POST`.
- **Test:** added `server/src/__tests__/postgres-server-users-route.test.ts` — asserts POST reaches the handler (200), PUT is unregistered (404), and an empty body is rejected (400).

### 2. Onboarding cache invalidations were no-ops (latent) 🟡
On onboarding completion the handler invalidated `queryKeys.selfBackup.configLegacy` (`["selfBackupConfig"]`) and `queryKeys.settings.tlsSettingsLegacy` (`["tlsSettings"]`), neither of which matches any live query.
- **Fix:** `client/src/hooks/use-onboarding.ts` — repointed to the real keys `queryKeys.selfBackup.config` (`["self-backup-config"]`) and `queryKeys.settings.tlsSettings` (`["settings","tls"]`).

### 3. Quick-setup backup-config's managed-databases invalidation was a no-op (latent) 🟡
`useQuickSetupPostgresBackup` invalidated `queryKeys.postgresDatabases.managedDatabasesLegacy` (`["managedDatabases"]`) — no live query.
- **Fix:** `client/src/hooks/use-postgres-backup-configs.ts` — the `onSuccess` handler now also receives the mutation `request` and repoints to `queryKeys.postgresServer.databasesForServer(request.serverId)` (the managed-databases list) and `queryKeys.postgresServer.database(databaseId)` (the single managed-database detail). `QuickBackupSetupRequest` carries `serverId`; the response carries `databaseId`.

### 4. Restore "available backups for container" 404'd with a databaseId (user-facing) 🔴
The client built `` `${restoreBackupsForContainer(containerName)}/${databaseId}` `` → `GET /api/postgres/restore/backups/:containerName/:databaseId`, but the server registers only `/restore/backups/:containerName`, so any call with a databaseId 404'd — the restore browser has been showing no backups.

**Decision: I took the database-scoped ("yes") path, implemented as a query-param filter rather than a new route.** Both "yes"-path criteria are met:
- Backups are stored as `${databaseId}/${operationId}_${timestamp}.dump` (`backup-job-pool-materialiser.ts`) inside a container that **defaults to a shared `"postgres-backups"`** across databases (`postgres-backup-configs.ts`).
- The restore page (`client/src/app/postgres/restore/page.tsx`) is scoped to one database, titled "Browse available backups and restore {database.name}", and maps the results directly as that database's backups.

So the pure "drop the segment" path would show every database's backups on a per-database page (a real UX regression on the shared default container), and would break pagination (server paginates the full container list). To avoid both, and to avoid ApiRoute-signature churn / `ALL_API_ROUTES` regeneration that a new `:databaseId` path segment would require, I scope via a `?databaseId=` query param:
- **Client** (`use-postgres-restore-operations.ts`): drop the bad path segment, set `databaseId` as a query param.
- **Server** (`postgres-restore.ts`): `listAvailableBackupsInContainer` takes an optional `filterDatabaseId` and skips blobs whose `<databaseId>/` prefix doesn't match (before any SAS minting); the route reads `req.query.databaseId`. Omitting it preserves the original list-all behaviour. Server-side filtering keeps pagination correct.

## Minor tidy-ups
- **Dead types deleted:** `ContainerResponse` and `ContainerActionRequest` in `lib/types/containers.ts` (grep-confirmed zero references across client/server/lib/sidecars).
- **`deploymentId` container-list filter dropped:** it was validated in `ContainerQuerySchema` but never applied, and wiring it up is non-trivial (the server never populates `deploymentInfo` on containers). It was also provably dead on the client — `filters.deploymentId` is never set anywhere. Removed end-to-end: the server schema field, the two dead client lines in `useContainers.ts`, and the `deploymentId` field on the shared `ContainerFilters` / `ContainerQueryParams` types.
- **Type alignment:** `server-modal.tsx` now types the `/api/containers/postgres` response as the shared `ContainerInfo[]` (matching `ContainerDashboard.tsx`) instead of an ad-hoc inline shape.
- **Legacy keys removed** from `lib/types/query-keys.ts` (`managedDatabasesLegacy`, `selfBackup.configLegacy`, `settings.tlsSettingsLegacy`) now that nothing references them.

## Not touched (confirmed correct)
Per the bug report, HAProxy hostname-conflict validation (`useValidateHostname` reading `.data.frontends`) is correct — the frontends query fetches with `{ unwrap: false }` so the cache holds the full envelope. Left untouched.

## Verification

**Build / lint / test (from worktree root):**
- `pnpm build:lib`, `pnpm --filter mini-infra-client build`, `pnpm --filter mini-infra-server build`, `pnpm build` — all pass.
- `pnpm --filter mini-infra-server test` — **2396 tests pass** (190 files), including the new password-route test.
- `pnpm --filter mini-infra-client lint` and `pnpm --filter mini-infra-server lint` — both clean.

**Smoke tests (rebuilt dev env, Vault auto-unlocked):**
- App loads with **no console errors** on dashboard, `/containers`, `/postgres-server`, and `/postgres-backup`; the "Add PostgreSQL Server" modal (which fetches `/api/containers/postgres` via the newly-aligned type) opened with 0 console errors.
- **#1:** `POST` to the password route reaches the handler (`{"success":false,"error":"Server not found"}` — handler-level, ran the service); `PUT` returns the app's `{"error":"Route not found"}` — exactly the 404 the old client hit.
- **#4:** the new query-param path matches a route (handler runs and hits storage; returns 500 only because the dev env's Azure has no `postgres-backups` container — the list-all path 500s identically, so it's environmental, not from my change); the old `/:databaseId` segment path returns `{"error":"Route not found"}`.
- **#2/#3:** cache-invalidation fixes aren't directly observable live; validated via TypeScript build + repointing to keys that are the actual live query keys used by `use-self-backup.ts`, `use-tls-settings.ts`, and `use-managed-databases.ts`.

## Open questions / notes
- None blocking. The #4 500 in dev is purely because the seeded Azure account has no `postgres-backups` container; in a real environment with backups present, the route returns 200 with the database-scoped list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
