### PR TITLE
fix(connectivity): stop unknown status crashing the GitHub page + fix validation routing

### DIFF
--- a/client/src/__tests__/connectivity-status.test.tsx
+++ b/client/src/__tests__/connectivity-status.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Regression test for the GitHub connectivity page crash.
+ *
+ * A connectivity record whose `status` fell outside CONNECTIVITY_STATUS_TYPES
+ * (production stored `"error"` with "Unsupported configuration category:
+ * github-app") made `StatusBadge` index `statusConfig` to `undefined` and read
+ * `.icon` off it — throwing "Cannot read properties of undefined (reading
+ * 'icon')" and taking the whole page into the auth error boundary.
+ *
+ * The fix moved the vocabulary + a `toConnectivityStatus` normaliser into
+ * @mini-infra/types, added an exhaustive `error` entry to the badge/dot config,
+ * and made both primitives degrade any unknown status to a known one instead of
+ * crashing. This test pins all three so the crash can't regress.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import {
+  CONNECTIVITY_STATUS_TYPES,
+  toConnectivityStatus,
+  type ConnectivityStatusType,
+} from "@mini-infra/types";
+import { StatusBadge, StatusDot } from "@/components/connectivity-status";
+
+describe("toConnectivityStatus", () => {
+  it("passes through every known vocabulary member unchanged", () => {
+    for (const status of CONNECTIVITY_STATUS_TYPES) {
+      expect(toConnectivityStatus(status)).toBe(status);
+    }
+  });
+
+  it("carries 'error' as a first-class status", () => {
+    expect(CONNECTIVITY_STATUS_TYPES).toContain("error");
+  });
+
+  it("degrades unknown / empty / null / undefined to 'error'", () => {
+    expect(toConnectivityStatus("unknown")).toBe("error");
+    expect(toConnectivityStatus("")).toBe("error");
+    expect(toConnectivityStatus(null)).toBe("error");
+    expect(toConnectivityStatus(undefined)).toBe("error");
+  });
+});
+
+describe("StatusBadge / StatusDot with an off-vocabulary status", () => {
+  it("renders the 'error' status (the exact prod value) without throwing", () => {
+    expect(() => render(<StatusBadge status="error" />)).not.toThrow();
+    expect(() => render(<StatusDot status="error" />)).not.toThrow();
+  });
+
+  it("degrades an unrecognised legacy DB value to a rendered badge instead of crashing", () => {
+    // TypeScript wouldn't permit this, but the DB column is a free string and
+    // can hold historic values — the primitives must not read `.icon` of undefined.
+    const bogus = "totally-bogus" as ConnectivityStatusType;
+
+    const { getByText } = render(<StatusBadge status={bogus} />);
+    expect(getByText("Error")).toBeInTheDocument();
+
+    expect(() => render(<StatusDot status={bogus} />)).not.toThrow();
+  });
+});

