### PR TITLE
fix(egress): keep sidecar NATS clients reconnecting through auth errors

### DIFF
--- a/egress-shared/natsbus/bus.go
+++ b/egress-shared/natsbus/bus.go
@@ -92,6 +92,16 @@ func Connect(ctx context.Context, opts ConnectOptions) (*Bus, error) {
 		nats.ReconnectWait(2 * time.Second),
 		nats.PingInterval(20 * time.Second),
 		nats.MaxPingsOutstanding(2),
+		// Keep retrying through auth failures. By default nats.go aborts the
+		// reconnect loop and permanently closes the connection after the server
+		// returns the *same* auth error twice in a row — which turns a transient
+		// Vault/NATS restart (NATS boots before Vault is unsealed, so it rejects
+		// our creds until its accounts load) into a permanent zombie: the proxy
+		// keeps running but never receives another container-map/rules push, so
+		// its ACL/container map go stale and every request is denied. The
+		// sidecars are unattended and must self-heal once NATS comes good, so we
+		// opt out of the abort and let MaxReconnects(-1) keep trying.
+		nats.IgnoreAuthErrorAbort(),
 		// Surface every transition through the structured logger — without
 		// these the agent silently flap-loops on a transient NATS bounce.
 		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {


### PR DESCRIPTION
## Problem

Production incident: browsing an internet-env app returned
`{"error":"egress denied: source IP 192.168.128.4 is not mapped to a managed stack"}`,
and the egress-fw-agent logged `heartbeat KV put failed ... nats: connection closed`.

**Root cause chain:** Vault got sealed → NATS (which reads its `nats.conf` +
account JWTs from Vault KV at container start) went unhealthy → the
egress-gateway's and egress-fw-agent's NATS clients dropped and went
**permanently `closed`**.

The shared client (`egress-shared/natsbus`) sets `MaxReconnects(-1)` (unlimited),
but nats.go's default behaviour aborts the reconnect loop and closes the
connection when the server returns the *same* auth error twice in a row
(`nats.go`: `if nc.current.lastErr == err && !nc.Opts.IgnoreAuthErrorAbort { nc.ar = true }`).
During a Vault/NATS restart, NATS can come up before Vault is unsealed and reject
the sidecars' creds until its accounts load — two consecutive rejections zombie
the sidecar for good.

**Why that's bad:** the container map / ACL are pushed to the gateway over NATS
(`container-map.apply.<env>` / `rules.apply.<env>`, req/reply). A zombied client
never receives another push, so the map goes stale/empty and the
`UnknownIPDenyHandler` 403s every request. This fires *before* policy, so
`detect`/`allow` mode doesn't save it. Recovery required manually recreating the
gateway container (a stack re-apply doesn't help — the reconciler skips
recreating an in-sync container).

## Fix

Add `nats.IgnoreAuthErrorAbort()` to the shared connect options (keeping
`MaxReconnects(-1)`), so the client keeps retrying through auth failures and
self-heals once NATS comes good.

Because the fix lives in `egress-shared/natsbus`, **both** sidecars are covered
by the one change — verified that the only raw `nats.Connect()` in the repo is
in that shared client, and both `egress-gateway/cmd/main.go` and
`egress-fw-agent/cmd/main.go` go through it.

## Testing

- `go build ./...` — egress-shared, egress-gateway, egress-fw-agent all OK
- `go vet ./natsbus/...` — clean
- `go test ./...` — egress-shared, egress-gateway, egress-fw-agent all pass
- Confirmed `IgnoreAuthErrorAbort()` semantics against the pinned nats.go v1.51.0 source

## Not in scope / follow-ups

- The 301 redirect loop observed on the recovered site is a separate origin/HAProxy
  `X-Forwarded-Proto` issue, not egress.
- Optional hardening: a gateway-health-KV staleness watch that recreates the
  container when its heartbeat goes stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)