### PR TITLE
fix(egress): honor egressFirewallEnabled flag in L7 proxy injection

### DIFF
--- a/client/src/components/egress/egress-environment-firewall-toggles.tsx
+++ b/client/src/components/egress/egress-environment-firewall-toggles.tsx
@@ -107,10 +107,12 @@ function EnvFirewallToggle({
               Disable egress firewall for {environmentName}?
             </AlertDialogTitle>
             <AlertDialogDescription>
-              The kernel-level enforcement layer will be torn down. Egress
-              events will stop being logged for this environment until you
-              re-enable it. This change is best-effort if the firewall agent is
-              offline.
+              The kernel-level enforcement layer will be torn down and egress
+              events will stop being logged for this environment. New and
+              redeployed containers will also no longer be routed through the
+              egress proxy; already-running containers keep their current proxy
+              settings until their stack is next applied. This change is
+              best-effort if the firewall agent is offline.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/server/src/__tests__/network-membership-compiler.integration.test.ts
+++ b/server/src/__tests__/network-membership-compiler.integration.test.ts
@@ -104,6 +104,9 @@ async function seedRepresentativeStack(): Promise<Fixture> {
       type: 'nonproduction',
       networkType: 'local',
       egressGatewayIp: '10.44.0.2',
+      // Egress injection now gates on this flag; enable it so the egress
+      // network membership reconcile fires for this fixture.
+      egressFirewallEnabled: true,
     },
   });
 

