### PR TITLE
fix(backup): scope pg-az-backup/restore-executor stack routing to database's environment

### DIFF
--- a/client/src/components/postgres-server/quick-backup-setup-modal.tsx
+++ b/client/src/components/postgres-server/quick-backup-setup-modal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -24,11 +24,13 @@ import { ManagedDatabaseInfo } from "@mini-infra/types";
 import { useQuickSetupPostgresBackup } from "@/hooks/use-postgres-backup-configs";
 import { useUserPreferences } from "@/hooks/use-user-preferences";
 import { useSystemSettings } from "@/hooks/use-settings";
+import { useEnvironments } from "@/hooks/use-environments";
 import { toast } from "sonner";
 
 // Validation schema
 const quickBackupSetupSchema = z.object({
   databaseName: z.string().min(1, "Database selection is required"),
+  environmentId: z.string().min(1, "Environment is required"),
 });
 
 type QuickBackupSetupFormData = z.infer<typeof quickBackupSetupSchema>;
@@ -53,6 +55,8 @@ export function QuickBackupSetupModal({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const quickSetupMutation = useQuickSetupPostgresBackup();
   const { data: userPreferences } = useUserPreferences();
+  const { data: environmentsData, isLoading: environmentsLoading } = useEnvironments();
+  const environments = useMemo(() => environmentsData?.environments ?? [], [environmentsData]);
 
   // Fetch default container setting
   const { data: defaultContainerData } = useSystemSettings({
@@ -74,10 +78,12 @@ export function QuickBackupSetupModal({
     resolver: zodResolver(quickBackupSetupSchema),
     defaultValues: {
       databaseName: preSelectedDatabase || "",
+      environmentId: "",
     },
   });
 
   const selectedDatabaseName = useWatch({ control, name: "databaseName" });
+  const selectedEnvironmentId = useWatch({ control, name: "environmentId" });
   const timezone = userPreferences?.timezone || "UTC";
   const defaultContainer =
     defaultContainerData?.data?.[0]?.value || "postgres-backups";
@@ -89,12 +95,20 @@ export function QuickBackupSetupModal({
     }
   }, [open, preSelectedDatabase, setValue]);
 
+  // Auto-select the sole environment, same as the main database registration form.
+  useEffect(() => {
+    if (!environmentsLoading && environments.length === 1 && !selectedEnvironmentId) {
+      setValue("environmentId", environments[0].id, { shouldValidate: true });
+    }
+  }, [environmentsLoading, environments, selectedEnvironmentId, setValue]);
+
   const handleFormSubmit = async (data: QuickBackupSetupFormData) => {
     setIsSubmitting(true);
     try {
       await quickSetupMutation.mutateAsync({
         serverId,
         databaseName: data.databaseName,
+        environmentId: data.environmentId,
       });
 
       toast.success("Backup configured successfully", {
@@ -167,6 +181,41 @@ export function QuickBackupSetupModal({
               )}
             </div>
 
+            {/* Environment Selection */}
+            <div className="space-y-2">
+              <Label htmlFor="environmentId">Environment *</Label>
+              <Select
+                value={selectedEnvironmentId}
+                onValueChange={(value) => setValue("environmentId", value, { shouldValidate: true })}
+                disabled={environments.length === 1 || environmentsLoading}
+              >
+                <SelectTrigger>
+                  <SelectValue
+                    placeholder={
+                      environmentsLoading
+                        ? "Loading environments..."
+                        : "Select an environment"
+                    }
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {environments.map((env) => (
+                    <SelectItem key={env.id} value={env.id}>
+                      {env.name}
+                      <span className="ml-2 text-xs text-muted-foreground">
+                        ({env.networkType})
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {errors.environmentId && (
+                <p className="text-sm text-destructive">
+                  {errors.environmentId.message}
+                </p>
+              )}
+            </div>
+
             {/* Configuration Preview */}
             <div className="rounded-lg border bg-muted/50 p-4 space-y-3">
               <h4 className="text-sm font-medium">Backup Configuration</h4>
@@ -215,7 +264,7 @@ export function QuickBackupSetupModal({
             </Button>
             <Button
               type="submit"
-              disabled={isSubmitting || !selectedDatabaseName}
+              disabled={isSubmitting || !selectedDatabaseName || !selectedEnvironmentId}
             >
               {isSubmitting ? (
                 <>

--- a/client/src/components/postgres/database-modal.tsx
+++ b/client/src/components/postgres/database-modal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@/components/ui/button";
@@ -32,6 +32,7 @@ import {
   useTestDatabaseConnection,
   useDiscoverDatabases,
 } from "@/hooks/use-postgres-databases";
+import { useEnvironments } from "@/hooks/use-environments";
 import { IconEye, IconEyeOff, IconFlask, IconLoader2, IconArrowRight, IconArrowLeft } from "@tabler/icons-react";
 import { toast } from "sonner";
 import {
@@ -70,6 +71,9 @@ export function DatabaseModal({
 
   const isEditing = !!database;
 
+  const { data: environmentsData, isLoading: environmentsLoading } = useEnvironments();
+  const environments = useMemo(() => environmentsData?.environments ?? [], [environmentsData]);
+
   const createMutation = useCreatePostgresDatabase();
   const updateMutation = useUpdatePostgresDatabase();
   const testConnectionMutation = useTestDatabaseConnection();
@@ -99,11 +103,11 @@ export function DatabaseModal({
       username: "",
       password: "",
       sslMode: "prefer",
+      environmentId: "",
       tags: [],
     },
     mode: "onChange",
   });
-
   // Reset forms and step when modal opens or database changes. The setState
   // calls are routed through a ref so the effect body itself doesn't call
   // setState directly (avoids set-state-in-effect).
@@ -120,6 +124,7 @@ export function DatabaseModal({
         username: database?.username || "",
         password: "",
         sslMode: (database?.sslMode as PostgreSSLMode) || "prefer",
+        environmentId: database?.environmentId || "",
         tags: database?.tags || [],
       });
     } else {
@@ -144,6 +149,7 @@ export function DatabaseModal({
         username: "",
         password: "",
         sslMode: "prefer",
+        environmentId: "",
         tags: [],
       });
     }
@@ -155,6 +161,27 @@ export function DatabaseModal({
   useEffect(() => {
     resetFormsRef.current();
   }, [isOpen, database, isEditing]);
+
+  // Auto-select the sole environment whenever the field is unset — covers
+  // both a fresh create (reset blanks it) and editing a legacy database that
+  // predates this field (environmentId: null). Must depend on `isOpen`: this
+  // component stays mounted while closed, so environments can finish loading
+  // (and this effect can fire) before the modal ever opens. Without `isOpen`
+  // in the deps, the *next* open's reset-forms effect blanks the field again
+  // and this effect has no reason to re-run to fix it, since none of its
+  // other deps changed. Declared after the reset-forms effect so that, in
+  // the shared open-triggering commit, the reset runs first and this effect
+  // (which reads the freshly-reset value) runs last and wins.
+  useEffect(() => {
+    if (
+      isOpen &&
+      !environmentsLoading &&
+      environments.length === 1 &&
+      !finalForm.getValues("environmentId")
+    ) {
+      finalForm.setValue("environmentId", environments[0].id, { shouldValidate: true });
+    }
+  }, [isOpen, environmentsLoading, environments, finalForm]);
 
   const handleConnectionTest = async () => {
     const formData = connectionForm.getValues();
@@ -198,6 +225,7 @@ export function DatabaseModal({
       username: connectionData.username,
       password: connectionData.password,
       sslMode: connectionData.sslMode,
+      environmentId: finalForm.getValues("environmentId"),
       tags: [],
     });
 
@@ -530,6 +558,46 @@ export function DatabaseModal({
                   )}
                 />
 
+                <FormField
+                  control={finalForm.control}
+                  name="environmentId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Environment</FormLabel>
+                      <Select
+                        onValueChange={field.onChange}
+                        value={field.value}
+                        disabled={environments.length === 1 || environmentsLoading}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue
+                              placeholder={
+                                environmentsLoading
+                                  ? "Loading environments..."
+                                  : "Select an environment"
+                              }
+                            />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {environments.map((env) => (
+                            <SelectItem key={env.id} value={env.id}>
+                              {env.name}
+                              <span className="ml-2 text-xs text-muted-foreground">
+                                ({env.networkType})
+                              </span>
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
                 <FormField
                   control={finalForm.control}
                   name="sslMode"

--- a/client/src/components/postgres/database-table.tsx
+++ b/client/src/components/postgres/database-table.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import {
   Table,
   TableBody,
@@ -7,7 +8,12 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { IconCalendar, IconDownload, IconPencil, IconTrash, IconPlayerPlay } from "@tabler/icons-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { IconCalendar, IconDownload, IconPencil, IconTrash, IconPlayerPlay, IconAlertTriangle } from "@tabler/icons-react";
 import { useFormattedDate } from "@/hooks/use-formatted-date";
 import { useCreateManualBackup } from "@/hooks/use-postgres-backup-operations";
 import { usePostgresBackupConfig } from "@/hooks/use-postgres-backup-configs";
@@ -47,7 +53,33 @@ export function DatabaseTable({
       <TableBody>
         {databases.map((database) => (
           <TableRow key={database.id}>
-            <TableCell className="font-medium">{database.name}</TableCell>
+            <TableCell className="font-medium">
+              <div className="flex items-center gap-2">
+                {database.name}
+                {!database.environmentId && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={() => onEditDatabase(database)}
+                        className="cursor-pointer"
+                      >
+                        <Badge
+                          variant="outline"
+                          className="text-yellow-700 border-yellow-200"
+                        >
+                          <IconAlertTriangle className="w-3 h-3 mr-1" />
+                          No environment
+                        </Badge>
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Not backed up — set an environment to enable automated backups</p>
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+              </div>
+            </TableCell>
             <TableCell>
               {database.host}:{database.port}
             </TableCell>

--- a/client/src/components/postgres/schemas.ts
+++ b/client/src/components/postgres/schemas.ts
@@ -28,6 +28,7 @@ export const postgresDbSchema = z.object({
     .min(1, "Password is required")
     .max(255, "Password must be less than 255 characters"),
   sslMode: z.enum(POSTGRES_SSL_MODES),
+  environmentId: z.string().min(1, "Environment is required"),
   tags: z.array(z.string()),
 });
 

--- a/lib/types/postgres.ts
+++ b/lib/types/postgres.ts
@@ -155,6 +155,7 @@ export interface PostgresDatabase {
   database: string;
   username: string;
   sslMode: string;
+  environmentId: string | null;
   tags: string; // JSON array
   createdAt: Date;
   updatedAt: Date;
@@ -172,6 +173,10 @@ export interface PostgresDatabaseInfo {
   database: string;
   username: string;
   sslMode: string;
+  // Which environment's pg-az-backup/restore-executor stack services this
+  // database. Null means "not backed up" — an environment-scoped backup
+  // stack can never match a null-environment database.
+  environmentId: string | null;
   tags: string[];
   createdAt: string;
   updatedAt: string;
@@ -201,6 +206,7 @@ export interface CreatePostgresDatabaseRequest {
   username: string;
   password: string; // Will be encrypted and stored in connectionString
   sslMode: PostgreSSLMode;
+  environmentId: string;
   tags?: string[];
 }
 
@@ -212,6 +218,7 @@ export interface UpdatePostgresDatabaseRequest {
   username?: string;
   password?: string; // Will be encrypted and stored in connectionString
   sslMode?: PostgreSSLMode;
+  environmentId?: string | null;
   tags?: string[];
 }
 
@@ -506,6 +513,7 @@ export interface UpdateBackupConfigurationRequest {
 export interface QuickBackupSetupRequest {
   serverId: string;
   databaseName: string;
+  environmentId: string;
 }
 
 // ====================

--- a/pg-az-backup/CLAUDE.md
+++ b/pg-az-backup/CLAUDE.md
@@ -13,11 +13,30 @@ scheduler + in-memory queue are gone.
 
 Per-pool concurrency cap is 2 (`jobPoolConfig.maxConcurrent`). Before
 Phase 4 this was a process-wide cap; now each applied pg-az-backup pool
-has its own slot. If multiple env-scoped pg-az-backup stacks are applied
-they each get their own 2-slot cap — running two scheduled backups for
-the same database via two different env stacks would result in duplicate
-runs. **For Phase 4 we recommend a single applied pg-az-backup stack**
-(documented constraint, not enforced by code).
+has its own slot.
+
+**Routing is environment-scoped.** `PostgresDatabase.environmentId` (nullable
+FK to `Environment`) determines which applied pg-az-backup stack owns a
+database's backups: `materialiseTriggersForStack` only picks up
+`BackupConfiguration` rows whose database's `environmentId` matches the
+stack's own, and the manual "Run now" / restore routes look up the stack
+the same way. One applied pg-az-backup stack per environment is correctly
+isolated — two stacks in *different* environments no longer double-fire the
+same backup. Applying a second pg-az-backup stack *within the same
+environment* is still unguarded (undefined which one wins); avoid it.
+
+A `PostgresDatabase` with no environment set (`environmentId: null`) is
+**never backed up** — an environment-scoped stack always has a non-null
+`environmentId`, so a null-environment database can never match one. The
+create/edit UI requires picking an environment for exactly this reason;
+legacy rows from before this field existed need to be assigned one before
+their backups will run. Reassigning a database's `environmentId` after its
+`BackupConfiguration` already has materialised triggers does not
+immediately move those triggers — the affected stacks re-materialise on
+their own next `BackupConfiguration` create/update/delete (see
+`refreshAllPgBackupTriggers` call sites in `backup-configuration-manager.ts`)
+or the next server boot, not automatically on the database's environment
+change.
 
 In-container NATS progress publishing: `nats-progress.sh` writes
 `mini-infra.backup.progress.<runId>` directly using the injected

--- a/server/prisma/migrations/20260706201947_postgres_database_environment_scope/migration.sql
+++ b/server/prisma/migrations/20260706201947_postgres_database_environment_scope/migration.sql
@@ -1,0 +1,27 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_postgres_databases" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "connectionString" TEXT NOT NULL,
+    "host" TEXT NOT NULL,
+    "port" INTEGER NOT NULL,
+    "database" TEXT NOT NULL,
+    "username" TEXT NOT NULL,
+    "sslMode" TEXT NOT NULL DEFAULT 'prefer',
+    "environmentId" TEXT,
+    "tags" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "lastHealthCheck" DATETIME,
+    "healthStatus" TEXT NOT NULL DEFAULT 'unknown',
+    CONSTRAINT "postgres_databases_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "environments" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_postgres_databases" ("connectionString", "createdAt", "database", "healthStatus", "host", "id", "lastHealthCheck", "name", "port", "sslMode", "tags", "updatedAt", "username") SELECT "connectionString", "createdAt", "database", "healthStatus", "host", "id", "lastHealthCheck", "name", "port", "sslMode", "tags", "updatedAt", "username" FROM "postgres_databases";
+DROP TABLE "postgres_databases";
+ALTER TABLE "new_postgres_databases" RENAME TO "postgres_databases";
+CREATE UNIQUE INDEX "postgres_databases_name_key" ON "postgres_databases"("name");
+CREATE INDEX "postgres_databases_environmentId_idx" ON "postgres_databases"("environmentId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -175,6 +175,11 @@ model PostgresDatabase {
   database         String
   username         String
   sslMode          String   @default("prefer")
+  // Which environment's pg-az-backup/restore-executor stack services this
+  // database. Nullable for legacy rows; a null-environment database can
+  // never match an environment-scoped backup stack (see pg-az-backup/CLAUDE.md).
+  environmentId    String?
+  environment      Environment? @relation(fields: [environmentId], references: [id], onDelete: SetNull)
   tags             String   // JSON array
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
@@ -185,6 +190,7 @@ model PostgresDatabase {
   backupOperations BackupOperation[]
   restoreOperations RestoreOperation[]
 
+  @@index([environmentId])
   @@map("postgres_databases")
 }
 
@@ -309,6 +315,7 @@ model Environment {
   stackTemplates   StackTemplate[]
   infraResources   InfraResource[]
   egressPolicies   EgressPolicy[]
+  postgresDatabases PostgresDatabase[]
 
   @@index([type])
   @@index([networkType])

--- a/server/src/__tests__/backup-job-pool-materialiser-environment-scope.integration.test.ts
+++ b/server/src/__tests__/backup-job-pool-materialiser-environment-scope.integration.test.ts
@@ -1,0 +1,133 @@
+import { createId } from "@paralleldrive/cuid2";
+import { testPrisma } from "./integration-test-helpers";
+import {
+  materialiseTriggersForStack,
+  refreshAllPgBackupTriggers,
+  PG_AZ_BACKUP_SERVICE_NAME,
+} from "../services/backup/backup-job-pool-materialiser";
+import type { JobPoolConfig } from "@mini-infra/types";
+
+async function seedEnvironment() {
+  return testPrisma.environment.create({
+    data: {
+      name: `env-${createId().slice(0, 8)}`,
+      type: "nonproduction",
+      networkType: "local",
+    },
+  });
+}
+
+async function seedPgAzBackupStack(environmentId: string | null) {
+  const stack = await testPrisma.stack.create({
+    data: {
+      name: `pg-az-backup-${createId().slice(0, 8)}`,
+      environmentId,
+      version: 1,
+      networks: [],
+      volumes: [],
+    },
+  });
+
+  const service = await testPrisma.stackService.create({
+    data: {
+      stackId: stack.id,
+      serviceName: PG_AZ_BACKUP_SERVICE_NAME,
+      serviceType: "JobPool",
+      dockerImage: "mini-infra-pg-az-backup",
+      dockerTag: "latest",
+      containerConfig: {},
+      configFiles: [],
+      initCommands: [],
+      dependsOn: [],
+      order: 0,
+    },
+  });
+
+  return { stackId: stack.id, serviceId: service.id };
+}
+
+async function seedDatabaseWithBackupConfig(environmentId: string | null, schedule = "0 2 * * *") {
+  const token = createId().slice(0, 8);
+  const database = await testPrisma.postgresDatabase.create({
+    data: {
+      name: `db-${token}`,
+      connectionString: "postgresql://user:pass@host:5432/db",
+      host: "host",
+      port: 5432,
+      database: "db",
+      username: "user",
+      environmentId,
+      tags: "[]",
+    },
+  });
+
+  await testPrisma.backupConfiguration.create({
+    data: {
+      databaseId: database.id,
+      schedule,
+      isEnabled: true,
+    },
+  });
+
+  return database;
+}
+
+function cronTriggerNames(config: unknown): string[] {
+  const triggers = (config as JobPoolConfig | null)?.triggers ?? [];
+  return triggers.filter((t) => t.kind === "cron").map((t) => t.name);
+}
+
+describe("materialiseTriggersForStack — environment scoping", () => {
+  it("only materialises triggers for BackupConfiguration rows in the stack's own environment", async () => {
+    const envA = await seedEnvironment();
+    const envB = await seedEnvironment();
+
+    const stackA = await seedPgAzBackupStack(envA.id);
+    const stackB = await seedPgAzBackupStack(envB.id);
+
+    const dbA = await seedDatabaseWithBackupConfig(envA.id);
+    const dbB = await seedDatabaseWithBackupConfig(envB.id);
+
+    await materialiseTriggersForStack(testPrisma, stackA.stackId);
+    await materialiseTriggersForStack(testPrisma, stackB.stackId);
+
+    const serviceA = await testPrisma.stackService.findUniqueOrThrow({ where: { id: stackA.serviceId } });
+    const serviceB = await testPrisma.stackService.findUniqueOrThrow({ where: { id: stackB.serviceId } });
+
+    expect(cronTriggerNames(serviceA.jobPoolConfig)).toEqual([`cron-${dbA.id}`]);
+    expect(cronTriggerNames(serviceB.jobPoolConfig)).toEqual([`cron-${dbB.id}`]);
+  });
+
+  it("never materialises a trigger for a database with no environment set", async () => {
+    const env = await seedEnvironment();
+    const stack = await seedPgAzBackupStack(env.id);
+
+    // Orphaned database — no environment assigned.
+    await seedDatabaseWithBackupConfig(null);
+    const scopedDb = await seedDatabaseWithBackupConfig(env.id);
+
+    await materialiseTriggersForStack(testPrisma, stack.stackId);
+
+    const service = await testPrisma.stackService.findUniqueOrThrow({ where: { id: stack.serviceId } });
+    expect(cronTriggerNames(service.jobPoolConfig)).toEqual([`cron-${scopedDb.id}`]);
+  });
+
+  it("refreshAllPgBackupTriggers keeps every applied stack independently scoped", async () => {
+    const envA = await seedEnvironment();
+    const envB = await seedEnvironment();
+
+    const stackA = await seedPgAzBackupStack(envA.id);
+    const stackB = await seedPgAzBackupStack(envB.id);
+
+    const dbA = await seedDatabaseWithBackupConfig(envA.id);
+    const dbB = await seedDatabaseWithBackupConfig(envB.id);
+
+    await refreshAllPgBackupTriggers(testPrisma);
+
+    const serviceA = await testPrisma.stackService.findUniqueOrThrow({ where: { id: stackA.serviceId } });
+    const serviceB = await testPrisma.stackService.findUniqueOrThrow({ where: { id: stackB.serviceId } });
+
+    expect(cronTriggerNames(serviceA.jobPoolConfig)).toEqual([`cron-${dbA.id}`]);
+    expect(cronTriggerNames(serviceB.jobPoolConfig)).toEqual([`cron-${dbB.id}`]);
+  });
+});

--- a/server/src/__tests__/postgres-system-wide.integration.test.ts
+++ b/server/src/__tests__/postgres-system-wide.integration.test.ts
@@ -1,3 +1,4 @@
+import { createId } from "@paralleldrive/cuid2";
 import { testPrisma } from "./integration-test-helpers";
 import { PostgresDatabaseManager } from "../services/postgres";
 import { CreatePostgresDatabaseRequest } from "@mini-infra/types";
@@ -5,14 +6,28 @@ import { buildPostgresDatabaseRequest } from "./test-data-factories";
 
 describe("PostgreSQL System-Wide Database Management", () => {
   let databaseConfigService: PostgresDatabaseManager;
+  let environmentId: string;
 
   beforeAll(() => {
     databaseConfigService = new PostgresDatabaseManager(testPrisma);
   });
 
+  beforeEach(async () => {
+    // The integration suite truncates the DB after every test (see
+    // setup-integration.ts's global afterEach) — re-seed per test.
+    const environment = await testPrisma.environment.create({
+      data: {
+        name: `env-${createId().slice(0, 8)}`,
+        type: "nonproduction",
+        networkType: "local",
+      },
+    });
+    environmentId = environment.id;
+  });
+
   describe("Database Creation", () => {
     it("should create a database without requiring userId", async () => {
-      const createRequest: CreatePostgresDatabaseRequest = buildPostgresDatabaseRequest({
+      const createRequest: CreatePostgresDatabaseRequest = buildPostgresDatabaseRequest(environmentId, {
         name: "test-database",
         host: "localhost",
         port: 5432,
@@ -31,10 +46,11 @@ describe("PostgreSQL System-Wide Database Management", () => {
       expect(createdDatabase.port).toBe(5432);
       expect(createdDatabase.tags).toEqual(["test"]);
       expect(createdDatabase.connectionString).toBe("[REDACTED]");
+      expect(createdDatabase.environmentId).toBe(environmentId);
     });
 
     it("should enforce system-wide unique database names", async () => {
-      const createRequest: CreatePostgresDatabaseRequest = buildPostgresDatabaseRequest({
+      const createRequest: CreatePostgresDatabaseRequest = buildPostgresDatabaseRequest(environmentId, {
         name: "unique-database",
         host: "localhost",
         port: 5432,
@@ -52,11 +68,21 @@ describe("PostgreSQL System-Wide Database Management", () => {
         databaseConfigService.createDatabase(createRequest)
       ).rejects.toThrow("Database configuration with name 'unique-database' already exists");
     });
+
+    it("should reject an environmentId that doesn't exist", async () => {
+      const createRequest: CreatePostgresDatabaseRequest = buildPostgresDatabaseRequest("nonexistent-env-id", {
+        name: "orphan-database",
+      });
+
+      await expect(
+        databaseConfigService.createDatabase(createRequest)
+      ).rejects.toThrow("Environment 'nonexistent-env-id' not found");
+    });
   });
 
   describe("Database Retrieval", () => {
     it("should retrieve database by ID without userId filter", async () => {
-      const createRequest: CreatePostgresDatabaseRequest = buildPostgresDatabaseRequest({
+      const createRequest: CreatePostgresDatabaseRequest = buildPostgresDatabaseRequest(environmentId, {
         name: "retrievable-database",
         host: "localhost",
         port: 5432,
@@ -78,7 +104,7 @@ describe("PostgreSQL System-Wide Database Management", () => {
     it("should list all databases system-wide", async () => {
       // Create multiple databases
       const databases = [
-        buildPostgresDatabaseRequest({
+        buildPostgresDatabaseRequest(environmentId, {
           name: "database-1",
           host: "host1.example.com",
           port: 5432,
@@ -87,7 +113,7 @@ describe("PostgreSQL System-Wide Database Management", () => {
           password: "pass1",
           sslMode: "prefer" as const,
         }),
-        buildPostgresDatabaseRequest({
+        buildPostgresDatabaseRequest(environmentId, {
           name: "database-2",
           host: "host2.example.com",
           port: 5433,
@@ -112,7 +138,7 @@ describe("PostgreSQL System-Wide Database Management", () => {
 
   describe("Database Updates", () => {
     it("should update database without userId parameter", async () => {
-      const createRequest: CreatePostgresDatabaseRequest = buildPostgresDatabaseRequest({
+      const createRequest: CreatePostgresDatabaseRequest = buildPostgresDatabaseRequest(environmentId, {
         name: "updatable-database",
         host: "localhost",
         port: 5432,
@@ -142,7 +168,7 @@ describe("PostgreSQL System-Wide Database Management", () => {
 
     it("should rebuild connection string preserving password when only host/port changes", async () => {
       const createdDatabase = await databaseConfigService.createDatabase(
-        buildPostgresDatabaseRequest({
+        buildPostgresDatabaseRequest(environmentId, {
           name: "partial-update-db",
           host: "oldhost.example.com",
           port: 5432,
@@ -174,7 +200,7 @@ describe("PostgreSQL System-Wide Database Management", () => {
 
     it("should rebuild connection string when password changes", async () => {
       const createdDatabase = await databaseConfigService.createDatabase(
-        buildPostgresDatabaseRequest({
+        buildPostgresDatabaseRequest(environmentId, {
           name: "password-update-db",
           host: "host.example.com",
           port: 5432,
@@ -197,11 +223,47 @@ describe("PostgreSQL System-Wide Database Management", () => {
         "postgresql://myuser:new-pw@host.example.com:5432/mydb?sslmode=require",
       );
     });
+
+    it("should update and clear environmentId", async () => {
+      const otherEnvironment = await testPrisma.environment.create({
+        data: {
+          name: `env-${createId().slice(0, 8)}`,
+          type: "nonproduction",
+          networkType: "local",
+        },
+      });
+
+      const createdDatabase = await databaseConfigService.createDatabase(
+        buildPostgresDatabaseRequest(environmentId, { name: "env-reassign-db" }),
+      );
+
+      const reassigned = await databaseConfigService.updateDatabase(createdDatabase.id, {
+        environmentId: otherEnvironment.id,
+      });
+      expect(reassigned.environmentId).toBe(otherEnvironment.id);
+
+      const cleared = await databaseConfigService.updateDatabase(createdDatabase.id, {
+        environmentId: null,
+      });
+      expect(cleared.environmentId).toBeNull();
+    });
+
+    it("should reject updating to an environmentId that doesn't exist", async () => {
+      const createdDatabase = await databaseConfigService.createDatabase(
+        buildPostgresDatabaseRequest(environmentId, { name: "env-update-reject-db" }),
+      );
+
+      await expect(
+        databaseConfigService.updateDatabase(createdDatabase.id, {
+          environmentId: "nonexistent-env-id",
+        }),
+      ).rejects.toThrow("Environment 'nonexistent-env-id' not found");
+    });
   });
 
   describe("Database Deletion", () => {
     it("should delete database without userId parameter", async () => {
-      const createRequest: CreatePostgresDatabaseRequest = buildPostgresDatabaseRequest({
+      const createRequest: CreatePostgresDatabaseRequest = buildPostgresDatabaseRequest(environmentId, {
         name: "deletable-database",
         host: "localhost",
         port: 5432,

--- a/server/src/__tests__/test-data-factories.ts
+++ b/server/src/__tests__/test-data-factories.ts
@@ -45,6 +45,7 @@ export function buildRegistryCredentialUpdateRequest(
 }
 
 export function buildPostgresDatabaseRequest(
+  environmentId: string,
   overrides: Partial<CreatePostgresDatabaseRequest> = {},
 ): CreatePostgresDatabaseRequest {
   const token = nextTestToken("postgres");
@@ -57,6 +58,7 @@ export function buildPostgresDatabaseRequest(
     username: `${token.replace(/-/g, "_")}_user`,
     password: `pass-${token}`,
     sslMode: "prefer",
+    environmentId,
     tags: [token],
     ...overrides,
   };

--- a/server/src/routes/__tests__/postgres-databases.test.ts
+++ b/server/src/routes/__tests__/postgres-databases.test.ts
@@ -105,6 +105,7 @@ describe("PostgreSQL Databases API Routes", () => {
       database: "prod_db",
       username: "prod_user",
       sslMode: "require",
+      environmentId: "env-1",
       tags: ["production"],
       createdAt: "2023-01-01T10:00:00.000Z",
       updatedAt: "2023-01-01T11:00:00.000Z",
@@ -121,6 +122,7 @@ describe("PostgreSQL Databases API Routes", () => {
       database: "dev_db",
       username: "dev_user",
       sslMode: "prefer",
+      environmentId: null,
       tags: ["development"],
       createdAt: "2023-01-02T10:00:00.000Z",
       updatedAt: "2023-01-02T11:00:00.000Z",
@@ -325,6 +327,7 @@ describe("PostgreSQL Databases API Routes", () => {
       username: "newuser",
       password: "newpass",
       sslMode: "prefer",
+      environmentId: "env-1",
       tags: ["test"],
     };
 
@@ -337,6 +340,7 @@ describe("PostgreSQL Databases API Routes", () => {
       database: "newdb",
       username: "newuser",
       sslMode: "prefer",
+      environmentId: "env-1",
       tags: ["test"],
       createdAt: "2023-01-01T10:00:00.000Z",
       updatedAt: "2023-01-01T10:00:00.000Z",
@@ -407,6 +411,52 @@ describe("PostgreSQL Databases API Routes", () => {
         message: "Invalid request data",
       });
     });
+
+    it("should reject a request with no environmentId", async () => {
+      const { environmentId, ...requestWithoutEnvironment } = validCreateRequest;
+
+      const response = await request(app)
+        .post("/api/postgres/databases")
+        .send(requestWithoutEnvironment)
+        .expect(400);
+
+      expect(response.body).toMatchObject({
+        error: "Bad Request",
+        message: "Invalid request data",
+      });
+      expect(mockPostgresDatabaseManager.createDatabase).not.toHaveBeenCalled();
+    });
+
+    it("should pass environmentId through to the manager", async () => {
+      mockPostgresDatabaseManager.createDatabase.mockResolvedValue(
+        mockCreatedDatabase,
+      );
+
+      await request(app)
+        .post("/api/postgres/databases")
+        .send(validCreateRequest)
+        .expect(201);
+
+      expect(mockPostgresDatabaseManager.createDatabase).toHaveBeenCalledWith(
+        expect.objectContaining({ environmentId: "env-1" }),
+      );
+    });
+
+    it("should map an unknown environment to 400", async () => {
+      mockPostgresDatabaseManager.createDatabase.mockRejectedValue(
+        new Error("Environment 'env-1' not found"),
+      );
+
+      const response = await request(app)
+        .post("/api/postgres/databases")
+        .send(validCreateRequest)
+        .expect(400);
+
+      expect(response.body).toMatchObject({
+        error: "Bad Request",
+        message: "Environment 'env-1' not found",
+      });
+    });
   });
 
   describe("PUT /api/postgres/databases/:id", () => {
@@ -425,6 +475,7 @@ describe("PostgreSQL Databases API Routes", () => {
       database: "prod_db",
       username: "prod_user",
       sslMode: "require",
+      environmentId: "env-1",
       tags: ["production"],
       createdAt: "2023-01-01T10:00:00.000Z",
       updatedAt: "2023-01-01T13:00:00.000Z",
@@ -485,6 +536,39 @@ describe("PostgreSQL Databases API Routes", () => {
 
       expect(response.body).toMatchObject({
         error: "Not Found",
+      });
+    });
+
+    it("should pass an explicit null environmentId through to clear it", async () => {
+      mockPostgresDatabaseManager.updateDatabase.mockResolvedValue({
+        ...mockUpdatedDatabase,
+        environmentId: null,
+      });
+
+      await request(app)
+        .put("/api/postgres/databases/db-1")
+        .send({ environmentId: null })
+        .expect(200);
+
+      expect(mockPostgresDatabaseManager.updateDatabase).toHaveBeenCalledWith(
+        "db-1",
+        expect.objectContaining({ environmentId: null }),
+      );
+    });
+
+    it("should map an unknown environment to 400, not 404", async () => {
+      mockPostgresDatabaseManager.updateDatabase.mockRejectedValue(
+        new Error("Environment 'bad-env' not found"),
+      );
+
+      const response = await request(app)
+        .put("/api/postgres/databases/db-1")
+        .send({ environmentId: "bad-env" })
+        .expect(400);
+
+      expect(response.body).toMatchObject({
+        error: "Bad Request",
+        message: "Environment 'bad-env' not found",
       });
     });
   });

--- a/server/src/routes/__tests__/postgres-restore.test.ts
+++ b/server/src/routes/__tests__/postgres-restore.test.ts
@@ -253,6 +253,7 @@ describe("PostgreSQL Restore API", () => {
       userId: "test-user-id",
       database: "testdb",
       name: "Test Database",
+      environmentId: "env-a",
     };
 
     const mockQueuedRestore = {
@@ -318,6 +319,84 @@ describe("PostgreSQL Restore API", () => {
           }),
         }),
       );
+
+      expect(mockPrismaClient.stackService.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            stack: { environmentId: "env-a" },
+          }),
+        }),
+      );
+    });
+
+    it("should route to the null-environment restore-executor stack for a null-environment database", async () => {
+      mockPrismaClient.postgresDatabase.findFirst.mockResolvedValue({
+        ...mockDatabase,
+        environmentId: null,
+      });
+      mockPrismaClient.restoreOperation.findFirst.mockResolvedValue(null);
+      mockPrismaClient.backupOperation.findFirst.mockResolvedValue(null);
+      mockPrismaClient.stackService.findFirst.mockResolvedValue({
+        stackId: "restore-stack-1",
+      });
+      mockBackupValidator.validateBackupFile.mockResolvedValue({
+        isValid: true,
+        sizeBytes: 1024,
+        lastModified: new Date(),
+      });
+      mockRunJobPool.mockResolvedValue({
+        ok: true,
+        runId: "restore-operation-1",
+        instanceRowId: "row-1",
+        containerId: "container-1",
+      });
+      mockPrismaClient.restoreOperation.findUnique.mockResolvedValue({
+        ...mockQueuedRestore,
+      });
+
+      await request(app)
+        .post("/api/postgres/restore/test-db-id")
+        .send({
+          backupUrl: "https://storage.blob.core.windows.net/backups/backup.sql",
+          confirmRestore: true,
+        })
+        .expect(201);
+
+      expect(mockPrismaClient.stackService.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            stack: { environmentId: null },
+          }),
+        }),
+      );
+    });
+
+    it("should return 503 when no restore-executor stack is applied for the database's environment", async () => {
+      mockPrismaClient.postgresDatabase.findFirst.mockResolvedValue(
+        mockDatabase,
+      );
+      mockPrismaClient.restoreOperation.findFirst.mockResolvedValue(null);
+      mockPrismaClient.backupOperation.findFirst.mockResolvedValue(null);
+      // Simulates a restore-executor stack existing, but not for this
+      // database's environment — the query's `where` filter excludes it.
+      mockPrismaClient.stackService.findFirst.mockResolvedValue(null);
+      mockBackupValidator.validateBackupFile.mockResolvedValue({
+        isValid: true,
+        sizeBytes: 1024,
+        lastModified: new Date(),
+      });
+
+      const response = await request(app)
+        .post("/api/postgres/restore/test-db-id")
+        .send({
+          backupUrl: "https://storage.blob.core.windows.net/backups/backup.sql",
+          confirmRestore: true,
+        })
+        .expect(503);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.error).toBe("Restore template not deployed");
+      expect(mockRunJobPool).not.toHaveBeenCalled();
     });
 
     it("should return 404 if database not found", async () => {

--- a/server/src/routes/postgres-backup-configs.ts
+++ b/server/src/routes/postgres-backup-configs.ts
@@ -86,6 +86,7 @@ const updateBackupConfigSchema = z.object({
 const quickBackupSetupSchema = z.object({
   serverId: z.string().min(1, "Server ID is required"),
   databaseName: z.string().min(1, "Database name is required"),
+  environmentId: z.string().min(1, "Environment is required"),
 });
 
 /**
@@ -187,6 +188,7 @@ router.post("/quick-setup", requirePermission(Permission.PostgresWrite) as Reque
       username: server.adminUsername,
       password: adminPassword,
       sslMode: server.sslMode as "prefer" | "require" | "disable",
+      environmentId: setupRequest.environmentId,
       tags: [`server:${server.name}`, "backup"],
     });
 

--- a/server/src/routes/postgres-databases.ts
+++ b/server/src/routes/postgres-databases.ts
@@ -89,6 +89,7 @@ const createDatabaseSchema = z.object({
   username: z.string().min(1, "Username is required"),
   password: z.string().min(1, "Password is required"),
   sslMode: z.enum(POSTGRES_SSL_MODES),
+  environmentId: z.string().min(1, "Environment is required"),
   tags: z.array(z.string()).optional().default([]),
 });
 
@@ -110,6 +111,7 @@ const updateDatabaseSchema = z.object({
   username: z.string().min(1, "Username is required").optional(),
   password: z.string().min(1, "Password is required").optional(),
   sslMode: z.enum(POSTGRES_SSL_MODES).optional(),
+  environmentId: z.string().min(1).nullable().optional(),
   tags: z.array(z.string()).optional(),
 });
 
@@ -431,7 +433,8 @@ router.post("/", requirePermission(Permission.PostgresWrite) as RequestHandler, 
 
       if (
         error.message.includes("Encryption failed") ||
-        error.message.includes("Invalid")
+        error.message.includes("Invalid") ||
+        (error.message.includes("Environment") && error.message.includes("not found"))
       ) {
         return res.status(400).json({
           error: "Bad Request",
@@ -548,6 +551,15 @@ router.put("/:id", requirePermission(Permission.PostgresWrite) as RequestHandler
     );
 
     if (error instanceof Error) {
+      if (error.message.includes("Environment") && error.message.includes("not found")) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: error.message,
+          timestamp: new Date().toISOString(),
+          requestId,
+        });
+      }
+
       if (
         error.message.includes("not found") ||
         error.message.includes("Access denied")

--- a/server/src/routes/postgres-restore.ts
+++ b/server/src/routes/postgres-restore.ts
@@ -575,15 +575,17 @@ router.post(
         });
       }
 
-      // Locate the applied restore-executor JobPool stack. For Phase 5 the
-      // constraint is "at most one applied restore-executor stack" (same
-      // shape as pg-az-backup) — grab the first one. Failure here means an
-      // operator hasn't deployed the template yet; surface as 503 so the
-      // UI can hint the right next step.
+      // Locate the applied restore-executor JobPool stack whose environment
+      // matches this database's own — mirrors the pg-az-backup routing fix
+      // (see backup-executor.ts's findPgBackupStackForDatabase). Failure
+      // here means an operator hasn't deployed the template for this
+      // environment yet; surface as 503 so the UI can hint the right next
+      // step.
       const restoreService = await prisma.stackService.findFirst({
         where: {
           serviceName: RESTORE_EXECUTOR_SERVICE_NAME,
           serviceType: "JobPool",
+          stack: { environmentId: database.environmentId },
         },
         select: { stackId: true },
       });

--- a/server/src/services/__tests__/backup-executor.integration.test.ts
+++ b/server/src/services/__tests__/backup-executor.integration.test.ts
@@ -1,0 +1,138 @@
+import { createId } from "@paralleldrive/cuid2";
+import { testPrisma } from "../../__tests__/integration-test-helpers";
+
+const { mockRunJobPool } = vi.hoisted(() => ({
+  mockRunJobPool: vi.fn(),
+}));
+
+vi.mock("../docker-executor", () => ({
+  DockerExecutorService: vi.fn(function () {
+    return { initialize: vi.fn().mockResolvedValue(undefined) };
+  }),
+}));
+
+vi.mock("../stacks/job-pool-spawner", () => ({
+  runJobPool: (...args: unknown[]) => mockRunJobPool(...args),
+}));
+
+import { BackupExecutorService } from "../backup/backup-executor";
+import { PG_AZ_BACKUP_SERVICE_NAME } from "../backup/backup-job-pool-materialiser";
+
+async function seedEnvironment() {
+  return testPrisma.environment.create({
+    data: {
+      name: `env-${createId().slice(0, 8)}`,
+      type: "nonproduction",
+      networkType: "local",
+    },
+  });
+}
+
+async function seedPgAzBackupStack(environmentId: string | null) {
+  const stack = await testPrisma.stack.create({
+    data: {
+      name: `pg-az-backup-${createId().slice(0, 8)}`,
+      environmentId,
+      version: 1,
+      networks: [],
+      volumes: [],
+    },
+  });
+
+  await testPrisma.stackService.create({
+    data: {
+      stackId: stack.id,
+      serviceName: PG_AZ_BACKUP_SERVICE_NAME,
+      serviceType: "JobPool",
+      dockerImage: "mini-infra-pg-az-backup",
+      dockerTag: "latest",
+      containerConfig: {},
+      configFiles: [],
+      initCommands: [],
+      dependsOn: [],
+      order: 0,
+    },
+  });
+
+  return stack.id;
+}
+
+async function seedDatabase(environmentId: string | null) {
+  const token = createId().slice(0, 8);
+  return testPrisma.postgresDatabase.create({
+    data: {
+      name: `db-${token}`,
+      connectionString: "postgresql://user:pass@host:5432/db",
+      host: "host",
+      port: 5432,
+      database: "db",
+      username: "user",
+      environmentId,
+      tags: "[]",
+    },
+  });
+}
+
+describe("BackupExecutorService.queueBackup — environment-scoped stack routing", () => {
+  beforeEach(() => {
+    mockRunJobPool.mockReset();
+  });
+
+  it("routes a manual backup to the pg-az-backup stack in the database's own environment", async () => {
+    const envA = await seedEnvironment();
+    const envB = await seedEnvironment();
+    const stackA = await seedPgAzBackupStack(envA.id);
+    await seedPgAzBackupStack(envB.id);
+    const dbA = await seedDatabase(envA.id);
+
+    mockRunJobPool.mockResolvedValue({
+      ok: true,
+      runId: "op-1",
+      instanceRowId: "row-1",
+      containerId: "container-1",
+    });
+    await testPrisma.backupOperation.create({
+      data: {
+        id: "op-1",
+        databaseId: dbA.id,
+        operationType: "manual",
+        status: "pending",
+      },
+    });
+
+    const executor = new BackupExecutorService(testPrisma);
+    await executor.queueBackup(dbA.id, "manual", "user-1");
+
+    expect(mockRunJobPool).toHaveBeenCalledWith(
+      testPrisma,
+      expect.anything(),
+      expect.objectContaining({ stackId: stackA }),
+    );
+  });
+
+  it("throws when the database doesn't exist", async () => {
+    const executor = new BackupExecutorService(testPrisma);
+
+    await expect(
+      executor.queueBackup("nonexistent-db-id", "manual", "user-1"),
+    ).rejects.toThrow("Database nonexistent-db-id not found");
+    expect(mockRunJobPool).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to a stack applied in a different environment", async () => {
+    const envA = await seedEnvironment();
+    const envB = await seedEnvironment();
+    // Only environment B has an applied pg-az-backup stack.
+    await seedPgAzBackupStack(envB.id);
+    const dbA = await seedDatabase(envA.id);
+
+    const executor = new BackupExecutorService(testPrisma);
+
+    await expect(
+      executor.queueBackup(dbA.id, "manual", "user-1"),
+    ).rejects.toThrow(
+      "No pg-az-backup stack is currently applied. Deploy the pg-az-backup template from the template catalog before triggering a manual backup.",
+    );
+    expect(mockRunJobPool).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/services/backup/backup-executor.ts
+++ b/server/src/services/backup/backup-executor.ts
@@ -195,13 +195,26 @@ export class BackupExecutorService {
 
   /**
    * Find the applied pg-az-backup JobPool stack that owns this database's
-   * backup. For Phase 4 the constraint is "at most one applied pg-az-backup
-   * stack across the host" (documented in pg-az-backup/CLAUDE.md), so we
-   * grab the first one we find.
+   * backup — the stack whose `environmentId` matches the database's own.
+   * Throws if the database itself doesn't exist; returns `null` (not a
+   * stack from a different environment) if the database exists but no
+   * pg-az-backup stack is applied for its environment yet.
    */
-  private async findPgBackupStackForDatabase(_databaseId: string): Promise<{ id: string } | null> {
+  private async findPgBackupStackForDatabase(databaseId: string): Promise<{ id: string } | null> {
+    const database = await this.prisma.postgresDatabase.findUnique({
+      where: { id: databaseId },
+      select: { environmentId: true },
+    });
+    if (!database) {
+      throw new Error(`Database ${databaseId} not found`);
+    }
+
     const service = await this.prisma.stackService.findFirst({
-      where: { serviceName: PG_AZ_BACKUP_SERVICE_NAME, serviceType: "JobPool" },
+      where: {
+        serviceName: PG_AZ_BACKUP_SERVICE_NAME,
+        serviceType: "JobPool",
+        stack: { environmentId: database.environmentId },
+      },
       select: { stackId: true },
     });
     if (!service) return null;

--- a/server/src/services/backup/backup-job-pool-materialiser.ts
+++ b/server/src/services/backup/backup-job-pool-materialiser.ts
@@ -8,11 +8,12 @@
  * registry. This module is the bridge:
  *
  *   1. `materialiseTriggersForStack(stackId)` — given a pg-az-backup stack id,
- *      read every `BackupConfiguration` row whose database lives in this
- *      stack's environment (or, for the host-scoped fallback case, every
- *      enabled row), and write the derived triggers + maxConcurrent onto the
- *      stack's `pg-az-backup` JobPool service row. Then refresh the
- *      JobPoolCron/Nats registries so the change takes effect immediately.
+ *      read every `BackupConfiguration` row whose database's `environmentId`
+ *      matches this stack's own `environmentId`, and write the derived
+ *      triggers + maxConcurrent onto the stack's `pg-az-backup` JobPool
+ *      service row. Then refresh the JobPoolCron/Nats registries so the
+ *      change takes effect immediately. A database with no environment set
+ *      is never picked up — see pg-az-backup/CLAUDE.md.
  *
  *   2. `refreshAllPgBackupTriggers()` — boot-time backfill that walks every
  *      applied `pg-az-backup` stack and re-materialises its triggers. Picks
@@ -120,24 +121,21 @@ export async function materialiseTriggersForStack(
       serviceName: PG_AZ_BACKUP_SERVICE_NAME,
       serviceType: "JobPool",
     },
+    include: { stack: { select: { environmentId: true } } },
   });
   if (!service) {
     log.debug({ stackId }, "materialiseTriggersForStack: no pg-az-backup JobPool service on this stack");
     return { triggerCount: 0 };
   }
 
-  // `PostgresDatabase` rows are not currently environment-scoped (no
-  // `environmentId` column on the model — see prisma schema). For Phase 4
-  // the JobPool template is environment-scoped because it inherits the
-  // per-env egress network + proxy injection, but the source-of-truth
-  // BackupConfiguration table is host-flat. We expose every enabled
-  // BackupConfiguration row as a cron trigger on every applied pg-az-backup
-  // stack and document the single-instance-per-host constraint in
-  // pg-az-backup/CLAUDE.md — applying a second env-scoped pg-az-backup
-  // stack would cause duplicate runs. A future ticket can add an
-  // `environmentId` to `PostgresDatabase` and filter here; for now the
-  // shape matches the legacy single-runner behavior.
+  // Only pick up BackupConfiguration rows whose database is scoped to this
+  // stack's environment — each environment's pg-az-backup stack owns exactly
+  // its own environment's databases, so two applied stacks never double-fire
+  // the same backup. A `PostgresDatabase` with no environment set can never
+  // match here (env-scoped stacks always have a non-null `environmentId` —
+  // see pg-az-backup/CLAUDE.md).
   const configs = await prisma.backupConfiguration.findMany({
+    where: { database: { environmentId: service.stack.environmentId } },
     select: { databaseId: true, schedule: true, timezone: true, isEnabled: true },
   });
 

--- a/server/src/services/postgres/postgres-database-manager.ts
+++ b/server/src/services/postgres/postgres-database-manager.ts
@@ -107,6 +107,13 @@ export class PostgresDatabaseManager {
         );
       }
 
+      const environment = await this.prisma.environment.findUnique({
+        where: { id: request.environmentId },
+      });
+      if (!environment) {
+        throw new Error(`Environment '${request.environmentId}' not found`);
+      }
+
       // Create database configuration
       const createdDb = await this.prisma.postgresDatabase.create({
         data: {
@@ -117,6 +124,7 @@ export class PostgresDatabaseManager {
           database: request.database,
           username: request.username,
           sslMode: request.sslMode,
+          environmentId: request.environmentId,
           tags: JSON.stringify(request.tags || []),
           healthStatus: "unknown",
         },
@@ -264,6 +272,20 @@ export class PostgresDatabaseManager {
 
       if (request.tags !== undefined) {
         updateData.tags = JSON.stringify(request.tags);
+      }
+
+      if (request.environmentId !== undefined) {
+        if (request.environmentId !== null) {
+          const environment = await this.prisma.environment.findUnique({
+            where: { id: request.environmentId },
+          });
+          if (!environment) {
+            throw new Error(`Environment '${request.environmentId}' not found`);
+          }
+        }
+        updateData.environment = request.environmentId
+          ? { connect: { id: request.environmentId } }
+          : { disconnect: true };
       }
 
       // Update database
@@ -900,6 +922,7 @@ export class PostgresDatabaseManager {
       database: database.database,
       username: database.username,
       sslMode: database.sslMode,
+      environmentId: database.environmentId,
       tags: JSON.parse(database.tags || "[]"),
       createdAt: database.createdAt.toISOString(),
       updatedAt: database.updatedAt.toISOString(),


### PR DESCRIPTION
## Summary

- `PostgresDatabase` had no `environmentId`, so the `pg-az-backup`/`restore-executor` JobPool stacks (both `"scope": "environment"`) had no way to route work to the correct environment's stack:
  - `materialiseTriggersForStack` put **every** enabled `BackupConfiguration` row onto **every** applied `pg-az-backup` stack's cron triggers — two stacks in different environments would double-fire the same scheduled backup.
  - The manual "Run backup now" route and the restore route both grabbed whichever stack was found first, host-wide, instead of the one matching the database's environment.
- Added a nullable `environmentId` FK on `PostgresDatabase` (mirrors the `EgressPolicy` pattern) and scoped all three lookups to match the target database's environment. A null-environment database can never match an environment-scoped stack, so the field is **required** on create (including the "Quick Backup Setup" flow, which also creates a `PostgresDatabase` under the hood) — legacy rows get a "No environment" banner in the UI linking straight to the fix.
- Considered making the templates host-scoped instead (avoids needing `environmentId` at all), but ruled it out: host-scoped stacks get no egress firewall in this codebase, and this template was moved to JobPool specifically to close a prior egress-bypass — flipping scope would silently reintroduce it.

## Test plan

- [x] `pnpm --filter mini-infra-server test` — 2730 tests pass, including new integration coverage for environment-scoped trigger materialisation (`backup-job-pool-materialiser-environment-scope.integration.test.ts`) and manual-backup routing (`backup-executor.integration.test.ts`)
- [x] `pnpm build` (lib, acme, server, client) — clean
- [x] `pnpm --filter mini-infra-server lint` / `pnpm --filter mini-infra-client lint` — clean
- [x] Verified live in a rebuilt dev environment: created a database via the UI wizard against a throwaway Postgres container, confirmed the environment picker auto-selects the sole environment and persists via the API; cleared a row's `environmentId` via the API to simulate a legacy row, confirmed the "No environment" banner renders and clicking it into Edit auto-fills the environment so a single "Update" click fixes it
- [x] Caught and fixed a real effect-ordering race during that manual testing: the auto-select effect could fire while the modal was still closed (component stays mounted), and reopening it would silently reset the value with nothing left to re-fix it — confirmed via console instrumentation, fixed by keying the effect off `isOpen`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
