### PR TITLE
fix(egress): bypass egress injection for cloudflared and haproxy infra containers

### DIFF
--- a/server/src/__tests__/cloudflare-tunnel-template-load.test.ts
+++ b/server/src/__tests__/cloudflare-tunnel-template-load.test.ts
@@ -72,4 +72,17 @@ describe('cloudflare-tunnel template.json', () => {
     expect(test[0]).not.toBe('CMD-SHELL');
     expect(test.join(' ')).not.toMatch(/\b(wget|curl)\b/);
   });
+
+  it('bypasses egress injection — cloudflared is an ingress connector, not firewalled egress', () => {
+    const svc = loadTunnel().definition.services[0];
+    // cloudflared reaches its internal HAProxy origin AND the Cloudflare edge.
+    // With HTTP_PROXY injected it tries to CONNECT through the egress-gateway
+    // proxy (which it can't even resolve — it only joins the `tunnel` network),
+    // so the origin is unreachable and the tunnel serves a Cloudflare error.
+    // Treat it like the other infra containers (egress-gateway, fw-agent).
+    expect(svc.containerConfig.egressBypass).toBe(true);
+    // A bypassed service must not also carry an egress allowlist — it never
+    // touches the proxy, so `requiredEgress` would be dead and misleading.
+    expect(svc.containerConfig.requiredEgress).toBeUndefined();
+  });
 });

--- a/server/src/__tests__/haproxy-template-load.test.ts
+++ b/server/src/__tests__/haproxy-template-load.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Regression tests for the built-in `haproxy` load-balancer template.
+ *
+ * HAProxy is the environment's *internal* router — its backends are all
+ * container-local, and it never makes controlled internet egress. When the
+ * egress firewall injected HTTP_PROXY/HTTPS_PROXY into it, the container had to
+ * carry a defensive `unset HTTP_PROXY …` in its healthcheck so the localhost
+ * stats probe wouldn't be routed through the (often unreachable) egress-gateway
+ * proxy. Marking the service `egressBypass: true` removes the proxy env at the
+ * source and keeps HAProxy out of the egress firewall's scope entirely, the
+ * same way the egress-gateway and fw-agent infra containers are handled.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as path from 'path';
+import { loadTemplateFromDirectory } from '../services/stacks/template-file-loader';
+
+const TEMPLATES_DIR = path.resolve(process.cwd(), 'templates');
+
+function loadHaproxy() {
+  return loadTemplateFromDirectory(path.join(TEMPLATES_DIR, 'haproxy'));
+}
+
+describe('haproxy template.json', () => {
+  it('parses successfully via loadTemplateFromDirectory', () => {
+    expect(() => loadHaproxy()).not.toThrow();
+  });
+
+  it('has a single haproxy service', () => {
+    const loaded = loadHaproxy();
+    expect(loaded.definition.services).toHaveLength(1);
+    expect(loaded.definition.services[0].serviceName).toBe('haproxy');
+  });
+
+  it('bypasses egress injection — HAProxy is an internal router, not firewalled egress', () => {
+    const svc = loadHaproxy().definition.services[0];
+    expect(svc.containerConfig.egressBypass).toBe(true);
+  });
+});

--- a/server/templates/cloudflare-tunnel/template.json
+++ b/server/templates/cloudflare-tunnel/template.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-tunnel",
   "displayName": "Cloudflare Tunnel",
-  "builtinVersion": 8,
+  "builtinVersion": 9,
   "scope": "environment",
   "networkType": "internet",
   "category": "infrastructure",
@@ -26,7 +26,7 @@
         "dynamicEnv": {
           "TUNNEL_TOKEN": { "kind": "cloudflare-tunnel-token" }
         },