--- a/server/src/services/stacks/__tests__/egress-injection.test.ts
+++ b/server/src/services/stacks/__tests__/egress-injection.test.ts
@@ -10,12 +10,16 @@ const log = {
 } as any;
 
 function buildPrisma(
-  envRow: { egressGatewayIp: string | null } | null,
+  envRow: { egressGatewayIp: string | null; egressFirewallEnabled?: boolean } | null,
   egressResource: { name: string; metadata: unknown } | null = null,
 ) {
+  // The egress firewall defaults ON in these fixtures so the existing injection
+  // tests exercise the happy path. Pass `egressFirewallEnabled: false`
+  // explicitly to cover the opt-out gate.
+  const row = envRow === null ? null : { egressFirewallEnabled: true, ...envRow };
   return {
     environment: {
-      findUnique: vi.fn().mockResolvedValue(envRow),
+      findUnique: vi.fn().mockResolvedValue(row),
     },
     infraResource: {
       findFirst: vi.fn().mockResolvedValue(egressResource),
@@ -75,6 +79,19 @@ describe('resolveEgressEnv', () => {
     const prisma = buildPrisma({ egressGatewayIp: null });
     const env = await resolveEgressEnv(prisma, 'env-1', false);
     expect(env).toEqual({});
+    expect(prisma.infraResource.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('returns empty when egressFirewallEnabled is false (firewall opt-out)', async () => {
+    // Gateway is provisioned (egressGatewayIp set) but the operator has the
+    // firewall switched off — no proxy env should be injected.
+    const prisma = buildPrisma(
+      { egressGatewayIp: '172.30.16.3', egressFirewallEnabled: false },
+      { name: 'env1-egress', metadata: { subnet: '172.30.16.0/24' } },
+    );
+    const env = await resolveEgressEnv(prisma, 'env-1', false);
+    expect(env).toEqual({});
+    // Short-circuits after the env read — never touches the InfraResource.
     expect(prisma.infraResource.findFirst).not.toHaveBeenCalled();
   });
 
@@ -149,6 +166,19 @@ describe('attachEgressNetworkIfNeeded', () => {
     await attachEgressNetworkIfNeeded(prisma, cm, 'container-1', 'env-1', false, log);
 
     expect(cm.connectToNetwork).not.toHaveBeenCalled();
+  });
+
+  it('skips connect when egressFirewallEnabled is false (firewall opt-out)', async () => {
+    const prisma = buildPrisma(
+      { egressGatewayIp: '172.30.16.3', egressFirewallEnabled: false },
+      { name: 'env1-egress', metadata: { subnet: '172.30.16.0/24' } },
+    );
+    const cm = buildContainerManager();
+
+    await attachEgressNetworkIfNeeded(prisma, cm, 'container-1', 'env-1', false, log);
+
+    expect(cm.connectToNetwork).not.toHaveBeenCalled();
+    expect(prisma.infraResource.findFirst).not.toHaveBeenCalled();
   });
 
   it('skips connect when egress InfraResource is missing', async () => {

--- a/server/src/services/stacks/__tests__/stack-container-manager-egress.test.ts
+++ b/server/src/services/stacks/__tests__/stack-container-manager-egress.test.ts
@@ -72,12 +72,16 @@ describe('StackContainerManager — egress env injection', () => {
   });
 
   function buildManager(
-    envResult: { egressGatewayIp: string | null } | null,
+    envResult: { egressGatewayIp: string | null; egressFirewallEnabled?: boolean } | null,
     egressResource: { name: string; metadata: unknown } | null = null,
   ) {
     mockPrisma = {
       environment: {
-        findUnique: vi.fn().mockResolvedValue(envResult),
+        // Default the firewall ON so the injection happy-path fixtures keep
+        // exercising injection; egress-injection now gates on this flag.
+        findUnique: vi
+          .fn()
+          .mockResolvedValue(envResult === null ? null : { egressFirewallEnabled: true, ...envResult }),
       },
       infraResource: {
         findFirst: vi.fn().mockResolvedValue(egressResource),
@@ -209,10 +213,14 @@ describe('StackContainerManager — egress bypass label', () => {
     });
   });
 
-  function buildManager(envResult: { egressGatewayIp: string | null } | null) {
+  function buildManager(envResult: { egressGatewayIp: string | null; egressFirewallEnabled?: boolean } | null) {
     mockPrisma = {
       environment: {
-        findUnique: vi.fn().mockResolvedValue(envResult),
+        // Default the firewall ON so the injection happy-path fixtures keep
+        // exercising injection; egress-injection now gates on this flag.
+        findUnique: vi
+          .fn()
+          .mockResolvedValue(envResult === null ? null : { egressFirewallEnabled: true, ...envResult }),
       },
       infraResource: {
         findFirst: vi.fn().mockResolvedValue(null),

--- a/server/src/services/stacks/egress-injection.ts
+++ b/server/src/services/stacks/egress-injection.ts
@@ -45,6 +45,11 @@ interface EgressContext {
  * Gates (in order):
  * - egressBypass === true → no injection (egress-gateway itself, fw-agent, etc.)
  * - No environmentId → host-level stack, no injection.
+ * - egressFirewallEnabled === false → firewall opt-out (the default). Keeps L7
+ *   proxy env + network attach consistent with the L3/L4 fw-agent, which also
+ *   no-ops when the flag is off (see env-firewall-manager). The egress-gateway
+ *   is provisioned unconditionally at env creation, so gating on egressGatewayIp
+ *   alone kept injecting even after the operator switched the firewall off.
  * - Environment has no egressGatewayIp → gateway not provisioned, skip.
  * - No `egress` InfraResource for the env → gateway provisioning incomplete, skip.
  *
@@ -67,9 +72,15 @@ export async function resolveEgressContext(
   try {
     const env = await prisma.environment.findUnique({
       where: { id: environmentId },
-      select: { egressGatewayIp: true },
+      select: { egressGatewayIp: true, egressFirewallEnabled: true },
     });
-    if (!env?.egressGatewayIp) return { shouldInject: false };
+    // Egress firewall is opt-in per environment (egressFirewallEnabled defaults
+    // to false). Honour it here so disabling the firewall actually stops L7
+    // injection — the L3/L4 fw-agent already no-ops when off, but the gateway is
+    // provisioned unconditionally at env creation, so gating on egressGatewayIp
+    // alone left the proxy env pointed at a gateway the operator switched off.
+    if (!env?.egressFirewallEnabled) return { shouldInject: false };
+    if (!env.egressGatewayIp) return { shouldInject: false };
 
     const resource = await prisma.infraResource.findFirst({
       where: {


### PR DESCRIPTION
## Problem

The egress firewall has two enforcement layers:
- **L3/L4** — the fw-agent (nftables), gated on `Environment.egressFirewallEnabled` (default `false`). Its own docs: *"Nothing is called for envs with the flag OFF."*
- **L7** — the gateway: `resolveEgressContext` injects `HTTP_PROXY=egress-gateway:3128` into every non-bypass container and attaches it to the per-env egress network.

But L7 gated **only on `egressGatewayIp`**, not the flag. The egress-gateway is provisioned *unconditionally* at environment creation (`createEnvironment` → `provisionEgressGateway`), so `egressGatewayIp` is always set. Net effect: **toggling the firewall OFF did nothing to the L7 proxy** — containers were still handed the proxy env and attached to the egress network. (This is what surfaced in the field: an env with the firewall "off" was still injecting `HTTP_PROXY` into cloudflared.)

## Fix

Gate `resolveEgressContext` — the single chokepoint for **both** proxy-env injection (`resolveEgressEnv`) and network attach (`attachEgressNetworkIfNeeded`) — on `egressFirewallEnabled`. Now L7 matches L3/L4: flag off → nothing injected.

- One extra column in the existing `findUnique` select (no new query).
- Takes effect on the next container recreate/apply (env vars can't be hot-swapped) — same propagation model as any other env/template change. The disable-confirmation dialog copy is updated to say so.

## Behaviour change (intentional)

Because the flag defaults `false`, environments that never explicitly enabled the firewall but were being L7-injected (all of them, due to the unconditional gateway) will **stop** injecting on their next apply. This aligns L7 with the flag's documented meaning — the always-on L7 injection was the bug. Enable the toggle on `/egress` to opt an environment in.

Complementary to #487 (bypass cloudflared/haproxy): even with the firewall *enabled*, those infra containers must still bypass. Zero file overlap between the two PRs.

## Testing

- Full server suite: **213 files / 2654 tests** pass
- `egress-injection.test.ts`: fixtures default the flag ON (happy path); added opt-out cases for both `resolveEgressEnv` and `attachEgressNetworkIfNeeded` (asserts short-circuit before the InfraResource lookup)
- `stack-container-manager-egress.test.ts`, `network-membership-compiler.integration.test.ts`: fixtures updated to enable the firewall
- client build clean; server + client lint clean

## Follow-up (not in this PR)

The egress-gateway is still **provisioned unconditionally** even when the firewall is off — it just sits idle now. Gating provisioning/teardown on the flag (and re-applying an env's stacks on toggle so running containers pick up the change immediately) would be a larger, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)