### PR TITLE
feat(containers): Networks section on container detail page — imperative attach/detach

### DIFF
--- a/client/src/app/containers/[id]/_components/container-networks-card.tsx
+++ b/client/src/app/containers/[id]/_components/container-networks-card.tsx
@@ -1,0 +1,254 @@
+import { useMemo, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { IconNetwork, IconPlus, IconTrash } from "@tabler/icons-react";
+import type { DockerNetwork } from "@mini-infra/types";
+import {
+  useNetworks,
+  useConnectContainerNetwork,
+  useDisconnectContainerNetwork,
+} from "@/hooks/use-networks";
+
+interface ContainerNetworksCardProps {
+  containerId: string;
+  containerName: string;
+  /** Called after a successful attach/detach so the parent can refresh the
+   *  container detail (e.g. the primary IP-address row). */
+  onMutated?: () => void;
+}
+
+/**
+ * Networks a container may be attached to via `docker network connect`.
+ * Excludes only the `host`/`none` pseudo-networks (you can't `connect` to
+ * those). Unlike the application "Connected Networks" picker
+ * (`isUsableLinkNetwork`), the default `bridge` IS offered here — this is a
+ * raw, imperative attach, not a DNS-linking join.
+ */
+function isAttachableNetwork(net: DockerNetwork): boolean {
+  if (net.driver === "host" || net.driver === "null") return false;
+  if (net.name === "host" || net.name === "none") return false;
+  return true;
+}
+
+/**
+ * Container detail's "Networks" card. Lists every Docker network this
+ * container is currently attached to (with its IP on each) and lets the
+ * operator attach/detach networks with immediate, imperative semantics —
+ * exactly `docker network connect` / `docker network disconnect`. Detach is
+ * guarded by a confirm dialog since it can disrupt a running container.
+ *
+ * The connected + addable lists are both derived from the single
+ * `useNetworks()` query (matching this container by name against each
+ * network's attached-container list), so no per-container read endpoint is
+ * needed.
+ */
+export function ContainerNetworksCard({
+  containerId,
+  containerName,
+  onMutated,
+}: ContainerNetworksCardProps) {
+  const { data, isLoading, error } = useNetworks();
+  const [pendingPick, setPendingPick] = useState("");
+  const [networkToRemove, setNetworkToRemove] = useState<DockerNetwork | null>(null);
+
+  const connectMutation = useConnectContainerNetwork({
+    onSuccess: () => onMutated?.(),
+  });
+  const disconnectMutation = useDisconnectContainerNetwork({
+    onSuccess: () => {
+      setNetworkToRemove(null);
+      onMutated?.();
+    },
+  });
+
+  const networks = useMemo(() => data?.networks ?? [], [data]);
+
+  const connected = useMemo(
+    () =>
+      networks
+        .filter((n) => n.containers.some((c) => c.name === containerName))
+        .map((n) => ({
+          network: n,
+          ip: n.containers.find((c) => c.name === containerName)?.ipv4Address ?? "",
+        }))
+        .sort((a, b) => a.network.name.localeCompare(b.network.name)),
+    [networks, containerName],
+  );
+
+  const addable = useMemo(() => {
+    const connectedIds = new Set(connected.map((r) => r.network.id));
+    return networks
+      .filter((n) => isAttachableNetwork(n) && !connectedIds.has(n.id))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [networks, connected]);
+
+  const isMutating = connectMutation.isPending || disconnectMutation.isPending;
+
+  const handleAdd = () => {
+    if (!pendingPick) return;
+    connectMutation.mutate({ networkId: pendingPick, containerId });
+    setPendingPick("");
+  };
+
+  return (
+    <Card data-tour="container-networks-card">
+      <CardHeader>
+        <CardTitle>Networks</CardTitle>
+        <CardDescription>
+          Docker networks this container is attached to. Add or remove networks
+          below — changes take effect immediately (equivalent to{" "}
+          <code className="text-xs">docker network connect</code> /{" "}
+          <code className="text-xs">disconnect</code>).
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-9 w-full" />
+            <Skeleton className="h-9 w-full" />
+          </div>
+        ) : error ? (
+          <p className="text-sm text-muted-foreground">
+            Failed to load networks: {error instanceof Error ? error.message : "unknown error"}
+          </p>
+        ) : (
+          <>
+            {connected.length > 0 ? (
+              <ul className="divide-y">
+                {connected.map(({ network, ip }) => (
+                  <li key={network.id} className="flex items-center gap-1">
+                    <div className="flex-1 min-w-0 flex items-center justify-between gap-3 py-2.5">
+                      <div className="min-w-0 flex items-center gap-2">
+                        <IconNetwork className="h-4 w-4 text-muted-foreground shrink-0" />
+                        <div className="min-w-0">
+                          <div className="font-medium text-sm truncate">{network.name}</div>
+                          <div className="text-xs text-muted-foreground truncate">
+                            {ip ? `IP: ${ip}` : "Attached"}
+                          </div>
+                        </div>
+                      </div>
+                      <Badge variant="outline" className="text-xs shrink-0">
+                        {network.driver}
+                      </Badge>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="shrink-0"
+                      onClick={() => setNetworkToRemove(network)}
+                      disabled={isMutating}
+                      aria-label={`Disconnect network ${network.name}`}
+                    >
+                      <IconTrash className="h-4 w-4" />
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                This container isn't attached to any networks.
+              </p>
+            )}
+
+            {/* Attach a network (imperative docker network connect) */}
+            <div className="flex flex-col gap-2 rounded-md border border-dashed p-3 sm:flex-row sm:items-center">
+              <Select
+                value={pendingPick}
+                onValueChange={setPendingPick}
+                disabled={addable.length === 0 || isMutating}
+              >
+                <SelectTrigger className="w-full sm:flex-1">
+                  <SelectValue
+                    placeholder={
+                      addable.length === 0
+                        ? "No networks available to attach"
+                        : "Select a network to attach"
+                    }
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {addable.map((net) => (
+                    <SelectItem key={net.id} value={net.id}>
+                      {net.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleAdd}
+                disabled={!pendingPick || isMutating}
+                className="shrink-0"
+              >
+                <IconPlus className="mr-1 h-4 w-4" />
+                Attach network
+              </Button>
+            </div>
+          </>
+        )}
+      </CardContent>
+
+      <AlertDialog
+        open={!!networkToRemove}
+        onOpenChange={(open) => !open && setNetworkToRemove(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Disconnect network</AlertDialogTitle>
+            <AlertDialogDescription>
+              Disconnect this container from the network "{networkToRemove?.name}"?
+              If the container is running this may interrupt its connectivity on
+              that network. You can re-attach it afterwards.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={disconnectMutation.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (networkToRemove) {
+                  disconnectMutation.mutate({
+                    networkId: networkToRemove.id,
+                    containerId,
+                  });
+                }
+              }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Disconnect
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+}

--- a/client/src/app/containers/[id]/page.tsx
+++ b/client/src/app/containers/[id]/page.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { LogViewer } from "@/components/containers/LogViewer";
+import { ContainerNetworksCard } from "./_components/container-networks-card";
 import { ContainerStatusBadge } from "../ContainerStatusBadge";
 import { useContainerActions, containerDetailKey } from "@/hooks/use-container-actions";
 import { ContainerInfo } from "@mini-infra/types/containers";
@@ -262,6 +263,13 @@ export default function ContainerDetailPage() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Networks Card */}
+      <ContainerNetworksCard
+        containerId={container.id}
+        containerName={container.name}
+        onMutated={refetch}
+      />
 
       {/* Volumes Card */}
       {container.volumes.length > 0 && (

--- a/client/src/hooks/use-networks.ts
+++ b/client/src/hooks/use-networks.ts
@@ -3,6 +3,7 @@ import {
   DockerNetwork,
   DockerNetworkListResponse,
   DockerNetworkDeleteResponse,
+  NetworkAttachmentResponse,
   ManagedNetworkListResponse,
   ManagedNetworkView,
   DockerNetworkGcResponse,
@@ -175,6 +176,102 @@ export function useDeleteNetwork(options: UseDeleteNetworkOptions = {}) {
       if (onError) {
         onError(networkId, error);
       }
+    },
+  });
+}
+
+export interface ContainerNetworkMutationInput {
+  networkId: string;
+  containerId: string;
+  /** disconnect only — force-detach even from a running container. */
+  force?: boolean;
+}
+
+async function connectContainerNetwork(
+  input: ContainerNetworkMutationInput,
+): Promise<NetworkAttachmentResponse> {
+  return apiFetch<NetworkAttachmentResponse>(
+    ApiRoute.docker.networkConnect(input.networkId),
+    {
+      method: "POST",
+      body: { containerId: input.containerId },
+      correlationIdPrefix: "connect-container-network",
+      unwrap: false,
+    },
+  );
+}
+
+async function disconnectContainerNetwork(
+  input: ContainerNetworkMutationInput,
+): Promise<NetworkAttachmentResponse> {
+  return apiFetch<NetworkAttachmentResponse>(
+    ApiRoute.docker.networkDisconnect(input.networkId),
+    {
+      method: "POST",
+      body: { containerId: input.containerId, force: input.force },
+      correlationIdPrefix: "disconnect-container-network",
+      unwrap: false,
+    },
+  );
+}
+
+export interface UseContainerNetworkOptions {
+  onSuccess?: (result: NetworkAttachmentResponse) => void;
+  onError?: (error: Error) => void;
+}
+
+/**
+ * Attach a container to a Docker network — the imperative equivalent of
+ * `docker network connect`. On success invalidates both the raw and managed
+ * network lists so the container detail's Networks card (which derives its rows
+ * from the raw list) refreshes immediately, independent of the socket push.
+ */
+export function useConnectContainerNetwork(options: UseContainerNetworkOptions = {}) {
+  const { onSuccess, onError } = options;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: ContainerNetworkMutationInput) => connectContainerNetwork(input),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.docker.networks });
+      queryClient.invalidateQueries({ queryKey: queryKeys.docker.managedNetworksAll });
+      toast.success(
+        result.alreadyConnected
+          ? "Container is already connected to this network"
+          : "Connected container to network",
+      );
+      onSuccess?.(result);
+    },
+    onError: (error: Error) => {
+      toast.error("Failed to connect container to network", {
+        description: error.message,
+      });
+      onError?.(error);
+    },
+  });
+}
+
+/**
+ * Detach a container from a Docker network — the imperative equivalent of
+ * `docker network disconnect`. Same cache-invalidation as connect above.
+ */
+export function useDisconnectContainerNetwork(options: UseContainerNetworkOptions = {}) {
+  const { onSuccess, onError } = options;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: ContainerNetworkMutationInput) => disconnectContainerNetwork(input),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.docker.networks });
+      queryClient.invalidateQueries({ queryKey: queryKeys.docker.managedNetworksAll });
+      toast.success("Disconnected container from network");
+      onSuccess?.(result);
+    },
+    onError: (error: Error) => {
+      toast.error("Failed to disconnect container from network", {
+        description: error.message,
+      });
+      onError?.(error);
     },
   });
 }

