### PR TITLE
fix(monitoring): nearest-series chart tooltip, stop scroll jump on poll

### DIFF
--- a/client/src/app/dashboard/ContainerSummary.tsx
+++ b/client/src/app/dashboard/ContainerSummary.tsx
@@ -7,6 +7,10 @@ import { useContainers } from "@/hooks/useContainers";
 import { useConnectivityStatus } from "@/hooks/use-settings";
 import { useFormattedDate } from "@/hooks/use-formatted-date";
 import {
+  useDebouncedFalse,
+  INFRA_BLIP_GRACE_MS,
+} from "@/hooks/use-debounced-false";
+import {
   useMonitoringStatus,
   usePrometheusRangeQuery,
 } from "@/hooks/use-monitoring";
@@ -37,27 +41,36 @@ export function ContainerSummary() {
 
   // Get the latest Docker connectivity status
   const latestDockerStatus = connectivityData?.data?.[0];
-  const isDockerConnected = latestDockerStatus?.status === "connected";
+  const isDockerConnectedLive = latestDockerStatus?.status === "connected";
+  // Debounced so a brief connectivity blip doesn't collapse this whole section
+  // and shift page scroll (see useDebouncedFalse).
+  const isDockerConnected = useDebouncedFalse(
+    isDockerConnectedLive,
+    INFRA_BLIP_GRACE_MS,
+  );
   const hasDockerError =
     latestDockerStatus?.status === "failed" ||
     latestDockerStatus?.status === "error";
 
   // Check if monitoring stack is running
   const { data: monitoringStatus } = useMonitoringStatus();
-  const isMonitoringRunning = monitoringStatus?.running === true;
+  const isMonitoringRunning = useDebouncedFalse(
+    monitoringStatus?.running === true,
+    INFRA_BLIP_GRACE_MS,
+  );
 
   // Fetch CPU and memory metrics (1h range, 60s step) — only when monitoring is up
   const { data: cpuData } = usePrometheusRangeQuery(
     'rate(docker_container_cpu_usage_total{container_name!=""}[5m]) / 1e9',
     3600,
     "60s",
-    { enabled: isMonitoringRunning }
+    { enabled: isMonitoringRunning },
   );
   const { data: memoryData } = usePrometheusRangeQuery(
     'docker_container_mem_usage{container_name!=""}',
     3600,
     "60s",
-    { enabled: isMonitoringRunning }
+    { enabled: isMonitoringRunning },
   );
 
   // Only fetch containers if Docker is connected

--- a/client/src/app/monitoring/MetricsChart.tsx
+++ b/client/src/app/monitoring/MetricsChart.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from "react";
+import { useMemo, useRef, useState } from "react";
+import type { MouseHandlerDataParam } from "recharts";
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import {
   Card,
@@ -31,6 +32,10 @@ const COLOR_MAP: Record<string, string> = {
   orange: "hsl(25, 95%, 53%)",
 };
 
+// Hovered series within this many pixels of the nearest one are all treated as "closest"
+// (handles overlapping/tied lines rather than picking one arbitrarily)
+const NEAREST_SERIES_TOLERANCE_PX = 6;
+
 // Stable color palette for containers
 const CONTAINER_COLORS = [
   "hsl(217, 91%, 60%)",
@@ -51,14 +56,30 @@ export function MetricsChart({
   valueFormatter,
   color,
 }: MetricsChartProps) {
+  const chartWrapperRef = useRef<HTMLDivElement>(null);
+  // Container names nearest the cursor's Y position at the hovered timestamp.
+  // null means "unknown/not hovering" - the tooltip falls back to showing every series.
+  const [nearestNames, setNearestNames] = useState<Set<string> | null>(null);
+
   const { chartData, containerNames, chartConfig } = useMemo(() => {
     if (!data?.data?.result?.length) {
-      return { chartData: [], containerNames: [] as string[], chartConfig: {} as ChartConfig };
+      return {
+        chartData: [],
+        containerNames: [] as string[],
+        chartConfig: {} as ChartConfig,
+      };
     }
 
-    const names = [...new Set(data.data.result.map(
-      (r) => r.metric.container_name || r.metric.com_docker_compose_service || "unknown"
-    ))];
+    const names = [
+      ...new Set(
+        data.data.result.map(
+          (r) =>
+            r.metric.container_name ||
+            r.metric.com_docker_compose_service ||
+            "unknown",
+        ),
+      ),
+    ];
 
     // Build time-series data keyed by timestamp
     const timeMap = new Map<number, Record<string, number>>();
@@ -80,7 +101,7 @@ export function MetricsChart({
     }
 
     const sorted = Array.from(timeMap.values()).sort(
-      (a, b) => (a.timestamp as number) - (b.timestamp as number)
+      (a, b) => (a.timestamp as number) - (b.timestamp as number),
     );
 
     // Build chart config
@@ -88,7 +109,10 @@ export function MetricsChart({
     for (let i = 0; i < names.length; i++) {
       config[names[i]] = {
         label: names[i],
-        color: names.length === 1 ? COLOR_MAP[color] : CONTAINER_COLORS[i % CONTAINER_COLORS.length],
+        color:
+          names.length === 1
+            ? COLOR_MAP[color]
+            : CONTAINER_COLORS[i % CONTAINER_COLORS.length],
       };
     }
 
@@ -114,6 +138,57 @@ export function MetricsChart({
     );
   }
 
+  const updateNearestNames = (
+    state: MouseHandlerDataParam,
+    event: { clientY: number },
+  ) => {
+    // activeTooltipIndex is a stringified array index (recharts v3 TooltipIndex type)
+    const parsedIndex =
+      typeof state.activeTooltipIndex === "string"
+        ? Number(state.activeTooltipIndex)
+        : NaN;
+    const index = Number.isInteger(parsedIndex) ? parsedIndex : null;
+    const wrapper = chartWrapperRef.current;
+    const row = index !== null ? chartData[index] : undefined;
+    if (index === null || !wrapper || !row) {
+      setNearestNames(null);
+      return;
+    }
+
+    const presentNames = containerNames.filter(
+      (name) => row[name] !== undefined,
+    );
+    const cursorY = event.clientY;
+
+    // Defer to the next frame so Recharts has painted the active dots
+    // for this hover position before we measure them.
+    requestAnimationFrame(() => {
+      const dots = Array.from(
+        wrapper.querySelectorAll<SVGCircleElement>(
+          ".recharts-active-dot circle",
+        ),
+      );
+      if (dots.length === 0 || dots.length !== presentNames.length) {
+        // Mismatch between rendered dots and known series - fail open to showing all.
+        setNearestNames(null);
+        return;
+      }
+
+      const distances = dots.map((dot) => {
+        const rect = dot.getBoundingClientRect();
+        return Math.abs(rect.top + rect.height / 2 - cursorY);
+      });
+      const minDistance = Math.min(...distances);
+      const nearest = new Set<string>();
+      distances.forEach((distance, i) => {
+        if (distance - minDistance <= NEAREST_SERIES_TOLERANCE_PX) {
+          nearest.add(presentNames[i]);
+        }
+      });
+      setNearestNames(nearest);
+    });
+  };
+
   return (
     <Card>
       <CardHeader>
@@ -124,74 +199,95 @@ export function MetricsChart({
         <CardDescription>{description}</CardDescription>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig} className="h-[250px] w-full">
-          <AreaChart data={chartData}>
-            <CartesianGrid vertical={false} />
-            <XAxis
-              dataKey="timestamp"
-              tickLine={false}
-              axisLine={false}
-              tickMargin={8}
-              minTickGap={40}
-              tickFormatter={(value) => {
-                const date = new Date(value * 1000);
-                return date.toLocaleTimeString([], {
-                  hour: "2-digit",
-                  minute: "2-digit",
-                });
-              }}
-            />
-            <YAxis
-              tickLine={false}
-              axisLine={false}
-              tickMargin={8}
-              width={60}
-              tickFormatter={valueFormatter}
-            />
-            <ChartTooltip
-              cursor={false}
-              content={
-                <ChartTooltipContent
-                  labelFormatter={(_value, payload) => {
-                    const timestamp = payload?.[0]?.payload?.timestamp;
-                    if (!timestamp) return "Unknown";
-                    const date = new Date(Number(timestamp) * 1000);
-                    return date.toLocaleTimeString([], {
-                      hour: "2-digit",
-                      minute: "2-digit",
-                      second: "2-digit",
-                    });
-                  }}
-                  formatter={(value, name, item) => (
-                    <div className="flex flex-1 items-center gap-2">
-                      <div
-                        className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
-                        style={{ backgroundColor: item.color }}
-                      />
-                      <span className="text-muted-foreground flex-1">
-                        {name as string}
-                      </span>
-                      <span className="text-foreground font-mono font-medium tabular-nums">
-                        {valueFormatter(Number(value))}
-                      </span>
-                    </div>
-                  )}
-                  hideIndicator
-                />
-              }
-            />
-            {containerNames.map((name) => (
-              <Area
-                key={name}
-                dataKey={name}
-                type="monotone"
-                fill="transparent"
-                stroke={chartConfig[name]?.color || COLOR_MAP[color]}
-                strokeWidth={2}
+        <div ref={chartWrapperRef}>
+          <ChartContainer config={chartConfig} className="h-[250px] w-full">
+            <AreaChart
+              data={chartData}
+              onMouseEnter={updateNearestNames}
+              onMouseMove={updateNearestNames}
+              onMouseLeave={() => setNearestNames(null)}
+            >
+              <CartesianGrid vertical={false} />
+              <XAxis
+                dataKey="timestamp"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                minTickGap={40}
+                tickFormatter={(value) => {
+                  const date = new Date(value * 1000);
+                  return date.toLocaleTimeString([], {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  });
+                }}
               />
-            ))}
-          </AreaChart>
-        </ChartContainer>
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                width={60}
+                tickFormatter={valueFormatter}
+              />
+              <ChartTooltip
+                cursor={false}
+                content={({ active, payload, label, coordinate }) => {
+                  const filtered = nearestNames
+                    ? payload?.filter(
+                        (item) =>
+                          item.name != null &&
+                          nearestNames.has(String(item.name)),
+                      )
+                    : payload;
+
+                  return (
+                    <ChartTooltipContent
+                      active={active}
+                      payload={filtered?.length ? filtered : payload}
+                      label={label}
+                      coordinate={coordinate}
+                      labelFormatter={(_value, payload) => {
+                        const timestamp = payload?.[0]?.payload?.timestamp;
+                        if (!timestamp) return "Unknown";
+                        const date = new Date(Number(timestamp) * 1000);
+                        return date.toLocaleTimeString([], {
+                          hour: "2-digit",
+                          minute: "2-digit",
+                          second: "2-digit",
+                        });
+                      }}
+                      formatter={(value, name, item) => (
+                        <div className="flex flex-1 items-center gap-2">
+                          <div
+                            className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+                            style={{ backgroundColor: item.color }}
+                          />
+                          <span className="text-muted-foreground flex-1">
+                            {name as string}
+                          </span>
+                          <span className="text-foreground font-mono font-medium tabular-nums">
+                            {valueFormatter(Number(value))}
+                          </span>
+                        </div>
+                      )}
+                      hideIndicator
+                    />
+                  );
+                }}
+              />
+              {containerNames.map((name) => (
+                <Area
+                  key={name}
+                  dataKey={name}
+                  type="monotone"
+                  fill="transparent"
+                  stroke={chartConfig[name]?.color || COLOR_MAP[color]}
+                  strokeWidth={2}
+                />
+              ))}
+            </AreaChart>
+          </ChartContainer>
+        </div>
       </CardContent>
     </Card>
   );

--- a/client/src/app/monitoring/page.tsx
+++ b/client/src/app/monitoring/page.tsx
@@ -18,7 +18,15 @@ import {
   useMonitoringStatus,
   usePrometheusRangeQuery,
 } from "@/hooks/use-monitoring";
-import { formatCpu, formatBytes, formatBytesPerSec } from "@/lib/format-metrics";
+import {
+  useDebouncedFalse,
+  INFRA_BLIP_GRACE_MS,
+} from "@/hooks/use-debounced-false";
+import {
+  formatCpu,
+  formatBytes,
+  formatBytesPerSec,
+} from "@/lib/format-metrics";
 import { MetricsChart } from "./MetricsChart";
 
 type TimeRange = "15m" | "1h" | "6h" | "24h";
@@ -40,12 +48,14 @@ const TIME_RANGE_STEP: Record<TimeRange, string> = {
 export function MonitoringPage() {
   const [timeRange, setTimeRange] = useState<TimeRange>("1h");
 
-  const {
-    data: status,
-    error: statusError,
-  } = useMonitoringStatus();
+  const { data: status, error: statusError } = useMonitoringStatus();
 
-  const isRunning = status?.running === true;
+  // Debounced so a brief infra blip (e.g. the prometheus container restarting)
+  // doesn't collapse the whole chart grid and shift page scroll.
+  const isRunning = useDebouncedFalse(
+    status?.running === true,
+    INFRA_BLIP_GRACE_MS,
+  );
 
   const rangeSeconds = TIME_RANGE_SECONDS[timeRange];
   const step = TIME_RANGE_STEP[timeRange];
@@ -55,28 +65,28 @@ export function MonitoringPage() {
     'rate(docker_container_cpu_usage_total{container_name!=""}[5m]) / 1e9',
     rangeSeconds,
     step,
-    { enabled: isRunning }
+    { enabled: isRunning },
   );
 
   const { data: memoryRangeData } = usePrometheusRangeQuery(
     'docker_container_mem_usage{container_name!=""}',
     rangeSeconds,
     step,
-    { enabled: isRunning }
+    { enabled: isRunning },
   );
 
   const { data: networkRxRangeData } = usePrometheusRangeQuery(
     'rate(docker_container_net_rx_bytes{container_name!=""}[5m])',
     rangeSeconds,
     step,
-    { enabled: isRunning }
+    { enabled: isRunning },
   );
 
   const { data: networkTxRangeData } = usePrometheusRangeQuery(
     'rate(docker_container_net_tx_bytes{container_name!=""}[5m])',
     rangeSeconds,
     step,
-    { enabled: isRunning }
+    { enabled: isRunning },
   );
 
   if (statusError) {
@@ -104,7 +114,8 @@ export function MonitoringPage() {
       <div className="px-4 lg:px-6">
         {!isRunning && (
           <p className="text-sm text-muted-foreground">
-            Monitoring is not currently running. Deploy the monitoring stack from the Host page to view container metrics.
+            Monitoring is not currently running. Deploy the monitoring stack
+            from the Host page to view container metrics.
           </p>
         )}
 

--- a/client/src/hooks/use-debounced-false.ts
+++ b/client/src/hooks/use-debounced-false.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+
+// A brief infra blip (e.g. a container restarting) shouldn't collapse large
+// gated UI sections and shift page scroll - ride out anything shorter than this.
+export const INFRA_BLIP_GRACE_MS = 20000;
+
+/**
+ * Returns `value`, but delays any transition to `false` by `graceMs`. A value
+ * that flips false and recovers to true within the grace window never becomes
+ * visible to the caller.
+ */
+export function useDebouncedFalse(value: boolean, graceMs: number): boolean {
+  const [debounced, setDebounced] = useState(value);
+  const [prevValue, setPrevValue] = useState(value);
+
+  // Adopt `true` immediately (React's "adjusting state when a prop changes"
+  // pattern - avoids a synchronous setState inside the effect below).
+  if (value !== prevValue) {
+    setPrevValue(value);
+    if (value) {
+      setDebounced(true);
+    }
+  }
+
+  useEffect(() => {
+    if (value) return undefined;
+    const timer = setTimeout(() => setDebounced(false), graceMs);
+    return () => clearTimeout(timer);
+  }, [value, graceMs]);
+
+  return debounced;
+}


### PR DESCRIPTION
## Summary
- `MetricsChart`'s hover tooltip listed every container series at the hovered timestamp — unusable once a host has 20+ containers. It now shows only the series nearest the cursor's Y position, with ties within a few pixels shown together (per product decision: overlapping/tied lines should all be listed rather than picking one arbitrarily). Measured from Recharts' actual rendered active-dot positions rather than an approximated y-scale, so it stays correct regardless of chart height/margins. Fixes both the standalone `/monitoring` charts and the dashboard's inline CPU/Memory cards, which share this component.
- `/dashboard` and `/monitoring` lost scroll position during background polling. Root cause confirmed empirically (0.5s-resolution poll of the raw API across a container restart): `/api/monitoring/status`'s live-computed `running` flag genuinely flips to `false` for about half a second during a restart before recovering, which collapsed the gated chart section and shifted the page's scroll position with no restore. Added a `useDebouncedFalse` hook that adopts `true` immediately but delays adopting `false` by 20s — long enough to ride out a normal restart blip, short enough to still reflect a genuinely sustained outage.

## Test plan
- [x] `pnpm --filter mini-infra-client build` passes
- [x] `pnpm --filter mini-infra-client exec eslint .` clean
- [x] `pnpm --filter mini-infra-client test` — 162/162 passing
- [x] Verified hover behavior live in a worktree dev environment with 12 real containers reporting metrics: nearest-only filtering and tie-grouping both confirmed via screenshots
- [x] Reproduced the scroll jump pre-fix (forced a `docker restart` on the prometheus container, `scrollY` moved 100→40 and never restored), then re-ran the identical restart post-fix and `scrollY` held steady at 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)