### PR TITLE
fix(tailscale): make outbound fetch survive high-latency / no-IPv6 links

### DIFF
--- a/server/src/__tests__/net-runtime.test.ts
+++ b/server/src/__tests__/net-runtime.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import dns from 'node:dns';
+import net from 'node:net';
+import { configureOutboundNetworking } from '../lib/net-runtime';
+
+/**
+ * The load-bearing fix is raising the Happy Eyeballs attempt timeout above
+ * Node's aggressive 250ms default — that default abandons healthy cross-region
+ * connects (e.g. ~280ms to api.tailscale.com) and makes `fetch` fail where curl
+ * succeeds. IPv4-first + explicit Happy Eyeballs are hardening on top.
+ */
+describe('configureOutboundNetworking', () => {
+  it('raises the family attempt timeout well above the 250ms default', () => {
+    const state = configureOutboundNetworking();
+
+    expect(state.autoSelectFamilyAttemptTimeoutMs).toBeGreaterThanOrEqual(1000);
+    expect(net.getDefaultAutoSelectFamilyAttemptTimeout()).toBe(
+      state.autoSelectFamilyAttemptTimeoutMs,
+    );
+  });
+
+  it('sets ipv4first result order and keeps autoSelectFamily on', () => {
+    const state = configureOutboundNetworking();
+
+    expect(state.dnsResultOrder).toBe('ipv4first');
+    expect(state.autoSelectFamily).toBe(true);
+    expect(dns.getDefaultResultOrder()).toBe('ipv4first');
+    expect(net.getDefaultAutoSelectFamily()).toBe(true);
+  });
+
+  it('is idempotent', () => {
+    const first = configureOutboundNetworking();
+    const second = configureOutboundNetworking();
+    expect(second).toEqual(first);
+  });
+});

