### PR TITLE
fix(backup): stop self-backup health indicator from reporting not_configured forever

### DIFF
--- a/server/src/services/backup/__tests__/backup-health-calculator.test.ts
+++ b/server/src/services/backup/__tests__/backup-health-calculator.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const findUnique = vi.fn();
+const selfBackupFindFirst = vi.fn();
+const selfBackupCount = vi.fn();
+
+vi.mock("../../../lib/prisma", () => ({
+  default: {
+    systemSettings: { findUnique: (...args: unknown[]) => findUnique(...args) },
+    selfBackup: {
+      findFirst: (...args: unknown[]) => selfBackupFindFirst(...args),
+      count: (...args: unknown[]) => selfBackupCount(...args),
+    },
+  },
+}));
+
+import { calculateBackupHealth } from "../backup-health-calculator";
+
+function mockSettings({
+  storageLocationId,
+  enabled,
+}: {
+  storageLocationId: string | null;
+  enabled: boolean;
+}) {
+  findUnique.mockImplementation(({ where }: { where: { category_key: { key: string } } }) => {
+    const { key } = where.category_key;
+    if (key === "storage_location_id") {
+      return Promise.resolve(storageLocationId ? { value: storageLocationId } : null);
+    }
+    if (key === "enabled") {
+      return Promise.resolve({ value: enabled ? "true" : "false" });
+    }
+    return Promise.resolve(null);
+  });
+}
+
+describe("calculateBackupHealth", () => {
+  beforeEach(() => {
+    findUnique.mockReset();
+    selfBackupFindFirst.mockReset();
+    selfBackupCount.mockReset();
+  });
+
+  it("reports not_configured when no storage location is set, even with a healthy backup history", async () => {
+    mockSettings({ storageLocationId: null, enabled: true });
+
+    const result = await calculateBackupHealth();
+
+    expect(result.status).toBe("not_configured");
+    expect(result.message).toBe("Self-backup not configured");
+  });
+
+  it("reports healthy once a storage location is configured, enabled, and backups are recent", async () => {
+    mockSettings({ storageLocationId: "miniinfrabackup", enabled: true });
+    selfBackupFindFirst
+      .mockResolvedValueOnce({ startedAt: new Date(), status: "completed" }) // lastBackup
+      .mockResolvedValueOnce({ completedAt: new Date() }); // lastSuccessfulBackup
+    selfBackupCount.mockResolvedValue(0);
+
+    const result = await calculateBackupHealth();
+
+    expect(result.status).toBe("healthy");
+    expect(result.message).toBe("Backups running normally");
+  });
+
+  it("reports disabled when a storage location is configured but scheduling is off", async () => {
+    mockSettings({ storageLocationId: "miniinfrabackup", enabled: false });
+
+    const result = await calculateBackupHealth();
+
+    expect(result.status).toBe("not_configured");
+    expect(result.message).toBe("Self-backup disabled");
+  });
+});

--- a/server/src/services/backup/backup-health-calculator.ts
+++ b/server/src/services/backup/backup-health-calculator.ts
@@ -13,11 +13,11 @@ import type { BackupHealthStatus } from "@mini-infra/types";
  */
 export async function calculateBackupHealth(): Promise<BackupHealthStatus> {
   // Check if configuration exists
-  const containerSetting = await prisma.systemSettings.findUnique({
+  const storageLocationSetting = await prisma.systemSettings.findUnique({
     where: {
       category_key: {
         category: "self-backup",
-        key: "azure_container_name",
+        key: "storage_location_id",
       },
     },
   });
@@ -32,7 +32,7 @@ export async function calculateBackupHealth(): Promise<BackupHealthStatus> {
   });
 
   const isEnabled = enabledSetting?.value === "true";
-  const isConfigured = !!containerSetting?.value;
+  const isConfigured = !!storageLocationSetting?.value;
 
   if (!isConfigured || !isEnabled) {
     return {


### PR DESCRIPTION
## Summary
- The top-nav self-backup health light was permanently stuck grey/"not configured" on prod, even though scheduled backups were enabled and completing successfully every day.
- Root cause: `calculateBackupHealth()` checked a `SystemSettings` row keyed `azure_container_name` to determine whether storage was configured. That key is never written anywhere in the codebase — storage config moved to the generic `storage_location_id` key when backups were generalized beyond Azure-only. So `isConfigured` was always `false`.
- Fix: check `storage_location_id` instead, matching what `settings-self-backup.ts` actually reads/writes.

## Test plan
- [x] Added `backup-health-calculator.test.ts` — 3 cases (not configured with no location, healthy with location + recent backup, disabled when scheduling off). Verified it fails against the pre-fix code and passes with the fix.
- [x] Full backend suite (`pnpm --filter mini-infra-server test`) — 2717 tests passing.
- [x] Lint clean (`pnpm --filter mini-infra-server lint`).
- [x] Verified live in a rebuilt dev worktree: configured a storage location + enabled scheduling → indicator showed "No successful backup in 48 hours" (error), then flipped to "Backups running normally" (healthy/green) after triggering "Backup Now".

🤖 Generated with [Claude Code](https://claude.com/claude-code)