### PR TITLE
fix(egress): stop hourly NATS cred expiry from triggering self-heal recreate

### DIFF
--- a/server/src/__tests__/egress-fw-agent-template.test.ts
+++ b/server/src/__tests__/egress-fw-agent-template.test.ts
@@ -23,7 +23,7 @@ describe("egress-fw-agent template", () => {
     expect(json.name).toBe("egress-fw-agent");
     expect(json.scope).toBe("host");
     expect(json.category).toBe("infrastructure");
-    expect(json.builtinVersion).toBe(5);
+    expect(json.builtinVersion).toBe(6);
 
     // The agent role declares the KV bucket Phase 2 needs.
     expect(json.nats.subjectPrefix).toBe("mini-infra.egress.fw");
@@ -42,6 +42,10 @@ describe("egress-fw-agent template", () => {
     // requests) but no SUB, so KV Puts hit a Permissions Violation on the
     // ack-subscribe and timed out as `context deadline exceeded`.
     expect(role.inboxAuto).toBe("both");
+    // Non-expiring credential JWT. The unset (3600s default) TTL caused the
+    // agent's cred to expire hourly, which the self-heal supervisor (Phase 4)
+    // "fixed" by force-recreating the stack every ~61 minutes forever.
+    expect(role.ttlSeconds).toBe(0);
 
     // Host networking + privileged caps are the whole reason this template
     // exists (vs being a regular bridge-mode stack).
@@ -82,6 +86,7 @@ describe("egress-fw-agent template", () => {
       subscribe: ["rules.apply"],
       kvBuckets: ["egress-fw-health"],
       inboxAuto: "both",
+      ttlSeconds: 0,
     };
     expect(() => templateNatsRoleSchema.parse(role)).not.toThrow();
   });

--- a/server/templates/egress-fw-agent/template.json
+++ b/server/templates/egress-fw-agent/template.json
@@ -1,7 +1,7 @@
 {
   "name": "egress-fw-agent",
   "displayName": "Egress Firewall Agent",
-  "builtinVersion": 5,
+  "builtinVersion": 6,
   "scope": "host",
   "category": "infrastructure",
   "description": "Blocks outbound network traffic that breaks your environment's egress rules. Runs once per host. Logs every blocked connection so you can see what was denied and why. Requires a synced NATS host stack (which transitively requires Vault to be bootstrapped).",
@@ -35,7 +35,8 @@
         "kvBuckets": [
           "egress-fw-health"
         ],
-        "inboxAuto": "both"
+        "inboxAuto": "both",
+        "ttlSeconds": 0
       }
     ]
   },

--- a/server/templates/egress-gateway/template.json
+++ b/server/templates/egress-gateway/template.json
@@ -1,7 +1,7 @@
 {
   "name": "egress-gateway",
   "displayName": "Egress Gateway",
-  "builtinVersion": 12,
+  "builtinVersion": 13,
   "scope": "environment",
   "category": "infrastructure",
   "description": "Smokescreen-based HTTP/HTTPS forward proxy for environment egress traffic control. Talks to the Mini Infra server over NATS (subjects under mini-infra.egress.gw.>). Requires a synced NATS host stack (which transitively requires Vault to be bootstrapped).",
@@ -43,7 +43,8 @@
         "kvBuckets": [
           "egress-gw-health"
         ],
-        "inboxAuto": "both"
+        "inboxAuto": "both",
+        "ttlSeconds": 0
       }
     ]
   },


### PR DESCRIPTION
## Why

PR #490 (Egress agent NATS credential resilience) has been silently self-triggering in production every ~61 minutes since it merged — not a recurrence of the original 15-hour incident, but a new, distinct failure mode from the same PR's own defaults.

Confirmed live via the production instance's `UserEvent` audit log: 60+ "Auto-heal: recreate egress-fw-agent / egress-gateway" events, one per stack roughly every hour since 2026-07-06 04:42 UTC, each always "attempt 1/5" (meaning it "recovers" and then fails again ~61 minutes later).

**Root cause:**
- Neither the `egress-fw-agent` (`agent` role) nor `egress-gateway` (`gw` role) NATS role set an explicit `ttlSeconds`, so both fell back to the hardcoded 1-hour default in `materializeRole` (`stack-nats-apply-orchestrator.ts`).
- That TTL is baked into each minted NATS user JWT's `exp` claim. When it lapses, NATS rejects the connection with `nats: authentication expired` — which `bus.go`'s `isAuthError()` correctly (by design) classifies identically to a rejected/rotated credential: `auth-failed`.
- Phase 6 ("live cred refresh" — the graceful fix that pushes a fresh cred with no recreate) only fires on a genuine NATS **identity** (operator/account seed) rotation (`NatsIdentityRotationInfo.rotated`), never on a plain per-role JWT TTL expiry. There's no proactive "refresh before expiry" job for these credentials.
- So every hour, the JWT expires on schedule and only Phase 4's reactive, 30-second-dwell, full-container-recreate self-heal backstop ever catches it — a mechanism designed as a rare-incident safety net, not a permanent hourly babysitter.

Both egress gateways are `Stateful` services (stop/start replacement, not zero-downtime), so every recreate is a real ~18-19s outage window for outbound traffic through that gateway, happening roughly hourly, indefinitely.

## What

Set `ttlSeconds: 0` (non-expiring) on the `agent` role in `egress-fw-agent/template.json` and the `gw` role in `egress-gateway/template.json` — matching the pattern already used for the NATS control plane's own JWT (`nats-key-manager.ts`: "Pass 0 for ttlSeconds to mint a non-expiring JWT"). Bumped `builtinVersion` on both templates (6, 13) so existing stacks pick up the fix on their next apply.

## Testing
- `egress-fw-agent-template.test.ts` updated: pins the new `builtinVersion` and asserts `ttlSeconds: 0` on the role, with a comment on why.
- Full server suite: 2714 tests pass, lint clean.

## Not included
This doesn't retroactively fix already-running production containers' baked-in creds — the next self-heal recreate (imminent; last cycle completed 18:55 UTC) will pick up the new `ttlSeconds: 0` profile automatically. No manual intervention needed once this deploys.