-        "requiredEgress": ["*.cloudflare.com", "*.argotunnel.com"],
+        "egressBypass": true,
         "joinResourceNetworks": ["tunnel"],
         "restartPolicy": "unless-stopped",
         "healthcheck": {

--- a/server/templates/haproxy/template.json
+++ b/server/templates/haproxy/template.json
@@ -1,7 +1,7 @@
 {
   "name": "haproxy",
   "displayName": "HAProxy Load Balancer",
-  "builtinVersion": 10,
+  "builtinVersion": 11,
   "scope": "environment",
   "category": "infrastructure",
   "description": "HAProxy load balancer with DataPlane API",
@@ -47,6 +47,7 @@
           "HAPROXY_MWORKER": "1",
           "DATAPLANEAPI_USERLIST_FILE": "/usr/local/etc/haproxy/haproxy.cfg"
         },
+        "egressBypass": true,
         "ports": [
           { "containerPort": 80, "hostPort": "{{params.http-port}}", "protocol": "tcp", "exposeOnHost": "{{params.expose-on-host}}" },
           { "containerPort": 443, "hostPort": "{{params.https-port}}", "protocol": "tcp", "exposeOnHost": "{{params.expose-on-host}}" },


### PR DESCRIPTION
## Problem

After the egress gateway itself was recovered, `kumikodesigner.io` still failed — Cloudflare served an error page. The cloudflared logs showed the real reason:

```
ERR Unable to reach the origin service ... proxyconnect tcp: dial tcp:
lookup egress-gateway on 127.0.0.11:53: no such host
originService=http://internet-haproxy-haproxy:80
```

The egress firewall injects `HTTP_PROXY/HTTPS_PROXY=http://egress-gateway:3128` (+ a `NO_PROXY` of loopback + the egress subnet) into **every** container in an environment that has an egress gateway, unless the service opts out with `egressBypass: true`. Only `egress-gateway` and `egress-fw-agent` set that today.

That's wrong for the environment's ingress/router infra:

- **cloudflared** must reach its internal HAProxy origin (`http://internet-haproxy-haproxy:80`) and the Cloudflare edge. The origin **hostname** isn't matched by `NO_PROXY` (Go's proxy matcher won't resolve a hostname to test it against the CIDR), so cloudflared tries to `CONNECT` through `egress-gateway:3128` — which it can't even resolve, because it only joins the `tunnel` network, not `egress`. Origin unreachable → Cloudflare error. Forcing a tunnel connector through an HTTP `CONNECT` proxy is unworkable anyway (QUIC edge connections).
- **haproxy** is an internal router; its backends are all container-local and it makes no controlled internet egress. The injected proxy env was harmful enough that its healthcheck already carried a defensive `unset HTTP_PROXY …`.

## Fix

Mark both infra services `egressBypass: true`, exactly like `egress-gateway`/`egress-fw-agent`:

- `cloudflare-tunnel/template.json`: add `egressBypass: true`, drop the now-dead `requiredEgress` allowlist (a bypassed service never touches the proxy), bump `builtinVersion` 8 → 9.
- `haproxy/template.json`: add `egressBypass: true`, bump `builtinVersion` 10 → 11.

`egressBypass` short-circuits both the proxy-env injection **and** the egress-network attach (`resolveEgressContext`), so these containers reach their peers directly. The egress firewall stays focused on the actual app workloads.

## Testing

- `pnpm build:lib` + `pnpm --filter mini-infra-server build` (tsc) — clean
- `egress-injection`, `egress-policy-lifecycle`, `egress-fw-agent-template`, `template-file-loader`, `service-schema-drift`, tunnel + new haproxy template-load tests — all pass
- eslint clean on changed files
- Added regression assertions pinning `egressBypass: true` on both templates (and `requiredEgress` removed on cloudflared)

## Deploying

After release, the `cloudflare-tunnel` and `haproxy` stacks will show drift (new template version) — re-apply each to recreate the containers **without** the proxy env. That's what clears the current tunnel-origin failure in prod.

## Follow-up (not in this PR)

`resolveEgressContext` injects based on `env.egressGatewayIp` + the egress network resource existing — it does **not** honor the environment's `egressFirewallEnabled` flag, so toggling the firewall "off" doesn't stop injection. Worth reconciling separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)