--- a/lib/types/api-routes.generated.ts
+++ b/lib/types/api-routes.generated.ts
@@ -54,6 +54,8 @@ export const ALL_API_ROUTES: readonly ApiRouteEntry[] = [
   { method: "GET", path: "/api/docker/info" },
   { method: "GET", path: "/api/docker/networks" },
   { method: "DELETE", path: "/api/docker/networks/:id" },
+  { method: "POST", path: "/api/docker/networks/:id/connect" },
+  { method: "POST", path: "/api/docker/networks/:id/disconnect" },
   { method: "POST", path: "/api/docker/networks/backfill-memberships" },
   { method: "POST", path: "/api/docker/networks/gc" },
   { method: "GET", path: "/api/docker/networks/managed" },

--- a/lib/types/api-routes.ts
+++ b/lib/types/api-routes.ts
@@ -220,6 +220,10 @@ export const ApiRoute = {
     networks: (): string => `${ApiBase.docker}/networks`,
     /** DELETE /api/docker/networks/:id */
     network: (id: string): string => `${ApiBase.docker}/networks/${id}`,
+    /** POST /api/docker/networks/:id/connect — attach a container to a network */
+    networkConnect: (id: string): string => `${ApiBase.docker}/networks/${id}/connect`,
+    /** POST /api/docker/networks/:id/disconnect — detach a container from a network */
+    networkDisconnect: (id: string): string => `${ApiBase.docker}/networks/${id}/disconnect`,
     /** GET /api/docker/networks/managed */
     networksManaged: (): string => `${ApiBase.docker}/networks/managed`,
     /** POST /api/docker/networks/gc */

--- a/lib/types/docker.ts
+++ b/lib/types/docker.ts
@@ -50,6 +50,20 @@ export interface DockerNetworkDeleteResponse {
   networkId: string;
 }
 
+/**
+ * Response for the imperative container↔network attach/detach routes
+ * (`POST /api/docker/networks/:id/connect` and `.../disconnect`) — the
+ * equivalent of `docker network connect/disconnect`. Shared by both.
+ */
+export interface NetworkAttachmentResponse {
+  success: boolean;
+  message: string;
+  networkId: string;
+  containerId: string;
+  /** connect only: true when the container was already attached (idempotent no-op). */
+  alreadyConnected?: boolean;
+}
+
 // ====================
 // Docker Network GC Types (network overhaul Phase 4 — label-driven GC)
 // ====================

--- a/server/src/__tests__/docker-networks-attach-route.test.ts
+++ b/server/src/__tests__/docker-networks-attach-route.test.ts
@@ -1,0 +1,210 @@
+import request from "supertest";
+import express from "express";
+
+/**
+ * Route tests for the imperative container↔network attach/detach endpoints
+ * (`POST /api/docker/networks/:id/connect` and `.../disconnect`) added for the
+ * container detail page's Networks card. Exercises the real Express handlers
+ * over supertest (per server/CLAUDE.md), with the Docker plumbing mocked, and
+ * asserts they route through `NetworkManager.connect/disconnect` (the boundary
+ * the network-api-boundary test enforces) with the right arguments and return
+ * the `NetworkAttachmentResponse` shape.
+ */
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — declared before any vi.mock() that references them
+// ---------------------------------------------------------------------------
+const {
+  mockNetworkManager,
+  mockCreateNetworkManager,
+  mockLogger,
+  mockRequirePermission,
+  mockIsConnected,
+} = vi.hoisted(() => {
+  const mockNetworkManager = {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  };
+  return {
+    mockNetworkManager,
+    mockCreateNetworkManager: vi.fn(() => mockNetworkManager),
+    mockLogger: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+    mockRequirePermission: vi.fn(
+      () => (_req: any, _res: any, next: any) => next(),
+    ),
+    mockIsConnected: vi.fn(() => true),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+vi.mock("../lib/prisma", () => ({ default: {} }));
+
+vi.mock("../lib/logger-factory", () => ({
+  getLogger: vi.fn(() => mockLogger),
+  clearLoggerCache: vi.fn(),
+}));
+
+vi.mock("../middleware/auth", () => ({
+  requirePermission: mockRequirePermission,
+}));
+
+vi.mock("../services/docker", () => ({
+  default: { getInstance: () => ({ isConnected: mockIsConnected }) },
+}));
+
+vi.mock("../services/docker-executor", () => ({
+  DockerExecutorService: class {
+    async initialize() {}
+  },
+}));
+
+// The volume services are imported by routes/docker.ts for the volume routes;
+// stub them so importing the router doesn't pull in the real implementations.
+vi.mock("../services/volume", () => ({
+  VolumeInspectorService: class {},
+  VolumeFileContentService: class {},
+}));
+
+vi.mock("../services/networks", () => ({
+  createNetworkManager: mockCreateNetworkManager,
+  runNetworkGc: vi.fn(),
+  backfillNetworkMemberships: vi.fn(),
+  reconcileStack: vi.fn(),
+  reconcileEnvironment: vi.fn(),
+  reconcileAll: vi.fn(),
+  convergeStack: vi.fn(),
+  convergeEnvironment: vi.fn(),
+  convergeAll: vi.fn(),
+  listManagedNetworks: vi.fn(),
+}));
+
+// Import the router AFTER the mocks are set up
+import dockerRoutes from "../routes/docker";
+
+describe("Docker container↔network attach/detach routes", () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use("/api/docker", dockerRoutes);
+    app.use((err: any, _req: any, res: any, _next: any) => {
+      res.status(500).json({ error: "Internal Server Error", message: err.message });
+    });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsConnected.mockReturnValue(true);
+    mockNetworkManager.connect.mockResolvedValue({
+      connected: true,
+      alreadyConnected: false,
+    });
+    mockNetworkManager.disconnect.mockResolvedValue(undefined);
+  });
+
+  // =========================================================================
+  // POST /api/docker/networks/:id/connect
+  // =========================================================================
+  describe("POST /networks/:id/connect", () => {
+    it("connects the container and returns a NetworkAttachmentResponse", async () => {
+      const res = await request(app)
+        .post("/api/docker/networks/net-abc/connect")
+        .send({ containerId: "c-123" });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        success: true,
+        networkId: "net-abc",
+        containerId: "c-123",
+        alreadyConnected: false,
+      });
+      expect(res.body.message).toContain("connected");
+      // Routes through NetworkManager, not raw dockerode (boundary invariant).
+      expect(mockNetworkManager.connect).toHaveBeenCalledWith("c-123", "net-abc");
+    });
+
+    it("surfaces an idempotent already-connected attach", async () => {
+      mockNetworkManager.connect.mockResolvedValue({
+        connected: true,
+        alreadyConnected: true,
+      });
+
+      const res = await request(app)
+        .post("/api/docker/networks/net-abc/connect")
+        .send({ containerId: "c-123" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.alreadyConnected).toBe(true);
+      expect(res.body.message.toLowerCase()).toContain("already");
+    });
+
+    it("400s when containerId is missing", async () => {
+      const res = await request(app)
+        .post("/api/docker/networks/net-abc/connect")
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(mockNetworkManager.connect).not.toHaveBeenCalled();
+    });
+
+    it("503s when Docker is not connected", async () => {
+      mockIsConnected.mockReturnValue(false);
+
+      const res = await request(app)
+        .post("/api/docker/networks/net-abc/connect")
+        .send({ containerId: "c-123" });
+
+      expect(res.status).toBe(503);
+      expect(mockNetworkManager.connect).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // POST /api/docker/networks/:id/disconnect
+  // =========================================================================
+  describe("POST /networks/:id/disconnect", () => {
+    it("disconnects the container and returns a NetworkAttachmentResponse", async () => {
+      const res = await request(app)
+        .post("/api/docker/networks/net-abc/disconnect")
+        .send({ containerId: "c-123" });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        success: true,
+        networkId: "net-abc",
+        containerId: "c-123",
+      });
+      expect(mockNetworkManager.disconnect).toHaveBeenCalledWith("c-123", "net-abc", {
+        force: undefined,
+      });
+    });
+
+    it("forwards force: true when requested", async () => {
+      const res = await request(app)
+        .post("/api/docker/networks/net-abc/disconnect")
+        .send({ containerId: "c-123", force: true });
+
+      expect(res.status).toBe(200);
+      expect(mockNetworkManager.disconnect).toHaveBeenCalledWith("c-123", "net-abc", {
+        force: true,
+      });
+    });
+
+    it("400s when containerId is missing", async () => {
+      const res = await request(app)
+        .post("/api/docker/networks/net-abc/disconnect")
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(mockNetworkManager.disconnect).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/server/src/routes/docker.ts
+++ b/server/src/routes/docker.ts
@@ -4,7 +4,7 @@ import DockerService from "../services/docker";
 import { VolumeInspectorService, VolumeFileContentService } from "../services/volume";
 import { getLogger } from "../lib/logger-factory";
 import { requirePermission } from "../middleware/auth";
-import { DockerNetworkListResponse, DockerNetworkApiResponse, DockerNetworkDeleteResponse, DockerVolumeListResponse, DockerVolumeApiResponse, DockerVolumeDeleteResponse, VolumeInspectionResponse, VolumeInspectionStartResponse, FetchFileContentsRequest, FetchFileContentsResponse, VolumeFileContentResponse, DockerNetworkGcResponse, NetworkMembershipBackfillResponse, NetworkReconcileResponse, NetworkConvergeResponse, SetNetworkEnforceMembershipsResponse, ManagedNetworkListResponse, Permission } from "@mini-infra/types";
+import { DockerNetworkListResponse, DockerNetworkApiResponse, DockerNetworkDeleteResponse, NetworkAttachmentResponse, DockerVolumeListResponse, DockerVolumeApiResponse, DockerVolumeDeleteResponse, VolumeInspectionResponse, VolumeInspectionStartResponse, FetchFileContentsRequest, FetchFileContentsResponse, VolumeFileContentResponse, DockerNetworkGcResponse, NetworkMembershipBackfillResponse, NetworkReconcileResponse, NetworkConvergeResponse, SetNetworkEnforceMembershipsResponse, ManagedNetworkListResponse, Permission } from "@mini-infra/types";
 import prisma from "../lib/prisma";
 import { DockerExecutorService } from "../services/docker-executor";
 import { createNetworkManager, runNetworkGc, backfillNetworkMemberships, reconcileStack, reconcileEnvironment, reconcileAll, convergeStack, convergeEnvironment, convergeAll, listManagedNetworks } from "../services/networks";
@@ -35,6 +35,11 @@ const managedNetworkListQuerySchema = z.object({
   scope: z.enum(["host", "environment", "stack"]).optional(),
   environmentId: z.string().optional(),
   stackId: z.string().optional(),
+});
+
+const containerNetworkMutationSchema = z.object({
+  containerId: z.string().min(1),
+  force: z.boolean().optional(),
 });
 
 /**
@@ -225,6 +230,124 @@ router.delete(
       }
 
       logger.error({ error, networkId: req.params.id }, "Failed to remove Docker network");
+      next(error);
+    }
+  }
+);
+
+/**
+ * POST /api/docker/networks/:id/connect
+ * Attach a container to a Docker network — the imperative equivalent of
+ * `docker network connect <network> <container>`. Idempotent: re-attaching an
+ * already-attached container succeeds as a no-op (`alreadyConnected: true`).
+ *
+ * Gated by `docker:write` (an ordinary network mutation, mirroring the
+ * single-network DELETE above) rather than the `docker:admin` the declarative
+ * managed-network endpoints use — this is a direct, user-driven attach, not
+ * managed-network administration.
+ */
+router.post(
+  "/networks/:id/connect",
+  requirePermission(Permission.DockerWrite),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const networkId = String(req.params.id);
+      const parsed = containerNetworkMutationSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({
+          success: false,
+          message: "Invalid request body",
+          details: parsed.error.issues,
+        });
+      }
+
+      const dockerService = DockerService.getInstance();
+      if (!dockerService.isConnected()) {
+        logger.warn("Docker service not connected");
+        return res.status(503).json({
+          success: false,
+          message: "Docker service not connected",
+        });
+      }
+
+      const { containerId } = parsed.data;
+      const executor = new DockerExecutorService();
+      await executor.initialize();
+      const networkManager = createNetworkManager(executor);
+      const result = await networkManager.connect(containerId, networkId);
+
+      const response: NetworkAttachmentResponse = {
+        success: true,
+        message: result.alreadyConnected
+          ? "Container is already connected to this network"
+          : "Container connected to network successfully",
+        networkId,
+        containerId,
+        alreadyConnected: result.alreadyConnected,
+      };
+
+      res.json(response);
+    } catch (error) {
+      logger.error(
+        { error, networkId: req.params.id },
+        "Failed to connect container to network",
+      );
+      next(error);
+    }
+  }
+);
+
+/**
+ * POST /api/docker/networks/:id/disconnect
+ * Detach a container from a Docker network — the imperative equivalent of
+ * `docker network disconnect <network> <container>`. Idempotent: disconnecting
+ * an already-detached container (or a network that's already gone) is a no-op
+ * success. Pass `{ force: true }` to force-disconnect. `docker:write`, like
+ * connect above.
+ */
+router.post(
+  "/networks/:id/disconnect",
+  requirePermission(Permission.DockerWrite),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const networkId = String(req.params.id);
+      const parsed = containerNetworkMutationSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({
+          success: false,
+          message: "Invalid request body",
+          details: parsed.error.issues,
+        });
+      }
+
+      const dockerService = DockerService.getInstance();
+      if (!dockerService.isConnected()) {
+        logger.warn("Docker service not connected");
+        return res.status(503).json({
+          success: false,
+          message: "Docker service not connected",
+        });
+      }
+
+      const { containerId, force } = parsed.data;
+      const executor = new DockerExecutorService();
+      await executor.initialize();
+      const networkManager = createNetworkManager(executor);
+      await networkManager.disconnect(containerId, networkId, { force });
+
+      const response: NetworkAttachmentResponse = {
+        success: true,
+        message: "Container disconnected from network successfully",
+        networkId,
+        containerId,
+      };
+
+      res.json(response);
+    } catch (error) {
+      logger.error(
+        { error, networkId: req.params.id },
+        "Failed to disconnect container from network",
+      );
       next(error);
     }
   }


### PR DESCRIPTION
## What & why

The container detail page showed image, IP, ports, env, deployment, **Volumes**, and logs — but nothing about which Docker networks the container was attached to, and there was no way to attach/detach a network from the UI (that meant SSHing to the host and running `docker network connect/disconnect`).

This PR adds a **Networks** card immediately above the Volumes card that:

- lists every network the container is attached to, with its per-network IP;
- lets you **attach** a network (dropdown of attachable networks) and **detach** one;
- takes effect **immediately** — exactly equivalent to `docker network connect` / `docker network disconnect`.

Detach is guarded by a confirm dialog since it can interrupt a running container.

> **Behaviour note (by design):** this is imperative, not declarative. For a *managed* network with membership enforcement ON, the declarative reconciler can later revert a manual change — acceptable for the common case (ordinary / user-defined networks). No `NetworkMembership` row is persisted.

## Backend

- **`server/src/routes/docker.ts`** — two `docker:write` routes:
  - `POST /api/docker/networks/:id/connect` — body `{ containerId }`
  - `POST /api/docker/networks/:id/disconnect` — body `{ containerId, force? }`

  Both construct a `NetworkManager` via `createNetworkManager()` and call `NetworkManager.connect()/disconnect()` — staying inside the `services/networks/` boundary the `network-api-boundary` test enforces. Idempotent (already-connected / already-gone are no-ops), zod-validated body, 503 when Docker isn't connected. `docker:write` mirrors the existing single-network DELETE (an ordinary network mutation, not `docker:admin` managed-network administration).
- **`lib/types/docker.ts`** — shared `NetworkAttachmentResponse`.
- **`lib/types/api-routes.ts`** — `networkConnect` / `networkDisconnect` builders; **`api-routes.generated.ts`** regenerated via `pnpm gen:api-routes`.

## Frontend

- **`client/src/hooks/use-networks.ts`** — `useConnectContainerNetwork` / `useDisconnectContainerNetwork` mutation hooks (modelled on `useDeleteNetwork`), invalidating the raw + managed network lists on success so the card refreshes immediately.
- **`client/src/app/containers/[id]/_components/container-networks-card.tsx`** (new) — derives **both** the connected list and the add-picker from the single existing `useNetworks()` query (matching the container by name against each network's attached-container list), so no per-container read endpoint was needed. Add-picker excludes already-connected and the `host`/`none` pseudo-networks. Layout mirrors the application "Connected Networks" card; detach uses the `AlertDialog` confirm pattern from `NetworksList`.
- **`client/src/app/containers/[id]/page.tsx`** — renders the card before Volumes.

## Reuse / DRY

- Reads reuse `useNetworks()` (`GET /api/docker/networks`) for both display and the picker — no new read endpoint.
- Writes reuse the existing `NetworkManager.connect/disconnect` service methods; the routes are thin.

## Tests & verification

- **`server/src/__tests__/docker-networks-attach-route.test.ts`** — supertest coverage for both routes: correct `NetworkManager` invocation & arguments, idempotent already-connected, `force: true` passthrough, 400 (missing `containerId`), 503 (Docker down).
- `network-api-boundary` and `api-routes-drift` guard tests pass.
- `pnpm build`, server + client ESLint: clean.
- **End-to-end (Playwright, live daemon):** on the `nats` container the card rendered above Volumes listing `bridge` (172.17.0.3) and `mini-infra-nats` (172.22.0.2) matching `docker inspect`; attached a throwaway `detail-test-net` (reflected in UI **and** `docker network inspect`); detached it via the confirm dialog (gone from UI **and** daemon). Zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
