### PR TITLE
fix(stacks,haproxy,networks): StatelessWeb volumes, configurable health-check timeout, dataplane self-membership backfill

### DIFF
--- a/lib/types/deployments.ts
+++ b/lib/types/deployments.ts
@@ -16,6 +16,13 @@ export interface DeploymentVolume {
   hostPath: string;
   containerPath: string;
   mode?: 'rw' | 'ro';
+  /**
+   * When true, `hostPath` is already the final Docker volume name (e.g. a
+   * stack-owned `${projectName}_<name>` volume resolved upstream) and must NOT
+   * have the deploy path's environment-name prefix applied again. See
+   * `container-lifecycle-manager.buildVolumeBindings`.
+   */
+  preResolved?: boolean;
 }
 
 // Environment variable configuration

--- a/server/src/services/container/container-lifecycle-manager.ts
+++ b/server/src/services/container/container-lifecycle-manager.ts
@@ -790,8 +790,10 @@ export class ContainerLifecycleManager {
       const originalHostPath = hostPath;
 
       // If environmentName is provided and hostPath doesn't look like an absolute path
-      // (doesn't start with / or a Windows drive letter), prefix it with the environment name
-      if (environmentName && !hostPath.startsWith('/') && !hostPath.match(/^[a-zA-Z]:/)) {
+      // (doesn't start with / or a Windows drive letter), prefix it with the environment name.
+      // `preResolved` volumes already carry their final Docker volume name (e.g. a stack-owned
+      // `${projectName}_<name>` volume resolved upstream), so they must NOT be re-prefixed.
+      if (!volume.preResolved && environmentName && !hostPath.startsWith('/') && !hostPath.match(/^[a-zA-Z]:/)) {
         hostPath = `${environmentName}-${hostPath}`;
 
         getLogger("docker", "container-lifecycle-manager").debug(

--- a/server/src/services/haproxy/__tests__/health-check-timeout.test.ts
+++ b/server/src/services/haproxy/__tests__/health-check-timeout.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveHealthCheckTimeoutMs,
+  DEFAULT_HEALTH_CHECK_TIMEOUT_MS,
+  MAX_HEALTH_CHECK_TIMEOUT_MS,
+} from '../health-check-timeout';
+
+describe('resolveHealthCheckTimeoutMs', () => {
+  it('falls back to the 90s default when startPeriod is unset', () => {
+    expect(resolveHealthCheckTimeoutMs(undefined)).toBe(DEFAULT_HEALTH_CHECK_TIMEOUT_MS);
+    expect(resolveHealthCheckTimeoutMs(null)).toBe(DEFAULT_HEALTH_CHECK_TIMEOUT_MS);
+  });
+
+  it('falls back to the default for non-positive or non-finite values', () => {
+    expect(resolveHealthCheckTimeoutMs(0)).toBe(DEFAULT_HEALTH_CHECK_TIMEOUT_MS);
+    expect(resolveHealthCheckTimeoutMs(-5_000)).toBe(DEFAULT_HEALTH_CHECK_TIMEOUT_MS);
+    expect(resolveHealthCheckTimeoutMs(Number.NaN)).toBe(DEFAULT_HEALTH_CHECK_TIMEOUT_MS);
+    expect(resolveHealthCheckTimeoutMs(Number.POSITIVE_INFINITY)).toBe(DEFAULT_HEALTH_CHECK_TIMEOUT_MS);
+  });
+
+  it('floors at the 90s default so we never regress below the historical timeout', () => {
+    // A shorter startPeriod (e.g. 30s) still gets the 90s floor — the timeout
+    // is an upper bound on the wait, so flooring never slows a healthy deploy.
+    expect(resolveHealthCheckTimeoutMs(30_000)).toBe(DEFAULT_HEALTH_CHECK_TIMEOUT_MS);
+    expect(resolveHealthCheckTimeoutMs(DEFAULT_HEALTH_CHECK_TIMEOUT_MS)).toBe(DEFAULT_HEALTH_CHECK_TIMEOUT_MS);
+  });
+
+  it('honours a longer startPeriod verbatim for slow-booting images', () => {
+    // The Kumiko case: ~1 GB CAD kernel import needs > 90s before binding.
+    expect(resolveHealthCheckTimeoutMs(180_000)).toBe(180_000);
+    expect(resolveHealthCheckTimeoutMs(300_000)).toBe(300_000);
+  });
+
+  it('caps at the 10-minute maximum so a misconfig cannot hang a deploy', () => {
+    expect(resolveHealthCheckTimeoutMs(3_600_000)).toBe(MAX_HEALTH_CHECK_TIMEOUT_MS);
+    expect(resolveHealthCheckTimeoutMs(MAX_HEALTH_CHECK_TIMEOUT_MS + 1)).toBe(MAX_HEALTH_CHECK_TIMEOUT_MS);
+  });
+});

--- a/server/src/services/haproxy/actions/perform-health-checks.ts
+++ b/server/src/services/haproxy/actions/perform-health-checks.ts
@@ -1,6 +1,7 @@
 import type { ActionContext, HealthCheckEmit } from './types';
 import { getLogger } from '../../../lib/logger-factory';
 import { HAProxyDataPlaneClient } from '../haproxy-dataplane-client';
+import { DEFAULT_HEALTH_CHECK_TIMEOUT_MS } from '../health-check-timeout';
 
 const logger = getLogger("deploy", "perform-health-checks");
 
@@ -47,7 +48,10 @@ export class PerformHealthChecks {
             const backendName = context.applicationName;
             const serverName = `${context.applicationName}-${context.containerId.slice(0, 8)}`;
 
-            const timeoutMs = 90000; // 90 seconds as defined in state machine
+            // Sourced from the service's healthcheck.startPeriod (via context),
+            // mirroring the state machine's `healthCheckTimeout` delay so the
+            // action's own poll loop and the machine's `after` bound agree.
+            const timeoutMs = context.healthCheckTimeoutMs ?? DEFAULT_HEALTH_CHECK_TIMEOUT_MS;
             const pollIntervalMs = 2000; // Poll every 2 seconds
             const startTime = Date.now();
 

--- a/server/src/services/haproxy/actions/types.ts
+++ b/server/src/services/haproxy/actions/types.ts
@@ -82,6 +82,8 @@ export interface ActionContext {
     healthCheckEndpoint?: string;
     healthCheckInterval?: number;
     healthCheckRetries?: number;
+    /** Max ms to wait for the green server to report UP before rolling back. */
+    healthCheckTimeoutMs?: number;
 
     // Deployment metadata
     triggerType?: string;

--- a/server/src/services/haproxy/blue-green-deployment-state-machine.ts
+++ b/server/src/services/haproxy/blue-green-deployment-state-machine.ts
@@ -1,4 +1,5 @@
 import { assign, setup } from 'xstate';
+import { DEFAULT_HEALTH_CHECK_TIMEOUT_MS } from './health-check-timeout';
 import { getLogger } from '../../lib/logger-factory';
 import type { DeploymentVolume } from '@mini-infra/types';
 import { DeployApplicationContainers } from './actions/deploy-application-containers';
@@ -96,6 +97,7 @@ export interface BlueGreenDeploymentContext {
     healthCheckEndpoint?: string;
     healthCheckInterval?: number;
     healthCheckRetries?: number;
+    healthCheckTimeoutMs?: number;
     containerPorts?: { containerPort: number; hostPort: number; protocol: 'tcp' | 'udp' }[];
     containerVolumes?: DeploymentVolume[];
     containerEnvironment?: Record<string, string>;
@@ -596,6 +598,11 @@ export const blueGreenDeploymentMachine = setup({
         canRetry: ({ context }) => {
             return context.retryCount < 3;
         }
+    },
+    delays: {
+        // Blue-green health-check timeout — per-service via context (sourced
+        // from healthcheck.startPeriod), defaulting to the historical 90s.
+        healthCheckTimeout: ({ context }) => context.healthCheckTimeoutMs ?? DEFAULT_HEALTH_CHECK_TIMEOUT_MS,
     }
 }).createMachine({
     id: 'blueGreenDeployment',
@@ -652,6 +659,7 @@ export const blueGreenDeploymentMachine = setup({
         healthCheckEndpoint: input?.healthCheckEndpoint,
         healthCheckInterval: input?.healthCheckInterval,
         healthCheckRetries: input?.healthCheckRetries,
+        healthCheckTimeoutMs: input?.healthCheckTimeoutMs,
         containerPorts: input?.containerPorts,
         containerVolumes: input?.containerVolumes,
         containerEnvironment: input?.containerEnvironment,
@@ -879,9 +887,12 @@ export const blueGreenDeploymentMachine = setup({
                 }
             },
             after: {
-                90000: { // 90 second timeout
+                healthCheckTimeout: {
                     target: 'rollbackRemoveGreenHaproxyConfig',
-                    actions: assign({ error: 'Health check timeout after 90 seconds' })
+                    actions: assign({
+                        error: ({ context }) =>
+                            `Health check timeout after ${Math.round((context.healthCheckTimeoutMs ?? DEFAULT_HEALTH_CHECK_TIMEOUT_MS) / 1000)} seconds`,
+                    })
                 }
             }
         },

--- a/server/src/services/haproxy/blue-green-update-state-machine.ts
+++ b/server/src/services/haproxy/blue-green-update-state-machine.ts
@@ -1,4 +1,5 @@
 import { assign, setup } from 'xstate';
+import { DEFAULT_HEALTH_CHECK_TIMEOUT_MS } from './health-check-timeout';
 import { getLogger } from '../../lib/logger-factory';
 import type { DeploymentVolume } from '@mini-infra/types';
 import { DeployApplicationContainers } from './actions/deploy-application-containers';
@@ -87,6 +88,7 @@ export interface BlueGreenUpdateContext {
     healthCheckEndpoint?: string;
     healthCheckInterval?: number;
     healthCheckRetries?: number;
+    healthCheckTimeoutMs?: number;
     containerPorts?: { containerPort: number; hostPort: number; protocol: 'tcp' | 'udp' }[];
     containerVolumes?: DeploymentVolume[];
     containerEnvironment?: Record<string, string>;
@@ -527,6 +529,11 @@ export const blueGreenUpdateMachine = setup({
         canRetry: ({ context }) => {
             return context.retryCount < 3;
         }
+    },
+    delays: {
+        // Blue-green health-check timeout — per-service via context (sourced
+        // from healthcheck.startPeriod), defaulting to the historical 90s.
+        healthCheckTimeout: ({ context }) => context.healthCheckTimeoutMs ?? DEFAULT_HEALTH_CHECK_TIMEOUT_MS,
     }
 }).createMachine({
     id: 'blueGreenUpdate',
@@ -581,6 +588,7 @@ export const blueGreenUpdateMachine = setup({
         healthCheckEndpoint: input?.healthCheckEndpoint,
         healthCheckInterval: input?.healthCheckInterval,
         healthCheckRetries: input?.healthCheckRetries,
+        healthCheckTimeoutMs: input?.healthCheckTimeoutMs,
         containerPorts: input?.containerPorts,
         containerVolumes: input?.containerVolumes,
         containerEnvironment: input?.containerEnvironment,
@@ -808,9 +816,12 @@ export const blueGreenUpdateMachine = setup({
                 }
             },
             after: {
-                90000: { // 90 second timeout
+                healthCheckTimeout: {
                     target: 'rollbackRemoveGreenHaproxyConfig',
-                    actions: assign({ error: 'Health check timeout after 90 seconds' })
+                    actions: assign({
+                        error: ({ context }) =>
+                            `Health check timeout after ${Math.round((context.healthCheckTimeoutMs ?? DEFAULT_HEALTH_CHECK_TIMEOUT_MS) / 1000)} seconds`,
+                    })
                 }
             }
         },

--- a/server/src/services/haproxy/health-check-timeout.ts
+++ b/server/src/services/haproxy/health-check-timeout.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared health-check timeout resolution for HAProxy blue-green deploys.
+ *
+ * The blue-green state machines wait up to this long for a freshly-deployed
+ * server to report UP in HAProxy before failing the deploy and rolling back.
+ * It used to be hardcoded to 90s in three state machines plus
+ * `perform-health-checks.ts` — too short for heavy images that run DB
+ * migrations or warm large caches before binding their port (e.g. an app that
+ * imports a ~1 GB CAD kernel on boot). The value is now sourced per-service
+ * from `healthcheck.startPeriod` (the app's declared boot grace) so
+ * slow-booting services can extend it.
+ *
+ * Unit note: `healthcheck.startPeriod` is stored in **milliseconds** by the
+ * application authoring UI (it multiplies the user's seconds input by 1000 —
+ * see `client/src/app/applications/new/page.tsx`), which is the surface every
+ * StatelessWeb/AdoptedWeb service is created through.
+ *
+ * We never shorten below the historical 90s default and cap at 10 minutes:
+ * the timeout is an *upper bound* on the wait, not a fixed delay — a healthy
+ * server flips UP as soon as it responds, so flooring only affects how long a
+ * genuinely-failing deploy waits before giving up (never slows a good one),
+ * and the cap stops a misconfigured value from hanging a deploy indefinitely.
+ */
+export const DEFAULT_HEALTH_CHECK_TIMEOUT_MS = 90_000;
+export const MAX_HEALTH_CHECK_TIMEOUT_MS = 600_000;
+
+/**
+ * Resolve the effective health-check timeout (ms) from a service's declared
+ * `healthcheck.startPeriod` (ms). Falls back to the 90s default when unset or
+ * invalid, floors at the default, and caps at the 10-minute maximum.
+ */
+export function resolveHealthCheckTimeoutMs(startPeriodMs: number | undefined | null): number {
+  const requested =
+    startPeriodMs != null && Number.isFinite(startPeriodMs) && startPeriodMs > 0
+      ? startPeriodMs
+      : DEFAULT_HEALTH_CHECK_TIMEOUT_MS;
+  return Math.min(Math.max(requested, DEFAULT_HEALTH_CHECK_TIMEOUT_MS), MAX_HEALTH_CHECK_TIMEOUT_MS);
+}

--- a/server/src/services/haproxy/initial-deployment-state-machine.ts
+++ b/server/src/services/haproxy/initial-deployment-state-machine.ts
@@ -1,4 +1,5 @@
 import { assign, setup } from 'xstate';
+import { DEFAULT_HEALTH_CHECK_TIMEOUT_MS } from './health-check-timeout';
 import type { DeploymentVolume } from '@mini-infra/types';
 import { DeployApplicationContainers} from './actions/deploy-application-containers';
 import { MonitorContainerStartup } from './actions/monitor-container-startup';
@@ -80,6 +81,7 @@ export interface InitialDeploymentContext {
     healthCheckEndpoint?: string;
     healthCheckInterval?: number;
     healthCheckRetries?: number;
+    healthCheckTimeoutMs?: number;
     containerPorts?: { containerPort: number; hostPort: number; protocol: 'tcp' | 'udp' }[];
     containerVolumes?: DeploymentVolume[];
     containerEnvironment?: Record<string, string>;
@@ -282,6 +284,11 @@ export const initialDeploymentMachine = setup({
         serversHealthy: ({ context }) => {
             return context.healthChecksPassed;
         }
+    },
+    delays: {
+        // Blue-green health-check timeout — per-service via context (sourced
+        // from healthcheck.startPeriod), defaulting to the historical 90s.
+        healthCheckTimeout: ({ context }) => context.healthCheckTimeoutMs ?? DEFAULT_HEALTH_CHECK_TIMEOUT_MS,
     }
 }).createMachine({
     id: 'initialDeployment',
@@ -336,6 +343,7 @@ export const initialDeploymentMachine = setup({
         healthCheckEndpoint: deploymentInput?.healthCheckEndpoint,
         healthCheckInterval: deploymentInput?.healthCheckInterval,
         healthCheckRetries: deploymentInput?.healthCheckRetries,
+        healthCheckTimeoutMs: deploymentInput?.healthCheckTimeoutMs,
         containerPorts: deploymentInput?.containerPorts,
         containerVolumes: deploymentInput?.containerVolumes,
         containerEnvironment: deploymentInput?.containerEnvironment,
@@ -453,9 +461,12 @@ export const initialDeploymentMachine = setup({
                 }
             },
             after: {
-                90000: { // 90 second timeout
+                healthCheckTimeout: {
                     target: 'rollbackRemoveHaproxyConfig',
-                    actions: assign({ error: 'Health check timeout after 90 seconds' })
+                    actions: assign({
+                        error: ({ context }) =>
+                            `Health check timeout after ${Math.round((context.healthCheckTimeoutMs ?? DEFAULT_HEALTH_CHECK_TIMEOUT_MS) / 1000)} seconds`,
+                    })
                 }
             }
         },

--- a/server/src/services/networks/__tests__/membership-backfill.test.ts
+++ b/server/src/services/networks/__tests__/membership-backfill.test.ts
@@ -133,4 +133,92 @@ describe('backfillNetworkMemberships — InfraResource identity self-heal', () =
       }),
     );
   });
+
+  it('seeds the mini-infra `self` membership for a joinSelf resource network the producing stack declares', async () => {
+    // Regression: a dataplane-network stack that stayed `synced` across the
+    // network-overhaul deploy never had `connectSelfToNetwork` write the
+    // `containerName: 'self'` row (that only happens at apply time), so boot
+    // convergence had nothing to reconnect after the app container was
+    // recreated — stranding mini-infra off the dataplane network. The backfill
+    // must seed that self-membership from the producing stack's joinSelf output.
+    const dataplaneResource = {
+      id: 'ir-dp', type: 'docker-network', purpose: 'dataplane', scope: 'host',
+      environmentId: null, name: 'mini-infra-dataplane', stackId: 'stack-dp',
+    };
+    const managedNetworkCreate = vi.fn().mockResolvedValue({ id: 'mn-dp' });
+    const networkMembershipCreate = vi.fn().mockResolvedValue({});
+    const prisma = {
+      infraResource: { findMany: vi.fn().mockResolvedValue([dataplaneResource]) },
+      managedNetwork: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: managedNetworkCreate,
+        update: vi.fn(),
+        count: vi.fn().mockResolvedValue(1),
+      },
+      // First findMany (section 1, `select: {id, resourceOutputs}`) sees the
+      // producing dataplane stack; the second (section 2, per-stack membership)
+      // gets `[]` so that pass is a no-op for this focused test.
+      stack: {
+        findMany: vi.fn()
+          .mockResolvedValueOnce([
+            { id: 'stack-dp', resourceOutputs: [{ type: 'docker-network', purpose: 'dataplane', joinSelf: true }] },
+          ])
+          .mockResolvedValue([]),
+      },
+      networkMembership: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: networkMembershipCreate,
+        count: vi.fn().mockResolvedValue(0),
+      },
+    } as unknown as PrismaClient;
+
+    const dockerExecutor = makeDockerExecutor(new Set(['mini-infra-dataplane']));
+
+    await backfillNetworkMemberships(dockerExecutor, prisma, log);
+
+    expect(networkMembershipCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ containerName: 'self', networkId: 'mn-dp', source: 'system' }),
+      }),
+    );
+  });
+
+  it('does not seed a self membership for a resource network with no joinSelf output', async () => {
+    // A per-environment `applications` network is HAProxy's/apps' network, not
+    // one the mini-infra server joins — no joinSelf output, so no self row.
+    const appsResource = {
+      id: 'ir-app', type: 'docker-network', purpose: 'applications', scope: 'environment',
+      environmentId: 'env-1', name: 'internet-applications', stackId: 'stack-hap',
+    };
+    const networkMembershipCreate = vi.fn().mockResolvedValue({});
+    const prisma = {
+      infraResource: { findMany: vi.fn().mockResolvedValue([appsResource]) },
+      managedNetwork: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue({ id: 'mn-app' }),
+        update: vi.fn(),
+        count: vi.fn().mockResolvedValue(1),
+      },
+      stack: {
+        findMany: vi.fn()
+          .mockResolvedValueOnce([
+            { id: 'stack-hap', resourceOutputs: [{ type: 'docker-network', purpose: 'applications', joinSelf: false }] },
+          ])
+          .mockResolvedValue([]),
+      },
+      networkMembership: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: networkMembershipCreate,
+        count: vi.fn().mockResolvedValue(0),
+      },
+    } as unknown as PrismaClient;
+
+    const dockerExecutor = makeDockerExecutor(new Set(['internet-applications']));
+
+    await backfillNetworkMemberships(dockerExecutor, prisma, log);
+
+    expect(networkMembershipCreate).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/services/networks/membership-backfill.ts
+++ b/server/src/services/networks/membership-backfill.ts
@@ -41,6 +41,7 @@ import type {
   NetworkMembershipBackfillSummary,
   StackContainerConfig,
   StackNetwork,
+  StackResourceOutput,
 } from '@mini-infra/types';
 import type { DockerExecutorService } from '../docker-executor';
 import { NetworkManager } from './network-manager';
@@ -108,6 +109,32 @@ export async function backfillNetworkMemberships(
   // membership of their own (that's compiled per-stack below), just the
   // ManagedNetwork row itself.
   const resources = await prisma.infraResource.findMany({ where: { type: 'docker-network' } });
+
+  // Detect which of those resource networks the mini-infra server itself is
+  // meant to join (`joinSelf: true` on the producing stack's resource output —
+  // dataplane/database/vault/nats). `connectSelfToNetwork` only records the
+  // `containerName: 'self'` membership for these at *apply* time, so a stack
+  // that stayed `synced` across the network-overhaul deploy never got one; boot
+  // convergence (`convergeAll`) then has no self-row to reconnect after the app
+  // container is recreated, stranding mini-infra off the dataplane network (and
+  // failing every HAProxy-routed deploy with "HAProxy environment context not
+  // available"). Seed the row here from the producing stack's declared outputs
+  // so the self-heal works for already-applied infra without a re-apply.
+  const producingStacks = await prisma.stack.findMany({
+    where: { removedAt: null },
+    select: { id: true, resourceOutputs: true },
+  });
+  const resourceOutputsByStackId = new Map<string, StackResourceOutput[]>(
+    producingStacks.map((s) => [s.id, (s.resourceOutputs as unknown as StackResourceOutput[]) ?? []]),
+  );
+  const isJoinSelfResource = (res: { stackId: string | null; purpose: string }): boolean => {
+    if (!res.stackId) return false;
+    const outputs = resourceOutputsByStackId.get(res.stackId) ?? [];
+    return outputs.some(
+      (o) => o.type === 'docker-network' && o.purpose === res.purpose && o.joinSelf === true,
+    );
+  };
+
   for (const r of resources) {
     summary.infraResourcesScanned++;
     const existence = await networkManager.exists(r.name);
@@ -139,6 +166,7 @@ export async function backfillNetworkMemberships(
     // ahead of this exact InfraResource-backed identity for an
     // environment-scoped network like `${env}-egress`.
     const existingByName = await prisma.managedNetwork.findUnique({ where: { name: r.name } });
+    let managedNetworkId: string;
     if (
       existingByName &&
       (existingByName.scope !== scope ||
@@ -153,18 +181,31 @@ export async function backfillNetworkMemberships(
         },
         'Backfill: correcting ManagedNetwork identity to match authoritative InfraResource row',
       );
-      await prisma.managedNetwork.update({
+      const corrected = await prisma.managedNetwork.update({
         where: { id: existingByName.id },
         data: { scope, environmentId: r.environmentId ?? null, purpose: r.purpose },
       });
-      continue;
+      managedNetworkId = corrected.id;
+    } else {
+      const row = await upsertManagedNetworkByIdentity(
+        prisma,
+        { scope, environmentId: r.environmentId, stackId: null, purpose: r.purpose },
+        r.name,
+      );
+      managedNetworkId = row.id;
     }
 
-    await upsertManagedNetworkByIdentity(
-      prisma,
-      { scope, environmentId: r.environmentId, stackId: null, purpose: r.purpose },
-      r.name,
-    );
+    // Seed the mini-infra server's own `self` membership for joinSelf resource
+    // networks (see the note above the loop). Idempotent — identical to the row
+    // `connectSelfToNetwork` writes at apply time, so re-runs here and a later
+    // re-apply both no-op rather than duplicating.
+    if (isJoinSelfResource(r)) {
+      await upsertNetworkMembership(prisma, {
+        containerName: 'self',
+        networkId: managedNetworkId,
+        source: 'system',
+      });
+    }
   }
 
   // 2. Stack-owned networks + per-service memberships, from every

--- a/server/src/services/stacks/__tests__/stack-mounts.test.ts
+++ b/server/src/services/stacks/__tests__/stack-mounts.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { resolveStackMountSource, mountsToDeploymentVolumes } from '../stack-mounts';
+
+describe('resolveStackMountSource', () => {
+  it('prefixes a named volume with the project name (matches reconciler volume creation)', () => {
+    // stack-reconciler.ts creates the volume as `${projectName}_${vol.name}`,
+    // so the mount source must resolve to the same string or the container
+    // mounts a different (empty) volume.
+    expect(
+      resolveStackMountSource({ source: 'kumiko-logs', type: 'volume' }, 'internet-kumiko-designer-website'),
+    ).toBe('internet-kumiko-designer-website_kumiko-logs');
+  });
+
+  it('passes a bind mount (absolute host path) through unchanged', () => {
+    expect(resolveStackMountSource({ source: '/srv/data', type: 'bind' }, 'proj')).toBe('/srv/data');
+  });
+
+  it('does not prefix a volume-typed source that already contains a slash', () => {
+    expect(resolveStackMountSource({ source: '/host/path', type: 'volume' }, 'proj')).toBe('/host/path');
+  });
+});
+
+describe('mountsToDeploymentVolumes', () => {
+  it('maps declared mounts to pre-resolved DeploymentVolumes', () => {
+    const result = mountsToDeploymentVolumes(
+      [
+        { source: 'kumiko-logs', target: '/logs', type: 'volume' },
+        { source: 'kumiko-data', target: '/data', type: 'volume', readOnly: true },
+      ],
+      'proj',
+    );
+    // preResolved: true is load-bearing — it stops container-lifecycle-manager
+    // from re-applying its `${environmentName}-` prefix to an already-final name.
+    expect(result).toEqual([
+      { hostPath: 'proj_kumiko-logs', containerPath: '/logs', mode: 'rw', preResolved: true },
+      { hostPath: 'proj_kumiko-data', containerPath: '/data', mode: 'ro', preResolved: true },
+    ]);
+  });
+
+  it('returns an empty array when there are no mounts', () => {
+    expect(mountsToDeploymentVolumes(undefined, 'proj')).toEqual([]);
+  });
+});

--- a/server/src/services/stacks/stack-container-manager.ts
+++ b/server/src/services/stacks/stack-container-manager.ts
@@ -7,6 +7,7 @@ import {
 import { getLogger } from '../../lib/logger-factory';
 import { groupByProperty } from './utils';
 import { resolveEgressEnv } from './egress-injection';
+import { resolveStackMountSource } from './stack-mounts';
 import type { PrismaClient } from '../../generated/prisma/client';
 import { createNetworkManager, type NetworkManager } from '../networks';
 
@@ -168,10 +169,12 @@ export class StackContainerManager {
         ? internalOnlyPorts.map((p) => `${p.containerPort}/${p.protocol}`)
         : undefined;
 
-    // Convert mounts to Docker format, prefixing volume sources with projectName
+    // Convert mounts to Docker format, resolving volume sources to their real
+    // `${projectName}_<name>` volume (shared with the blue-green deploy path via
+    // stack-mounts.ts so the two never drift).
     const mounts = config.mounts?.map((m) => ({
       Target: m.target,
-      Source: m.type === 'volume' && !m.source.includes('/') ? `${options.projectName}_${m.source}` : m.source,
+      Source: resolveStackMountSource(m, options.projectName),
       Type: m.type,
       ReadOnly: m.readOnly,
     }));

--- a/server/src/services/stacks/stack-mounts.ts
+++ b/server/src/services/stacks/stack-mounts.ts
@@ -1,0 +1,46 @@
+import type { DeploymentVolume } from '@mini-infra/types';
+
+/** A stack service mount as declared in `containerConfig.mounts`. */
+export interface StackMount {
+  source: string;
+  target: string;
+  type: string;
+  readOnly?: boolean;
+}
+
+/**
+ * Resolve a stack service mount's Docker source name. Named volumes get the
+ * `${projectName}_` prefix — matching how the reconciler creates stack-owned
+ * volumes (`stack-reconciler.ts`: `${projectName}_${vol.name}`) — while bind
+ * mounts (absolute host paths, which contain a `/`) pass through unchanged.
+ *
+ * Shared by the Stateful container path (`stack-container-manager`) and the
+ * blue-green/StatelessWeb deploy context (`stack-state-machine-context`) so the
+ * two never drift on how a declared mount maps to a real Docker volume name.
+ */
+export function resolveStackMountSource(
+  mount: Pick<StackMount, 'source' | 'type'>,
+  projectName: string,
+): string {
+  return mount.type === 'volume' && !mount.source.includes('/')
+    ? `${projectName}_${mount.source}`
+    : mount.source;
+}
+
+/**
+ * Map a stack service's declared mounts to the flat `DeploymentVolume[]` the
+ * blue-green deploy pipeline consumes. `preResolved: true` marks the source as
+ * a final Docker volume name so the deploy path does not re-apply its own
+ * environment-name prefix (see `container-lifecycle-manager.buildVolumeBindings`).
+ */
+export function mountsToDeploymentVolumes(
+  mounts: StackMount[] | undefined,
+  projectName: string,
+): DeploymentVolume[] {
+  return (mounts ?? []).map((m) => ({
+    hostPath: resolveStackMountSource(m, projectName),
+    containerPath: m.target,
+    mode: m.readOnly ? 'ro' : 'rw',
+    preResolved: true,
+  }));
+}

--- a/server/src/services/stacks/stack-state-machine-context.ts
+++ b/server/src/services/stacks/stack-state-machine-context.ts
@@ -10,6 +10,8 @@ import type { HAProxyDataPlaneClient } from '../haproxy';
 import { EnvironmentValidationService, type HAProxyEnvironmentContext } from '../environment';
 import type { StackRoutingManager, StackRoutingContext } from './stack-routing-manager';
 import { resolveEgressEnv } from './egress-injection';
+import { resolveHealthCheckTimeoutMs } from '../haproxy/health-check-timeout';
+import { mountsToDeploymentVolumes } from './stack-mounts';
 
 export interface StackWithReconcilerContext {
   id: string;
@@ -145,8 +147,21 @@ export async function buildStateMachineContext(
       ? Math.round(Number(serviceDef.containerConfig.healthcheck.interval) / 1_000_000)
       : 2000,
     healthCheckRetries: Number(serviceDef.containerConfig.healthcheck?.retries ?? 2),
+    // Blue-green health-check timeout (ms): how long the deploy waits for the
+    // green server to report UP before rolling back. Sourced from the service's
+    // declared `healthcheck.startPeriod` (ms) so slow-booting images can extend
+    // past the historical 90s default. See health-check-timeout.ts.
+    healthCheckTimeoutMs: resolveHealthCheckTimeoutMs(
+      serviceDef.containerConfig.healthcheck?.startPeriod != null
+        ? Number(serviceDef.containerConfig.healthcheck.startPeriod)
+        : undefined,
+    ),
     containerPorts: serviceDef.containerConfig.ports ?? [],
-    containerVolumes: [],
+    // Declared mounts → DeploymentVolume[] so StatelessWeb/AdoptedWeb services
+    // actually get their volumes (previously hardcoded empty, silently dropping
+    // them). Sources are pre-resolved to the real `${projectName}_<name>` volume
+    // so the deploy path doesn't re-prefix them. See stack-mounts.ts.
+    containerVolumes: mountsToDeploymentVolumes(serviceDef.containerConfig.mounts, projectName),
     containerEnvironment: envRecord,
     containerLabels: {
       'mini-infra.stack': stack.name,


### PR DESCRIPTION
## Summary

Three independent bugs in the stack **deploy path**, all surfaced while diagnosing a production StatelessWeb ("Kumiko") deploy that failed first with `HAProxy environment context not available` and then with a health-check timeout. Each is a real platform defect (separate from the app-side config issues in that deploy).

### 1. Backfill never seeds the mini-infra `self` membership for `joinSelf` networks
`connectSelfToNetwork` only writes the `containerName: 'self'` `NetworkMembership` row (dataplane/database/vault/nats) **at apply time**. A stack that stayed `synced` across the network-overhaul deploy therefore never got one, so boot convergence (`convergeAll`) had no row to reconnect after the app container was recreated — stranding mini-infra off the `dataplane` network and failing **every** HAProxy-routed deploy with `HAProxy environment context not available for environment <id>`.

`backfillNetworkMemberships` now seeds that self-membership from the producing stack's declared `joinSelf` resource outputs. Idempotent — identical to the row apply-time writes, so re-runs and a later re-apply both no-op.

### 2. StatelessWeb/AdoptedWeb deploys silently drop declared volumes
`buildStateMachineContext` hardcoded `containerVolumes: []`, so declared `containerConfig.mounts` never reached the container. (Stateful services attach mounts fine — this was StatelessWeb-only.) Now maps declared mounts → `DeploymentVolume[]`, resolving named-volume sources to the real `${projectName}_<name>` volume the reconciler creates.

Flow-on fix: the deploy path prefixes volume names with `${environmentName}-`, which would double-prefix an already-resolved stack volume. Added `DeploymentVolume.preResolved` so `container-lifecycle-manager` skips its prefix for stack-sourced volumes. The `mounts → source` resolution is now a **shared helper** (`stack-mounts.ts`) used by both the Stateful and blue-green paths so they can't drift.

### 3. Health-check timeout hardcoded at 90s
The blue-green health check waited a fixed 90s (in three state machines + `perform-health-checks.ts`) before failing and rolling back — too short for heavy images that run migrations or warm large caches before binding their port. Now sourced per-service from `healthcheck.startPeriod` via a dynamic xstate `delays` entry, **floored at the historical 90s** (the timeout is an upper bound, so flooring never slows a healthy deploy) and **capped at 10 minutes**. The timeout error message now reports the actual value.

## Changes
- `services/networks/membership-backfill.ts` — seed `self` membership for joinSelf resource networks
- `services/stacks/stack-mounts.ts` *(new)* — shared `resolveStackMountSource` / `mountsToDeploymentVolumes`
- `services/stacks/stack-state-machine-context.ts` — map mounts → volumes; source health-check timeout
- `services/stacks/stack-container-manager.ts` — use shared mount resolver (Stateful path)
- `services/container/container-lifecycle-manager.ts` — skip env-prefix for `preResolved` volumes
- `services/haproxy/health-check-timeout.ts` *(new)* — timeout resolver (default/floor/cap)
- `services/haproxy/{initial-deployment,blue-green-deployment,blue-green-update}-state-machine.ts` — dynamic `healthCheckTimeout` delay
- `services/haproxy/actions/{perform-health-checks,types}.ts` — read timeout from context
- `lib/types/deployments.ts` — add `DeploymentVolume.preResolved`

## Tests
- New unit tests: `stack-mounts.test.ts`, `health-check-timeout.test.ts`, plus two cases in `membership-backfill.test.ts` (seeds self on joinSelf; skips when no joinSelf output).
- Full server suite green (2645 tests; one unrelated `postgres-backups` ECONNRESET was transient and passes on re-run). Typecheck + ESLint clean.

## Reversibility
All three are safe/additive: #1 seeds desired-state rows that convergeAll already reconciles idempotently; #2 only affects StatelessWeb stacks declaring mounts (none worked before); #3 keeps the 90s default and only extends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)