--- a/server/src/lib/net-runtime.ts
+++ b/server/src/lib/net-runtime.ts
@@ -1,0 +1,79 @@
+import dns from "node:dns";
+import net from "node:net";
+
+/**
+ * How long Node's Happy Eyeballs (`autoSelectFamily`) waits for one connection
+ * attempt before racing the next address. Node's default is **250ms**, which is
+ * shorter than real-world cross-region connect latency and is the actual cause
+ * of the Tailscale connector failure below. 2s gives ample headroom for slow
+ * links while still failing over within a couple of seconds if an address is
+ * genuinely dead.
+ */
+const OUTBOUND_FAMILY_ATTEMPT_TIMEOUT_MS = 2000;
+
+/**
+ * Make the server's outbound connections robust on high-latency and no-IPv6
+ * links — the way `curl` and browsers already are.
+ *
+ * Field failure this fixes: outbound `fetch` to `api.tailscale.com` (which
+ * publishes both AAAA and A records) failed with a bare `TypeError: fetch
+ * failed` after ~4s on a host behind a CGNAT / no-IPv6 ISP, even though a plain
+ * `net.connect` to the very same IPv4 address succeeded in ~280ms. The cause
+ * was Node's Happy Eyeballs (`autoSelectFamily`, default-on since Node 20):
+ *   - it races each resolved address with `autoSelectFamilyAttemptTimeout`
+ *     (**250ms** default) between attempts, and
+ *   - the real TLS-capable connect to Tailscale's anycast IPs took ~280ms,
+ *     i.e. *just over* that budget — so every IPv4 attempt was abandoned at
+ *     250ms (`ETIMEDOUT`) while every IPv6 attempt was `EHOSTUNREACH`, and the
+ *     whole request failed after cycling through all 32 addresses.
+ *
+ * `curl` worked because its Happy Eyeballs doesn't kill a healthy in-flight
+ * connection. The fix mirrors that:
+ *   - `net.setDefaultAutoSelectFamilyAttemptTimeout(2000)` — the load-bearing
+ *     fix: don't abandon a connection that just needs a bit longer than 250ms.
+ *   - `dns.setDefaultResultOrder("ipv4first")` — on a no-IPv6 host, try the
+ *     reachable IPv4 family first (Node's own default before v17; harmless on
+ *     dual-stack hosts).
+ *   - `net.setDefaultAutoSelectFamily(true)` — keep Happy Eyeballs on
+ *     explicitly, so IPv6-only / IPv4-broken destinations still fail over.
+ *
+ * Must run before any module makes an outbound request — call it first thing in
+ * server bootstrap, right after logging config. Kept dependency-free (only
+ * `node:dns` / `node:net`) so it is safe to import at the very top of boot.
+ *
+ * Returns the applied state so the caller can log it (and so it is unit
+ * testable). Never throws — a runtime that lacks these APIs simply keeps its
+ * defaults.
+ */
+export function configureOutboundNetworking(): {
+  dnsResultOrder: string;
+  autoSelectFamily: boolean | "unknown";
+  autoSelectFamilyAttemptTimeoutMs: number | "unknown";
+} {
+  if (typeof net.setDefaultAutoSelectFamilyAttemptTimeout === "function") {
+    net.setDefaultAutoSelectFamilyAttemptTimeout(
+      OUTBOUND_FAMILY_ATTEMPT_TIMEOUT_MS,
+    );
+  }
+  if (typeof net.setDefaultAutoSelectFamily === "function") {
+    net.setDefaultAutoSelectFamily(true);
+  }
+  if (typeof dns.setDefaultResultOrder === "function") {
+    dns.setDefaultResultOrder("ipv4first");
+  }
+
+  return {
+    dnsResultOrder:
+      typeof dns.getDefaultResultOrder === "function"
+        ? dns.getDefaultResultOrder()
+        : "unknown",
+    autoSelectFamily:
+      typeof net.getDefaultAutoSelectFamily === "function"
+        ? net.getDefaultAutoSelectFamily()
+        : "unknown",
+    autoSelectFamilyAttemptTimeoutMs:
+      typeof net.getDefaultAutoSelectFamilyAttemptTimeout === "function"
+        ? net.getDefaultAutoSelectFamilyAttemptTimeout()
+        : "unknown",
+  };
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -4,6 +4,15 @@ console.log("[STARTUP] Starting Mini Infra server...");
 // level instead of the in-code fallback.
 import { loadLoggingConfig } from "./lib/logging-config";
 loadLoggingConfig();
+// Harden outbound connections (Happy Eyeballs attempt-timeout + IPv4-first)
+// BEFORE any service module (which may make outbound fetches) is imported.
+// Node's 250ms default abandons healthy cross-region connects (e.g. to
+// api.tailscale.com), making `fetch` fail where curl succeeds. See net-runtime.
+import { configureOutboundNetworking } from "./lib/net-runtime";
+const outboundNet = configureOutboundNetworking();
+console.log(
+  `[STARTUP] Outbound networking: dnsResultOrder=${outboundNet.dnsResultOrder} autoSelectFamily=${outboundNet.autoSelectFamily} attemptTimeoutMs=${outboundNet.autoSelectFamilyAttemptTimeoutMs}`,
+);
 console.log("[STARTUP] Importing app module...");
 import { createServer } from "http";
 import v8 from "v8";

--- a/server/src/services/tailscale/__tests__/tailscale-fetch-error.test.ts
+++ b/server/src/services/tailscale/__tests__/tailscale-fetch-error.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { describeFetchError } from '../tailscale-service';
+
+/**
+ * `describeFetchError` unwraps the `error.cause` that Node's global `fetch`
+ * hides behind a bare "fetch failed". This is what turned an undiagnosable
+ * Tailscale connectivity failure into an actionable one — the field bug was a
+ * no-IPv6 host where every AAAA address was `ENETUNREACH`, which `fetch`
+ * reported only as "fetch failed" until the cause was surfaced.
+ */
+describe('describeFetchError', () => {
+  it('appends the cause code + message for a single-address failure', () => {
+    const err = new TypeError('fetch failed');
+    (err as { cause?: unknown }).cause = Object.assign(
+      new Error('connect ECONNREFUSED 192.200.0.101:443'),
+      { code: 'ECONNREFUSED' },
+    );
+
+    const out = describeFetchError(err);
+    expect(out).toContain('fetch failed');
+    expect(out).toContain('ECONNREFUSED');
+    expect(out).toContain('192.200.0.101:443');
+  });
+
+  it('flattens per-address errors from a Happy Eyeballs AggregateError cause', () => {
+    const err = new TypeError('fetch failed');
+    const aggregate = new AggregateError(
+      [
+        Object.assign(new Error('connect ENETUNREACH'), {
+          code: 'ENETUNREACH',
+          address: '2606:b740:49::105',
+        }),
+        Object.assign(new Error('connect ETIMEDOUT'), {
+          code: 'ETIMEDOUT',
+          address: '192.200.0.101',
+        }),
+      ],
+      'All connection attempts failed',
+    );
+    (err as { cause?: unknown }).cause = aggregate;
+
+    const out = describeFetchError(err);
+    expect(out).toContain('2606:b740:49::105 ENETUNREACH');
+    expect(out).toContain('192.200.0.101 ETIMEDOUT');
+  });
+
+  it('handles an Error with no cause', () => {
+    expect(describeFetchError(new Error('boom'))).toBe('boom');
+  });
+
+  it('handles a non-Error input', () => {
+    expect(describeFetchError('nope')).toBe('nope');
+    expect(describeFetchError(42)).toBe('42');
+  });
+
+  it('handles a non-Error cause', () => {
+    const err = new TypeError('fetch failed');
+    (err as { cause?: unknown }).cause = 'raw string cause';
+    expect(describeFetchError(err)).toContain('raw string cause');
+  });
+});

--- a/server/src/services/tailscale/tailscale-service.ts
+++ b/server/src/services/tailscale/tailscale-service.ts
@@ -193,7 +193,7 @@ export class TailscaleService extends ConfigurationService {
       }
       throw new TailscaleAuthError(
         `Failed to reach Tailscale OAuth endpoint: ${
-          err instanceof Error ? err.message : "unknown"
+          describeFetchError(err)
         }`,
         TAILSCALE_ERROR_CODES.NETWORK_ERROR,
       );
@@ -390,7 +390,7 @@ export class TailscaleService extends ConfigurationService {
       }
       throw new TailscaleAuthError(
         `Failed to reach Tailscale DNS endpoint: ${
-          err instanceof Error ? err.message : "unknown"
+          describeFetchError(err)
         }`,
         TAILSCALE_ERROR_CODES.NETWORK_ERROR,
       );
@@ -516,7 +516,7 @@ export class TailscaleService extends ConfigurationService {
       }
       throw new TailscaleAuthError(
         `Failed to reach Tailscale device-list endpoint: ${
-          err instanceof Error ? err.message : "unknown"
+          describeFetchError(err)
         }`,
         TAILSCALE_ERROR_CODES.NETWORK_ERROR,
       );
@@ -601,7 +601,7 @@ export class TailscaleService extends ConfigurationService {
       }
       throw new TailscaleAuthError(
         `Failed to reach Tailscale device-delete endpoint: ${
-          err instanceof Error ? err.message : "unknown"
+          describeFetchError(err)
         }`,
         TAILSCALE_ERROR_CODES.NETWORK_ERROR,
       );
@@ -736,6 +736,48 @@ async function safeReadText(response: Response): Promise<string> {
   } catch {
     return "<unavailable>";
   }
+}
+
+/**
+ * Build a diagnostic string from a `fetch`/undici failure. Node's global
+ * `fetch` surfaces connection problems as a bare `TypeError: fetch failed` and
+ * hides the actionable reason (DNS miss, ENETUNREACH, ETIMEDOUT, connection
+ * refused, TLS error) on `error.cause`. When Happy Eyeballs tries several
+ * addresses the cause is an `AggregateError` whose `errors[]` carry the
+ * per-address `code` and `address`. Flatten all of that into one line so the
+ * connectivity logs — and the `validationMessage` shown to operators — explain
+ * *why* the reach failed instead of just "fetch failed".
+ *
+ * Exported for unit testing.
+ */
+export function describeFetchError(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+
+  const parts: string[] = [err.message];
+  const cause = (err as { cause?: unknown }).cause;
+
+  if (cause instanceof Error) {
+    const code = (cause as { code?: string }).code;
+    parts.push(code ? `${code}: ${cause.message}` : cause.message);
+
+    // Happy Eyeballs / multi-address failures aggregate the per-address errors.
+    const subErrors = (cause as { errors?: unknown }).errors;
+    if (Array.isArray(subErrors) && subErrors.length > 0) {
+      const detail = subErrors
+        .filter((e): e is Error => e instanceof Error)
+        .map((e) => {
+          const c = (e as { code?: string }).code;
+          const addr = (e as { address?: string }).address;
+          return [addr, c].filter(Boolean).join(" ") || e.message;
+        })
+        .join("; ");
+      if (detail) parts.push(`(${detail})`);
+    }
+  } else if (cause !== undefined && cause !== null) {
+    parts.push(String(cause));
+  }
+
+  return parts.join(" — ");
 }
 
 /**


### PR DESCRIPTION
## Problem

On the production host, saving valid Tailscale OAuth credentials fails with **"Couldn't reach Tailscale — check your network or try again."** The credentials, endpoint, scopes, and tailnet ACLs are all correct — verified independently (`api.tailscale.com/api/v2/oauth/token` returns `200` with scopes `devices:core auth_keys` and owns `tag:mini-infra-managed`).

The server's `POST /api/settings/tailscale` returns `200` but with `isValid:false`, `errorCode:NETWORK_ERROR`, message **`Failed to reach Tailscale OAuth endpoint: fetch failed`**.

## Root cause

The prod box is behind a **CGNAT / no-IPv6 ISP**, and `api.tailscale.com` publishes both AAAA and A records.

- A plain `net.connect` to Tailscale's IPv4 (`192.200.0.101:443`) succeeds in **~280ms**.
- But Node's global `fetch` fails after ~4s. The `AggregateError` cause shows **every** address failing: IPv6 = `EHOSTUNREACH` (instant), IPv4 = `ETIMEDOUT`.

Node's Happy Eyeballs (`autoSelectFamily`, default-on since Node 20) races each address with `autoSelectFamilyAttemptTimeout` = **250ms** default. The real connect to Tailscale's anycast IPs takes ~280ms — *just over* that budget — so each healthy IPv4 attempt is **abandoned at 250ms** before it can complete, then the next is tried and abandoned, through all 32 addresses. `curl` works because it never kills a healthy in-flight connection.

Other services (Cloudflare, etc.) escape only because their DNS happens to return a faster-connecting address first.

## Fix

New `server/src/lib/net-runtime.ts`, applied at server boot **before any outbound call**:

- **`setDefaultAutoSelectFamilyAttemptTimeout(2000)`** — the load-bearing fix: don't abandon a connection that just needs a little longer than 250ms.
- `setDefaultResultOrder("ipv4first")` — on a no-IPv6 host, try the reachable family first (Node's own default before v17; harmless on dual-stack).
- `setDefaultAutoSelectFamily(true)` — keep Happy Eyeballs on explicitly so IPv6-only / IPv4-broken destinations still fail over.

Also: `TailscaleService` now surfaces `error.cause` (including per-address `AggregateError` codes) in its fetch failures, so this class of problem shows the real reason (`ETIMEDOUT`/`EHOSTUNREACH`/…) in logs and the validation message instead of a bare "fetch failed".

## Verification

Reproduced on a host with the identical no-IPv6 condition (Node v24.13.0):

| | before | after |
|---|---|---|
| `fetch api.tailscale.com/oauth/token` | `fetch failed` @ **4074ms** | `HTTP 401` @ **897ms** ✅ |

(401 = TLS connected fine with an empty body — exactly what the OAuth mint needs.) Verified end-to-end through the actual `configureOutboundNetworking()` module the server runs.

- `pnpm --filter mini-infra-server exec tsc --noEmit` — clean
- lint — clean
- 37 tests pass (new `net-runtime` + `describeFetchError` unit tests + existing tailscale suite)

## Scope note

Blast radius is the whole server's outbound (all services benefit — this is a general resilience fix for high-latency / single-stack links), but behaviour only changes on connections that were previously being abandoned too early. No API/schema/permission changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)