--- a/client/src/components/connectivity-status.tsx
+++ b/client/src/components/connectivity-status.tsx
@@ -5,6 +5,7 @@ import {
   IconCircleX,
   IconClock,
   IconAlertCircle,
+  IconAlertTriangle,
 } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -27,6 +28,7 @@ import {
   ConnectivityStatusInfo,
   ConnectivityService,
   ConnectivityStatusType,
+  toConnectivityStatus,
 } from "@mini-infra/types";
 import {
   useServiceConnectivity,
@@ -45,34 +47,50 @@ interface StatusBadgeProps {
   showResponseTime?: boolean;
 }
 
+type StatusBadgeConfig = {
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+  variant: "default" | "destructive" | "secondary" | "outline";
+  className: string;
+};
+
+// Keyed exhaustively by ConnectivityStatusType via `satisfies` — adding a new
+// status to the shared vocabulary without a config entry here is a compile
+// error, so the badge/dot can never index this map to `undefined` at runtime.
 const statusConfig = {
   connected: {
     label: "Connected",
     icon: IconCircleCheck,
-    variant: "default" as const,
+    variant: "default",
     className:
       "bg-green-100 text-green-800 border-green-200 hover:bg-green-100",
   },
   failed: {
     label: "Failed",
     icon: IconCircleX,
-    variant: "destructive" as const,
+    variant: "destructive",
     className: "bg-red-100 text-red-800 border-red-200 hover:bg-red-100",
   },
   timeout: {
     label: "Timeout",
     icon: IconClock,
-    variant: "secondary" as const,
+    variant: "secondary",
     className:
       "bg-yellow-100 text-yellow-800 border-yellow-200 hover:bg-yellow-100",
   },
   unreachable: {
     label: "Unreachable",
     icon: IconAlertCircle,
-    variant: "outline" as const,
+    variant: "outline",
     className: "bg-gray-100 text-gray-800 border-gray-200 hover:bg-gray-100",
   },
-} as const;
+  error: {
+    label: "Error",
+    icon: IconAlertTriangle,
+    variant: "destructive",
+    className: "bg-red-100 text-red-800 border-red-200 hover:bg-red-100",
+  },
+} as const satisfies Record<ConnectivityStatusType, StatusBadgeConfig>;
 
 export function StatusBadge({
   status,
@@ -80,7 +98,10 @@ export function StatusBadge({
   size = "md",
   showResponseTime = true,
 }: StatusBadgeProps) {
-  const config = statusConfig[status];
+  // Normalise defensively: a raw/legacy DB value outside the vocabulary must
+  // degrade to a known status rather than index statusConfig to `undefined`.
+  const normalizedStatus = toConnectivityStatus(status);
+  const config = statusConfig[normalizedStatus];
   const Icon = config.icon;
 
   const sizeClasses = {
@@ -112,7 +133,7 @@ export function StatusBadge({
     >
       <Icon className={iconSizes[size]} />
       <span>{config.label}</span>
-      {showResponseTime && responseTimeMs && status === "connected" && (
+      {showResponseTime && responseTimeMs && normalizedStatus === "connected" && (
         <span className="ml-1 opacity-75">
           ({formatResponseTime(responseTimeMs)})
         </span>
@@ -136,7 +157,8 @@ export function StatusDot({
   size = "md",
   pulse = false,
 }: StatusDotProps) {
-  const config = statusConfig[status];
+  const normalizedStatus = toConnectivityStatus(status);
+  const config = statusConfig[normalizedStatus];
 
   const dotSizes = {
     sm: "h-2 w-2",
@@ -149,14 +171,15 @@ export function StatusDot({
     failed: "bg-red-500",
     timeout: "bg-yellow-500",
     unreachable: "bg-gray-500",
-  };
+    error: "bg-red-600",
+  } satisfies Record<ConnectivityStatusType, string>;
 
   return (
     <div
       className={cn(
         "rounded-full",
         dotSizes[size],
-        colors[status],
+        colors[normalizedStatus],
         pulse && "animate-pulse",
       )}
       aria-label={`Status: ${config.label}`}
@@ -264,7 +287,7 @@ export function ServiceStatusCard({
           <div className="flex items-center justify-between">
             <div className="space-y-1">
               <CardTitle className="text-base font-medium flex items-center gap-2">
-                <StatusDot status={status.status as ConnectivityStatusType} />
+                <StatusDot status={status.status} />
                 {serviceLabels[service]}
               </CardTitle>
               <CardDescription className="text-sm">
@@ -273,7 +296,7 @@ export function ServiceStatusCard({
             </div>
             <div className="flex items-center gap-2">
               <StatusBadge
-                status={status.status as ConnectivityStatusType}
+                status={status.status}
                 responseTimeMs={status.responseTimeMs}
                 size="sm"
               />
@@ -388,7 +411,7 @@ export function CompactStatus({
             )}
             onClick={onClick}
           >
-            <StatusDot status={status.status as ConnectivityStatusType} />
+            <StatusDot status={status.status} />
             {showLabel && (
               <span className="font-medium">{serviceLabels[service]}</span>
             )}
@@ -408,7 +431,7 @@ export function CompactStatus({
             <p className="font-medium">{serviceLabels[service]}</p>
             <div className="flex items-center gap-2">
               <StatusBadge
-                status={status.status as ConnectivityStatusType}
+                status={status.status}
                 responseTimeMs={status.responseTimeMs}
                 size="sm"
                 showResponseTime={false}

--- a/client/src/components/github/connected-status-card.tsx
+++ b/client/src/components/github/connected-status-card.tsx
@@ -31,7 +31,7 @@ import {
   IconTrash,
 } from "@tabler/icons-react";
 import { toast } from "sonner";
-import type { ConnectivityStatusType, GitHubAgentAccessLevel } from "@mini-infra/types";
+import type { GitHubAgentAccessLevel } from "@mini-infra/types";
 import { PackageAccessSection } from "./package-access-section";
 import { AgentAccessSection } from "./agent-access-section";
 
@@ -106,9 +106,7 @@ export function ConnectedStatusCard({
           </div>
           {githubConnectivity && (
             <StatusBadge
-              status={
-                githubConnectivity.status as ConnectivityStatusType
-              }
+              status={githubConnectivity.status}
               responseTimeMs={githubConnectivity.responseTimeMs}
               size="sm"
             />

--- a/client/src/components/storage/StorageConnectivityStatus.tsx
+++ b/client/src/components/storage/StorageConnectivityStatus.tsx
@@ -36,10 +36,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Progress } from "@/components/ui/progress";
-import {
-  ConnectivityStatusInfo,
-  ConnectivityStatusType,
-} from "@mini-infra/types";
+import { ConnectivityStatusInfo } from "@mini-infra/types";
 import {
   ServiceStatusCard,
   StatusBadge,
@@ -252,7 +249,7 @@ function StatusHistoryTimeline({
                 <div key={status.id} className="flex items-start gap-3">
                   <div className="relative">
                     <StatusDot
-                      status={status.status as ConnectivityStatusType}
+                      status={status.status}
                       pulse={isLatest}
                     />
                     {index < historyItems.length - 1 && (
@@ -262,7 +259,7 @@ function StatusHistoryTimeline({
                   <div className="flex-1 min-w-0 pb-4">
                     <div className="flex items-center gap-2 mb-1">
                       <StatusBadge
-                        status={status.status as ConnectivityStatusType}
+                        status={status.status}
                         responseTimeMs={status.responseTimeMs}
                         size="sm"
                       />

--- a/lib/types/settings.ts
+++ b/lib/types/settings.ts
@@ -137,7 +137,7 @@ export interface ConnectivityStatus {
 export interface ConnectivityStatusInfo {
   id: string;
   service: string;
-  status: string;
+  status: ConnectivityStatusType;
   responseTimeMs: number | null;
   errorMessage: string | null;
   errorCode: string | null;
@@ -153,8 +153,27 @@ export interface ConnectivityStatusInfo {
 
 export type ConnectivityService = "cloudflare" | "docker" | "storage" | "system" | "deployments" | "tls" | "github" | "github-app" | "vault" | "nats" | "tailscale";
 
-export const CONNECTIVITY_STATUS_TYPES = ["connected", "failed", "timeout", "unreachable"] as const;
+export const CONNECTIVITY_STATUS_TYPES = ["connected", "failed", "timeout", "unreachable", "error"] as const;
 export type ConnectivityStatusType = typeof CONNECTIVITY_STATUS_TYPES[number];
+
+/**
+ * Normalise an arbitrary status string into a known {@link ConnectivityStatusType}.
+ *
+ * The DB column is a free string, so legacy rows (or a future producer) can hold
+ * a value outside the current vocabulary. Rendering code indexes a per-status
+ * config map by this value, so an unknown status must degrade to a safe member
+ * rather than yield `undefined` and crash the page. Unknown values map to
+ * `"error"` — an unrecognised status is, from the UI's perspective, an error
+ * condition. Use this at every boundary where a raw string becomes a typed
+ * `ConnectivityStatusType` instead of an unchecked `as` cast.
+ */
+export function toConnectivityStatus(
+  raw: string | null | undefined,
+): ConnectivityStatusType {
+  return (CONNECTIVITY_STATUS_TYPES as readonly string[]).includes(raw ?? "")
+    ? (raw as ConnectivityStatusType)
+    : "error";
+}
 
 // ====================
 // Connectivity API Response Types

--- a/server/src/routes/__tests__/settings-validation.test.ts
+++ b/server/src/routes/__tests__/settings-validation.test.ts
@@ -5,7 +5,8 @@ import {
   ValidationResult,
 } from "@mini-infra/types";
 
-const { mockPrisma, mockLogger, mockConfigService, mockConfigFactory } = vi.hoisted(() => ({
+const { mockPrisma, mockLogger, mockConfigService, mockConfigFactory, mockGithubAppValidate } = vi.hoisted(() => ({
+  mockGithubAppValidate: vi.fn(),
   mockPrisma: {
     systemSettings: {
       findMany: vi.fn(),
@@ -105,6 +106,12 @@ vi.mock("../../services/configuration-factory", () => ({
     .mockImplementation(function() { return mockConfigFactory; }),
 }));
 
+// Mock the GitHub App service singleton — github-app is validated by its own
+// on-demand service rather than the configuration factory.
+vi.mock("../../services/github-app/github-app-service", () => ({
+  githubAppService: { validate: mockGithubAppValidate },
+}));
+
 import settingsValidationRouter from "../settings-validation";
 
 describe("Settings Validation API Routes", () => {
@@ -161,6 +168,12 @@ describe("Settings Validation API Routes", () => {
       service: "docker",
       status: "connected",
       lastChecked: new Date(),
+    });
+
+    mockGithubAppValidate.mockResolvedValue({
+      isValid: true,
+      message: "GitHub App connected",
+      responseTimeMs: 120,
     });
   });
 
@@ -314,7 +327,7 @@ describe("Settings Validation API Routes", () => {
       expect(mockPrisma.systemSettings.updateMany).not.toHaveBeenCalled();
     });
 
-    it("should return 400 for invalid service", async () => {
+    it("should return 400 for an unknown service", async () => {
       const response = await request(app)
         .post("/api/settings/validate/invalid-service")
         .send({})
@@ -322,8 +335,69 @@ describe("Settings Validation API Routes", () => {
 
       expect(response.body).toMatchObject({
         error: "Bad Request",
-        message:
-          "Invalid service 'invalid-service'. Must be one of: docker, cloudflare, azure, system, deployments, haproxy, tls, github-app, tailscale",
+        message: expect.stringContaining(
+          "Service 'invalid-service' does not support connectivity validation",
+        ),
+      });
+    });
+
+    it("should return 400 for a service with no live validator (haproxy)", async () => {
+      // haproxy/system/deployments are settings categories with no connectivity
+      // check — they must be rejected cleanly, not throw and record an "error" row.
+      const response = await request(app)
+        .post("/api/settings/validate/haproxy")
+        .send({})
+        .expect(400);
+
+      expect(response.body.message).toContain(
+        "does not support connectivity validation",
+      );
+      expect(mockConfigFactory.create).not.toHaveBeenCalled();
+      expect(mockPrisma.connectivityStatus.create).not.toHaveBeenCalled();
+    });
+
+    it("should validate github-app via its own service, not the factory", async () => {
+      mockGithubAppValidate.mockResolvedValue({
+        isValid: true,
+        message: "GitHub App connected (mini-infra), 96 repositories accessible",
+        responseTimeMs: 200,
+      });
+      mockPrisma.connectivityStatus.create.mockResolvedValue({});
+
+      const response = await request(app)
+        .post("/api/settings/validate/github-app")
+        .send({})
+        .expect(200);
+
+      expect(response.body).toMatchObject({
+        success: true,
+        message: "github-app service validation successful",
+        data: { service: "github-app", isValid: true },
+      });
+
+      // Dispatched to the dedicated github-app service, never the factory.
+      expect(mockGithubAppValidate).toHaveBeenCalled();
+      expect(mockConfigFactory.create).not.toHaveBeenCalled();
+
+      expect(mockPrisma.connectivityStatus.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          service: "github-app",
+          status: "connected",
+        }),
+      });
+    });
+
+    it("maps the azure service name to the storage-azure category", async () => {
+      mockConfigService.validate.mockResolvedValue(mockValidationResult);
+      mockPrisma.connectivityStatus.create.mockResolvedValue({});
+
+      await request(app)
+        .post("/api/settings/validate/azure")
+        .send({})
+        .expect(200);
+
+      expect(mockConfigFactory.create).toHaveBeenCalledWith({
+        category: "storage-azure",
       });
     });
 

--- a/server/src/routes/settings-connectivity.ts
+++ b/server/src/routes/settings-connectivity.ts
@@ -11,7 +11,7 @@ const logger = getLogger("http", "settings-connectivity");
 import { requirePermission, getAuthenticatedUser } from "../middleware/auth";
 import prisma from "../lib/prisma";
 import { Prisma } from "../generated/prisma/client";
-import { ConnectivityStatus, ConnectivityStatusInfo, ConnectivityStatusListResponse, SORT_ORDERS, Permission } from "@mini-infra/types";
+import { ConnectivityStatus, ConnectivityStatusInfo, ConnectivityStatusListResponse, SORT_ORDERS, Permission, toConnectivityStatus } from "@mini-infra/types";
 
 const router = express.Router();
 
@@ -21,6 +21,7 @@ function serializeConnectivityStatus(
 ): ConnectivityStatusInfo {
   return {
     ...status,
+    status: toConnectivityStatus(status.status),
     responseTimeMs: status.responseTimeMs
       ? Number(status.responseTimeMs)
       : null,

--- a/server/src/routes/settings-validation.ts
+++ b/server/src/routes/settings-validation.ts
@@ -11,7 +11,13 @@ const logger = getLogger("http", "settings-validation");
 import { requirePermission, getAuthenticatedUser } from "../middleware/auth";
 import prisma from "../lib/prisma";
 import { ConfigurationServiceFactory } from "../services/configuration-factory";
-import { SettingsCategory, Permission } from "@mini-infra/types";
+import { githubAppService } from "../services/github-app/github-app-service";
+import {
+  SettingsCategory,
+  Permission,
+  type ConnectivityStatusType,
+  type ValidationResult,
+} from "@mini-infra/types";
 
 const router = express.Router();
 
@@ -54,6 +60,50 @@ async function raceWithTimeout<T>(
   }
 }
 
+type ServiceValidator = (
+  settings?: Record<string, string>,
+) => Promise<ValidationResult>;
+
+/**
+ * Connectivity service name → the config category the factory validates it
+ * under. Typed against `SettingsCategory`, so a non-existent category is a
+ * compile error rather than a runtime "Unsupported configuration category"
+ * throw. Aliases (`azure`/`storage` → `storage-azure`) are spelled out because
+ * the manual-validation service name and the config category diverge.
+ */
+const FACTORY_VALIDATABLE_SERVICES: Record<string, SettingsCategory> = {
+  docker: "docker",
+  cloudflare: "cloudflare",
+  azure: "storage-azure",
+  storage: "storage-azure",
+  "storage-azure": "storage-azure",
+  tls: "tls",
+  tailscale: "tailscale",
+  vault: "vault",
+};
+
+const VALIDATABLE_SERVICE_NAMES = [
+  ...Object.keys(FACTORY_VALIDATABLE_SERVICES),
+  "github-app",
+];
+
+/**
+ * Resolve the validator for a connectivity service, or `null` when the service
+ * has no live connectivity check (e.g. `system`, `deployments`, `haproxy`,
+ * `nats` — settings categories with no validator). `github-app` is validated by
+ * its own on-demand service rather than the factory; it is intentionally kept
+ * out of the factory so the periodic scheduler doesn't start hitting the GitHub
+ * API every cycle.
+ */
+function getServiceValidator(service: string): ServiceValidator | null {
+  if (service === "github-app") {
+    return (settings) => githubAppService.validate(settings);
+  }
+  const category = FACTORY_VALIDATABLE_SERVICES[service];
+  if (!category) return null;
+  return (settings) => configFactory.create({ category }).validate(settings);
+}
+
 // Validation request schema
 const validateServiceSchema = z.object({
   settings: z.record(z.string(), z.string()).optional(), // Optional settings to validate with
@@ -91,23 +141,15 @@ router.post("/:service", requirePermission(Permission.SettingsWrite) as RequestH
       });
     }
 
-    // Validate service parameter
-    if (
-      ![
-        "docker",
-        "cloudflare",
-        "azure",
-        "system",
-        "deployments",
-        "haproxy",
-        "tls",
-        "github-app",
-        "tailscale",
-      ].includes(service)
-    ) {
+    // Resolve how this service is validated. Services with no live connectivity
+    // check (system, deployments, haproxy, nats, …) resolve to null and are
+    // rejected here — rather than throwing deeper in the factory and recording a
+    // bogus "error" connectivity row.
+    const validator = getServiceValidator(service);
+    if (!validator) {
       return res.status(400).json({
         error: "Bad Request",
-        message: `Invalid service '${service}'. Must be one of: docker, cloudflare, azure, system, deployments, haproxy, tls, github-app, tailscale`,
+        message: `Service '${service}' does not support connectivity validation. Validatable services: ${VALIDATABLE_SERVICE_NAMES.join(", ")}`,
         timestamp: new Date().toISOString(),
         requestId,
       });
@@ -137,23 +179,13 @@ router.post("/:service", requirePermission(Permission.SettingsWrite) as RequestH
 
     const { settings } = bodyValidation.data;
 
-    // Get the configuration service for the requested service type
-    const configService = configFactory.create({
-      category: service as SettingsCategory,
-    });
-
     // Perform validation with timeout protection
     const startTime = Date.now();
-    const validationResult = (await raceWithTimeout(
-      configService.validate(settings),
+    const validationResult = await raceWithTimeout(
+      validator(settings),
       30000,
       "Validation timeout",
-    )) as {
-      isValid: boolean;
-      message?: string;
-      errorCode?: string;
-      metadata?: Record<string, unknown>;
-    };
+    );
 
     const responseTime = Date.now() - startTime;
 
@@ -161,7 +193,9 @@ router.post("/:service", requirePermission(Permission.SettingsWrite) as RequestH
     await prisma.connectivityStatus.create({
       data: {
         service,
-        status: validationResult.isValid ? "connected" : "failed",
+        status: (validationResult.isValid
+          ? "connected"
+          : "failed") satisfies ConnectivityStatusType,
         responseTimeMs: responseTime,
         errorMessage: validationResult.isValid
           ? null
@@ -230,7 +264,7 @@ router.post("/:service", requirePermission(Permission.SettingsWrite) as RequestH
       await prisma.connectivityStatus.create({
         data: {
           service,
-          status: "error",
+          status: "error" satisfies ConnectivityStatusType,
           responseTimeMs: responseTime,
           errorMessage:
             error instanceof Error ? error.message : "Unknown validation error",

--- a/server/src/routes/storage-connectivity.ts
+++ b/server/src/routes/storage-connectivity.ts
@@ -18,7 +18,7 @@ import { getLogger } from "../lib/logger-factory";
 import { requirePermission, getAuthenticatedUser } from "../middleware/auth";
 import prisma from "../lib/prisma";
 import { Prisma } from "../generated/prisma/client";
-import { CONNECTIVITY_STATUS_TYPES, ConnectivityStatusListResponse, ConnectivityStatusResponse, SORT_ORDERS, Permission } from "@mini-infra/types";
+import { CONNECTIVITY_STATUS_TYPES, ConnectivityStatusListResponse, ConnectivityStatusResponse, SORT_ORDERS, Permission, toConnectivityStatus } from "@mini-infra/types";
 
 const logger = getLogger("integrations", "storage-connectivity");
 const router = express.Router();
@@ -67,7 +67,7 @@ router.get("/", requirePermission(Permission.StorageRead) as RequestHandler, (as
       data: {
         id: latestStatus.id,
         service: latestStatus.service,
-        status: latestStatus.status,
+        status: toConnectivityStatus(latestStatus.status),
         responseTimeMs:
           latestStatus.responseTimeMs != null
             ? Number(latestStatus.responseTimeMs)
@@ -144,7 +144,7 @@ router.get("/history", requirePermission(Permission.StorageRead) as RequestHandl
       data: records.map((r) => ({
         id: r.id,
         service: r.service,
-        status: r.status,
+        status: toConnectivityStatus(r.status),
         responseTimeMs:
           r.responseTimeMs != null ? Number(r.responseTimeMs) : null,
         errorMessage: r.errorMessage,

--- a/server/src/services/connectivity-socket-emitter.ts
+++ b/server/src/services/connectivity-socket-emitter.ts
@@ -6,7 +6,7 @@
  * so no debounce is needed.
  */
 
-import { Channel, ServerEvent } from "@mini-infra/types";
+import { Channel, ServerEvent, toConnectivityStatus } from "@mini-infra/types";
 import type { ConnectivityStatusInfo } from "@mini-infra/types";
 import { emitToChannel } from "../lib/socket";
 import prisma from "../lib/prisma";
@@ -34,6 +34,7 @@ function serializeConnectivityStatus(
 ): ConnectivityStatusInfo {
   return {
     ...status,
+    status: toConnectivityStatus(status.status),
     responseTimeMs: status.responseTimeMs
       ? Number(status.responseTimeMs)
       : null,


### PR DESCRIPTION
## Problem

The GitHub connectivity page (`/connectivity-github`) crashed into the **"Authentication Error"** boundary with `Cannot read properties of undefined (reading 'icon')`. Reproduced on production — the `github-app` connectivity row held `status: "error"` (`"Unsupported configuration category: github-app"`).

Two defects combined to produce it, and both are the same class of bug: a lying `as` cast papering over a real type mismatch.

## 1. Frontend crash (the page bug)

`StatusBadge`/`StatusDot` did `statusConfig[status].icon` with no guard. `"error"` wasn't in `CONNECTIVITY_STATUS_TYPES`, so the lookup was `undefined` and `.icon` threw. Systemic — `connected-status-card`, `StorageConnectivityStatus`, and `connectivity-status` all cast a raw DB string `as ConnectivityStatusType` into the same unguarded map, so Tailscale/HAProxy pages had the same latent crash.

**Fix — shared library (`@mini-infra/types`):**
- `"error"` added as a first-class status (its own icon/label/red badge)
- `ConnectivityStatusInfo.status` typed as `ConnectivityStatusType` (was `string`) — the tightened type forced **4 server ingestion sites** to normalise
- New dependency-free `toConnectivityStatus()` normaliser; unknown/legacy values degrade to `"error"` instead of crashing
- `statusConfig` is now `as const satisfies Record<ConnectivityStatusType, …>` → **adding a status without an icon/label is a compile error**
- All 7 `as ConnectivityStatusType` casts removed

## 2. Why the bad row existed (validation routing)

`POST /api/settings/validate/:service` accepted `github-app`/`azure`/`system`/`deployments`/`haproxy` but dispatched every service through `ConfigurationServiceFactory` (supports only `docker`/`cloudflare`/`storage-azure`/`tls`/`vault`/`tailscale`) via `service as SettingsCategory` → threw "Unsupported configuration category" → recorded `status: "error"`.

**Fix — server:** typed `service → category` dispatch replacing the out-of-sync allowlist + cast.
- `github-app` validates via its own on-demand `githubAppService` — **deliberately kept out of the factory** so the 5-min connectivity scheduler doesn't start hitting the GitHub API every cycle
- `azure`/`storage` → `storage-azure` (also fixes the Storage card's refresh button, previously a silent 400)
- `system`/`deployments`/`haproxy`/`nats` → clean **400** "does not support validation" instead of a bogus `"error"` row

## Verification
- `build:lib`, client build, server build — all clean
- client + server lint — clean
- **New client regression test** renders the exact prod `"error"` value (and a garbage legacy value) without throwing — 5/5 pass
- `settings-validation` route tests updated + extended (github-app dispatch, haproxy rejection, azure→storage-azure mapping) — 11/11 pass
- **Full server suite green — 2636 tests**

🤖 Generated with [Claude Code](https://claude.com/claude-code)