### PR TITLE
fix(applications): lock update button during deploy + stop false "update failed"

### DIFF
--- a/client/src/app/applications/application-card.tsx
+++ b/client/src/app/applications/application-card.tsx
@@ -105,12 +105,18 @@ export function ApplicationCard({
   };
   const closeUpdateForm = () => setFlipped(false);
 
-  const { registerTask } = useTaskTracker();
+  const { registerTask, getTask } = useTaskTracker();
   const deployUpdate = useDeployApplicationUpdate();
 
-  // Cover the gap between deployUpdate resolving and the socket "pending" event
-  // arriving — keep the card locked until one or the other is true.
-  const effectivelyBusy = isBusy || deployUpdate.isPending;
+  // An in-flight tracked task for this stack is the authoritative "deploy is
+  // running" signal: it's registered synchronously when the user hits Redeploy
+  // and only clears on the terminal socket event. `deployUpdate.isPending` is
+  // fire-and-forget (clears on the "started" ACK) and the stack status only
+  // flips to "pending" after a refetch, so neither reliably covers the whole
+  // deploy — the tracked task does. Keep the card locked while any of them hold.
+  const trackedTask = primaryStack ? getTask(primaryStack.id) : undefined;
+  const taskExecuting = trackedTask?.operationState.phase === "executing";
+  const effectivelyBusy = isBusy || deployUpdate.isPending || taskExecuting;
 
   // Don't show the flipped face while the stack is churning — the busy overlay
   // takes precedence. Derived rather than an effect to avoid cascading renders.
@@ -277,6 +283,7 @@ export function ApplicationCard({
                       size="sm"
                       variant="outline"
                       className="flex-1"
+                      disabled={effectivelyBusy}
                       onClick={openUpdateForm}
                     >
                       <IconRefresh className="h-4 w-4 mr-1" />

--- a/server/src/services/haproxy/__tests__/blue-green-drain-non-fatal.test.ts
+++ b/server/src/services/haproxy/__tests__/blue-green-drain-non-fatal.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { transition, type AnyStateMachine } from 'xstate';
+import {
+  blueGreenUpdateMachine,
+  type BlueGreenUpdateContext,
+} from '../blue-green-update-state-machine';
+import {
+  blueGreenDeploymentMachine,
+  type BlueGreenDeploymentContext,
+} from '../blue-green-deployment-state-machine';
+
+/**
+ * Regression guard for the "update succeeded but the tracker reported failed" bug.
+ *
+ * In both blue-green machines, traffic is cut over to green (which is already
+ * health-checked and live) *before* the old blue container is drained and
+ * removed. Previously, a slow or failing drain of that superseded blue —
+ * DRAIN_TIMEOUT, DRAIN_ISSUES, or the 2-minute `after` fallback — rolled the
+ * whole deployment back, ending in `rollbackComplete`. That final state makes
+ * the reconciler report `success: false`, which the UI renders as "failed" even
+ * though the new version was already serving every request.
+ *
+ * Draining the superseded blue must be non-critical (force-remove blue) and land
+ * in `completed`, exactly like the later blue-teardown steps (LB removal / stop /
+ * remove) already are. These tests drive the *real* machines with xstate's pure
+ * `transition()` (no side effects executed) to pin that behaviour.
+ */
+
+const baseUpdateContext: BlueGreenUpdateContext = {
+  deploymentId: 'dep-1',
+  configurationId: 'cfg-1',
+  applicationName: 'kumiko-designer',
+  dockerImage: 'ghcr.io/example/app',
+  environmentId: 'env-1',
+  environmentName: 'prod',
+  haproxyContainerId: 'haproxy-1',
+  haproxyNetworkName: 'prod-haproxy',
+  blueHealthy: true,
+  greenHealthy: true,
+  greenBackendConfigured: true,
+  trafficOpenedToGreen: true,
+  trafficValidated: true,
+  blueDraining: true,
+  blueDrained: false,
+  validationErrors: 0,
+  retryCount: 0,
+  activeConnections: 1,
+  triggerType: 'manual',
+  startTime: 0,
+  oldContainerId: 'old-blue-container-id',
+  newContainerId: 'new-green-container-id',
+};
+
+const baseDeploymentContext: BlueGreenDeploymentContext = {
+  ...baseUpdateContext,
+  frontendConfigured: true,
+};
+
+const machines: Array<{
+  name: string;
+  machine: AnyStateMachine;
+  context: Record<string, unknown>;
+}> = [
+  {
+    name: 'blue-green update (redeploy / same tag)',
+    machine: blueGreenUpdateMachine,
+    context: baseUpdateContext,
+  },
+  {
+    name: 'blue-green deployment (tag change)',
+    machine: blueGreenDeploymentMachine,
+    context: baseDeploymentContext,
+  },
+];
+
+describe.each(machines)(
+  '$name — post-cutover blue drain is non-fatal',
+  ({ machine, context }) => {
+    // Pure single-step transition from a synthetic snapshot at `value`.
+    const step = (value: string, event: { type: string }) => {
+      const snapshot = machine.resolveState({ value, context });
+      return transition(machine, snapshot, event)[0];
+    };
+
+    it('routes a drain timeout in waitingForDrain to blue teardown, not rollback', () => {
+      const next = step('waitingForDrain', { type: 'DRAIN_TIMEOUT' });
+      expect(next.value).toBe('decommissioningBlueLB');
+      expect(String(next.value)).not.toContain('rollback');
+      expect(next.context.error).toContain('Non-Critical');
+    });
+
+    it('routes drain issues in waitingForDrain to blue teardown, not rollback', () => {
+      const next = step('waitingForDrain', {
+        type: 'DRAIN_ISSUES',
+        error: 'dataplane hiccup',
+      });
+      expect(next.value).toBe('decommissioningBlueLB');
+      expect(String(next.value)).not.toContain('rollback');
+    });
+
+    it('routes drain-initiation issues in drainingBlue to blue teardown, not rollback', () => {
+      const next = step('drainingBlue', {
+        type: 'DRAIN_ISSUES',
+        error: 'could not set drain mode',
+      });
+      expect(next.value).toBe('decommissioningBlueLB');
+      expect(String(next.value)).not.toContain('rollback');
+    });
+
+    it('drives a drain timeout all the way to completed (success), never rollbackComplete', () => {
+      // waitingForDrain --DRAIN_TIMEOUT--> decommission --> stop --> remove --> completed
+      let snapshot = machine.resolveState({ value: 'waitingForDrain', context });
+      snapshot = transition(machine, snapshot, { type: 'DRAIN_TIMEOUT' })[0];
+      expect(snapshot.value).toBe('decommissioningBlueLB');
+      snapshot = transition(machine, snapshot, { type: 'LB_REMOVAL_SUCCESS' })[0];
+      expect(snapshot.value).toBe('stoppingBlueApp');
+      snapshot = transition(machine, snapshot, { type: 'STOP_SUCCESS' })[0];
+      expect(snapshot.value).toBe('removingBlueApp');
+      snapshot = transition(machine, snapshot, { type: 'REMOVAL_SUCCESS' })[0];
+      expect(snapshot.value).toBe('completed');
+      expect(snapshot.status).toBe('done');
+    });
+  },
+);

--- a/server/src/services/haproxy/blue-green-deployment-state-machine.ts
+++ b/server/src/services/haproxy/blue-green-deployment-state-machine.ts
@@ -264,6 +264,26 @@ export const blueGreenDeploymentMachine = setup({
             monitorDrain.execute(context, (event) => self.send(event));
         },
 
+        // Draining the old blue container happens *after* traffic has already
+        // been cut over to green (green is health-checked and live). A slow or
+        // failed drain of the superseded blue therefore must NOT roll back a
+        // healthy green — treat it as non-critical and fall through to the same
+        // best-effort blue teardown the later decommission steps already use.
+        markDrainFailureNonCritical: assign({
+            error: 'Blue connection drain did not complete cleanly (Non-Critical) - green is live',
+        }),
+
+        logDrainFailureNonCritical: ({ context, event }) => {
+            const logger = getLogger("deploy", "blue-green-deployment-state-machine");
+            logger.warn({
+                deploymentId: context.deploymentId,
+                applicationName: context.applicationName,
+                oldContainerId: context.oldContainerId?.slice(0, 12),
+                event: event.type,
+                error: 'error' in event ? event.error : undefined,
+            }, 'Blue drain did not complete post-cutover - force-removing blue instead of rolling back (green is live)');
+        },
+
         // Blue decommission actions
         removeBlueFromLB: ({ context, self }) => {
             // Map oldContainerId to containerId for the action
@@ -314,24 +334,6 @@ export const blueGreenDeploymentMachine = setup({
         },
 
         // Rollback actions
-        restoreBlueTraffic: ({ context, self }) => {
-            // Map oldContainerId to containerId for the action
-            const contextWithContainerId = {
-                ...context,
-                containerId: context.oldContainerId
-            };
-            enableTraffic.execute(contextWithContainerId, (event) => {
-                // Map the standard traffic events to rollback events
-                if (event.type === 'TRAFFIC_ENABLED') {
-                    self.send({ type: 'ROLLBACK_BLUE_TRAFFIC_RESTORED' });
-                } else if (event.type === 'TRAFFIC_ENABLE_FAILED') {
-                    self.send({ type: 'ROLLBACK_ERROR', error: event.error });
-                } else {
-                    self.send(event);
-                }
-            });
-        },
-
         disableGreenTraffic: ({ context, self }) => {
             // Map newContainerId to containerId for the action
             const contextWithContainerId = {
@@ -948,9 +950,11 @@ export const blueGreenDeploymentMachine = setup({
                     target: 'waitingForDrain',
                     actions: assign({ blueDraining: true })
                 },
+                // Post-cutover: drain-initiation trouble on the old blue is
+                // non-fatal — force-remove blue rather than roll back live green.
                 DRAIN_ISSUES: {
-                    target: 'rollbackRestoreBlueTraffic',
-                    actions: 'preserveErrorContext'
+                    target: 'decommissioningBlueLB',
+                    actions: ['markDrainFailureNonCritical', 'logDrainFailureNonCritical']
                 }
             }
         },
@@ -966,19 +970,23 @@ export const blueGreenDeploymentMachine = setup({
                         activeConnections: 0
                     })
                 },
+                // A blue that won't drain in time (long-lived/websocket
+                // connections) or a HAProxy hiccup while draining is non-fatal
+                // post-cutover — proceed to force-remove blue, don't roll back
+                // the already-live green.
                 DRAIN_TIMEOUT: {
-                    target: 'rollbackRestoreBlueTraffic',
-                    actions: assign({ error: 'Blue connection drain timeout' })
+                    target: 'decommissioningBlueLB',
+                    actions: ['markDrainFailureNonCritical', 'logDrainFailureNonCritical']
                 },
                 DRAIN_ISSUES: {
-                    target: 'rollbackRestoreBlueTraffic',
-                    actions: 'preserveErrorContext'
+                    target: 'decommissioningBlueLB',
+                    actions: ['markDrainFailureNonCritical', 'logDrainFailureNonCritical']
                 }
             },
             after: {
-                120000: { // 2 minute drain timeout
-                    target: 'rollbackRestoreBlueTraffic',
-                    actions: assign({ error: 'Forced drain timeout after 2 minutes' })
+                120000: { // 2 minute drain budget — then force-remove blue (non-fatal)
+                    target: 'decommissioningBlueLB',
+                    actions: ['markDrainFailureNonCritical', 'logDrainFailureNonCritical']
                 }
             }
         },
@@ -1087,21 +1095,8 @@ export const blueGreenDeploymentMachine = setup({
             }
         },
 
-        // Rollback states
-        rollbackRestoreBlueTraffic: {
-            description: 'Restoring traffic to the blue application during rollback',
-            entry: 'restoreBlueTraffic',
-            on: {
-                ROLLBACK_BLUE_TRAFFIC_RESTORED: {
-                    target: 'rollbackDisableGreenTraffic'
-                },
-                ROLLBACK_ERROR: {
-                    target: 'rollbackDisableGreenTraffic',
-                    actions: 'preserveErrorContext'
-                }
-            }
-        },
-
+        // Rollback states (reached only by pre-cutover failures; once traffic
+        // is on green there is no rollback — a failed blue drain is non-fatal).
         rollbackDisableGreenTraffic: {
             description: 'Disabling traffic to green environment during rollback',
             entry: 'disableGreenTraffic',

--- a/server/src/services/haproxy/blue-green-update-state-machine.ts
+++ b/server/src/services/haproxy/blue-green-update-state-machine.ts
@@ -237,6 +237,26 @@ export const blueGreenUpdateMachine = setup({
             monitorDrain.execute(context, (event) => self.send(event));
         },
 
+        // Draining the old blue container happens *after* traffic has already
+        // been cut over to green (green is health-checked and live). A slow or
+        // failed drain of the superseded blue therefore must NOT roll back a
+        // healthy green — treat it as non-critical and fall through to the same
+        // best-effort blue teardown the later decommission steps already use.
+        markDrainFailureNonCritical: assign({
+            error: 'Blue connection drain did not complete cleanly (Non-Critical) - green is live',
+        }),
+
+        logDrainFailureNonCritical: ({ context, event }) => {
+            const logger = getLogger("deploy", "blue-green-update-state-machine");
+            logger.warn({
+                deploymentId: context.deploymentId,
+                applicationName: context.applicationName,
+                oldContainerId: context.oldContainerId?.slice(0, 12),
+                event: event.type,
+                error: 'error' in event ? event.error : undefined,
+            }, 'Blue drain did not complete post-cutover - force-removing blue instead of rolling back (green is live)');
+        },
+
         // Blue decommission actions
         removeBlueFromLB: ({ context, self }) => {
             // Map oldContainerId to containerId for the action
@@ -287,24 +307,6 @@ export const blueGreenUpdateMachine = setup({
         },
 
         // Rollback actions
-        restoreBlueTraffic: ({ context, self }) => {
-            // Map oldContainerId to containerId for the action
-            const contextWithContainerId = {
-                ...context,
-                containerId: context.oldContainerId
-            };
-            enableTraffic.execute(contextWithContainerId, (event) => {
-                // Map the standard traffic events to rollback events
-                if (event.type === 'TRAFFIC_ENABLED') {
-                    self.send({ type: 'ROLLBACK_BLUE_TRAFFIC_RESTORED' });
-                } else if (event.type === 'TRAFFIC_ENABLE_FAILED') {
-                    self.send({ type: 'ROLLBACK_ERROR', error: event.error });
-                } else {
-                    self.send(event);
-                }
-            });
-        },
-
         removeGreenHAProxyConfig: ({ context, self }) => {
             // Map newContainerId to containerId for the action
             const contextWithContainerId = {
@@ -850,9 +852,11 @@ export const blueGreenUpdateMachine = setup({
                     target: 'waitingForDrain',
                     actions: assign({ blueDraining: true })
                 },
+                // Post-cutover: drain-initiation trouble on the old blue is
+                // non-fatal — force-remove blue rather than roll back live green.
                 DRAIN_ISSUES: {
-                    target: 'rollbackRestoreBlueTraffic',
-                    actions: 'preserveErrorContext'
+                    target: 'decommissioningBlueLB',
+                    actions: ['markDrainFailureNonCritical', 'logDrainFailureNonCritical']
                 }
             }
         },
@@ -868,19 +872,23 @@ export const blueGreenUpdateMachine = setup({
                         activeConnections: 0
                     })
                 },
+                // A blue that won't drain in time (long-lived/websocket
+                // connections) or a HAProxy hiccup while draining is non-fatal
+                // post-cutover — proceed to force-remove blue, don't roll back
+                // the already-live green.
                 DRAIN_TIMEOUT: {
-                    target: 'rollbackRestoreBlueTraffic',
-                    actions: assign({ error: 'Blue connection drain timeout' })
+                    target: 'decommissioningBlueLB',
+                    actions: ['markDrainFailureNonCritical', 'logDrainFailureNonCritical']
                 },
                 DRAIN_ISSUES: {
-                    target: 'rollbackRestoreBlueTraffic',
-                    actions: 'preserveErrorContext'
+                    target: 'decommissioningBlueLB',
+                    actions: ['markDrainFailureNonCritical', 'logDrainFailureNonCritical']
                 }
             },
             after: {
-                120000: { // 2 minute drain timeout
-                    target: 'rollbackRestoreBlueTraffic',
-                    actions: assign({ error: 'Forced drain timeout after 2 minutes' })
+                120000: { // 2 minute drain budget — then force-remove blue (non-fatal)
+                    target: 'decommissioningBlueLB',
+                    actions: ['markDrainFailureNonCritical', 'logDrainFailureNonCritical']
                 }
             }
         },
@@ -989,21 +997,8 @@ export const blueGreenUpdateMachine = setup({
             }
         },
 
-        // Rollback states
-        rollbackRestoreBlueTraffic: {
-            description: 'Restoring traffic to the blue application during rollback',
-            entry: 'restoreBlueTraffic',
-            on: {
-                ROLLBACK_BLUE_TRAFFIC_RESTORED: {
-                    target: 'rollbackRemoveGreenHaproxyConfig'
-                },
-                ROLLBACK_ERROR: {
-                    target: 'rollbackRemoveGreenHaproxyConfig',
-                    actions: 'preserveErrorContext'
-                }
-            }
-        },
-
+        // Rollback states (reached only by pre-cutover failures; once traffic
+        // is on green there is no rollback — a failed blue drain is non-fatal).
         rollbackRemoveGreenHaproxyConfig: {
             description: 'Remove green haproxy server and backends during rollback',
             entry: 'removeGreenHAProxyConfig',


### PR DESCRIPTION
## What & why

Two issues in the application **Update** (blue-green redeploy) flow, reported from production on `/applications`:

1. **The Update button isn't disabled while a deploy is running** — you can click it again mid-deploy.
2. **The top-right task tracker eventually says the update *failed* — when it actually succeeded.**

## Root causes

**Bug 1 — button stays live during deploy.** `application-card.tsx` locked the card via `effectivelyBusy = isBusy || deployUpdate.isPending`. But `deployUpdate` is fire-and-forget (the mutation resolves on the server's "started" ACK, so `isPending` clears within a second), and `isBusy` only becomes true once the stack status flips to `"pending"` **after a refetch**. That leaves a race gap where the front Update button is fully clickable while the deploy is still churning. Reproduced live: the button reappeared ~11 s in while the tracker still showed `0/1 steps · 31s`.

**Bug 2 — false "failed".** In both blue-green state machines, traffic is cut over to green (health-checked and already serving) **before** the old blue container is drained and removed. A slow/failing drain of that superseded blue — `DRAIN_TIMEOUT`, `DRAIN_ISSUES`, or the 2-minute `after` fallback — rolled the *whole deploy* back to `rollbackComplete`. That makes `ServiceApplyResult.success = false` → `ApplyResult.success = false` → a single `STACK_APPLY_COMPLETED { success: false }`, which the tracker renders as failed (and toasts "— failed") even though the new version was live the entire time. The later blue-teardown steps (LB removal / stop / remove) were *already* treated as non-critical and still reach `completed`; only the drain was wrongly fatal. The word "eventually" matches the ~2-minute drain window.

## The fix

**Client (`application-card.tsx`)** — lock the card off the authoritative in-progress signal: the tracked task (`getTask(stackId)`), which is registered synchronously the instant the user hits Redeploy and only clears on the terminal socket event. Added `taskExecuting` to `effectivelyBusy` and an explicit `disabled` guard on the front Update button (covers keyboard, matches the Stop button's pattern).

**Server (both blue-green state machines)** — route the post-cutover drain failures (`DRAIN_TIMEOUT` / `DRAIN_ISSUES` / `after: 120000`) to `decommissioningBlueLB` (force-remove blue, non-fatal) instead of `rollbackRestoreBlueTraffic`, so a blue that won't drain still lands in `completed` (`success: true`) with green live. Extracted two DRY named actions (`markDrainFailureNonCritical` / `logDrainFailureNonCritical`) used at all four sites in each machine. This makes `rollbackRestoreBlueTraffic` (and its `restoreBlueTraffic` action) unreachable, so both were removed.

## Testing

- New `blue-green-drain-non-fatal.test.ts` drives **both real machines** with xstate's pure `transition()` (no side effects) to pin that a drain failure routes to `decommissioningBlueLB` and continues all the way to `completed`, never `rollbackComplete`. 8 assertions (4 × 2 machines) — would have failed before this change.
- Full haproxy + reconciler + state-machine-runner suites: **68 passed**.
- `pnpm build` (server tsc + client tsc/vite) clean; server & client `lint` clean.
- Live-reproduced bug 1 on prod; bug 2 is intermittent (needs a slow drain) so it's covered by the code trace + the state-machine regression test rather than a live repro.

## Verification note

Bug 1's fix is a small derived-state change verified by build + reasoning; it was **not** re-run in a live dev env (prod runs the old code). Bug 2's routing change is unit-tested against the real machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)