### PR TITLE
feat(addons): authoring UI for Service Addons

### DIFF
--- a/client/src/__tests__/application-draft.test.ts
+++ b/client/src/__tests__/application-draft.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "vitest";
-import type { StackTemplateVersionInfo } from "@mini-infra/types";
-import { buildDraftFromVersion } from "@/lib/application-draft";
+import type {
+  StackTemplateServiceInfo,
+  StackTemplateVersionInfo,
+} from "@mini-infra/types";
+import {
+  buildDraftFromVersion,
+  mapServiceInfoToDefinition,
+} from "@/lib/application-draft";
 
 function makeVersion(): StackTemplateVersionInfo {
   return {
@@ -160,5 +166,116 @@ describe("buildDraftFromVersion", () => {
       { type: "docker-network", purpose: "applications" },
     ]);
     expect(draft.services[0].containerConfig.env).toEqual({ FOO: "bar" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapServiceInfoToDefinition — the canonical, write-safe per-service mapper the
+// stack-templates draft editor reuses (Phase 4, Part A). It must carry EVERY
+// authoring field (`addons`, `poolConfig`, vault/nats refs) AND strip
+// read-model nulls so its output is a valid `DraftVersionInput.services[]`
+// entry standalone.
+// ---------------------------------------------------------------------------
+
+function makeServiceInfo(
+  overrides: Partial<StackTemplateServiceInfo> = {},
+): StackTemplateServiceInfo {
+  return {
+    id: "svc-x",
+    versionId: "ver-1",
+    serviceName: "web",
+    serviceType: "Stateful",
+    dockerImage: "nginx",
+    dockerTag: "latest",
+    containerConfig: {},
+    initCommands: null,
+    dependsOn: [],
+    order: 1,
+    routing: null,
+    poolConfig: null,
+    jobPoolConfig: null,
+    vaultAppRoleId: null,
+    vaultAppRoleRef: null,
+    natsCredentialId: null,
+    natsCredentialRef: null,
+    natsRole: null,
+    natsSigner: null,
+    addons: null,
+    ...overrides,
+  };
+}
+
+describe("mapServiceInfoToDefinition", () => {
+  it("carries the addons block and non-null per-service binding fields through", () => {
+    const svc = makeServiceInfo({
+      addons: { "tailscale-ssh": { authKey: "tskey-abc" } },
+      natsRole: "worker",
+      vaultAppRoleRef: "my-approle",
+    });
+
+    const def = mapServiceInfoToDefinition(svc);
+
+    expect(def.addons).toEqual({ "tailscale-ssh": { authKey: "tskey-abc" } });
+    expect(def.natsRole).toBe("worker");
+    expect(def.vaultAppRoleRef).toBe("my-approle");
+  });
+
+  it("strips read-model nulls so its output is a valid draft service standalone", () => {
+    const def = mapServiceInfoToDefinition(makeServiceInfo());
+
+    // Deep scan: no property may be null (the draft schema rejects null on the
+    // .optional() service fields).
+    const findNullPath = (value: unknown, path = "$"): string | null => {
+      if (value === null) return path;
+      if (Array.isArray(value)) {
+        for (let i = 0; i < value.length; i++) {
+          const hit = findNullPath(value[i], `${path}[${i}]`);
+          if (hit) return hit;
+        }
+        return null;
+      }
+      if (typeof value === "object") {
+        for (const [k, v] of Object.entries(value)) {
+          const hit = findNullPath(v, `${path}.${k}`);
+          if (hit) return hit;
+        }
+      }
+      return null;
+    };
+
+    expect(findNullPath(def)).toBeNull();
+    expect(def.jobPoolConfig).toBeUndefined();
+    expect(def.natsRole).toBeUndefined();
+    expect(def.addons).toBeUndefined();
+    // DB-only fields are dropped.
+    expect(def).not.toHaveProperty("id");
+    expect(def).not.toHaveProperty("versionId");
+  });
+
+  it("editing one service does not strip a sibling service's addons (Part A regression)", () => {
+    // The exact footgun the fix closes: the editor rebuilds the WHOLE services
+    // list via the mapper on any edit. Before the fix the map was partial and
+    // dropped `addons` off every service. Service B carries an addon; the map
+    // pass (as run by `buildDraftInput` / `toServiceDefinition`) must keep it.
+    const serviceA = makeServiceInfo({
+      id: "svc-a",
+      serviceName: "api",
+      order: 1,
+    });
+    const serviceB = makeServiceInfo({
+      id: "svc-b",
+      serviceName: "web",
+      order: 2,
+      addons: { "tailscale-web": { port: 443 } },
+    });
+
+    // Simulate editing service A: remap every service, replace index 0.
+    const rebuilt = [serviceA, serviceB].map(mapServiceInfoToDefinition);
+    rebuilt[0] = { ...rebuilt[0], dockerTag: "1.29" };
+
+    expect(rebuilt[0].serviceName).toBe("api");
+    expect(rebuilt[0].dockerTag).toBe("1.29");
+    // Service B's addon survives the edit to A.
+    expect(rebuilt[1].addons).toEqual({ "tailscale-web": { port: 443 } });
   });
 });

--- a/client/src/__tests__/attach-addon-dialog.test.tsx
+++ b/client/src/__tests__/attach-addon-dialog.test.tsx
@@ -1,0 +1,251 @@
+/**
+ * Tests for the shared "attach add-on" surface (Phase 3 of the
+ * addon-authoring-ui plan).
+ *
+ * Two layers:
+ *   1. The pure gating + config-mapping helpers (`addon-applicability.ts`) —
+ *      the load-bearing logic both the Overview card and the Phase-4
+ *      Services-tab row share, so it's tested in isolation.
+ *   2. The `AttachAddonDialog` component — that applicability gating disables
+ *      the right rows with the right reasons, and that a filled config form
+ *      maps into the config object handed to `onAttach`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import React from "react";
+import type { AddonCatalogEntry } from "@mini-infra/types";
+import {
+  buildAddonConfig,
+  getAddonAvailability,
+  initialFormState,
+} from "@/components/stacks/addon-applicability";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const webAddon: AddonCatalogEntry = {
+  id: "tailscale-web",
+  description: "Expose the target over HTTPS on the tailnet.",
+  kind: "tailscale",
+  mode: "sidecar",
+  appliesTo: ["Stateful", "StatelessWeb", "Pool"],
+  requiresConnectedService: "tailscale",
+  configFields: [
+    {
+      name: "port",
+      label: "Target Port",
+      type: "number",
+      required: true,
+      min: 1,
+      max: 65535,
+    },
+    {
+      name: "extraTags",
+      label: "Extra Tags",
+      type: "string[]",
+      required: false,
+      pattern: "^tag:[a-z0-9-]+$",
+    },
+  ],
+};
+
+const poolOnlyAddon: AddonCatalogEntry = {
+  id: "pool-only",
+  description: "Only attaches to pool services.",
+  mode: "sidecar",
+  appliesTo: ["Pool"],
+  configFields: [],
+};
+
+// ---------------------------------------------------------------------------
+// Pure helpers — applicability gating
+// ---------------------------------------------------------------------------
+
+describe("getAddonAvailability", () => {
+  it("disables an addon whose appliesTo excludes the target service type", () => {
+    const result = getAddonAvailability(poolOnlyAddon, "Stateful", {
+      tailscale: "up",
+    });
+    expect(result.available).toBe(false);
+    expect(result.reason).toContain("Stateful");
+    // Applicability is unfixable — no settings link.
+    expect(result.fix).toBeUndefined();
+  });
+
+  it("disables an addon whose required connected service is down, with a fix link", () => {
+    const result = getAddonAvailability(webAddon, "Stateful", {
+      tailscale: "down",
+    });
+    expect(result.available).toBe(false);
+    expect(result.reason).toBe("Requires Tailscale — not connected");
+    expect(result.fix?.to).toBe("/connectivity-tailscale");
+  });
+
+  it("allows an applicable addon whose prerequisite is up", () => {
+    const result = getAddonAvailability(webAddon, "StatelessWeb", {
+      tailscale: "up",
+    });
+    expect(result.available).toBe(true);
+  });
+
+  it("allows an applicable addon whose prerequisite status is unknown (server re-validates)", () => {
+    const result = getAddonAvailability(webAddon, "StatelessWeb", {
+      tailscale: "unknown",
+    });
+    expect(result.available).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure helpers — config-form → config mapping
+// ---------------------------------------------------------------------------
+
+describe("buildAddonConfig", () => {
+  it("errors when a required field is blank", () => {
+    const state = initialFormState(webAddon.configFields); // port -> ""
+    const result = buildAddonConfig(webAddon.configFields, state);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors.port).toContain("required");
+  });
+
+  it("coerces a numeric field and omits an empty optional list", () => {
+    const state = { port: "8080", extraTags: [] as string[] };
+    const result = buildAddonConfig(webAddon.configFields, state);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.config).toEqual({ port: 8080 });
+      // Empty optional string[] is omitted, not written as [].
+      expect("extraTags" in result.config).toBe(false);
+    }
+  });
+
+  it("enforces numeric min/max advisory bounds", () => {
+    const result = buildAddonConfig(webAddon.configFields, {
+      port: "70000",
+      extraTags: [],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors.port).toContain("at most");
+  });
+
+  it("includes a validated string[] and rejects a pattern mismatch", () => {
+    const ok = buildAddonConfig(webAddon.configFields, {
+      port: "443",
+      extraTags: ["tag:dev-team"],
+    });
+    expect(ok.ok).toBe(true);
+    if (ok.ok) expect(ok.config).toEqual({ port: 443, extraTags: ["tag:dev-team"] });
+
+    const bad = buildAddonConfig(webAddon.configFields, {
+      port: "443",
+      extraTags: ["NOT-A-TAG"],
+    });
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.errors.extraTags).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Component — AttachAddonDialog
+// ---------------------------------------------------------------------------
+
+const mockCatalog = vi.fn<() => { addons: AddonCatalogEntry[] }>();
+// `useServiceConnectivity` returns `{ data: <ConnectivityStatusListResponse> }`;
+// the dialog reads `data.data[0].status`. This mock supplies that inner value.
+const mockConnectivity = vi.fn<() => { data: Array<{ status: string }> }>();
+
+vi.mock("@/hooks/use-addon-catalog", () => ({
+  useAddonCatalog: vi.fn(() => ({
+    data: mockCatalog(),
+    isLoading: false,
+    isError: false,
+  })),
+}));
+
+vi.mock("@/hooks/use-settings-validation", () => ({
+  useServiceConnectivity: vi.fn(() => ({ data: mockConnectivity() })),
+}));
+
+vi.mock("react-router-dom", () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) =>
+    React.createElement("a", { href: to }, children),
+}));
+
+import { AttachAddonDialog } from "@/components/stacks/attach-addon-dialog";
+
+function renderDialog(
+  props: Partial<React.ComponentProps<typeof AttachAddonDialog>> = {},
+) {
+  const defaults: React.ComponentProps<typeof AttachAddonDialog> = {
+    open: true,
+    onOpenChange: vi.fn(),
+    serviceName: "web",
+    serviceType: "Stateful",
+    attachedAddonIds: [],
+    onAttach: vi.fn(),
+    onRemove: vi.fn(),
+  };
+  return render(
+    React.createElement(AttachAddonDialog, { ...defaults, ...props }),
+  );
+}
+
+describe("AttachAddonDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCatalog.mockReturnValue({ addons: [webAddon, poolOnlyAddon] });
+    mockConnectivity.mockReturnValue({ data: [{ status: "connected" }] });
+  });
+
+  it("disables an addon that does not apply to the service type and shows the reason", () => {
+    renderDialog({ serviceType: "Stateful" });
+    const row = screen.getByTestId("addon-row-pool-only");
+    expect(within(row).getByText(/Not available for Stateful services/)).toBeTruthy();
+    expect(within(row).getByRole("button", { name: "Configure" })).toHaveProperty(
+      "disabled",
+      true,
+    );
+  });
+
+  it("disables an addon whose required service is down and links to settings", () => {
+    mockConnectivity.mockReturnValue({ data: [{ status: "failed" }] });
+    renderDialog({ serviceType: "Stateful" });
+    const row = screen.getByTestId("addon-row-tailscale-web");
+    expect(
+      within(row).getByText(/Requires Tailscale .* not connected/),
+    ).toBeTruthy();
+    const link = within(row).getByRole("link", { name: "Connectivity settings" });
+    expect(link.getAttribute("href")).toBe("/connectivity-tailscale");
+  });
+
+  it("maps the config form into the addon config passed to onAttach", () => {
+    const onAttach = vi.fn();
+    const onOpenChange = vi.fn();
+    renderDialog({ serviceType: "Stateful", onAttach, onOpenChange });
+
+    const row = screen.getByTestId("addon-row-tailscale-web");
+    fireEvent.click(within(row).getByRole("button", { name: "Configure" }));
+
+    fireEvent.change(screen.getByLabelText(/Target Port/), {
+      target: { value: "8080" },
+    });
+    fireEvent.click(within(row).getByRole("button", { name: "Attach" }));
+
+    expect(onAttach).toHaveBeenCalledWith("tailscale-web", { port: 8080 });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("blocks attach and shows a field error when a required field is blank", () => {
+    const onAttach = vi.fn();
+    renderDialog({ serviceType: "Stateful", onAttach });
+
+    const row = screen.getByTestId("addon-row-tailscale-web");
+    fireEvent.click(within(row).getByRole("button", { name: "Configure" }));
+    fireEvent.click(within(row).getByRole("button", { name: "Attach" }));
+
+    expect(within(row).getByText(/Target Port is required/)).toBeTruthy();
+    expect(onAttach).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/__tests__/template-services-section.test.tsx
+++ b/client/src/__tests__/template-services-section.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * Tests for the per-service Add-ons affordance in the stack-templates draft
+ * editor (Phase 4, Part B) and the lossless save path it rides on (Part A).
+ *
+ * The shared `AttachAddonDialog` (its own catalog/connectivity gating is
+ * covered by attach-addon-dialog.test.tsx) and the heavy `ServiceEditDrawer`
+ * (react-hook-form + zod + every field tab) are both mocked so this suite can
+ * focus on: which service the dialog scopes to, that attach/remove writes that
+ * service's `addons`, and that touching a sibling never strips another
+ * service's addons.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import type {
+  StackServiceDefinition,
+  StackTemplateServiceInfo,
+} from "@mini-infra/types";
+
+vi.mock(
+  "@/components/stack-templates/service-drawer/service-edit-drawer",
+  () => ({ ServiceEditDrawer: () => null }),
+);
+
+vi.mock("@/components/stacks/attach-addon-dialog", () => ({
+  AttachAddonDialog: ({
+    open,
+    serviceName,
+    attachedAddonIds,
+    onAttach,
+    onRemove,
+  }: {
+    open: boolean;
+    serviceName: string;
+    attachedAddonIds: string[];
+    onAttach: (id: string, config: Record<string, unknown>) => void;
+    onRemove: (id: string) => void;
+  }) =>
+    open
+      ? React.createElement(
+          "div",
+          { "data-testid": "attach-addon-dialog" },
+          React.createElement(
+            "span",
+            { "data-testid": "dialog-service-name" },
+            serviceName,
+          ),
+          React.createElement(
+            "span",
+            { "data-testid": "dialog-attached-ids" },
+            attachedAddonIds.join(","),
+          ),
+          React.createElement(
+            "button",
+            {
+              type: "button",
+              onClick: () =>
+                onAttach("tailscale-ssh", { authKey: "tskey-x" }),
+            },
+            "mock-attach",
+          ),
+          React.createElement(
+            "button",
+            { type: "button", onClick: () => onRemove("tailscale-web") },
+            "mock-remove",
+          ),
+        )
+      : null,
+}));
+
+import { TemplateServicesSection } from "@/components/stack-templates/template-services-section";
+
+function serviceInfo(
+  overrides: Partial<StackTemplateServiceInfo> = {},
+): StackTemplateServiceInfo {
+  return {
+    id: "svc",
+    versionId: "ver-1",
+    serviceName: "svc",
+    serviceType: "Stateful",
+    dockerImage: "nginx",
+    dockerTag: "latest",
+    containerConfig: {},
+    initCommands: null,
+    dependsOn: [],
+    order: 1,
+    routing: null,
+    poolConfig: null,
+    jobPoolConfig: null,
+    addons: null,
+    ...overrides,
+  };
+}
+
+const serviceA = serviceInfo({ id: "svc-a", serviceName: "api", order: 1 });
+const serviceB = serviceInfo({
+  id: "svc-b",
+  serviceName: "web",
+  order: 2,
+  addons: { "tailscale-web": { port: 443 } },
+});
+
+function renderSection(
+  props: {
+    services?: StackTemplateServiceInfo[];
+    readOnly?: boolean;
+    onServicesChange?: (services: StackServiceDefinition[]) => void;
+  } = {},
+) {
+  const onServicesChange =
+    props.onServicesChange ?? vi.fn<(s: StackServiceDefinition[]) => void>();
+  const services = props.services ?? [serviceA, serviceB];
+  render(
+    React.createElement(TemplateServicesSection, {
+      services,
+      allServiceNames: services.map((s) => s.serviceName),
+      readOnly: props.readOnly,
+      onServicesChange,
+    }),
+  );
+  return { onServicesChange };
+}
+
+describe("TemplateServicesSection — per-service add-ons", () => {
+  it("shows an attached add-on badge on the service that declares it", () => {
+    renderSection();
+    expect(screen.getByText("from tailscale-web")).toBeTruthy();
+  });
+
+  it("scopes the dialog to the chosen service and writes its addons on attach", () => {
+    const onServicesChange = vi.fn<(s: StackServiceDefinition[]) => void>();
+    renderSection({ onServicesChange });
+
+    fireEvent.click(screen.getByLabelText("Add-ons for web"));
+
+    expect(screen.getByTestId("dialog-service-name").textContent).toBe("web");
+    expect(screen.getByTestId("dialog-attached-ids").textContent).toBe(
+      "tailscale-web",
+    );
+
+    fireEvent.click(screen.getByText("mock-attach"));
+
+    expect(onServicesChange).toHaveBeenCalledTimes(1);
+    const next = onServicesChange.mock.calls[0]![0];
+    const web = next.find((s) => s.serviceName === "web")!;
+    const api = next.find((s) => s.serviceName === "api")!;
+    // New addon merged onto B; the existing one is preserved.
+    expect(web.addons).toEqual({
+      "tailscale-web": { port: 443 },
+      "tailscale-ssh": { authKey: "tskey-x" },
+    });
+    // Sibling A is untouched.
+    expect(api.addons).toBeUndefined();
+  });
+
+  it("removing the last add-on clears the block (undefined, not {})", () => {
+    const onServicesChange = vi.fn<(s: StackServiceDefinition[]) => void>();
+    renderSection({ onServicesChange });
+
+    fireEvent.click(screen.getByLabelText("Add-ons for web"));
+    fireEvent.click(screen.getByText("mock-remove"));
+
+    const next = onServicesChange.mock.calls[0]![0];
+    const web = next.find((s) => s.serviceName === "web")!;
+    expect(web.addons).toBeUndefined();
+  });
+
+  it("deleting a sibling service preserves the other's addons (Part A regression)", () => {
+    const onServicesChange = vi.fn<(s: StackServiceDefinition[]) => void>();
+    renderSection({ onServicesChange });
+
+    fireEvent.click(screen.getByLabelText("Delete api"));
+
+    const next = onServicesChange.mock.calls[0]![0];
+    expect(next).toHaveLength(1);
+    expect(next[0]!.serviceName).toBe("web");
+    expect(next[0]!.addons).toEqual({ "tailscale-web": { port: 443 } });
+  });
+
+  it("hides the add-ons affordance when read-only but still shows the badge", () => {
+    renderSection({ services: [serviceB], readOnly: true });
+    expect(screen.getByText("from tailscale-web")).toBeTruthy();
+    expect(screen.queryByLabelText("Add-ons for web")).toBeNull();
+  });
+});

--- a/client/src/app/applications/[id]/_components/addons-card.tsx
+++ b/client/src/app/applications/[id]/_components/addons-card.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useState } from "react";
+import { IconPlus, IconTrash } from "@tabler/icons-react";
+import type { StackTemplateInfo } from "@mini-infra/types";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { AddonBadge } from "@/components/stacks/addon-badge";
+import { AttachAddonDialog } from "@/components/stacks/attach-addon-dialog";
+import { useAddonCatalog } from "@/hooks/use-addon-catalog";
+import { useUpdateApplication } from "@/hooks/use-applications";
+import { buildDraftFromVersion } from "@/lib/application-draft";
+
+interface AddonsCardProps {
+  /** The application's stack template — id + version drive attach/remove. */
+  templateId: string;
+  template: StackTemplateInfo;
+}
+
+/**
+ * Application Overview "Add-ons" card. Lists the Service Addons declared on the
+ * application's primary service and offers an attach action (the shared
+ * `AttachAddonDialog`). Attach and remove both republish the template through
+ * the LOSSLESS path (`buildDraftFromVersion`, §4.2 of the addon-authoring-ui
+ * plan) — overlaying only `services[0].addons` so nothing else the form
+ * doesn't model (`vault`, `nats`, `resourceInputs`, `joinNetworks`, …) is
+ * dropped. Mirrors the Connected Networks card's `persistJoinNetworks`.
+ *
+ * Unlike the Connect card (which needs an applied snapshot), this card renders
+ * off the template's current-or-draft version, so an operator can attach
+ * addons at config time — before the app's first deploy.
+ */
+export function AddonsCard({ templateId, template }: AddonsCardProps) {
+  const version = template.currentVersion ?? template.draftVersion ?? null;
+  const primaryService = version?.services?.[0] ?? null;
+
+  const updateApplication = useUpdateApplication();
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  // Catalog is used only to enrich the read-out rows with descriptions; the
+  // dialog fetches it too, and both share the one cached query.
+  const { data: catalogData } = useAddonCatalog();
+  const catalogById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const entry of catalogData?.addons ?? []) {
+      map.set(entry.id, entry.description);
+    }
+    return map;
+  }, [catalogData?.addons]);
+
+  const declared = useMemo(
+    () => (primaryService?.addons ?? {}) as Record<string, unknown>,
+    [primaryService],
+  );
+  const attachedIds = useMemo(() => Object.keys(declared), [declared]);
+
+  // Nothing to author against until the template has a version. (Applications
+  // always have one by the time their detail page renders, so this is a guard,
+  // not an expected empty state.)
+  if (!version || !primaryService) return null;
+
+  const persistAddons = async (next: Record<string, unknown>) => {
+    const draft = buildDraftFromVersion(version);
+    const svc = draft.services[0];
+    if (!svc) return;
+    draft.services[0] = { ...svc, addons: next };
+    try {
+      await updateApplication.mutateAsync({
+        templateId,
+        metadata: {
+          displayName: template.displayName,
+          description: template.description ?? undefined,
+        },
+        draft,
+      });
+    } catch {
+      // Error surfaced by the mutation hook's global toast.
+    }
+  };
+
+  const handleAttach = (addonId: string, config: Record<string, unknown>) => {
+    void persistAddons({ ...declared, [addonId]: config });
+  };
+
+  const handleRemove = (addonId: string) => {
+    const next = { ...declared };
+    delete next[addonId];
+    void persistAddons(next);
+  };
+
+  return (
+    <Card data-tour="addons-card">
+      <CardHeader>
+        <CardTitle>Add-ons</CardTitle>
+        <CardDescription>
+          Attach capabilities like Tailscale SSH or HTTPS to this application.
+          Changes take effect on the next redeploy.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {attachedIds.length > 0 ? (
+          <ul className="divide-y">
+            {attachedIds.map((id) => (
+              <li
+                key={id}
+                data-testid={`attached-addon-${id}`}
+                className="flex items-center justify-between gap-3 py-2.5"
+              >
+                <div className="min-w-0 flex items-center gap-2">
+                  <AddonBadge addonName={id} />
+                  <span className="text-xs text-muted-foreground truncate">
+                    {catalogById.get(id) ?? "Attached add-on"}
+                  </span>
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="shrink-0"
+                  onClick={() => handleRemove(id)}
+                  disabled={updateApplication.isPending}
+                  aria-label={`Remove ${id} add-on`}
+                >
+                  <IconTrash className="h-4 w-4" />
+                </Button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No add-ons attached yet.
+          </p>
+        )}
+
+        <div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setDialogOpen(true)}
+            disabled={updateApplication.isPending}
+          >
+            <IconPlus className="mr-1 h-4 w-4" />
+            Add add-on
+          </Button>
+        </div>
+
+        {attachedIds.length > 0 && (
+          <p className="text-xs text-muted-foreground">
+            Add-on changes take effect on the next redeploy — Stop, then Deploy
+            this application to apply them.
+          </p>
+        )}
+      </CardContent>
+
+      <AttachAddonDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        serviceName={primaryService.serviceName}
+        serviceType={primaryService.serviceType}
+        attachedAddonIds={attachedIds}
+        onAttach={handleAttach}
+        onRemove={handleRemove}
+        isPending={updateApplication.isPending}
+      />
+    </Card>
+  );
+}

--- a/client/src/app/applications/[id]/configuration/page.tsx
+++ b/client/src/app/applications/[id]/configuration/page.tsx
@@ -28,13 +28,18 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { StackServiceType } from "@mini-infra/types";
+import type {
+  DraftVersionInput,
+  StackServiceDefinition,
+  StackServiceType,
+} from "@mini-infra/types";
 import {
   editApplicationFormSchema,
   editApplicationDefaults,
   applicationsNetworkDeclaration,
   type EditApplicationFormData,
 } from "@/lib/application-schemas";
+import { buildDraftFromVersion } from "@/lib/application-draft";
 import { ConfigurationCard } from "../../components/configuration-card";
 import { RoutingCard } from "../../components/routing-card";
 import type { ApplicationDetailContext } from "../layout";
@@ -221,6 +226,61 @@ export default function ApplicationConfigurationTab() {
       formData.serviceType as StackServiceType,
     );
 
+    // Rebuild the draft LOSSLESSLY from the existing version (mirroring the
+    // Connected Networks card's `persistJoinNetworks`) so fields this form
+    // doesn't model survive the save: a service's `addons` block,
+    // `vault`/`nats`/`requires`, config files, parameters, etc. We overlay
+    // only what the Configuration form edits — services[0] plus the
+    // version-level networks/volumes/resourceInputs. Building `services` from
+    // scratch here (the old behaviour) silently dropped all of the above.
+    const baseDraft = existingVersion
+      ? buildDraftFromVersion(existingVersion)
+      : undefined;
+    // Applications are single-service (services[0]); if a version somehow
+    // carries more than one service, the extras are preserved untouched — the
+    // form only edits the first.
+    const baseService = baseDraft?.services[0];
+
+    const editedService: StackServiceDefinition = {
+      ...baseService,
+      serviceName: formData.serviceName,
+      serviceType: formData.serviceType as StackServiceType,
+      dockerImage: formData.dockerImage,
+      dockerTag: formData.dockerTag,
+      containerConfig: {
+        // Preserve container-config fields the form doesn't model (command,
+        // entrypoint, capAdd, devices, user, labels, dynamicEnv, networkMode,
+        // ...) — several are authored by addons — and override only the ones
+        // it edits.
+        ...baseService?.containerConfig,
+        env: Object.keys(env).length > 0 ? env : undefined,
+        ports: ports.length > 0 ? ports : undefined,
+        mounts: mounts.length > 0 ? mounts : undefined,
+        joinNetworks,
+        joinResourceNetworks,
+        restartPolicy: formData.restartPolicy,
+        healthcheck,
+      },
+      dependsOn: baseService?.dependsOn ?? [],
+      order: baseService?.order ?? 0,
+      routing,
+    };
+
+    const draft: DraftVersionInput = baseDraft
+      ? {
+          ...baseDraft,
+          networks,
+          resourceInputs,
+          volumes,
+          services: [editedService, ...baseDraft.services.slice(1)],
+        }
+      : {
+          networks,
+          resourceInputs,
+          volumes,
+          services: [editedService],
+        };
+
     try {
       await updateApplication.mutateAsync({
         templateId,
@@ -228,31 +288,7 @@ export default function ApplicationConfigurationTab() {
           displayName: formData.displayName,
           description: formData.description || undefined,
         },
-        draft: {
-          networks,
-          resourceInputs,
-          volumes,
-          services: [
-            {
-              serviceName: formData.serviceName,
-              serviceType: formData.serviceType as StackServiceType,
-              dockerImage: formData.dockerImage,
-              dockerTag: formData.dockerTag,
-              containerConfig: {
-                env: Object.keys(env).length > 0 ? env : undefined,
-                ports: ports.length > 0 ? ports : undefined,
-                mounts: mounts.length > 0 ? mounts : undefined,
-                joinNetworks,
-                joinResourceNetworks,
-                restartPolicy: formData.restartPolicy,
-                healthcheck,
-              },
-              dependsOn: [],
-              order: 0,
-              routing,
-            },
-          ],
-        },
+        draft,
       });
       navigate("/applications");
     } catch {

--- a/client/src/app/applications/[id]/overview/page.tsx
+++ b/client/src/app/applications/[id]/overview/page.tsx
@@ -40,6 +40,7 @@ import type { StackDeploymentRecord } from "@mini-infra/types";
 import { StatusStrip } from "../_components/status-strip";
 import { ConnectCard } from "../_components/connect-card";
 import { ConnectedNetworksCard } from "../_components/connected-networks-card";
+import { AddonsCard } from "../_components/addons-card";
 import type { ApplicationDetailContext } from "../layout";
 
 function formatDateTime(value: string | null): string {
@@ -179,6 +180,12 @@ export default function ApplicationOverviewTab() {
           template={template}
         />
       )}
+
+      {/* Unlike the Connect / Connected-Networks cards (gated behind an applied
+          snapshot), the Add-ons card renders whenever the app has a template
+          version — so operators can attach addons at config time, before the
+          first deploy. */}
+      <AddonsCard templateId={template.id} template={template} />
 
       {!hasStacks && (
         <Card>

--- a/client/src/app/stack-templates/[templateId]/page.tsx
+++ b/client/src/app/stack-templates/[templateId]/page.tsx
@@ -31,6 +31,7 @@ import { TemplateConfigFilesSection } from "@/components/stack-templates/config-
 import { TemplateResourceIOSection } from "@/components/stack-templates/template-resource-io-section";
 import { VersionSidebar } from "@/components/stack-templates/version-sidebar";
 import { CodeView } from "@/components/stack-templates/code-view/code-view";
+import { buildDraftFromVersion } from "@/lib/application-draft";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { toast } from "sonner";
 import type {
@@ -75,49 +76,32 @@ export default function StackTemplateDetailPage() {
     displayVersion.status !== "draft";
   const readOnly = !isViewingDraft;
 
-  // Build draft input from displayVersion with optional overrides. Preserves
-  // every optional field so saving one section (e.g. services) doesn't wipe
-  // others (config files, resource I/O, network type defaults, notes).
+  // Build draft input from displayVersion with optional overrides. Delegates to
+  // the canonical LOSSLESS mapper (`buildDraftFromVersion`) so saving one
+  // section (e.g. services) carries every other field through untouched —
+  // config files, resource I/O, network type defaults, notes, inputs, vault,
+  // nats, requires, AND every per-service field (`addons`, `poolConfig`,
+  // `jobPoolConfig`, vault/nats binding refs). A hand-rolled partial map here
+  // used to silently strip those, so editing/deleting any one service wiped
+  // addons off every service (and dropping the version-level nats/vault section
+  // while keeping a service's `natsRole`/`vaultAppRoleRef` would then fail
+  // validation). `buildDraftFromVersion` also strips read-model `null`s.
   const buildDraftInput = useCallback(
     (overrides: Partial<DraftVersionInput> = {}): DraftVersionInput => {
-      const v = displayVersion;
-      return {
-        parameters: v?.parameters ?? [],
-        defaultParameterValues: v?.defaultParameterValues ?? {},
-        networkTypeDefaults: v?.networkTypeDefaults ?? {},
-        resourceOutputs: v?.resourceOutputs ?? [],
-        resourceInputs: v?.resourceInputs ?? [],
-        networks: v?.networks ?? [],
-        volumes: v?.volumes ?? [],
-        services:
-          v?.services?.map((s) => ({
-            serviceName: s.serviceName,
-            serviceType: s.serviceType,
-            dockerImage: s.dockerImage,
-            dockerTag: s.dockerTag,
-            containerConfig: s.containerConfig,
-            initCommands: s.initCommands ?? undefined,
-            dependsOn: s.dependsOn,
-            order: s.order,
-            routing: s.routing ?? undefined,
-            adoptedContainer: s.adoptedContainer ?? undefined,
-          })) ?? [],
-        configFiles:
-          v?.configFiles?.map((cf) => ({
-            serviceName: cf.serviceName,
-            fileName: cf.fileName,
-            volumeName: cf.volumeName,
-            mountPath: cf.mountPath,
-            content: cf.content,
-            permissions: cf.permissions ?? undefined,
-            owner: cf.owner ?? undefined,
-          })) ?? [],
-        // Draft notes round-trip through the code view; carry them through
-        // graphical saves too so editing one section doesn't clobber notes.
-        // Omit entirely when undefined so we don't send `notes: null`.
-        ...(v?.notes != null ? { notes: v.notes } : {}),
-        ...overrides,
-      };
+      const base: DraftVersionInput = displayVersion
+        ? buildDraftFromVersion(displayVersion)
+        : {
+            parameters: [],
+            defaultParameterValues: {},
+            networkTypeDefaults: {},
+            resourceOutputs: [],
+            resourceInputs: [],
+            networks: [],
+            volumes: [],
+            services: [],
+            configFiles: [],
+          };
+      return { ...base, ...overrides };
     },
     [displayVersion],
   );

--- a/client/src/components/stack-templates/service-drawer/service-edit-drawer.tsx
+++ b/client/src/components/stack-templates/service-drawer/service-edit-drawer.tsx
@@ -102,7 +102,13 @@ export function ServiceEditDrawer({
   function onSubmit(values: ServiceFormValues) {
     try {
       const definition = formValuesToService(values);
-      onSave(definition);
+      // The form doesn't model every service field — `addons`, `poolConfig`,
+      // `jobPoolConfig`, and the vault/nats binding refs live outside the
+      // drawer's tabs. When editing an existing service, spread the incoming
+      // `service` UNDER the form-derived definition so those unmodeled fields
+      // survive the save (the form-edited fields still win). On add there's
+      // nothing to preserve.
+      onSave(service ? { ...service, ...definition } : definition);
       onOpenChange(false);
     } catch (err) {
       toastApiError(err, { title: "Invalid service config" });

--- a/client/src/components/stack-templates/template-services-section.tsx
+++ b/client/src/components/stack-templates/template-services-section.tsx
@@ -1,13 +1,16 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { IconPlus, IconEdit, IconTrash } from "@tabler/icons-react";
+import { IconPlus, IconEdit, IconTrash, IconPuzzle } from "@tabler/icons-react";
 import type {
   StackTemplateServiceInfo,
   StackServiceDefinition,
   StackServiceType,
 } from "@mini-infra/types";
 import { ServiceEditDrawer } from "./service-drawer/service-edit-drawer";
+import { mapServiceInfoToDefinition } from "@/lib/application-draft";
+import { AddonBadge } from "@/components/stacks/addon-badge";
+import { AttachAddonDialog } from "@/components/stacks/attach-addon-dialog";
 
 interface TemplateServicesSectionProps {
   services: StackTemplateServiceInfo[];
@@ -32,23 +35,6 @@ const TYPE_BORDER_CLASSES: Record<StackServiceType, string> = {
   JobPool: "border-l-rose-500",
 };
 
-function toServiceDefinition(
-  info: StackTemplateServiceInfo,
-): StackServiceDefinition {
-  return {
-    serviceName: info.serviceName,
-    serviceType: info.serviceType,
-    dockerImage: info.dockerImage,
-    dockerTag: info.dockerTag,
-    containerConfig: info.containerConfig,
-    initCommands: info.initCommands ?? undefined,
-    dependsOn: info.dependsOn,
-    order: info.order,
-    routing: info.routing ?? undefined,
-    adoptedContainer: info.adoptedContainer ?? undefined,
-  };
-}
-
 export function TemplateServicesSection({
   services,
   readOnly = false,
@@ -56,19 +42,33 @@ export function TemplateServicesSection({
 }: TemplateServicesSectionProps) {
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [isAdding, setIsAdding] = useState(false);
+  // The service whose Add-ons dialog is open (index into `sortedServices`), or
+  // null when closed. Attach/remove is order-preserving, so the index stays
+  // valid across a save/refetch.
+  const [addonServiceIndex, setAddonServiceIndex] = useState<number | null>(
+    null,
+  );
 
   const sortedServices = [...services].sort((a, b) => a.order - b.order);
 
   const editingService =
     editingIndex !== null
-      ? toServiceDefinition(sortedServices[editingIndex]!)
+      ? mapServiceInfoToDefinition(sortedServices[editingIndex]!)
       : null;
 
   const drawerOpen = isAdding || editingIndex !== null;
   const drawerService = isAdding ? null : editingService;
 
+  const addonService =
+    addonServiceIndex !== null ? sortedServices[addonServiceIndex] ?? null : null;
+  const addonServiceAttached = (addonService?.addons ?? {}) as Record<
+    string,
+    unknown
+  >;
+  const addonServiceAttachedIds = Object.keys(addonServiceAttached);
+
   function handleSave(updated: StackServiceDefinition) {
-    const definitions = sortedServices.map(toServiceDefinition);
+    const definitions = sortedServices.map(mapServiceInfoToDefinition);
 
     if (isAdding) {
       onServicesChange([...definitions, updated]);
@@ -85,7 +85,7 @@ export function TemplateServicesSection({
   function handleDelete(index: number) {
     const definitions = sortedServices
       .filter((_, i) => i !== index)
-      .map((svc, i) => ({ ...toServiceDefinition(svc), order: i + 1 }));
+      .map((svc, i) => ({ ...mapServiceInfoToDefinition(svc), order: i + 1 }));
     onServicesChange(definitions);
   }
 
@@ -94,6 +94,44 @@ export function TemplateServicesSection({
       setIsAdding(false);
       setEditingIndex(null);
     }
+  }
+
+  // Persist a change to one service's `addons` block through the same
+  // `onServicesChange` → draft-save path every other edit uses. Rebuilding the
+  // whole list via the canonical mapper keeps every OTHER service's per-service
+  // fields intact (Part A). An empty map is written as `undefined` so the addon
+  // block disappears rather than persisting as `{}`.
+  function persistServiceAddons(
+    index: number,
+    nextAddons: Record<string, unknown>,
+  ) {
+    const definitions = sortedServices.map(mapServiceInfoToDefinition);
+    const svc = definitions[index];
+    if (!svc) return;
+    definitions[index] = {
+      ...svc,
+      addons:
+        Object.keys(nextAddons).length > 0 ? nextAddons : undefined,
+    };
+    onServicesChange(definitions);
+  }
+
+  function handleAddonAttach(
+    addonId: string,
+    config: Record<string, unknown>,
+  ) {
+    if (addonServiceIndex === null) return;
+    persistServiceAddons(addonServiceIndex, {
+      ...addonServiceAttached,
+      [addonId]: config,
+    });
+  }
+
+  function handleAddonRemove(addonId: string) {
+    if (addonServiceIndex === null) return;
+    const next = { ...addonServiceAttached };
+    delete next[addonId];
+    persistServiceAddons(addonServiceIndex, next);
   }
 
   return (
@@ -125,6 +163,9 @@ export function TemplateServicesSection({
             const portCount = svc.containerConfig.ports?.length ?? 0;
             const envCount = Object.keys(svc.containerConfig.env ?? {}).length;
             const mountCount = svc.containerConfig.mounts?.length ?? 0;
+            const addonIds = Object.keys(
+              (svc.addons ?? {}) as Record<string, unknown>,
+            );
 
             return (
               <button
@@ -157,7 +198,19 @@ export function TemplateServicesSection({
                         size="icon"
                         variant="ghost"
                         className="h-7 w-7"
+                        onClick={() => setAddonServiceIndex(index)}
+                        aria-label={`Add-ons for ${svc.serviceName}`}
+                        title="Add-ons"
+                      >
+                        <IconPuzzle className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        className="h-7 w-7"
                         onClick={() => setEditingIndex(index)}
+                        aria-label={`Edit ${svc.serviceName}`}
                       >
                         <IconEdit className="h-4 w-4" />
                       </Button>
@@ -167,6 +220,7 @@ export function TemplateServicesSection({
                         variant="ghost"
                         className="h-7 w-7 text-destructive hover:text-destructive"
                         onClick={() => handleDelete(index)}
+                        aria-label={`Delete ${svc.serviceName}`}
                       >
                         <IconTrash className="h-4 w-4" />
                       </Button>
@@ -206,6 +260,16 @@ export function TemplateServicesSection({
                       {svc.adoptedContainer.listeningPort}
                     </span>
                   )}
+                  {addonIds.length > 0 && (
+                    <span className="col-span-2 flex flex-wrap items-center gap-1">
+                      <span className="font-medium text-foreground">
+                        Add-ons:
+                      </span>{" "}
+                      {addonIds.map((id) => (
+                        <AddonBadge key={id} addonName={id} />
+                      ))}
+                    </span>
+                  )}
                 </div>
               </button>
             );
@@ -219,6 +283,24 @@ export function TemplateServicesSection({
         service={drawerService}
         onSave={handleSave}
       />
+
+      {/* Per-service Add-ons authoring. Only mounted while editing the draft
+          (the affordance button is gated on `!readOnly`); attaching/removing
+          writes the service's `addons` block through `onServicesChange`. The
+          dialog itself gates each addon by service type + connectivity. */}
+      {addonService && (
+        <AttachAddonDialog
+          open={addonServiceIndex !== null}
+          onOpenChange={(open) => {
+            if (!open) setAddonServiceIndex(null);
+          }}
+          serviceName={addonService.serviceName}
+          serviceType={addonService.serviceType}
+          attachedAddonIds={addonServiceAttachedIds}
+          onAttach={handleAddonAttach}
+          onRemove={handleAddonRemove}
+        />
+      )}
     </div>
   );
 }

--- a/client/src/components/stack-templates/template-services-section.tsx
+++ b/client/src/components/stack-templates/template-services-section.tsx
@@ -168,12 +168,26 @@ export function TemplateServicesSection({
             );
 
             return (
-              <button
-                type="button"
+              // A clickable card that also hosts action buttons (edit / delete /
+              // add-ons). It must NOT be a <button> — nesting the action
+              // <button>s inside another <button> is invalid HTML and makes
+              // real clicks on them resolve unreliably (the add-ons button would
+              // sometimes open the edit drawer instead). A div with role=button
+              // keeps the whole-card "click to edit" affordance while letting the
+              // nested buttons behave normally.
+              <div
                 key={svc.id}
+                role={readOnly ? undefined : "button"}
+                tabIndex={readOnly ? undefined : 0}
                 onClick={() => !readOnly && setEditingIndex(index)}
-                disabled={readOnly}
-                className={`w-full text-left rounded-md border border-l-4 ${TYPE_BORDER_CLASSES[svc.serviceType]} bg-card p-3 transition-colors hover:bg-muted/30 disabled:cursor-default disabled:hover:bg-card`}
+                onKeyDown={(e) => {
+                  if (readOnly) return;
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setEditingIndex(index);
+                  }
+                }}
+                className={`w-full text-left rounded-md border border-l-4 ${TYPE_BORDER_CLASSES[svc.serviceType]} bg-card p-3 transition-colors ${readOnly ? "cursor-default" : "cursor-pointer hover:bg-muted/30"}`}
               >
                 <div className="flex items-center gap-2 flex-wrap">
                   <span className="font-medium text-sm">{svc.serviceName}</span>
@@ -271,7 +285,7 @@ export function TemplateServicesSection({
                     </span>
                   )}
                 </div>
-              </button>
+              </div>
             );
           })}
         </div>

--- a/client/src/components/stacks/addon-applicability.ts
+++ b/client/src/components/stacks/addon-applicability.ts
@@ -1,0 +1,231 @@
+import type {
+  AddonCatalogEntry,
+  AddonConfigFieldDescriptor,
+  StackServiceType,
+} from "@mini-infra/types";
+
+// ---------------------------------------------------------------------------
+// Applicability / gating
+//
+// The picker gates every catalog addon two ways, and BOTH surfaces that mount
+// the shared attach component (the Overview card here, the Services-tab row in
+// Phase 4) must gate identically — so the logic lives here as a pure function,
+// not inside the dialog's render. See §4.3 of the addon-authoring-ui plan.
+// ---------------------------------------------------------------------------
+
+/**
+ * Live connectivity of a connected service, as the picker sees it. `"down"` is
+ * the only state that blocks an addon — `"unknown"` (status not reported yet /
+ * still loading) is treated as usable because the server re-validates the
+ * prerequisite authoritatively at apply time. Mirrors how `connect-card.tsx`
+ * only treats `failed`/`timeout`/`unreachable` as "down".
+ */
+export type ConnectivityState = "up" | "down" | "unknown";
+
+/** A resolved link an unavailable-for-connectivity addon points the operator at. */
+export interface AddonFixLink {
+  to: string;
+  label: string;
+}
+
+/**
+ * Settings route + human label for a connected-service prerequisite. Keyed by
+ * the addon manifest's `requiresConnectedService` tag (e.g. `"tailscale"`).
+ * Tailscale is the only prerequisite any shipped addon declares today; the map
+ * grows as new connected-service-backed addons register.
+ */
+const CONNECTED_SERVICE_SETTINGS: Record<string, AddonFixLink> = {
+  tailscale: { to: "/connectivity-tailscale", label: "Connectivity settings" },
+};
+
+/** Human label for a connected-service tag; falls back to the raw tag. */
+const CONNECTED_SERVICE_LABELS: Record<string, string> = {
+  tailscale: "Tailscale",
+};
+
+export function connectedServiceLabel(tag: string): string {
+  return CONNECTED_SERVICE_LABELS[tag] ?? tag;
+}
+
+export function connectedServiceFixLink(tag: string): AddonFixLink | undefined {
+  return CONNECTED_SERVICE_SETTINGS[tag];
+}
+
+export interface AddonAvailability {
+  available: boolean;
+  /** Why the addon can't be attached (only set when `available` is false). */
+  reason?: string;
+  /** Where to go to fix an unavailable-for-connectivity addon, when known. */
+  fix?: AddonFixLink;
+}
+
+/**
+ * Whether `addon` can be attached to a service of `serviceType`, given the
+ * live connectivity of every connected service (keyed by the manifest's
+ * `requiresConnectedService` tag).
+ *
+ * Two gates, in order:
+ *  1. Applicability — the addon's `appliesTo` must include the target's
+ *     service type. `claude-shell` excludes `Pool`; the tailscale addons cover
+ *     `Stateful`/`StatelessWeb`/`Pool`. A mismatch is a hard, unfixable "not
+ *     available for X services".
+ *  2. Prerequisite — if the addon declares `requiresConnectedService` and that
+ *     service is `"down"`, it's unavailable with a fix link to the relevant
+ *     settings page.
+ */
+export function getAddonAvailability(
+  addon: AddonCatalogEntry,
+  serviceType: StackServiceType,
+  connectivity: Record<string, ConnectivityState>,
+): AddonAvailability {
+  if (!addon.appliesTo.includes(serviceType)) {
+    return {
+      available: false,
+      reason: `Not available for ${serviceType} services`,
+    };
+  }
+
+  const required = addon.requiresConnectedService;
+  if (required && connectivity[required] === "down") {
+    return {
+      available: false,
+      reason: `Requires ${connectedServiceLabel(required)} — not connected`,
+      fix: connectedServiceFixLink(required),
+    };
+  }
+
+  return { available: true };
+}
+
+// ---------------------------------------------------------------------------
+// Config-form value model + mapping
+//
+// The per-addon config form renders one control per `configField` and holds a
+// raw value keyed by the field name. `buildAddonConfig` coerces that raw state
+// into the addon's config object (the value written under
+// `services[].addons[addonId]`), enforcing `required` and the advisory
+// `min`/`max`/`pattern` hints. The server re-validates against the real zod
+// schema, so this is a UX pre-check, not the authority.
+// ---------------------------------------------------------------------------
+
+/**
+ * Raw form value for a single field, shaped by the descriptor `type`:
+ *  - `string` / `number` → the raw input text (numbers are parsed on submit)
+ *  - `boolean`           → the checkbox state
+ *  - `string[]`          → the committed chip list
+ */
+export type AddonFieldValue = string | boolean | string[];
+
+export type AddonFormState = Record<string, AddonFieldValue>;
+
+/** Blank form state for a set of fields — empty text, `false`, or `[]`. */
+export function initialFormState(
+  fields: AddonConfigFieldDescriptor[],
+): AddonFormState {
+  const state: AddonFormState = {};
+  for (const field of fields) {
+    switch (field.type) {
+      case "boolean":
+        state[field.name] = false;
+        break;
+      case "string[]":
+        state[field.name] = [];
+        break;
+      default:
+        state[field.name] = "";
+    }
+  }
+  return state;
+}
+
+export type BuildAddonConfigResult =
+  | { ok: true; config: Record<string, unknown> }
+  | { ok: false; errors: Record<string, string> };
+
+/**
+ * Coerce + validate the raw form state into the addon's config object.
+ *
+ * Omission semantics match the hand-rolled claude-shell preset (`parseExtraTags`
+ * returns `undefined` for an empty list): an optional field left blank is left
+ * OUT of the config entirely rather than written as `""` / `[]`, so the addon's
+ * zod schema sees it as not-provided. A required field left blank is an error.
+ */
+export function buildAddonConfig(
+  fields: AddonConfigFieldDescriptor[],
+  state: AddonFormState,
+): BuildAddonConfigResult {
+  const config: Record<string, unknown> = {};
+  const errors: Record<string, string> = {};
+
+  for (const field of fields) {
+    const raw = state[field.name];
+
+    switch (field.type) {
+      case "boolean": {
+        // A boolean is always meaningful (checked or unchecked); carry it.
+        config[field.name] = Boolean(raw);
+        break;
+      }
+
+      case "number": {
+        const text = typeof raw === "string" ? raw.trim() : "";
+        if (text.length === 0) {
+          if (field.required) errors[field.name] = `${field.label} is required`;
+          break;
+        }
+        const value = Number(text);
+        if (Number.isNaN(value)) {
+          errors[field.name] = `${field.label} must be a number`;
+          break;
+        }
+        if (field.min != null && value < field.min) {
+          errors[field.name] = `${field.label} must be at least ${field.min}`;
+          break;
+        }
+        if (field.max != null && value > field.max) {
+          errors[field.name] = `${field.label} must be at most ${field.max}`;
+          break;
+        }
+        config[field.name] = value;
+        break;
+      }
+
+      case "string[]": {
+        const list = Array.isArray(raw)
+          ? raw.map((t) => String(t).trim()).filter((t) => t.length > 0)
+          : [];
+        if (list.length === 0) {
+          if (field.required) errors[field.name] = `${field.label} is required`;
+          break;
+        }
+        if (field.pattern) {
+          const re = new RegExp(field.pattern);
+          const bad = list.find((t) => !re.test(t));
+          if (bad != null) {
+            errors[field.name] = `${field.label}: "${bad}" is invalid`;
+            break;
+          }
+        }
+        config[field.name] = list;
+        break;
+      }
+
+      default: {
+        // string
+        const text = typeof raw === "string" ? raw.trim() : "";
+        if (text.length === 0) {
+          if (field.required) errors[field.name] = `${field.label} is required`;
+          break;
+        }
+        if (field.pattern && !new RegExp(field.pattern).test(text)) {
+          errors[field.name] = `${field.label} is invalid`;
+          break;
+        }
+        config[field.name] = text;
+      }
+    }
+  }
+
+  if (Object.keys(errors).length > 0) return { ok: false, errors };
+  return { ok: true, config };
+}

--- a/client/src/components/stacks/attach-addon-dialog.tsx
+++ b/client/src/components/stacks/attach-addon-dialog.tsx
@@ -1,0 +1,392 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { IconAlertTriangle, IconTrash } from "@tabler/icons-react";
+import type {
+  AddonCatalogEntry,
+  AddonConfigFieldDescriptor,
+  StackServiceType,
+} from "@mini-infra/types";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { TagListInput } from "@/components/ui/tag-list-input";
+import { useAddonCatalog } from "@/hooks/use-addon-catalog";
+import { useServiceConnectivity } from "@/hooks/use-settings-validation";
+import {
+  buildAddonConfig,
+  getAddonAvailability,
+  initialFormState,
+  type AddonFieldValue,
+  type AddonFormState,
+  type ConnectivityState,
+} from "./addon-applicability";
+
+// ---------------------------------------------------------------------------
+// Shared "attach add-on" component (§4.3 of the addon-authoring-ui plan).
+//
+// Self-contained: it fetches the catalog and the connectivity it gates on
+// itself, so it can be dropped onto the Overview "Add-ons" card here AND onto
+// a Services-tab row in Phase 4 without either surface re-implementing the
+// applicability/gating logic. All gating lives in `getAddonAvailability`
+// (pure, in `addon-applicability.ts`) so both surfaces gate identically.
+// ---------------------------------------------------------------------------
+
+interface AttachAddonDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The service the addon attaches to (name for copy; type for gating). */
+  serviceName: string;
+  serviceType: StackServiceType;
+  /** Ids already declared on the service — shown as "Attached", not offered. */
+  attachedAddonIds: string[];
+  /** Persist an attach: write `services[].addons[addonId] = config`. */
+  onAttach: (addonId: string, config: Record<string, unknown>) => void;
+  /** Persist a remove: delete `services[].addons[addonId]`. */
+  onRemove: (addonId: string) => void;
+  /** Republish in flight — disables the action buttons. */
+  isPending?: boolean;
+}
+
+export function AttachAddonDialog({
+  open,
+  onOpenChange,
+  serviceName,
+  serviceType,
+  attachedAddonIds,
+  onAttach,
+  onRemove,
+  isPending = false,
+}: AttachAddonDialogProps) {
+  const catalogQuery = useAddonCatalog(open);
+  const { data: tailscaleConnectivity } = useServiceConnectivity("tailscale", {
+    enabled: open,
+  });
+
+  // Live connectivity keyed by connected-service tag, matching how
+  // `connect-card.tsx` reads the most-recent status. Only `"down"` blocks an
+  // addon; an unreported status is `"unknown"` (usable — server re-validates).
+  const tailscaleStatus = tailscaleConnectivity?.data?.[0]?.status;
+  const connectivity = useMemo<Record<string, ConnectivityState>>(() => {
+    const down =
+      tailscaleStatus === "failed" ||
+      tailscaleStatus === "timeout" ||
+      tailscaleStatus === "unreachable";
+    return {
+      tailscale: down ? "down" : tailscaleStatus ? "up" : "unknown",
+    };
+  }, [tailscaleStatus]);
+
+  const addons = useMemo(
+    () => catalogQuery.data?.addons ?? [],
+    [catalogQuery.data?.addons],
+  );
+
+  const attachedSet = useMemo(
+    () => new Set(attachedAddonIds),
+    [attachedAddonIds],
+  );
+
+  // The addon currently being configured (expanded inline) + its form state.
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [formState, setFormState] = useState<AddonFormState>({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const selectedAddon = useMemo(
+    () => addons.find((a) => a.id === selectedId) ?? null,
+    [addons, selectedId],
+  );
+
+  const startConfiguring = (addon: AddonCatalogEntry) => {
+    setSelectedId(addon.id);
+    setFormState(initialFormState(addon.configFields));
+    setErrors({});
+  };
+
+  const cancelConfiguring = () => {
+    setSelectedId(null);
+    setFormState({});
+    setErrors({});
+  };
+
+  // Reset the transient selection whenever the dialog closes so re-opening
+  // starts clean rather than mid-edit — done in the close handler (not an
+  // effect) to avoid a cascading-render setState-in-effect.
+  const handleOpenChange = (next: boolean) => {
+    if (!next) cancelConfiguring();
+    onOpenChange(next);
+  };
+
+  const setField = (name: string, value: AddonFieldValue) => {
+    setFormState((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const confirmAttach = () => {
+    if (!selectedAddon) return;
+    const result = buildAddonConfig(selectedAddon.configFields, formState);
+    if (!result.ok) {
+      setErrors(result.errors);
+      return;
+    }
+    onAttach(selectedAddon.id, result.config);
+    handleOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Add-ons for {serviceName}</DialogTitle>
+          <DialogDescription>
+            Attach a capability to this service. Changes are saved to the
+            application and take effect on its next redeploy.
+          </DialogDescription>
+        </DialogHeader>
+
+        {catalogQuery.isLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-16 w-full" />
+            <Skeleton className="h-16 w-full" />
+          </div>
+        ) : catalogQuery.isError ? (
+          <Alert variant="destructive">
+            <IconAlertTriangle className="h-4 w-4" />
+            <AlertTitle>Couldn&apos;t load add-ons</AlertTitle>
+            <AlertDescription>
+              The add-on catalog failed to load. Try reopening this dialog.
+            </AlertDescription>
+          </Alert>
+        ) : addons.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-4">
+            No add-ons are registered on this instance.
+          </p>
+        ) : (
+          <ul className="space-y-2 max-h-[24rem] overflow-y-auto">
+            {addons.map((addon) => {
+              const attached = attachedSet.has(addon.id);
+              const availability = getAddonAvailability(
+                addon,
+                serviceType,
+                connectivity,
+              );
+              const isSelected = selectedId === addon.id;
+              return (
+                <li
+                  key={addon.id}
+                  data-testid={`addon-row-${addon.id}`}
+                  className="rounded-md border p-3"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-sm">{addon.id}</span>
+                        <Badge variant="outline" className="text-[10px]">
+                          {addon.mode === "env-injection" ? "env" : "sidecar"}
+                        </Badge>
+                        {attached && (
+                          <Badge className="text-[10px]">Attached</Badge>
+                        )}
+                      </div>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        {addon.description}
+                      </p>
+                      {!attached && !availability.available && (
+                        <p className="text-xs text-amber-700 dark:text-amber-400 mt-1">
+                          {availability.reason}
+                          {availability.fix && (
+                            <>
+                              {" — "}
+                              <Link
+                                to={availability.fix.to}
+                                className="underline underline-offset-2"
+                              >
+                                {availability.fix.label}
+                              </Link>
+                            </>
+                          )}
+                        </p>
+                      )}
+                    </div>
+                    <div className="shrink-0">
+                      {attached ? (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => onRemove(addon.id)}
+                          disabled={isPending}
+                          aria-label={`Remove ${addon.id}`}
+                        >
+                          <IconTrash className="h-4 w-4" />
+                        </Button>
+                      ) : (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => startConfiguring(addon)}
+                          disabled={!availability.available || isPending || isSelected}
+                        >
+                          {isSelected ? "Configuring…" : "Configure"}
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+
+                  {isSelected && (
+                    <div className="mt-3 border-t pt-3">
+                      <AddonConfigForm
+                        fields={addon.configFields}
+                        state={formState}
+                        errors={errors}
+                        onChange={setField}
+                      />
+                      <div className="flex justify-end gap-2 mt-3">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={cancelConfiguring}
+                          disabled={isPending}
+                        >
+                          Cancel
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          onClick={confirmAttach}
+                          disabled={isPending}
+                        >
+                          Attach
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={isPending}
+          >
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Renders one control per `configField` and reports edits back through
+ * `onChange`. The control kind is chosen by descriptor `type`; validation
+ * (required / min / max / pattern) is enforced on submit by `buildAddonConfig`,
+ * with any resulting per-field message surfaced here from `errors`.
+ */
+function AddonConfigForm({
+  fields,
+  state,
+  errors,
+  onChange,
+}: {
+  fields: AddonConfigFieldDescriptor[];
+  state: AddonFormState;
+  errors: Record<string, string>;
+  onChange: (name: string, value: AddonFieldValue) => void;
+}) {
+  if (fields.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        This add-on has no configuration.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {fields.map((field) => {
+        const value = state[field.name];
+        const error = errors[field.name];
+        const controlId = `addon-field-${field.name}`;
+        return (
+          <div key={field.name} className="space-y-1">
+            {field.type === "boolean" ? (
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id={controlId}
+                  checked={value === true}
+                  onCheckedChange={(checked) =>
+                    onChange(field.name, checked === true)
+                  }
+                />
+                <Label htmlFor={controlId} className="text-sm font-normal">
+                  {field.label}
+                  {field.required && <span className="text-destructive"> *</span>}
+                </Label>
+              </div>
+            ) : (
+              <>
+                <Label htmlFor={controlId} className="text-sm">
+                  {field.label}
+                  {field.required && <span className="text-destructive"> *</span>}
+                </Label>
+                {field.type === "string[]" ? (
+                  <TagListInput
+                    ariaLabel={field.label}
+                    value={Array.isArray(value) ? value : []}
+                    onChange={(next) => onChange(field.name, next)}
+                    placeholder={field.placeholder ?? "Add value and press Enter"}
+                    validate={
+                      field.pattern
+                        ? (raw) =>
+                            new RegExp(field.pattern as string).test(raw)
+                              ? null
+                              : `Must match ${field.pattern}`
+                        : undefined
+                    }
+                  />
+                ) : (
+                  <Input
+                    id={controlId}
+                    type={field.type === "number" ? "number" : "text"}
+                    inputMode={field.type === "number" ? "numeric" : undefined}
+                    min={field.type === "number" ? field.min : undefined}
+                    max={field.type === "number" ? field.max : undefined}
+                    placeholder={field.placeholder}
+                    value={typeof value === "string" ? value : ""}
+                    onChange={(e) => onChange(field.name, e.target.value)}
+                  />
+                )}
+              </>
+            )}
+            {field.help && (
+              <p className="text-xs text-muted-foreground">{field.help}</p>
+            )}
+            {error && (
+              <p className="text-xs text-destructive" role="alert">
+                {error}
+              </p>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/client/src/hooks/use-addon-catalog.ts
+++ b/client/src/hooks/use-addon-catalog.ts
@@ -1,0 +1,34 @@
+import { useQuery } from "@tanstack/react-query";
+import { ApiRoute, queryKeys } from "@mini-infra/types";
+import type { AddonCatalogResponse } from "@mini-infra/types";
+import { apiFetch } from "@/lib/api-client";
+
+async function fetchAddonCatalog(): Promise<AddonCatalogResponse> {
+  // Raw response — `{ addons }` has no `{ success, data }` envelope (mirrors
+  // the sibling addon-endpoints route).
+  return apiFetch<AddonCatalogResponse>(ApiRoute.addons.catalog(), {
+    unwrap: false,
+    correlationIdPrefix: "addon-catalog",
+  });
+}
+
+/**
+ * Registry-driven Service Addon catalog (`GET /api/addons`). Every registered
+ * addon appears here with its applicability (`appliesTo`), connected-service
+ * prerequisite (`requiresConnectedService`), attachment `mode`, and the
+ * `configFields` descriptor list that drives the per-addon config form.
+ *
+ * The catalog is effectively static within a session — a new addon only shows
+ * up after a server restart registers it — so it's cached generously and never
+ * polled. The attach dialog and the Overview "Add-ons" card both read from
+ * this one query, so the second consumer is served from cache.
+ */
+export function useAddonCatalog(enabled: boolean = true) {
+  return useQuery({
+    queryKey: queryKeys.addons.catalog,
+    queryFn: fetchAddonCatalog,
+    enabled,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+  });
+}

--- a/client/src/lib/application-draft.ts
+++ b/client/src/lib/application-draft.ts
@@ -76,13 +76,24 @@ export function buildDraftFromVersion(
 /**
  * Map a persisted service (`StackTemplateServiceInfo`) back into the authoring
  * shape (`StackServiceDefinition`). DB-only fields (`id`, `versionId`) are
- * dropped; `null` on optional-non-nullable fields is normalized to `undefined`
- * so the draft matches what the create/draft schema expects.
+ * dropped, EVERY authoring field is carried through (`addons`, `poolConfig`,
+ * `jobPoolConfig`, and the vault/nats binding refs), and the whole result is
+ * run through `stripNull` so read-model `null`s on optional-non-nullable fields
+ * become absent — matching what the create/draft schema's `.optional()` fields
+ * accept.
+ *
+ * This is the single canonical service mapper. It is write-safe standalone
+ * (the `stripNull` pass means a caller can drop its output straight into a
+ * `DraftVersionInput.services[]` without re-stripping), so the stack-templates
+ * draft editor reuses it directly rather than hand-rolling a partial map that
+ * silently drops per-service `addons`/`poolConfig`/`nats*`/`vault*` whenever any
+ * service is edited. `buildDraftFromVersion` above also re-strips the whole
+ * draft, but that outer pass is now redundant for services (idempotent).
  */
-function mapServiceInfoToDefinition(
+export function mapServiceInfoToDefinition(
   svc: StackTemplateServiceInfo,
 ): StackServiceDefinition {
-  return {
+  return stripNull({
     serviceName: svc.serviceName,
     serviceType: svc.serviceType,
     dockerImage: svc.dockerImage,
@@ -102,7 +113,7 @@ function mapServiceInfoToDefinition(
     natsRole: svc.natsRole,
     natsSigner: svc.natsSigner,
     addons: svc.addons ?? undefined,
-  };
+  });
 }
 
 function mapConfigFileInfoToInput(

--- a/docs/planning/not-shipped/addon-authoring-ui-plan.md
+++ b/docs/planning/not-shipped/addon-authoring-ui-plan.md
@@ -71,7 +71,7 @@ A single client component renders the catalog-driven picker, the per-addon confi
 
 ## 5. Phased rollout
 
-Four phases, strictly sequential. Phase 1 is a safety fix that removes a data-loss footgun before the feature makes addons easy to attach; Phase 2 lands the backend catalog; Phase 3 is the primary operator-facing outcome; Phase 4 generalises to multi-service stacks and is optional.
+Four phases, strictly sequential. Phase 1 is a safety fix that removes a data-loss footgun before the feature makes addons easy to attach; Phase 2 lands the backend catalog; Phase 3 is the primary operator-facing outcome; Phase 4 generalises addon authoring to a chosen service on multi-service stack templates (and carries a sibling data-loss fix in the template editor).
 
 ### Phase 1 — Config-tab addon-safety fix
 
@@ -138,25 +138,27 @@ Done when: an operator can attach `tailscale-ssh` (or `tailscale-web` with a por
 
 Verify in prod: an operator attaches an addon via the card and, after deploy, the resulting SSH/HTTPS endpoint appears on that app's Connect card.
 
-### Phase 4 — Per-service addon authoring on the Services tab (optional, deferred)
+### Phase 4 — Per-service addon authoring in the stack-templates editor
 
-**Goal:** addon authoring generalises to a chosen service on multi-service stacks via the Services tab.
+**Goal:** addon authoring generalises to any chosen service on a multi-service stack template.
+
+Re-homing note (from implementation-time exploration): applications are single-service, so Phase 3's Overview card already covers them — the applications Services tab (this phase's originally-proposed home) would be redundant. The genuine multi-service authoring surface is the stack-templates **draft editor** (`client/src/app/stack-templates/[templateId]/page.tsx` → `TemplateServicesSection` / `ServiceEditDrawer`), where `handleServicesChange` already round-trips the whole services list. Phase 4 targets that surface.
 
 Deliverables:
-- A per-row "Add-ons" affordance on the Services tab that mounts the shared attach-add-on component (§4.3) against the selected service.
-- The currently read-only Services table row gains an actionable addon control while preserving its existing runtime-detail disclosure.
+- A per-service "Add-ons" affordance in the stack-templates draft editor that mounts the shared attach-add-on component (§4.3) against the selected service, editable only while viewing the draft (`readOnly` respected). Attach/remove writes that service's `addons` and saves via the existing `onServicesChange` → draft-save path.
+- A prerequisite lossless-mapping fix: the editor's two service round-trips — `buildDraftInput` (page) and `toServiceDefinition` (`TemplateServicesSection`) — currently drop per-service `addons` (and `poolConfig`/`jobPoolConfig`/`vault*`/`nats*`), so editing or deleting ANY service strips those from every service. Reuse the canonical `mapServiceInfoToDefinition` (`client/src/lib/application-draft.ts`) in both places so every per-service field survives an edit. Confirm the `ServiceEditDrawer`'s save preserves fields it doesn't model.
 
-Reversibility: safe — an additive client surface.
+Reversibility: safe — an additive client surface plus a data-loss fix.
 
 UI changes:
-- Services-tab rows gain a per-service add/remove-addon affordance. [design needed]
+- Each service in the stack-templates draft editor gains an add/remove-addon affordance. [design needed]
 
 Schema changes:
 - none.
 
-Done when: an operator can attach an addon to a specific service on a multi-service stack from the Services tab and it persists on that service's definition.
+Done when: an operator can attach an addon to a chosen service on a multi-service stack template from the draft editor, it persists on that service's definition, and editing a sibling service no longer strips it.
 
-Verify in prod: a multi-service stack shows an addon attached to a chosen (non-first) service via the Services tab.
+Verify in prod: a multi-service stack template shows an addon attached to a chosen (non-first) service, surviving edits to sibling services.
 
 ## 6. Risks & open questions
 
@@ -173,4 +175,4 @@ Manual checklist — check a box when that phase's PR merges. Phases are strictl
 - [ ] Phase 1: Config-tab addon-safety fix
 - [ ] Phase 2: Addon catalog endpoint + manifest metadata
 - [ ] Phase 3: Add-ons card on application Overview tab
-- [ ] Phase 4: Per-service addon authoring on Services tab (optional, deferred)
+- [ ] Phase 4: Per-service addon authoring in the stack-templates editor

--- a/docs/planning/not-shipped/addon-authoring-ui-plan.md
+++ b/docs/planning/not-shipped/addon-authoring-ui-plan.md
@@ -1,0 +1,176 @@
+# Addon authoring UI
+
+**Status:** planned, not implemented. Phased rollout — each phase ships as a separate PR. Phases land strictly in order.
+**Builds on:** the Service Addons framework and the `tailscale-ssh` / `tailscale-web` / `claude-shell` addons shipped through Phases 1–5 of [service-addons-plan.md](./service-addons-plan.md) (#364, #379, #383, #394, #396). Reuses the lossless-republish pattern (`client/src/lib/application-draft.ts`) established by the Connected Networks card.
+**Excludes:** the Service Addons framework's deferred Phase 6 (pool-service integration) — pool addon *authoring* rides with that work, not this plan.
+
+---
+
+## 1. Background
+
+The Service Addons framework and its three addons (`tailscale-ssh`, `tailscale-web`, `claude-shell`) let a stack service opt into a capability by adding an `addons:` block to its definition, which a render pass expands into synthetic sidecars or injected env at apply time. The framework, the addons, endpoint discovery (`GET /api/stacks/:id/addon-endpoints`), and read-only display (the Overview **Connect** card, the violet `AddonBadge` on synthetic rows) all shipped. What never shipped is an **authoring** surface: the only ways to attach an addon today are the raw API or the one hardcoded Claude Shell preset page. There is no generic way for an operator to add `tailscale-ssh` or `tailscale-web` to an ordinary application, and no endpoint that even lists the registered addons for a picker to consume. This plan adds a registry-driven authoring UI — primary surface an "Add-ons" card on the application Overview tab, sitting next to the Connect card that reads out what addons produce — built on the same lossless single-field republish pattern the Connected Networks card already uses.
+
+*Rubric waivers: none.*
+
+## 2. Goals
+
+1. Operators can attach, configure, and remove Service Addons on an application from the UI, without editing JSON or calling the API.
+2. The addon picker is driven by the live registry — a newly registered addon appears automatically with its config fields, applicability, and prerequisites, with no client-side change.
+3. The UI prevents invalid attachments — an addon whose service type is unsupported, or whose required connected service is unconfigured, is surfaced as unavailable with the reason and a path to fix it.
+4. Editing an application's configuration never silently drops its attached addons.
+5. Addon authoring generalises from single-service applications to a chosen service on multi-service stacks.
+
+## 3. Non-goals
+
+- **New addon types or capabilities.** This is UI for the existing framework and its three shipped addons only — no new addon behaviour.
+- **Live addon status / health.** The Connect card already renders tailnet device status; this plan adds authoring, not a richer status surface.
+- **Pool-service addon authoring.** Rides with the framework's deferred Phase 6 pool integration; `claude-shell` also excludes Pool by construction. Attaching addons to `Pool`-type services is out of scope here.
+- **Replacing the Claude Shell preset page.** The bespoke `/applications/new/claude-shell` wizard stays — the generic card complements it for arbitrary apps.
+- **Changing the addon render / expansion pipeline.** The work is purely additive: one read endpoint plus client surfaces. `expand-addons.ts` and the reconciler are untouched.
+
+## 4. Shared concepts
+
+### 4.1 The addon catalog contract
+
+The registry (`productionAddonRegistry`) holds each addon's manifest, its zod `configSchema`, and its definition. The zod schema cannot cross into `@mini-infra/types` (the lib package is zero-runtime-deps, per `lib/CLAUDE.md`), so the catalog endpoint projects each addon into a serialisable shape the client can render a form from. Two new types in `@mini-infra/types`, referenced by Phases 2, 3, and 4:
+
+```ts
+interface AddonConfigFieldDescriptor {
+  name: string;                               // config key, e.g. "port"
+  label: string;                              // human label for the form
+  type: "string" | "number" | "boolean" | "string[]";
+  required: boolean;
+  placeholder?: string;
+  help?: string;
+  // Advisory validation hints mirrored from the zod schema (server re-validates authoritatively).
+  pattern?: string;
+  min?: number;
+  max?: number;
+}
+
+interface AddonCatalogEntry {
+  id: string;                                 // registry id, e.g. "tailscale-ssh"
+  description: string;
+  kind?: string;                              // merge-group label
+  mode: "sidecar" | "env-injection";
+  appliesTo: StackServiceType[];              // service types the addon supports
+  requiresConnectedService?: string;          // connected-service prerequisite (e.g. "tailscale")
+  configFields: AddonConfigFieldDescriptor[]; // drives the per-addon config form
+}
+```
+
+Each production addon authors its `configFields` alongside its existing zod `configSchema`. The descriptor list is the source of truth for form rendering; the zod schema stays the source of truth for validation.
+
+### 4.2 The lossless-republish pattern
+
+Any surface that mutates a single field on an existing application must rebuild the full draft via `buildDraftFromVersion()` (`client/src/lib/application-draft.ts`) and overlay only the field it edits — otherwise it silently drops everything the form doesn't model (`addons`, `vault`, `nats`, `resourceInputs`, …). The Connected Networks card already follows this; Phases 1 and 3 both depend on it.
+
+### 4.3 The shared "attach add-on" component
+
+A single client component renders the catalog-driven picker, the per-addon config form, and the unavailable/disabled states with reasons. It is built in Phase 3 (mounted from the Overview card) and reused verbatim in Phase 4 (mounted from a Services-tab row). Applicability gating (by `appliesTo` and by connected-service connectivity via the existing `useServiceConnectivity` hook) lives in this component so both surfaces gate identically.
+
+## 5. Phased rollout
+
+Four phases, strictly sequential. Phase 1 is a safety fix that removes a data-loss footgun before the feature makes addons easy to attach; Phase 2 lands the backend catalog; Phase 3 is the primary operator-facing outcome; Phase 4 generalises to multi-service stacks and is optional.
+
+### Phase 1 — Config-tab addon-safety fix
+
+**Goal:** editing an application's configuration never drops its attached addons.
+
+Deliverables:
+- The application Configuration tab's save path rebuilds the draft losslessly (via the existing `buildDraftFromVersion` helper) and overlays only the form-edited fields, instead of constructing a fresh single-service array that omits `addons` / `vault` / `nats` / `requires` / `resourceInputs`.
+- A regression test (supertest against the draft route, per the server test conventions) that attaches an addon to an application, simulates a Configuration-tab save, and asserts the `addons` block survives on the resulting draft version.
+
+Reversibility: safe — revert the PR and the save returns to its current behaviour.
+
+UI changes:
+- none (behaviour-only; the Configuration form is visually unchanged).
+
+Schema changes:
+- none.
+
+Done when: saving an application that carries an `addons` block from the Configuration tab preserves that block (and `vault` / `nats`) on the resulting draft version.
+
+Verify in prod: a Claude Shell app still exposes its Tailscale SSH endpoint on the Connect card after an operator edits its configuration.
+
+### Phase 2 — Addon catalog endpoint + manifest metadata
+
+**Goal:** a registry-driven catalog endpoint exposes every registered addon plus enough metadata to render a picker and a per-addon config form.
+
+Deliverables:
+- `GET /api/addons` returning, per registered addon, an `AddonCatalogEntry` (§4.1): `id`, `description`, `kind`, `mode`, `appliesTo`, `requiresConnectedService`, and a serialisable `configFields` list.
+- `AddonCatalogEntry` and `AddonConfigFieldDescriptor` types in `@mini-infra/types`, plus the `ApiRoute` registry entry and the TanStack query key.
+- A `configFields` descriptor authored on each of the three production addons (`tailscale-ssh`, `tailscale-web`, `claude-shell`), covering the keys their zod `configSchema` accepts.
+- The endpoint gated by an existing read permission (the `Stacks`/`StacksRead` scope used by the sibling `addon-endpoints` route).
+
+Reversibility: safe — an additive read-only endpoint plus new types; nothing consumes it until Phase 3.
+
+UI changes:
+- none.
+
+Schema changes:
+- none.
+
+Done when: `GET /api/addons` returns the three registered addons with their `configFields`, `appliesTo`, `requiresConnectedService`, and `mode`, verified by an integration test that also asserts each addon's `configFields` covers its zod schema's keys.
+
+Verify in prod: n/a — internal only (no operator-visible surface until Phase 3).
+
+### Phase 3 — "Add-ons" card on the application Overview tab
+
+**Goal:** operators can attach, configure, and remove addons on an application from the Overview tab.
+
+Deliverables:
+- An "Add-ons" card on the application Overview tab that lists the app's currently-attached addons and offers an attach action. Renders whenever the application has a template version — including before its first deploy (unlike the Connect card, which needs an applied snapshot).
+- The shared "attach add-on" component (§4.3): a catalog-driven picker that gates each addon by `appliesTo` (against the app's service type) and `requiresConnectedService` (against live connectivity), plus a per-addon config form rendered from `configFields`.
+- Attach and remove write the `services[].addons` block through the lossless republish path (§4.2), mirroring the Connected Networks card — no new mutation endpoint.
+- Unavailable-state treatment: an addon that doesn't apply, or whose connected service is unconfigured, is shown disabled with the reason and a link to the relevant settings (e.g. Tailscale connectivity).
+
+Reversibility: safe — an additive client surface; revertable as a unit.
+
+UI changes:
+- New "Add-ons" card on the application Overview tab showing attached addons with add/remove controls, paired beneath the Connect card. [design needed]
+- An attach-add-on dialog: registry-driven picker, per-addon config fields, and disabled/unavailable rows with reasons and a fix link. [design needed]
+
+Schema changes:
+- none.
+
+Done when: an operator can attach `tailscale-ssh` (or `tailscale-web` with a port) to an application from the Overview card and the addon persists on the template's service-definition draft.
+
+Verify in prod: an operator attaches an addon via the card and, after deploy, the resulting SSH/HTTPS endpoint appears on that app's Connect card.
+
+### Phase 4 — Per-service addon authoring on the Services tab (optional, deferred)
+
+**Goal:** addon authoring generalises to a chosen service on multi-service stacks via the Services tab.
+
+Deliverables:
+- A per-row "Add-ons" affordance on the Services tab that mounts the shared attach-add-on component (§4.3) against the selected service.
+- The currently read-only Services table row gains an actionable addon control while preserving its existing runtime-detail disclosure.
+
+Reversibility: safe — an additive client surface.
+
+UI changes:
+- Services-tab rows gain a per-service add/remove-addon affordance. [design needed]
+
+Schema changes:
+- none.
+
+Done when: an operator can attach an addon to a specific service on a multi-service stack from the Services tab and it persists on that service's definition.
+
+Verify in prod: a multi-service stack shows an addon attached to a chosen (non-first) service via the Services tab.
+
+## 6. Risks & open questions
+
+- **Attach writes the draft; apply is separate.** Attaching an addon updates the template draft but requires a re-deploy/apply to materialise. The card must signal the "needs deploy" state clearly — confirm the exact UX at design time against how the Connected Networks card handles pending applies.
+- **Descriptor / schema drift.** `configFields` is hand-authored alongside each zod `configSchema` and can drift from it. Phase 2's test asserting coverage of the schema's keys mitigates this; consider whether the check should mirror the `assertPermissionCatalogInSync()` pattern in `lib/types/permissions.ts`.
+- **Removal cleanup.** Removing an attached addon from a deployed app relies on the render pipeline dropping the synthetic sidecar / injected env on next apply. Confirm the addon `cleanup()` hooks fire on removal (authkey revocation, tailnet device teardown) rather than orphaning tailnet devices.
+- **`claude-shell` presentation.** It is env-injection mode and excludes Pool; the picker's mode/`appliesTo` gating must present it correctly and never offer it on unsupported service types.
+- **Two editors for one app.** For apps created via the Claude Shell preset page, decide whether the generic card also surfaces/manages the `claude-shell` addon, or defers to the preset flow, to avoid two competing editors for the same app.
+
+## 7. Phase tracking
+
+Manual checklist — check a box when that phase's PR merges. Phases are strictly sequential.
+
+- [ ] Phase 1: Config-tab addon-safety fix
+- [ ] Phase 2: Addon catalog endpoint + manifest metadata
+- [ ] Phase 3: Add-ons card on application Overview tab
+- [ ] Phase 4: Per-service addon authoring on Services tab (optional, deferred)

--- a/lib/types/addons.ts
+++ b/lib/types/addons.ts
@@ -46,6 +46,40 @@ export type AddonRequiredConnectedService = string;
 export type AddonMode = 'sidecar' | 'env-injection';
 
 /**
+ * Serialisable description of a single config field an addon accepts,
+ * projected from that addon's zod `configSchema` so the client can render a
+ * form without the zod schema crossing the `@mini-infra/types` boundary
+ * (`lib/` is zero-runtime-deps, per `lib/CLAUDE.md`). Authored alongside each
+ * addon's schema and served by `GET /api/addons` (§4.1 of the
+ * addon-authoring-ui plan).
+ *
+ * The descriptor list is the source of truth for **form rendering**; the zod
+ * schema stays the source of truth for **validation**. The advisory hints
+ * (`pattern` / `min` / `max`) mirror the schema so the form can pre-validate,
+ * but the server always re-validates authoritatively against the schema.
+ */
+export interface AddonConfigFieldDescriptor {
+  /** Config key, e.g. `"port"` — matches a key the zod `configSchema` accepts. */
+  name: string;
+  /** Human-readable label for the form control. */
+  label: string;
+  /** Field shape driving the form control kind. */
+  type: 'string' | 'number' | 'boolean' | 'string[]';
+  /** Whether the zod schema requires this key (i.e. it is not `.optional()`). */
+  required: boolean;
+  /** Optional placeholder text for the form control. */
+  placeholder?: string;
+  /** Optional helper text explaining the field. */
+  help?: string;
+  /** Advisory regex pattern mirrored from the zod schema (server re-validates). */
+  pattern?: string;
+  /** Advisory numeric minimum mirrored from the zod schema (server re-validates). */
+  min?: number;
+  /** Advisory numeric maximum mirrored from the zod schema (server re-validates). */
+  max?: number;
+}
+
+/**
  * Identity, applicability, and config-shape declaration for an addon.
  *
  * The runtime consumes `id` for registry lookup, `appliesTo` to gate
@@ -83,6 +117,52 @@ export interface AddonManifest {
    * the matching `ProvisionedValues` shape from `provision()`.
    */
   mode?: AddonMode;
+  /**
+   * Serialisable projection of this addon's zod `configSchema`, authored
+   * alongside the schema on each production manifest. Drives the per-addon
+   * config form the catalog endpoint (`GET /api/addons`) exposes to the
+   * client — the zod schema itself can't cross into `lib/`. Its field
+   * `name`s must exactly cover the keys the schema accepts; a drift test
+   * pins the two together (see the addon-authoring-ui plan §4.1). Omitted
+   * when the addon takes no config (e.g. the no-op test addon).
+   */
+  configFields?: AddonConfigFieldDescriptor[];
+}
+
+/**
+ * One registered addon projected into the shape the catalog endpoint
+ * (`GET /api/addons`) serves — enough metadata to render a picker row and a
+ * per-addon config form without the server's zod schema crossing into
+ * `lib/`. See §4.1 of the addon-authoring-ui plan.
+ *
+ * Distinct from `AddonManifest`: the manifest is the server-side registration
+ * record (with `mode`/`configFields` optional for authoring ergonomics); this
+ * is the fully-resolved client contract (`mode` defaulted to `'sidecar'`,
+ * `configFields` defaulted to `[]`).
+ */
+export interface AddonCatalogEntry {
+  /** Registry id, e.g. `"tailscale-ssh"`. */
+  id: string;
+  description: string;
+  /** Merge-group label (addons sharing a `kind` collapse into one sidecar). */
+  kind?: string;
+  /** Attachment shape, resolved from the manifest (`'sidecar'` when omitted). */
+  mode: AddonMode;
+  /** Service types this addon supports — gates the picker per service type. */
+  appliesTo: StackServiceType[];
+  /** Connected-service prerequisite (e.g. `"tailscale"`), if any. */
+  requiresConnectedService?: AddonRequiredConnectedService;
+  /** Field descriptors driving the per-addon config form (`[]` when none). */
+  configFields: AddonConfigFieldDescriptor[];
+}
+
+/**
+ * Response body of `GET /api/addons` — the full registry-driven catalog.
+ * Mirrors the sibling `TailscaleAddonEndpointsResponse` envelope shape
+ * (a single named array field) served by the addon-endpoints route.
+ */
+export interface AddonCatalogResponse {
+  addons: AddonCatalogEntry[];
 }
 
 /**

--- a/lib/types/api-routes.generated.ts
+++ b/lib/types/api-routes.generated.ts
@@ -8,6 +8,7 @@
 export type ApiRouteEntry = { method: string; path: string };
 
 export const ALL_API_ROUTES: readonly ApiRouteEntry[] = [
+  { method: "GET", path: "/api/addons" },
   { method: "GET", path: "/api/agent-sidecar/config" },
   { method: "PUT", path: "/api/agent-sidecar/config" },
   { method: "POST", path: "/api/agent-sidecar/restart" },

--- a/lib/types/api-routes.ts
+++ b/lib/types/api-routes.ts
@@ -92,6 +92,7 @@ export const ApiBase = {
   apiRoutes: "/api/routes",
   openapi: "/api/openapi.json",
   agent: "/api/agent",
+  addons: "/api/addons",
   diagnostics: "/api/diagnostics",
   onboarding: "/api/onboarding",
   vaultPolicies: "/api/vault/policies",
@@ -132,6 +133,11 @@ export const ApiRoute = {
     /** POST /api/containers/:id/:action — start/stop/restart/remove */
     action: (id: string, action: ContainerAction): string =>
       `${ApiBase.containers}/${id}/${action}`,
+  },
+
+  addons: {
+    /** GET /api/addons — registry-driven addon catalog (picker + config-form metadata) */
+    catalog: (): string => `${ApiBase.addons}`,
   },
 
   agentSidecar: {

--- a/lib/types/query-keys.ts
+++ b/lib/types/query-keys.ts
@@ -58,6 +58,13 @@ export const queryKeys = {
     config: ["agent-sidecar", "config"] as const,
   },
 
+  addons: {
+    /** Root key for the addon resource — prefix-matches every narrower addons key. */
+    all: ["addons"] as const,
+    /** Registry-driven addon catalog (GET /api/addons). */
+    catalog: ["addons", "catalog"] as const,
+  },
+
   authSettings: {
     all: ["auth-settings"] as const,
   },

--- a/server/src/__tests__/addon-catalog-schema-drift.test.ts
+++ b/server/src/__tests__/addon-catalog-schema-drift.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Drift / coverage guard for the addon catalog (addon-authoring-ui plan,
+ * Phase 2 §4.1). Each production addon hand-authors a `configFields`
+ * descriptor list on its manifest alongside its zod `configSchema`; the two
+ * can silently drift. This test pins them together for every REGISTERED
+ * addon: the descriptor `name`s must exactly cover the keys the zod schema
+ * accepts, and each descriptor's `required` flag must match the schema's
+ * optionality for that key.
+ *
+ * Modelled on `assertPermissionCatalogInSync()` in `lib/types/permissions.ts`
+ * — same "two hand-maintained lists must stay in sync" shape, enforced by
+ * introspecting the authoritative source (here, the zod schema's shape).
+ *
+ * Importing `productionAddonRegistry` from the `stack-addons` barrel triggers
+ * the side-effect registrations, so `.list()` returns the live production set.
+ */
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { productionAddonRegistry } from "../services/stack-addons";
+
+/** Top-level keys a `z.object({...})` config schema accepts. */
+function schemaKeys(schema: z.ZodTypeAny): string[] {
+  if (schema instanceof z.ZodObject) {
+    return Object.keys(schema.shape);
+  }
+  throw new Error(
+    "Addon configSchema is not a ZodObject — the drift test's introspection " +
+      "needs updating for the new schema shape.",
+  );
+}
+
+/**
+ * A field is "not required" iff `undefined` is a valid value for it (i.e. the
+ * zod schema wraps it in `.optional()`). `safeParse(undefined)` is used rather
+ * than a version-specific `.isOptional()` so this survives zod upgrades.
+ */
+function isFieldRequired(schema: z.ZodObject<z.ZodRawShape>, key: string): boolean {
+  const field = schema.shape[key];
+  return !field.safeParse(undefined).success;
+}
+
+const registeredAddons = productionAddonRegistry.list();
+
+describe("addon catalog — configFields ↔ configSchema drift", () => {
+  it("registers exactly the three production addons (registry is populated)", () => {
+    const ids = registeredAddons.map((a) => a.manifest.id).sort();
+    expect(ids).toEqual(["claude-shell", "tailscale-ssh", "tailscale-web"]);
+  });
+
+  for (const addon of registeredAddons) {
+    const id = addon.manifest.id;
+
+    it(`${id}: configFields names exactly cover the zod schema's keys`, () => {
+      const keys = schemaKeys(addon.configSchema).sort();
+      const names = (addon.manifest.configFields ?? [])
+        .map((f) => f.name)
+        .sort();
+      expect(names).toEqual(keys);
+    });
+
+    it(`${id}: each configField.required matches the schema's optionality`, () => {
+      const schema = addon.configSchema;
+      if (!(schema instanceof z.ZodObject)) {
+        throw new Error(`${id}: configSchema is not a ZodObject`);
+      }
+      for (const field of addon.manifest.configFields ?? []) {
+        expect(
+          field.required,
+          `${id}.${field.name}.required should match zod optionality`,
+        ).toBe(isFieldRequired(schema, field.name));
+      }
+    });
+  }
+});

--- a/server/src/__tests__/addons-catalog-route.integration.test.ts
+++ b/server/src/__tests__/addons-catalog-route.integration.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Integration test for the addon catalog endpoint (addon-authoring-ui plan,
+ * Phase 2). Exercises `GET /api/addons` over the real router through
+ * supertest, asserting it returns the three registered addons projected into
+ * `AddonCatalogEntry` shape.
+ *
+ * The NON-EMPTY assertions are load-bearing: they prove the route module
+ * pulled `productionAddonRegistry` from the `stack-addons` BARREL (whose
+ * side-effect imports register the addons) rather than from `registry.ts`
+ * directly (which would yield an empty list). See `routes/addons.ts`.
+ *
+ * `requirePermission` is mocked to a pass-through so the test targets the
+ * handler + registry projection, not the auth middleware (the permission wire-
+ * up is covered structurally by the route + the api-routes drift check).
+ */
+import supertest from "supertest";
+import express, {
+  type Request,
+  type Response,
+  type NextFunction,
+} from "express";
+import { describe, it, expect, vi } from "vitest";
+import type { AddonCatalogEntry, AddonCatalogResponse } from "@mini-infra/types";
+import { errorHandler } from "../lib/error-handler";
+
+vi.mock("../middleware/auth", () => ({
+  requirePermission:
+    () => (req: Request, _res: Response, next: NextFunction) => {
+      (req as Request & { user?: { id: string } }).user = { id: "session-user" };
+      next();
+    },
+}));
+
+// Imported after the mock so the router picks up the mocked middleware.
+import addonsRoutes from "../routes/addons";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/addons", addonsRoutes);
+  app.use(errorHandler);
+  return app;
+}
+
+function getById(
+  addons: AddonCatalogEntry[],
+  id: string,
+): AddonCatalogEntry {
+  const entry = addons.find((a) => a.id === id);
+  if (!entry) throw new Error(`addon "${id}" missing from catalog`);
+  return entry;
+}
+
+describe("GET /api/addons — addon catalog", () => {
+  it("returns the three registered addons (registry is populated)", async () => {
+    const res = await supertest(buildApp()).get("/api/addons").expect(200);
+    const body = res.body as AddonCatalogResponse;
+
+    expect(Array.isArray(body.addons)).toBe(true);
+    // Load-bearing: a non-empty list proves the barrel side-effects ran.
+    expect(body.addons.length).toBe(3);
+    expect(body.addons.map((a) => a.id).sort()).toEqual([
+      "claude-shell",
+      "tailscale-ssh",
+      "tailscale-web",
+    ]);
+  });
+
+  it("projects tailscale-ssh with sidecar mode, Pool support, and its config field", async () => {
+    const res = await supertest(buildApp()).get("/api/addons").expect(200);
+    const entry = getById((res.body as AddonCatalogResponse).addons, "tailscale-ssh");
+
+    expect(entry.mode).toBe("sidecar");
+    expect(entry.requiresConnectedService).toBe("tailscale");
+    expect(entry.appliesTo).toEqual(
+      expect.arrayContaining(["Stateful", "StatelessWeb", "Pool"]),
+    );
+    expect(entry.configFields.map((f) => f.name)).toEqual(["extraTags"]);
+    expect(entry.configFields.every((f) => f.required === false)).toBe(true);
+  });
+
+  it("projects tailscale-web with a required numeric port field", async () => {
+    const res = await supertest(buildApp()).get("/api/addons").expect(200);
+    const entry = getById((res.body as AddonCatalogResponse).addons, "tailscale-web");
+
+    expect(entry.mode).toBe("sidecar");
+    expect(entry.requiresConnectedService).toBe("tailscale");
+    const port = entry.configFields.find((f) => f.name === "port");
+    expect(port).toMatchObject({
+      type: "number",
+      required: true,
+      min: 1,
+      max: 65535,
+    });
+    expect(entry.configFields.map((f) => f.name).sort()).toEqual([
+      "extraTags",
+      "path",
+      "port",
+    ]);
+  });
+
+  it("projects claude-shell as env-injection mode without Pool support", async () => {
+    const res = await supertest(buildApp()).get("/api/addons").expect(200);
+    const entry = getById((res.body as AddonCatalogResponse).addons, "claude-shell");
+
+    expect(entry.mode).toBe("env-injection");
+    expect(entry.requiresConnectedService).toBe("tailscale");
+    expect(entry.appliesTo).toEqual(["Stateful", "StatelessWeb"]);
+    expect(entry.appliesTo).not.toContain("Pool");
+    expect(entry.configFields.length).toBeGreaterThan(0);
+    expect(entry.configFields.map((f) => f.name).sort()).toEqual([
+      "extraTags",
+      "gitRepo",
+    ]);
+  });
+});

--- a/server/src/__tests__/stack-templates-config-save-addons.integration.test.ts
+++ b/server/src/__tests__/stack-templates-config-save-addons.integration.test.ts
@@ -1,0 +1,174 @@
+/**
+ * HTTP regression test for the application Configuration-tab save path —
+ * addon-authoring-ui plan, Phase 1 ("Config-tab addon-safety fix").
+ *
+ * The Configuration tab's `onSubmit`
+ * (`client/src/app/applications/[id]/configuration/page.tsx`) used to rebuild
+ * `services[]` from scratch, which silently dropped a service's `addons`
+ * block (plus `vault`/`nats`/`requires` and any container-config field the
+ * form doesn't model). The fix rebuilds the draft losslessly via
+ * `buildDraftFromVersion(existingVersion)` and overlays only the form-edited
+ * fields — mirroring the Connected Networks card's `persistJoinNetworks`.
+ *
+ * Per `server/CLAUDE.md`, a field-persistence regression must exercise the
+ * real HTTP boundary via supertest (direct Prisma seeding bypasses the Zod
+ * layer that previously stripped `vaultAppRoleRef`/`addons`). This test:
+ *   1. POSTs an initial draft carrying an `addons` block + unmodeled
+ *      container-config (`labels`) on services[0].
+ *   2. Reads the persisted row back — this is the "existing version" the
+ *      client loads and feeds through `buildDraftFromVersion`.
+ *   3. POSTs a Configuration-tab-shaped save that carries `addons` +
+ *      `containerConfig` forward and overlays a changed `dockerTag`/`env`
+ *      (exactly what the fixed `onSubmit` produces).
+ *   4. Asserts the `addons` block (and the unmodeled `labels`) survive on the
+ *      resulting draft version, and that the edited field did change.
+ *
+ * A no-op addon is registered into `productionAddonRegistry` so the draft
+ * schema's per-entry `superRefine` accepts the block. Vitest's `pool: 'forks'`
+ * isolates this mutation to this file's worker.
+ */
+
+import supertest from 'supertest';
+import express, { type Request, type Response, type NextFunction } from 'express';
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { testPrisma } from './integration-test-helpers';
+import { productionAddonRegistry } from '../services/stack-addons/registry';
+import { noopAddon } from '../services/stack-addons/test-addons/noop';
+
+vi.mock('../middleware/auth', () => ({
+  requirePermission: () => (req: Request, _res: Response, next: NextFunction) => {
+    (req as Request & { user?: { id: string } }).user = { id: 'session-user' };
+    next();
+  },
+}));
+
+vi.mock('../lib/prisma', () => ({ default: testPrisma }));
+
+import stackTemplateRouter from '../routes/stack-templates';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/stack-templates', stackTemplateRouter);
+  return app;
+}
+
+async function createUserTemplateRow(): Promise<string> {
+  const templateId = createId();
+  await testPrisma.stackTemplate.create({
+    data: {
+      id: templateId,
+      name: `tpl-${templateId.slice(0, 6)}`,
+      displayName: 'Config-save Addons Test Template',
+      source: 'user',
+      scope: 'environment',
+      currentVersionId: null,
+      draftVersionId: null,
+    },
+  });
+  return templateId;
+}
+
+async function readDraftService(templateId: string) {
+  const tmpl = await testPrisma.stackTemplate.findUnique({ where: { id: templateId } });
+  expect(tmpl?.draftVersionId).not.toBeNull();
+  const row = await testPrisma.stackTemplateService.findFirst({
+    where: { versionId: tmpl!.draftVersionId! },
+  });
+  expect(row).not.toBeNull();
+  return row!;
+}
+
+describe('Configuration-tab save preserves a service addons block (Phase 1)', () => {
+  beforeAll(() => {
+    if (!productionAddonRegistry.has('noop')) {
+      productionAddonRegistry.register(noopAddon);
+    }
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('carries `addons` (and unmodeled container-config) through a config-tab-shaped save while applying the edited field', async () => {
+    const templateId = await createUserTemplateRow();
+    const app = buildApp();
+
+    // 1. Initial application state — a service with an addon attached plus a
+    //    container-config field (`labels`) the Configuration form never models.
+    const initialBody = {
+      networks: [{ name: 'app-net' }],
+      volumes: [],
+      services: [
+        {
+          serviceName: 'web',
+          serviceType: 'Stateful',
+          dockerImage: 'nginx',
+          dockerTag: 'latest',
+          containerConfig: {
+            labels: { 'mini-infra.owner': 'phase-1-test' },
+            joinNetworks: ['app-net'],
+          },
+          dependsOn: [],
+          order: 0,
+          addons: { noop: { label: 'phase-1' } },
+        },
+      ],
+    };
+
+    const initialRes = await supertest(app)
+      .post(`/api/stack-templates/${templateId}/draft`)
+      .send(initialBody);
+    expect(initialRes.status).toBe(200);
+
+    // 2. Read the persisted version back — this is what the client loads and
+    //    feeds through `buildDraftFromVersion` to seed a lossless overlay.
+    const existing = await readDraftService(templateId);
+    expect(existing.addons).toEqual({ noop: { label: 'phase-1' } });
+    const existingContainerConfig =
+      (existing.containerConfig as Record<string, unknown>) ?? {};
+
+    // 3. Configuration-tab save. The fixed `onSubmit` rebuilds the draft from
+    //    the existing version and overlays only the form-edited fields — the
+    //    `addons` block and unmodeled `containerConfig.labels` ride along on
+    //    services[0]. Here we mirror that exact shape: carry them forward and
+    //    change `dockerTag` + `env` as the form would.
+    const configSaveBody = {
+      networks: [{ name: 'app-net' }],
+      volumes: [],
+      services: [
+        {
+          serviceName: 'web',
+          serviceType: 'Stateful',
+          dockerImage: 'nginx',
+          dockerTag: '1.27', // edited by the form
+          containerConfig: {
+            ...existingContainerConfig, // preserves `labels`
+            env: { FOO: 'bar' }, // edited by the form
+            joinNetworks: ['app-net'],
+            restartPolicy: 'unless-stopped',
+          },
+          dependsOn: [],
+          order: 0,
+          addons: existing.addons, // carried forward by buildDraftFromVersion
+        },
+      ],
+    };
+
+    const saveRes = await supertest(app)
+      .post(`/api/stack-templates/${templateId}/draft`)
+      .send(configSaveBody);
+    expect(saveRes.status).toBe(200);
+    expect(saveRes.body.success).toBe(true);
+
+    // 4. The addon block survived, the unmodeled label survived, and the
+    //    edited field actually changed.
+    const saved = await readDraftService(templateId);
+    expect(saved.addons).toEqual({ noop: { label: 'phase-1' } });
+    expect(saved.dockerTag).toBe('1.27');
+    const savedContainerConfig = saved.containerConfig as Record<string, unknown>;
+    expect(savedContainerConfig.labels).toEqual({ 'mini-infra.owner': 'phase-1-test' });
+    expect(savedContainerConfig.env).toEqual({ FOO: 'bar' });
+  });
+});

--- a/server/src/app-factory.ts
+++ b/server/src/app-factory.ts
@@ -63,6 +63,7 @@ import haproxyBackendsRoutes from "./routes/haproxy-backends";
 import githubAppSettingsRoutes from "./routes/github-app-settings";
 import githubAppResourcesRoutes from "./routes/github-app-resources";
 import agentRoutes from "./routes/agent";
+import addonsRoutes from "./routes/addons";
 import monitoringRoutes from "./routes/monitoring";
 import permissionPresetsRoutes from "./routes/permission-presets";
 import stacksRoutes from "./routes/stacks/index";
@@ -235,6 +236,7 @@ function getRouteDefinitions(): RouteDefinition[] {
     { id: "apiRoutes", path: ApiBase.apiRoutes, name: "apiRoutesRoutes", getRouter: () => apiRoutesRoutes },
     { id: "openapi", path: ApiBase.openapi, name: "openapiRoutes", getRouter: () => openapiRoutes },
     { id: "agent", path: ApiBase.agent, name: "agentRoutes", getRouter: () => agentRoutes },
+    { id: "addons", path: ApiBase.addons, name: "addonsRoutes", getRouter: () => addonsRoutes },
     { id: "diagnostics", path: ApiBase.diagnostics, name: "diagnosticsRoutes", getRouter: () => diagnosticsRoutes },
     { id: "onboarding", path: ApiBase.onboarding, name: "onboardingRoutes", getRouter: () => onboardingRoutes },
     { id: "vaultPolicies", path: ApiBase.vaultPolicies, name: "vaultPolicyRoutes", getRouter: () => vaultPolicyRoutes },

--- a/server/src/routes/addons.ts
+++ b/server/src/routes/addons.ts
@@ -1,0 +1,66 @@
+import { Router } from "express";
+import { asyncHandler } from "../lib/async-handler";
+import { requirePermission } from "../middleware/auth";
+import { getLogger } from "../lib/logger-factory";
+import {
+  Permission,
+  type AddonCatalogEntry,
+  type AddonCatalogResponse,
+} from "@mini-infra/types";
+// IMPORTANT: import from the `stack-addons` BARREL (index.ts), not from
+// `stack-addons/registry`. The production registry is populated purely by the
+// barrel's side-effect imports (`import './tailscale-ssh'` etc.). Importing
+// `registry.ts` directly would give an EMPTY registry and this endpoint would
+// return `{ addons: [] }`. The integration test asserts a non-empty list to
+// guard exactly this.
+import {
+  productionAddonRegistry,
+  type RegisteredAddon,
+} from "../services/stack-addons";
+
+const logger = getLogger("integrations", "addons-route");
+
+const router = Router();
+
+/**
+ * Project a registered addon into its serialisable catalog entry. `mode`
+ * defaults to `'sidecar'` (the framework default when a manifest omits it,
+ * matching `AddonManifest.mode`'s contract) and `configFields` defaults to
+ * `[]` for addons that take no config.
+ */
+function toCatalogEntry(addon: RegisteredAddon): AddonCatalogEntry {
+  const { manifest } = addon;
+  return {
+    id: manifest.id,
+    description: manifest.description,
+    kind: manifest.kind,
+    mode: manifest.mode ?? "sidecar",
+    appliesTo: manifest.appliesTo,
+    requiresConnectedService: manifest.requiresConnectedService,
+    configFields: manifest.configFields ?? [],
+  };
+}
+
+/**
+ * GET /api/addons
+ *
+ * Registry-driven catalog of every registered Service Addon, projected into
+ * the serialisable `AddonCatalogEntry` shape (§4.1 of the addon-authoring-ui
+ * plan) the client renders a picker + per-addon config form from. A newly
+ * registered addon appears here automatically with no client-side change.
+ *
+ * Gated by `stacks:read` — the same read scope the sibling
+ * `GET /api/stacks/:stackId/addon-endpoints` route uses.
+ */
+router.get(
+  "/",
+  requirePermission(Permission.StacksRead),
+  asyncHandler(async (_req, res) => {
+    const addons = productionAddonRegistry.list().map(toCatalogEntry);
+    logger.debug({ count: addons.length }, "Serving addon catalog");
+    const response: AddonCatalogResponse = { addons };
+    res.json(response);
+  }),
+);
+
+export default router;

--- a/server/src/services/stack-addons/claude-shell/manifest.ts
+++ b/server/src/services/stack-addons/claude-shell/manifest.ts
@@ -93,4 +93,26 @@ export const claudeShellManifest = {
     'Inject Tailscale-SSH bootstrap env (authkey + hostname + --ssh) into a Claude Shell workload container. The image bakes tailscaled in-process; the addon does not materialise a sidecar. Requires the Tailscale connected service.',
   appliesTo: ['Stateful', 'StatelessWeb'],
   requiresConnectedService: 'tailscale',
+  // Mirrors `claudeShellConfigSchema` above — the drift test in
+  // `addon-catalog-schema-drift.test.ts` pins these field names to the
+  // schema's keys.
+  configFields: [
+    {
+      name: 'gitRepo',
+      label: 'Git Repository',
+      type: 'string',
+      required: false,
+      placeholder: 'https://github.com/owner/repo.git',
+      help: 'Optional git repo URL cloned into the workspace volume on first start. Only anonymously-cloneable URLs are supported until deploy keys land.',
+    },
+    {
+      name: 'extraTags',
+      label: 'Extra Tags',
+      type: 'string[]',
+      required: false,
+      placeholder: 'tag:dev-team',
+      help: 'Additional Tailscale tags to apply to the device. Each must match tag:[a-z0-9-]+ and already exist in your ACL tagOwners.',
+      pattern: '^tag:[a-z0-9-]+$',
+    },
+  ],
 } as const satisfies AddonManifest;

--- a/server/src/services/stack-addons/tailscale-ssh/manifest.ts
+++ b/server/src/services/stack-addons/tailscale-ssh/manifest.ts
@@ -48,6 +48,20 @@ export const tailscaleSshManifest = {
     'Operator SSH into the target service via Tailscale identity. Materialises a tailscaled sidecar joined to the target container, gated by the tailnet ACL ssh check policy.',
   appliesTo: ['Stateful', 'StatelessWeb', 'Pool'],
   requiresConnectedService: 'tailscale',
+  // Mirrors `tailscaleSshConfigSchema` above — the drift test in
+  // `addon-catalog-schema-drift.test.ts` pins these field names to the
+  // schema's keys.
+  configFields: [
+    {
+      name: 'extraTags',
+      label: 'Extra Tags',
+      type: 'string[]',
+      required: false,
+      placeholder: 'tag:dev-team',
+      help: 'Additional Tailscale tags to apply to the device. Each must match tag:[a-z0-9-]+ and already exist in your ACL tagOwners.',
+      pattern: '^tag:[a-z0-9-]+$',
+    },
+  ],
 } as const satisfies AddonManifest;
 
 export const tailscaleSshTargetIntegration: TargetIntegration = {

--- a/server/src/services/stack-addons/tailscale-web/manifest.ts
+++ b/server/src/services/stack-addons/tailscale-web/manifest.ts
@@ -53,6 +53,39 @@ export const tailscaleWebManifest = {
     'Expose the target service over HTTPS on the tailnet with auto-provisioned TLS. Materialises a tailscaled sidecar running `tailscale serve` against ${TS_CERT_DOMAIN}:443 → http://<target>:<port>.',
   appliesTo: ['Stateful', 'StatelessWeb', 'Pool'],
   requiresConnectedService: 'tailscale',
+  // Mirrors `tailscaleWebConfigSchema` above — the drift test in
+  // `addon-catalog-schema-drift.test.ts` pins these field names to the
+  // schema's keys.
+  configFields: [
+    {
+      name: 'port',
+      label: 'Target Port',
+      type: 'number',
+      required: true,
+      placeholder: '8080',
+      help: 'Local port on the target service the sidecar proxies to over the shared Docker network.',
+      min: 1,
+      max: 65535,
+    },
+    {
+      name: 'path',
+      label: 'Path',
+      type: 'string',
+      required: false,
+      placeholder: '/',
+      help: 'Optional sub-path to expose (defaults to /). Must begin with "/".',
+      pattern: '^/',
+    },
+    {
+      name: 'extraTags',
+      label: 'Extra Tags',
+      type: 'string[]',
+      required: false,
+      placeholder: 'tag:dev-team',
+      help: 'Additional Tailscale tags to apply to the device. Each must match tag:[a-z0-9-]+ and already exist in your ACL tagOwners.',
+      pattern: '^tag:[a-z0-9-]+$',
+    },
+  ],
 } as const satisfies AddonManifest;
 
 export const tailscaleWebTargetIntegration: TargetIntegration = {


### PR DESCRIPTION
## Summary

Adds a generic, registry-driven UI to attach and configure **Service Addons** (`tailscale-ssh`, `tailscale-web`, `claude-shell`) on applications and stack templates — previously only possible via the raw API or the one hardcoded Claude Shell preset page. Implements all four phases of [`docs/planning/not-shipped/addon-authoring-ui-plan.md`](docs/planning/not-shipped/addon-authoring-ui-plan.md).

Each phase is its own commit.

### Phase 1 — Config-tab addon-safety fix
The application Configuration tab rebuilt `services[]` from scratch on save, silently dropping the service's `addons` block (plus `vault`/`nats`/`requires`/`resourceInputs`) — so editing a Claude Shell app's config would strip its addon and the next deploy would lose Tailscale SSH. The save now goes through `buildDraftFromVersion`, overlaying only form-edited fields (mirroring the Connected Networks card). Regression test over the draft route.

### Phase 2 — `GET /api/addons` catalog endpoint
A top-level, registry-driven endpoint projecting each registered addon into a serialisable `AddonCatalogEntry` (`id`, `description`, `kind`, `mode`, `appliesTo`, `requiresConnectedService`, `configFields`), so the UI can enumerate addons and render config forms without importing the server-side zod schemas. Adds `configFields` descriptors on all three manifests and a schema-drift test that pins them to each addon's zod schema. The route imports the `stack-addons` barrel so the registry self-populates.

### Phase 3 — "Add-ons" card on the application Overview tab
An "Add-ons" card plus a reusable `AttachAddonDialog`: a catalog-driven picker that gates each addon by the target service type (`appliesTo`) and connected-service availability, renders a per-addon config form from `configFields`, and attaches/removes via the lossless `buildDraftFromVersion` republish path. Renders off the template's current-or-draft version, so addons can be attached at config time — before the first deploy. Gating + config mapping live in a pure helper (`addon-applicability.ts`) reused by Phase 4.

### Phase 4 — Per-service addon authoring in the stack-templates editor
Re-homed from the applications Services tab (applications are single-service — Phase 3 covers them) to the **stack-templates draft editor**, the real multi-service surface. Each service card gains an "Add-ons" affordance mounting the shared `AttachAddonDialog`, gated on `readOnly`/`appliesTo`/connectivity, writing that service's `addons` via the existing `onServicesChange` draft-save path. **Also fixes a pre-existing data-loss bug** this surface exposed: the editor's two service round-trips (`buildDraftInput`, the section's `toServiceDefinition`) rebuilt each service from a partial field set, so editing/deleting any service stripped `addons`/`poolConfig`/`vault*`/`nats*` from every service — both now reuse the canonical lossless mapper (`mapServiceInfoToDefinition` / `buildDraftFromVersion`), and the service drawer spreads the incoming service so unmodeled fields survive.

## Test plan
- **Phase 1:** supertest regression — an `addons`-bearing app survives a Configuration-tab-shaped save.
- **Phase 2:** schema-drift test (configFields ↔ zod keys) + endpoint integration test (non-empty 3-addon list, correct `mode`/`appliesTo`/`requiresConnectedService`).
- **Phase 3:** 12 dialog/gating tests (applicability + connectivity gating, config-form → config mapping).
- **Phase 4:** mapper round-trip tests (editing service A keeps service B's addons; nulls stripped) + component tests (per-service attach writes `services[i].addons`, sibling untouched, read-only hides the control).
- Cumulative `build:lib` + server build + client build + both lints all green; client suite 211/211, server addon/stacks regression set passing.

## Notes
- **Not yet verified live** — proven by builds + tests, not yet rendered in a running dev instance (needs a container rebuild).
- New API route (`/api/addons`) and new user-facing surfaces — user-docs and any tour-manifest updates are not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)