### PR TITLE
feat(applications,networks): declaratively join apps to the environment's HAProxy applications network

### DIFF
--- a/client/src/app/applications/[id]/configuration/page.tsx
+++ b/client/src/app/applications/[id]/configuration/page.tsx
@@ -32,6 +32,7 @@ import type { StackServiceType } from "@mini-infra/types";
 import {
   editApplicationFormSchema,
   editApplicationDefaults,
+  applicationsNetworkDeclaration,
   type EditApplicationFormData,
 } from "@/lib/application-schemas";
 import { ConfigurationCard } from "../../components/configuration-card";
@@ -225,6 +226,14 @@ export default function ApplicationConfigurationTab() {
       ]),
     );
 
+    // HAProxy-routed services (StatelessWeb) must re-declare membership of the
+    // environment's `applications` network on every save — otherwise editing an
+    // app would drop the resource input the create flow set. The server also
+    // enforces this at apply time; declaring it keeps the draft self-describing.
+    const { resourceInputs, joinResourceNetworks } = applicationsNetworkDeclaration(
+      formData.serviceType as StackServiceType,
+    );
+
     try {
       await updateApplication.mutateAsync({
         templateId,
@@ -234,6 +243,7 @@ export default function ApplicationConfigurationTab() {
         },
         draft: {
           networks,
+          resourceInputs,
           volumes,
           services: [
             {
@@ -246,6 +256,7 @@ export default function ApplicationConfigurationTab() {
                 ports: ports.length > 0 ? ports : undefined,
                 mounts: mounts.length > 0 ? mounts : undefined,
                 joinNetworks,
+                joinResourceNetworks,
                 restartPolicy: formData.restartPolicy,
                 healthcheck,
               },

--- a/client/src/app/applications/adopt/page.tsx
+++ b/client/src/app/applications/adopt/page.tsx
@@ -43,7 +43,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { linkedContainerSchema } from "@/lib/application-schemas";
+import {
+  linkedContainerSchema,
+  applicationsNetworkDeclaration,
+} from "@/lib/application-schemas";
 import { ConnectToContainersField } from "../components/connect-to-containers-field";
 
 // ---- Zod Schema ----
@@ -163,6 +166,12 @@ export default function AdoptContainerPage() {
         : {}),
     };
 
+    // AdoptedWeb targets route through HAProxy, so they must join the
+    // environment's `applications` network (declared here + enforced by the
+    // server invariant at apply time).
+    const { resourceInputs, joinResourceNetworks } =
+      applicationsNetworkDeclaration("AdoptedWeb");
+
     // Networks the adopted container should join to reach linked containers
     // (e.g. a database). Applied to the existing container at deploy time.
     const joinNetworks = Array.from(
@@ -177,9 +186,7 @@ export default function AdoptContainerPage() {
         scope: "environment",
         environmentId: data.environmentId,
         deployImmediately: true,
-        resourceInputs: [
-          { type: "docker-network", purpose: "applications" },
-        ],
+        resourceInputs,
         networks: [],
         volumes: [],
         services: [
@@ -188,8 +195,10 @@ export default function AdoptContainerPage() {
             serviceType: "AdoptedWeb" as StackServiceType,
             dockerImage: "adopted",
             dockerTag: "n/a",
-            containerConfig:
-              joinNetworks.length > 0 ? { joinNetworks } : {},
+            containerConfig: {
+              ...(joinNetworks.length > 0 ? { joinNetworks } : {}),
+              joinResourceNetworks,
+            },
             dependsOn: [],
             order: 0,
             routing,

--- a/client/src/app/applications/new/page.tsx
+++ b/client/src/app/applications/new/page.tsx
@@ -19,6 +19,7 @@ import { Switch } from "@/components/ui/switch";
 import {
   createApplicationFormSchema,
   createApplicationDefaults,
+  applicationsNetworkDeclaration,
   type CreateApplicationFormData,
 } from "@/lib/application-schemas";
 
@@ -185,10 +186,12 @@ export default function NewApplicationPage() {
           }
         : undefined;
 
-    const resourceInputs =
-      data.serviceType === "StatelessWeb"
-        ? [{ type: "docker-network", purpose: "applications" }]
-        : undefined;
+    // HAProxy-routed services (StatelessWeb) must join the environment's
+    // `applications` network so HAProxy can reach the backend. Declared as a
+    // stack resource input + a service-level joinResourceNetworks membership.
+    const { resourceInputs, joinResourceNetworks } = applicationsNetworkDeclaration(
+      data.serviceType as StackServiceType,
+    );
 
     // Networks the app must join to reach linked containers (e.g. a database).
     const joinNetworks = Array.from(
@@ -216,6 +219,7 @@ export default function NewApplicationPage() {
               ports: ports.length > 0 ? ports : undefined,
               mounts: mounts.length > 0 ? mounts : undefined,
               joinNetworks: joinNetworks.length > 0 ? joinNetworks : undefined,
+              joinResourceNetworks,
               restartPolicy: data.restartPolicy,
               healthcheck,
             },

--- a/client/src/lib/application-schemas.ts
+++ b/client/src/lib/application-schemas.ts
@@ -3,7 +3,34 @@ import {
   STACK_SERVICE_TYPES,
   RESTART_POLICIES,
   NETWORK_PROTOCOLS,
+  APPLICATIONS_NETWORK_PURPOSE,
+  isHaproxyRoutedServiceType,
+  type StackResourceInput,
+  type StackServiceType,
 } from "@mini-infra/types";
+
+/**
+ * Network declarations that put an application's container onto the
+ * environment's HAProxy `applications` network. HAProxy-routed service types
+ * (StatelessWeb / AdoptedWeb) must join it for traffic to flow — returned as
+ * both the stack-level resource input (so the purpose resolves to
+ * `<environment>-applications` at apply time) and the service-level
+ * `joinResourceNetworks` membership. Non-routed types get `undefined` for
+ * both. The server enforces the same invariant at apply time; declaring it
+ * here keeps the stored definition self-describing across new/edit/adopt.
+ */
+export function applicationsNetworkDeclaration(serviceType: StackServiceType): {
+  resourceInputs: StackResourceInput[] | undefined;
+  joinResourceNetworks: string[] | undefined;
+} {
+  if (!isHaproxyRoutedServiceType(serviceType)) {
+    return { resourceInputs: undefined, joinResourceNetworks: undefined };
+  }
+  return {
+    resourceInputs: [{ type: "docker-network", purpose: APPLICATIONS_NETWORK_PURPOSE }],
+    joinResourceNetworks: [APPLICATIONS_NETWORK_PURPOSE],
+  };
+}
 
 // ---- Shared sub-schemas for application forms ----
 

--- a/lib/types/stacks.ts
+++ b/lib/types/stacks.ts
@@ -10,6 +10,29 @@ export const STACK_SERVICE_TYPES = ['Stateful', 'StatelessWeb', 'AdoptedWeb', 'P
 export type StackServiceType = typeof STACK_SERVICE_TYPES[number];
 export type ServiceActionType = 'create' | 'recreate' | 'remove' | 'no-op';
 
+/**
+ * Docker network `purpose` for an environment's HAProxy "applications"
+ * network — the network every HAProxy-routed backend must join so HAProxy can
+ * reach it. Resolves per environment to `<environment>-applications` (see
+ * `resourceNetworkName()` server-side). Declared here so the client authoring
+ * flows and the server-side apply-time invariant agree on the one literal
+ * instead of re-typing `'applications'` in a dozen places.
+ */
+export const APPLICATIONS_NETWORK_PURPOSE = 'applications';
+
+/**
+ * Service types that sit behind HAProxy and therefore must be members of the
+ * environment's `applications` network for traffic to flow. Used by both the
+ * client app-authoring flows (to declare the membership) and the server
+ * reconciler invariant (to guarantee it regardless of authoring surface).
+ */
+export const HAPROXY_ROUTED_SERVICE_TYPES = ['StatelessWeb', 'AdoptedWeb'] as const satisfies readonly StackServiceType[];
+
+/** True when a service type routes through HAProxy (see {@link HAPROXY_ROUTED_SERVICE_TYPES}). */
+export function isHaproxyRoutedServiceType(serviceType: StackServiceType): boolean {
+  return (HAPROXY_ROUTED_SERVICE_TYPES as readonly StackServiceType[]).includes(serviceType);
+}
+
 // Stack parameter types
 
 export const STACK_PARAMETER_TYPES = ['string', 'number', 'boolean'] as const;

--- a/server/src/__tests__/stack-reconciler-apply-stateless.test.ts
+++ b/server/src/__tests__/stack-reconciler-apply-stateless.test.ts
@@ -248,6 +248,23 @@ const mockPrisma = {
   infraResource: {
     // Default: no egress InfraResource. Auto-attach to egress network is a no-op.
     findFirst: vi.fn().mockResolvedValue(null),
+    // The apply-time applications-membership invariant declares the
+    // `applications` resource input for StatelessWeb stacks; resolveInputs
+    // resolves it here to a concrete network name.
+    findUnique: vi.fn().mockImplementation((args: any) => {
+      const purpose = args?.where?.type_purpose_scope_environmentId?.purpose;
+      if (purpose === 'applications') {
+        return Promise.resolve({
+          id: 'ir-applications',
+          type: 'docker-network',
+          purpose: 'applications',
+          scope: 'environment',
+          environmentId: 'env-1',
+          name: 'prod-applications',
+        });
+      }
+      return Promise.resolve(null);
+    }),
   },
   stackDeployment: {
     create: mockStackDeploymentCreate,

--- a/server/src/services/haproxy/actions/deploy-application-containers.ts
+++ b/server/src/services/haproxy/actions/deploy-application-containers.ts
@@ -46,13 +46,12 @@ export class DeployApplicationContainers {
                     ? Object.entries(context.containerEnvironment).map(([name, value]): ContainerEnvVar => ({ name, value }))
                     : [],
                 labels: context.containerLabels ?? {},
+                // Networks come purely from the caller's declared membership
+                // (`containerNetworks`, built from the stack's resource inputs).
+                // The HAProxy `applications` network is included there via the
+                // apply-time invariant — it is no longer force-attached here.
                 networks: context.containerNetworks ?? [context.haproxyNetworkName],
             };
-
-            // Ensure the container is attached to the HAProxy network
-            if (!containerConfig.networks.includes(context.haproxyNetworkName)) {
-                containerConfig.networks.push(context.haproxyNetworkName);
-            }
 
             // Add deployment-specific labels
             const deploymentLabels = {

--- a/server/src/services/networks/__tests__/applications-membership.test.ts
+++ b/server/src/services/networks/__tests__/applications-membership.test.ts
@@ -1,0 +1,130 @@
+import type { StackResourceInput, StackServiceDefinition, StackServiceType } from '@mini-infra/types';
+import {
+  stackNeedsApplicationsNetwork,
+  ensureApplicationsResourceInput,
+  ensureApplicationsJoinResourceNetwork,
+  ensureApplicationsMembership,
+} from '../applications-membership';
+
+function makeService(
+  serviceType: StackServiceType,
+  joinResourceNetworks?: string[],
+): StackServiceDefinition {
+  return {
+    serviceName: `svc-${serviceType}`,
+    serviceType,
+    dockerImage: 'nginx',
+    dockerTag: 'latest',
+    containerConfig: joinResourceNetworks ? { joinResourceNetworks } : {},
+    dependsOn: [],
+    order: 0,
+  };
+}
+
+const APPLICATIONS_INPUT: StackResourceInput = { type: 'docker-network', purpose: 'applications' };
+
+describe('applications-membership', () => {
+  describe('stackNeedsApplicationsNetwork', () => {
+    it('is true when any service routes through HAProxy', () => {
+      expect(stackNeedsApplicationsNetwork([makeService('Stateful'), makeService('StatelessWeb')])).toBe(true);
+      expect(stackNeedsApplicationsNetwork([makeService('AdoptedWeb')])).toBe(true);
+    });
+
+    it('is false for stacks with no HAProxy-routed service', () => {
+      expect(stackNeedsApplicationsNetwork([makeService('Stateful'), makeService('Pool')])).toBe(false);
+      expect(stackNeedsApplicationsNetwork([])).toBe(false);
+    });
+  });
+
+  describe('ensureApplicationsResourceInput', () => {
+    it('appends the applications docker-network input when absent', () => {
+      expect(ensureApplicationsResourceInput([])).toEqual([APPLICATIONS_INPUT]);
+    });
+
+    it('is idempotent when the input is already present', () => {
+      const inputs = [APPLICATIONS_INPUT];
+      expect(ensureApplicationsResourceInput(inputs)).toBe(inputs);
+    });
+
+    it('preserves unrelated resource inputs', () => {
+      const inputs: StackResourceInput[] = [{ type: 'docker-network', purpose: 'dataplane' }];
+      expect(ensureApplicationsResourceInput(inputs)).toEqual([...inputs, APPLICATIONS_INPUT]);
+    });
+  });
+
+  describe('ensureApplicationsJoinResourceNetwork', () => {
+    it('adds the applications join for HAProxy-routed services', () => {
+      expect(ensureApplicationsJoinResourceNetwork(makeService('StatelessWeb')).containerConfig.joinResourceNetworks).toEqual([
+        'applications',
+      ]);
+      expect(ensureApplicationsJoinResourceNetwork(makeService('AdoptedWeb')).containerConfig.joinResourceNetworks).toEqual([
+        'applications',
+      ]);
+    });
+
+    it('leaves non-routed services untouched (same reference)', () => {
+      const svc = makeService('Stateful');
+      expect(ensureApplicationsJoinResourceNetwork(svc)).toBe(svc);
+    });
+
+    it('is idempotent when the join is already declared (same reference)', () => {
+      const svc = makeService('StatelessWeb', ['applications']);
+      expect(ensureApplicationsJoinResourceNetwork(svc)).toBe(svc);
+    });
+
+    it('merges with existing joinResourceNetworks without dropping them', () => {
+      const svc = makeService('StatelessWeb', ['vault']);
+      expect(ensureApplicationsJoinResourceNetwork(svc).containerConfig.joinResourceNetworks).toEqual([
+        'vault',
+        'applications',
+      ]);
+    });
+
+    it('does not mutate the input definition', () => {
+      const svc = makeService('StatelessWeb');
+      ensureApplicationsJoinResourceNetwork(svc);
+      expect(svc.containerConfig.joinResourceNetworks).toBeUndefined();
+    });
+  });
+
+  describe('ensureApplicationsMembership', () => {
+    it('is a no-op for host-scoped stacks (null environment)', () => {
+      const resourceInputs: StackResourceInput[] = [];
+      const resolvedDefinitions = new Map([['a', makeService('StatelessWeb')]]);
+      const result = ensureApplicationsMembership(null, { resourceInputs, resolvedDefinitions });
+      expect(result.resourceInputs).toBe(resourceInputs);
+      expect(result.resolvedDefinitions).toBe(resolvedDefinitions);
+    });
+
+    it('is a no-op for stacks with no HAProxy-routed service', () => {
+      const resourceInputs: StackResourceInput[] = [];
+      const resolvedDefinitions = new Map([['a', makeService('Stateful')]]);
+      const result = ensureApplicationsMembership('env-1', { resourceInputs, resolvedDefinitions });
+      expect(result.resourceInputs).toBe(resourceInputs);
+      expect(result.resolvedDefinitions).toBe(resolvedDefinitions);
+    });
+
+    it('injects the resource input and per-service join for env-scoped routed stacks', () => {
+      const resourceInputs: StackResourceInput[] = [];
+      const resolvedDefinitions = new Map<string, StackServiceDefinition>([
+        ['web', makeService('StatelessWeb')],
+        ['db', makeService('Stateful')],
+      ]);
+      const result = ensureApplicationsMembership('env-1', { resourceInputs, resolvedDefinitions });
+
+      expect(result.resourceInputs).toEqual([APPLICATIONS_INPUT]);
+      expect(result.resolvedDefinitions.get('web')?.containerConfig.joinResourceNetworks).toEqual(['applications']);
+      // Non-routed services in the same stack are left alone.
+      expect(result.resolvedDefinitions.get('db')?.containerConfig.joinResourceNetworks).toBeUndefined();
+    });
+
+    it('does not mutate the inputs', () => {
+      const resourceInputs: StackResourceInput[] = [];
+      const web = makeService('StatelessWeb');
+      const resolvedDefinitions = new Map([['web', web]]);
+      ensureApplicationsMembership('env-1', { resourceInputs, resolvedDefinitions });
+      expect(resourceInputs).toEqual([]);
+      expect(web.containerConfig.joinResourceNetworks).toBeUndefined();
+    });
+  });
+});

--- a/server/src/services/networks/applications-membership.ts
+++ b/server/src/services/networks/applications-membership.ts
@@ -1,0 +1,106 @@
+import type { StackResourceInput, StackServiceDefinition } from '@mini-infra/types';
+import { APPLICATIONS_NETWORK_PURPOSE, isHaproxyRoutedServiceType } from '@mini-infra/types';
+
+/**
+ * Apply-time invariant: every HAProxy-routed service (StatelessWeb /
+ * AdoptedWeb) in an environment-scoped stack MUST be a member of the
+ * environment's `applications` network — otherwise HAProxy cannot reach the
+ * backend and `monitor-container-startup` fails the deploy.
+ *
+ * Historically the deploy path guaranteed this imperatively (the blue-green
+ * `deploy-application-containers` force-attached the HAProxy network; the
+ * AdoptedWeb attach passed it as `extraJoinNetworks`). With the declarative
+ * network overhaul the membership is instead *declared* on the service
+ * (`containerConfig.joinResourceNetworks: ['applications']`) plus the
+ * stack-level `applications` resource input, and the shared attach/deploy
+ * pipeline realises it like any other declared network.
+ *
+ * The authoring surfaces (the new/edit/adopt application flows) declare this
+ * themselves, but relying on every surface — including the generic service
+ * drawer and file-loaded templates — to remember it is fragile once the
+ * imperative safety-net is removed. This module re-establishes the invariant
+ * uniformly at reconcile time so the deploy path can source networks purely
+ * from the declared membership.
+ *
+ * All functions are pure and non-mutating: they return new structures and
+ * leave the stored definitions untouched (the injected membership is derived,
+ * never persisted).
+ */
+
+const DOCKER_NETWORK_RESOURCE_TYPE = 'docker-network';
+
+/** True when any resolved service in the stack routes through HAProxy. */
+export function stackNeedsApplicationsNetwork(
+  definitions: Iterable<Pick<StackServiceDefinition, 'serviceType'>>,
+): boolean {
+  for (const def of definitions) {
+    if (isHaproxyRoutedServiceType(def.serviceType)) return true;
+  }
+  return false;
+}
+
+/**
+ * Ensure `resourceInputs` declares the `applications` docker-network so
+ * `resolveInputs` maps it to `<environment>-applications` at apply time.
+ * Returns the same array reference when the input is already present.
+ */
+export function ensureApplicationsResourceInput(
+  resourceInputs: StackResourceInput[],
+): StackResourceInput[] {
+  const already = resourceInputs.some(
+    (i) => i.type === DOCKER_NETWORK_RESOURCE_TYPE && i.purpose === APPLICATIONS_NETWORK_PURPOSE,
+  );
+  if (already) return resourceInputs;
+  return [
+    ...resourceInputs,
+    { type: DOCKER_NETWORK_RESOURCE_TYPE, purpose: APPLICATIONS_NETWORK_PURPOSE },
+  ];
+}
+
+/**
+ * Ensure a HAProxy-routed service declares the `applications` join. Non-routed
+ * services and services that already declare it are returned unchanged (same
+ * reference); otherwise a shallow copy with an extended `joinResourceNetworks`.
+ */
+export function ensureApplicationsJoinResourceNetwork(
+  def: StackServiceDefinition,
+): StackServiceDefinition {
+  if (!isHaproxyRoutedServiceType(def.serviceType)) return def;
+  const current = def.containerConfig.joinResourceNetworks ?? [];
+  if (current.includes(APPLICATIONS_NETWORK_PURPOSE)) return def;
+  return {
+    ...def,
+    containerConfig: {
+      ...def.containerConfig,
+      joinResourceNetworks: [...current, APPLICATIONS_NETWORK_PURPOSE],
+    },
+  };
+}
+
+export interface ApplicationsMembershipInputs {
+  resourceInputs: StackResourceInput[];
+  resolvedDefinitions: Map<string, StackServiceDefinition>;
+}
+
+/**
+ * Enforce the applications-network invariant across a stack's resource inputs
+ * and resolved service definitions. A no-op (returns the inputs verbatim) for
+ * host-scoped stacks and stacks with no HAProxy-routed service.
+ */
+export function ensureApplicationsMembership(
+  environmentId: string | null,
+  { resourceInputs, resolvedDefinitions }: ApplicationsMembershipInputs,
+): ApplicationsMembershipInputs {
+  if (environmentId == null || !stackNeedsApplicationsNetwork(resolvedDefinitions.values())) {
+    return { resourceInputs, resolvedDefinitions };
+  }
+
+  const nextDefinitions = new Map<string, StackServiceDefinition>();
+  for (const [name, def] of resolvedDefinitions) {
+    nextDefinitions.set(name, ensureApplicationsJoinResourceNetwork(def));
+  }
+  return {
+    resourceInputs: ensureApplicationsResourceInput(resourceInputs),
+    resolvedDefinitions: nextDefinitions,
+  };
+}

--- a/server/src/services/networks/index.ts
+++ b/server/src/services/networks/index.ts
@@ -14,6 +14,7 @@ export * from './network-converger';
 export * from './network-convergence-scheduler';
 export * from './managed-network-listing';
 export * from './unified-network-declarations';
+export * from './applications-membership';
 
 /**
  * Construct a NetworkManager wired to invalidate `DockerService`'s cached

--- a/server/src/services/stacks/stack-reconciler.ts
+++ b/server/src/services/stacks/stack-reconciler.ts
@@ -51,6 +51,7 @@ import {
   compileStackNetworkMemberships,
   buildMembershipServiceInputs,
   convergeStack,
+  ensureApplicationsMembership,
   type NetworkManager,
 } from '../networks';
 import { recordEgressNetworkMemberships } from './egress-injection';
@@ -176,7 +177,7 @@ export class StackReconciler {
 
       // Build maps for service definitions, hashes, and resolved configs
       const serviceMap = new Map(stack.services.map((s) => [s.serviceName, s]));
-      const { resolvedConfigsMap, resolvedDefinitions, serviceHashes } = await resolveServiceConfigs(
+      const { resolvedConfigsMap, resolvedDefinitions: resolvedServiceDefinitions, serviceHashes } = await resolveServiceConfigs(
         stack.services,
         templateContext,
         {
@@ -191,9 +192,18 @@ export class StackReconciler {
         },
       );
 
+      // Apply-time invariant (network overhaul): HAProxy-routed services must
+      // declare membership of the environment's `applications` network. Inject
+      // it here — before resolveInputs and the handler dispatch below — so the
+      // deploy path attaches networks purely from the declared membership
+      // rather than force-attaching the HAProxy network imperatively.
+      const { resourceInputs, resolvedDefinitions } = ensureApplicationsMembership(stack.environmentId, {
+        resourceInputs: (stack.resourceInputs as unknown as StackResourceInput[]) ?? [],
+        resolvedDefinitions: resolvedServiceDefinitions,
+      });
+
       // 5a-i. Reconcile infra resource outputs (creates Docker networks + InfraResource records)
       const resourceOutputs = (stack.resourceOutputs as unknown as StackResourceOutput[]) ?? [];
-      const resourceInputs = (stack.resourceInputs as unknown as StackResourceInput[]) ?? [];
       const outputNetworkMap = await this.infraManager.reconcileOutputs(stack, resourceOutputs, log);
 
       // 5a-ii. Resolve infra resource inputs from other stacks
@@ -431,7 +441,10 @@ export class StackReconciler {
         data: {
           lastAppliedVersion: stack.version,
           lastAppliedAt: new Date(),
-          lastAppliedSnapshot: buildAppliedSnapshot(stack, resolvedDefinitions),
+          // Snapshot the *authored* (pre-invariant) definitions: the injected
+          // `applications` join is derived at apply time and must not enter the
+          // definition hash, or drift detection would perpetually recreate.
+          lastAppliedSnapshot: buildAppliedSnapshot(stack, resolvedServiceDefinitions),
           // Track the AppRole binding that was in effect on this apply so the
           // credential injector can detect binding changes on future re-applies.
           ...(allSucceeded
@@ -567,11 +580,17 @@ export class StackReconciler {
       );
       const templateContext = buildStackTemplateContext(stack, params);
       const serviceMap = new Map(stack.services.map((s) => [s.serviceName, s]));
-      const { resolvedConfigsMap, resolvedDefinitions, serviceHashes } = await resolveServiceConfigs(stack.services, templateContext);
+      const { resolvedConfigsMap, resolvedDefinitions: resolvedServiceDefinitions, serviceHashes } = await resolveServiceConfigs(stack.services, templateContext);
+
+      // Apply-time invariant — see the create path above. Ensures HAProxy-routed
+      // services declare the environment's `applications` network membership.
+      const { resourceInputs, resolvedDefinitions } = ensureApplicationsMembership(stack.environmentId, {
+        resourceInputs: (stack.resourceInputs as unknown as StackResourceInput[]) ?? [],
+        resolvedDefinitions: resolvedServiceDefinitions,
+      });
 
       // Reconcile infra resource outputs and inputs
       const resourceOutputs = (stack.resourceOutputs as unknown as StackResourceOutput[]) ?? [];
-      const resourceInputs = (stack.resourceInputs as unknown as StackResourceInput[]) ?? [];
       const outputNetworkMap = await this.infraManager.reconcileOutputs(stack, resourceOutputs, log);
       const inputNetworkMap = await this.infraManager.resolveInputs(stack.environmentId, resourceInputs, log);
       const infraNetworkMap = new Map([...outputNetworkMap, ...inputNetworkMap]);
@@ -684,7 +703,10 @@ export class StackReconciler {
           status: resultStatus,
           lastAppliedVersion: stack.version,
           lastAppliedAt: new Date(),
-          lastAppliedSnapshot: buildAppliedSnapshot(stack, resolvedDefinitions),
+          // Snapshot the *authored* (pre-invariant) definitions: the injected
+          // `applications` join is derived at apply time and must not enter the
+          // definition hash, or drift detection would perpetually recreate.
+          lastAppliedSnapshot: buildAppliedSnapshot(stack, resolvedServiceDefinitions),
           ...(allSucceeded
             ? { lastAppliedVaultAppRoleId: stack.vaultAppRoleId ?? null, lastFailureReason: null }
             // Same surfacing as in `apply` above — see that branch for context.

--- a/server/src/services/stacks/stack-service-handlers.ts
+++ b/server/src/services/stacks/stack-service-handlers.ts
@@ -282,16 +282,17 @@ export class StackServiceHandlers {
           };
         }
 
-        const { haproxyCtx, haproxyClient } = await getInitializedHAProxyClient(this.routingManager!, stack.environmentId!);
+        const { haproxyClient } = await getInitializedHAProxyClient(this.routingManager!, stack.environmentId!);
 
-        // Attach every network this AdoptedWeb target needs — the mandatory
-        // HAProxy dataplane network, declared external `joinNetworks` (e.g. a
-        // database it needs to reach), `joinResourceNetworks`, and the
+        // Attach every network this AdoptedWeb target needs — declared external
+        // `joinNetworks` (e.g. a database it needs to reach), the
+        // `joinResourceNetworks` (which include the `applications` network the
+        // apply-time invariant guarantees for HAProxy-routed services), and the
         // per-env egress network — through the same shared pipeline the
-        // static-service create/recreate paths use. Replaces a bespoke
-        // "already attached?" pre-check plus its own connect/
-        // joinResourceNetworks/joinNetworks loops; `NetworkManager.connect`
-        // is idempotent by inspection so the pre-check is redundant.
+        // static-service create/recreate paths use. The HAProxy `applications`
+        // network is no longer passed as an imperative `extraJoinNetworks`; it
+        // arrives declaratively via `joinResourceNetworks` like any other
+        // network. `NetworkManager.connect` is idempotent by inspection.
         await attachServiceNetworks(target.Id, action.serviceName, serviceDef, {
           networkManager: this.networkManager,
           containerManager: this.containerManager,
@@ -300,7 +301,6 @@ export class StackServiceHandlers {
           infraNetworkMap,
           environmentId: stack.environmentId,
           log,
-          extraJoinNetworks: [haproxyCtx.haproxyNetworkName],
         });
 
         const routingCtx: StackRoutingContext = {

--- a/server/src/services/stacks/stack-state-machine-context.ts
+++ b/server/src/services/stacks/stack-state-machine-context.ts
@@ -91,8 +91,14 @@ export async function buildStateMachineContext(
     }
   }
 
-  // Build networks list including environment networks, stack networks, and joinNetworks
-  const containerNetworks: string[] = [haproxyCtx.haproxyNetworkName];
+  // Build the container's network set purely from the stack's declared
+  // membership: infra-resource networks (which include the `applications`
+  // network — the apply-time invariant guarantees a HAProxy-routed service
+  // declares it as a resource input), stack-owned networks, external
+  // joinNetworks, and the per-env egress network. HAProxy's network is no
+  // longer force-seeded here; it arrives via the declared `applications`
+  // resource input like any other network.
+  const containerNetworks: string[] = [];
   for (const dockerName of infraNetworkMap.values()) {
     if (!containerNetworks.includes(dockerName)) {
       containerNetworks.push(dockerName);


### PR DESCRIPTION
## Summary

When you create an application in `/applications/new`, its container needs to join the environment's HAProxy **`applications`** network (`<environment>-applications`) so HAProxy can reach the backend and traffic flows. This makes that membership **declarative** across all the app-building flows and, per the network overhaul, **removes the imperative network handling** from the blue-green deploy path — networks now come purely from the declared membership.

Previously the applications-network attachment for HAProxy-routed services was force-attached imperatively (the blue-green `deploy-application-containers` pushed the HAProxy network; the AdoptedWeb attach passed it as `extraJoinNetworks`), while the service definition never *declared* it.

## What changed

### Shared types (`lib/types/stacks.ts`)
- `APPLICATIONS_NETWORK_PURPOSE`, `HAPROXY_ROUTED_SERVICE_TYPES`, and `isHaproxyRoutedServiceType()` — one source of truth for client + server (no more re-typed `'applications'` literals).

### Client — declare the membership
- New helper `applicationsNetworkDeclaration()` in `application-schemas.ts`, used by all three app-building flows so HAProxy-routed services declare `resourceInputs: [applications]` + `containerConfig.joinResourceNetworks: ['applications']`:
  - `applications/new` (StatelessWeb) — the original ask
  - `applications/adopt` (AdoptedWeb)
  - `applications/[id]/configuration` (edit) — also **fixes a latent bug** where editing an app silently dropped `resourceInputs` from the draft.

### Server — apply-time invariant (the safety net)
- New pure module `networks/applications-membership.ts` + `ensureApplicationsMembership()` wired into both reconciler apply paths. It guarantees any env-scoped stack with a StatelessWeb/AdoptedWeb service declares the `applications` resource input and per-service `joinResourceNetworks` — covering **every** authoring surface (app flows, the generic service drawer, file-loaded templates). This is what makes removing the imperative safety net safe.
- Applied to the **network-attach path only**: the applied snapshot is built from the **raw** (pre-invariant) definitions so the injected join never enters the definition hash — no spurious drift/recreates.

### Server — remove imperative network management
- `stack-state-machine-context.ts`: dropped the hardcoded `haproxyNetworkName` seed of the container network list.
- `deploy-application-containers.ts`: removed the force-push of the HAProxy network.
- `stack-service-handlers.ts`: removed the AdoptedWeb `extraJoinNetworks: [haproxyNetworkName]`.
- Container networks now come purely from the stack's declared membership (`infraNetworkMap`, built from the resource inputs the invariant guarantees).

## Why this is safe
- `membership-compiler` references the existing HAProxy-owned `applications` ManagedNetwork by name (no ownership collision / duplicate); the converger self-heals membership on no-op applies.
- `buildStateMachineContext` already fails fast (`getHAProxyEnvironmentContext`) if the applications network is absent, so the network is guaranteed to exist before container creation.
- Snapshot/hash use raw defs → no drift false-positives; existing apps are not mass-recreated.

## Testing
- `pnpm build:all` — all sub-builds pass (lib, client, server, sidecars, egress).
- `pnpm --filter mini-infra-server test` — **2618 passing**; new `applications-membership.test.ts` (14 cases); updated the stateless-reconciler test's prisma mock (it now exercises `resolveInputs`).
- Server + client **lint** clean.
- **Live dev deploy (strongest test):** created a StatelessWeb app with a **bare** definition (no `resourceInputs`, no `joinResourceNetworks`) → the container came up **running** and attached to `local-applications`, sharing that network with the HAProxy instance; stack went **synced**. This proves the server invariant + declarative attach work end-to-end with the imperative hardcode removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
