### PR TITLE
feat(stacks): P3 — correctness debt & truth-telling

### DIFF
--- a/client/src/app/network-access/page.tsx
+++ b/client/src/app/network-access/page.tsx
@@ -232,7 +232,7 @@ export default function NetworkAccessPage() {
   const deviceOnline = ingressStatus?.deviceOnline ?? false;
   const ingressUrl = ingressStatus?.ingressUrl ?? null;
   const stackStatus = hostStack?.status;
-  const isDeployed = !!hostStack && stackStatus !== "undeployed" && stackStatus !== "removed";
+  const isDeployed = !!hostStack && stackStatus !== "undeployed";
   const deploying =
     instantiate.isPending ||
     applyMutation.isPending ||

--- a/client/src/app/stacks/[stackId]/page.tsx
+++ b/client/src/app/stacks/[stackId]/page.tsx
@@ -79,7 +79,7 @@ export default function StackDetailPage() {
       ? `/applications/${stack.templateId}`
       : `/stack-templates/${stack.templateId}`
     : null;
-  const canStop = stack.status !== "undeployed" && stack.status !== "removed";
+  const canStop = stack.status !== "undeployed";
 
   return (
     <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">

--- a/client/src/app/stacks/[stackId]/page.tsx
+++ b/client/src/app/stacks/[stackId]/page.tsx
@@ -94,7 +94,10 @@ export default function StackDetailPage() {
           Back to Stacks
         </Button>
 
-        <div className="flex flex-wrap items-start justify-between gap-4">
+        <div
+          className="flex flex-wrap items-start justify-between gap-4"
+          data-tour="stack-detail-header"
+        >
           <div className="min-w-0">
             <h1 className="truncate text-3xl font-bold">{stack.name}</h1>
             <div className="mt-2 flex flex-wrap items-center gap-2">
@@ -145,6 +148,7 @@ export default function StackDetailPage() {
                 onClick={() =>
                   stopStack.mutate({ stackId: stack.id, label: `Stopping ${stack.name}` })
                 }
+                data-tour="stack-detail-stop-button"
               >
                 <IconPlayerStop className="mr-2 h-4 w-4" />
                 Stop
@@ -165,12 +169,12 @@ export default function StackDetailPage() {
 
       {/* Plan / apply / selective apply / redeploy / uninstall — the canonical
           stack operations panel, reused from the infra lists. */}
-      <div className="px-4 lg:px-6">
+      <div className="px-4 lg:px-6" data-tour="stack-detail-plan">
         <StackPlanView stackId={stack.id} onDestroyCompleted={() => navigate("/stacks")} />
       </div>
 
       {/* Deployment history — reused from the application activity tab. */}
-      <div className="px-4 lg:px-6">
+      <div className="px-4 lg:px-6" data-tour="stack-detail-history">
         <HistorySection primaryStack={stack} />
       </div>
     </div>

--- a/client/src/app/stacks/page.tsx
+++ b/client/src/app/stacks/page.tsx
@@ -96,7 +96,10 @@ export default function StacksPage() {
   return (
     <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
       <div className="px-4 lg:px-6">
-        <div className="flex items-center justify-between gap-3">
+        <div
+          className="flex items-center justify-between gap-3"
+          data-tour="stacks-page-header"
+        >
           <div className="flex items-center gap-3">
             <div className="rounded-md bg-purple-100 p-2 text-purple-800 dark:bg-purple-900 dark:text-purple-300">
               <IconStack2 className="h-5 w-5" />
@@ -114,6 +117,7 @@ export default function StacksPage() {
             size="sm"
             onClick={() => refetch()}
             disabled={isRefetching}
+            data-tour="stacks-refresh-button"
           >
             <IconRefresh className={`h-4 w-4 ${isRefetching ? "animate-spin" : ""}`} />
             Refresh
@@ -125,7 +129,7 @@ export default function StacksPage() {
         <Card>
           <CardContent className="space-y-4 pt-6">
             {/* Filters */}
-            <div className="flex flex-wrap items-end gap-3">
+            <div className="flex flex-wrap items-end gap-3" data-tour="stacks-filters">
               <div className="min-w-[200px] flex-1">
                 <Label className="text-xs">Search</Label>
                 <Input
@@ -133,12 +137,13 @@ export default function StacksPage() {
                   value={q}
                   onChange={(e) => setQ(e.target.value)}
                   className="h-9"
+                  data-tour="stacks-search-input"
                 />
               </div>
               <div>
                 <Label className="text-xs">Scope</Label>
                 <Select value={scope} onValueChange={(v) => setScope(v as ScopeFilter)}>
-                  <SelectTrigger className="h-9 w-[150px]">
+                  <SelectTrigger className="h-9 w-[150px]" data-tour="stacks-scope-filter">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -151,7 +156,7 @@ export default function StacksPage() {
               <div>
                 <Label className="text-xs">Source</Label>
                 <Select value={source} onValueChange={(v) => setSource(v as SourceFilter)}>
-                  <SelectTrigger className="h-9 w-[160px]">
+                  <SelectTrigger className="h-9 w-[160px]" data-tour="stacks-source-filter">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -165,7 +170,7 @@ export default function StacksPage() {
               <div>
                 <Label className="text-xs">Status</Label>
                 <Select value={status} onValueChange={(v) => setStatus(v as StatusFilter)}>
-                  <SelectTrigger className="h-9 w-[140px]">
+                  <SelectTrigger className="h-9 w-[140px]" data-tour="stacks-status-filter">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -183,6 +188,7 @@ export default function StacksPage() {
                   id="attention-only"
                   checked={attentionOnly}
                   onCheckedChange={setAttentionOnly}
+                  data-tour="stacks-needs-attention-toggle"
                 />
                 <Label htmlFor="attention-only" className="text-xs">
                   Needs attention
@@ -209,7 +215,7 @@ export default function StacksPage() {
               </div>
             ) : (
               <div className="overflow-x-auto">
-                <Table>
+                <Table data-tour="stacks-table">
                   <TableHeader>
                     <TableRow>
                       <TableHead>Name</TableHead>

--- a/client/src/components/host/host-templates-list.tsx
+++ b/client/src/components/host/host-templates-list.tsx
@@ -64,7 +64,7 @@ export function HostTemplatesList({ className }: HostTemplatesListProps) {
   };
 
   const isDeployable = (stack: StackTemplateLinkedStack | undefined): boolean => {
-    return !stack || stack.status === "removed" || stack.status === "undeployed";
+    return !stack || stack.status === "undeployed";
   };
 
   if (isError) {

--- a/client/src/components/stack-templates/instantiate-template-dialog.tsx
+++ b/client/src/components/stack-templates/instantiate-template-dialog.tsx
@@ -129,7 +129,7 @@ function InstantiateTemplateDialogContent({
   }
 
   return (
-    <DialogContent className="sm:max-w-md">
+    <DialogContent className="sm:max-w-md" data-tour="install-template-dialog">
       <DialogHeader>
         <DialogTitle>Install {template.displayName}</DialogTitle>
         <DialogDescription>
@@ -146,6 +146,7 @@ function InstantiateTemplateDialogContent({
             onChange={(e) => setName(e.target.value)}
             placeholder={template.name}
             disabled={saving}
+            data-tour="install-template-name-input"
           />
         </div>
 
@@ -159,7 +160,7 @@ function InstantiateTemplateDialogContent({
               onValueChange={setEnvironmentId}
               disabled={saving}
             >
-              <SelectTrigger id="instantiate-env">
+              <SelectTrigger id="instantiate-env" data-tour="install-template-environment-select">
                 <SelectValue placeholder="Select an environment" />
               </SelectTrigger>
               <SelectContent>
@@ -177,7 +178,11 @@ function InstantiateTemplateDialogContent({
           <>
             <Separator />
             {parameters.map((param) => (
-              <div key={param.name} className="space-y-1.5">
+              <div
+                key={param.name}
+                className="space-y-1.5"
+                data-tour="install-template-parameters"
+              >
                 <Label htmlFor={`instantiate-param-${param.name}`} className="font-medium">
                   {param.name}
                 </Label>
@@ -215,7 +220,11 @@ function InstantiateTemplateDialogContent({
           <>
             <Separator />
             {inputs.map((input) => (
-              <div key={input.name} className="space-y-1.5">
+              <div
+                key={input.name}
+                className="space-y-1.5"
+                data-tour="install-template-inputs"
+              >
                 <Label htmlFor={`instantiate-input-${input.name}`} className="font-medium">
                   {input.name}
                 </Label>
@@ -242,7 +251,11 @@ function InstantiateTemplateDialogContent({
         <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
           Cancel
         </Button>
-        <Button onClick={handleInstall} disabled={saving || missingEnv || missingInputs}>
+        <Button
+          onClick={handleInstall}
+          disabled={saving || missingEnv || missingInputs}
+          data-tour="install-template-confirm"
+        >
           {saving ? (
             <IconLoader2 className="h-4 w-4 mr-2 animate-spin" />
           ) : (

--- a/client/src/components/stack-templates/template-table.tsx
+++ b/client/src/components/stack-templates/template-table.tsx
@@ -73,7 +73,7 @@ function getVersionDisplay(template: StackTemplateInfo): string {
  * removed (see stack-template-service.deleteTemplate).
  */
 function isDeployed(stack: StackTemplateLinkedStack): boolean {
-  return stack.status !== "undeployed" && stack.status !== "removed";
+  return stack.status !== "undeployed";
 }
 
 export function TemplateTable({ templates }: TemplateTableProps) {

--- a/client/src/components/stack-templates/template-version-diff.tsx
+++ b/client/src/components/stack-templates/template-version-diff.tsx
@@ -24,14 +24,14 @@ export function TemplateVersionDiff({ from, to, emptyLabel }: TemplateVersionDif
 
   if (!diff.hasChanges) {
     return (
-      <p className="text-sm text-muted-foreground">
+      <p className="text-sm text-muted-foreground" data-tour="template-version-diff">
         {emptyLabel ?? "No differences between these versions."}
       </p>
     );
   }
 
   return (
-    <div className="space-y-4 text-sm">
+    <div className="space-y-4 text-sm" data-tour="template-version-diff">
       {diff.servicesAdded.length > 0 && (
         <div>
           <div className="mb-1 flex items-center gap-1.5 font-medium text-green-700 dark:text-green-400">

--- a/client/src/components/stacks/RotateInputsDialog.tsx
+++ b/client/src/components/stacks/RotateInputsDialog.tsx
@@ -80,7 +80,7 @@ function RotateInputsDialogContent({
   }
 
   return (
-    <DialogContent className="sm:max-w-md">
+    <DialogContent className="sm:max-w-md" data-tour="rotate-inputs-dialog">
       <DialogHeader>
         <DialogTitle>Supply upgrade inputs</DialogTitle>
         <DialogDescription>
@@ -93,7 +93,7 @@ function RotateInputsDialogContent({
 
       <div className="space-y-4 py-2">
         {inputs.map((input, index) => (
-          <div key={input.name}>
+          <div key={input.name} data-tour="rotate-inputs-fields">
             {index > 0 && <Separator className="mb-4" />}
             <div className="space-y-1.5">
               <Label htmlFor={`rotate-input-${input.name}`} className="font-medium">
@@ -119,7 +119,11 @@ function RotateInputsDialogContent({
         <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSaving}>
           Cancel
         </Button>
-        <Button onClick={handleConfirm} disabled={isSaving || !allFilled}>
+        <Button
+          onClick={handleConfirm}
+          disabled={isSaving || !allFilled}
+          data-tour="rotate-inputs-confirm"
+        >
           {isSaving ? (
             <IconLoader2 className="h-4 w-4 mr-2 animate-spin" />
           ) : (

--- a/client/src/components/stacks/RotateInputsDialog.tsx
+++ b/client/src/components/stacks/RotateInputsDialog.tsx
@@ -85,7 +85,7 @@ function RotateInputsDialogContent({
         <DialogTitle>Supply upgrade inputs</DialogTitle>
         <DialogDescription>
           {stackName ? `Upgrading ${stackName} needs ` : "This upgrade needs "}
-          fresh {inputs.length === 1 ? "a value" : "values"} for the following{" "}
+          {inputs.length === 1 ? "a fresh value" : "fresh values"} for the following{" "}
           {inputs.length === 1 ? "input" : "inputs"}, which must be rotated on every
           upgrade.
         </DialogDescription>

--- a/client/src/components/stacks/StackParametersDialog.tsx
+++ b/client/src/components/stacks/StackParametersDialog.tsx
@@ -91,7 +91,7 @@ function StackParametersDialogContent({
   }
 
   return (
-    <DialogContent className="sm:max-w-md">
+    <DialogContent className="sm:max-w-md" data-tour="stack-parameters-dialog">
       <DialogHeader>
           <DialogTitle>Configure {stackName}</DialogTitle>
           <DialogDescription>
@@ -102,7 +102,7 @@ function StackParametersDialogContent({
 
         <div className="space-y-4 py-2">
           {parameters.map((param, index) => (
-            <div key={param.name}>
+            <div key={param.name} data-tour="stack-parameters-fields">
               {index > 0 && <Separator className="mb-4" />}
               <div className="space-y-1.5">
                 <Label htmlFor={`param-${param.name}`} className="font-medium">
@@ -153,7 +153,11 @@ function StackParametersDialogContent({
           >
             Cancel
           </Button>
-          <Button onClick={handleConfirm} disabled={isSaving}>
+          <Button
+            onClick={handleConfirm}
+            disabled={isSaving}
+            data-tour="stack-parameters-save-deploy"
+          >
             {isSaving ? (
               <IconLoader2 className="h-4 w-4 mr-2 animate-spin" />
             ) : (

--- a/client/src/components/stacks/StackStatusBadge.tsx
+++ b/client/src/components/stacks/StackStatusBadge.tsx
@@ -48,11 +48,6 @@ const STACK_STATUS_BADGE: Record<StackStatus, StatusMeta> = {
     label: "Undeployed",
     tooltip: "Not deployed — its containers don't exist yet. Deploy or Apply to create them.",
   },
-  removed: {
-    className: "bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-300",
-    label: "Removed",
-    tooltip: "Marked removed.",
-  },
 };
 
 interface StackStatusBadgeProps {

--- a/client/src/components/stacks/stack-indicators.tsx
+++ b/client/src/components/stacks/stack-indicators.tsx
@@ -1,5 +1,11 @@
 import { useState } from "react";
-import { IconAlertTriangle, IconArrowUp, IconLoader2 } from "@tabler/icons-react";
+import {
+  IconAlertCircle,
+  IconAlertTriangle,
+  IconArrowUp,
+  IconArrowUpCircle,
+  IconLoader2,
+} from "@tabler/icons-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -12,7 +18,11 @@ import { cn } from "@/lib/utils";
 import { useUpgradeAndApplyStack, fetchStackUpgradeInputs } from "@/hooks/use-stacks";
 import { getStackAttention } from "@/lib/stack-attention";
 import { RotateInputsDialog } from "@/components/stacks/RotateInputsDialog";
-import type { StackInfo, TemplateInputDeclaration } from "@mini-infra/types";
+import type {
+  StackAttentionLevel,
+  StackInfo,
+  TemplateInputDeclaration,
+} from "@mini-infra/types";
 
 /**
  * "Update available" badge shown when a stack's template has a newer published
@@ -45,8 +55,45 @@ export function UpdateAvailableBadge({ className }: { className?: string }) {
 }
 
 /**
- * Single "needs attention" indicator rolling up drift, NATS drift, error
- * status, and update-available into one affordance with the reasons listed.
+ * Presentation per attention level. A stack whose service has crashed is an
+ * outage and must not look like "a newer template version exists" — before
+ * these levels existed, every reason rendered in the same amber and the badge
+ * could not tell the two apart.
+ */
+const ATTENTION_STYLES: Record<
+  StackAttentionLevel,
+  { label: string; className: string; icon: typeof IconAlertTriangle }
+> = {
+  critical: {
+    label: "Needs attention",
+    className:
+      "border-red-300 bg-red-50 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-300",
+    icon: IconAlertCircle,
+  },
+  warning: {
+    label: "Needs attention",
+    className:
+      "border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300",
+    icon: IconAlertTriangle,
+  },
+  info: {
+    label: "Update available",
+    className:
+      "border-blue-300 bg-blue-50 text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300",
+    icon: IconArrowUpCircle,
+  },
+  none: {
+    label: "Needs attention",
+    className:
+      "border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300",
+    icon: IconAlertTriangle,
+  },
+};
+
+/**
+ * Single "needs attention" indicator rolling up live runtime issues, drift,
+ * NATS drift, error status, and update-available into one affordance with the
+ * reasons listed. Severity comes from the server-computed level.
  * Renders nothing when the stack is healthy and nothing is pending.
  */
 export function NeedsAttentionBadge({
@@ -58,20 +105,21 @@ export function NeedsAttentionBadge({
 }) {
   const attention = getStackAttention(stack);
   if (!attention.needsAttention) return null;
+
+  const style = ATTENTION_STYLES[attention.level] ?? ATTENTION_STYLES.warning;
+  const Icon = style.icon;
+
   return (
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
           <Badge
             variant="outline"
-            className={cn(
-              "cursor-help border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300",
-              className,
-            )}
+            className={cn("cursor-help", style.className, className)}
             data-tour="stack-needs-attention-badge"
           >
-            <IconAlertTriangle className="mr-1 h-3 w-3" />
-            Needs attention
+            <Icon className="mr-1 h-3 w-3" />
+            {style.label}
           </Badge>
         </TooltipTrigger>
         <TooltipContent className="max-w-sm">

--- a/client/src/components/stacks/stack-indicators.tsx
+++ b/client/src/components/stacks/stack-indicators.tsx
@@ -3,7 +3,6 @@ import {
   IconAlertCircle,
   IconAlertTriangle,
   IconArrowUp,
-  IconArrowUpCircle,
   IconLoader2,
 } from "@tabler/icons-react";
 import { Badge } from "@/components/ui/badge";
@@ -56,34 +55,19 @@ export function UpdateAvailableBadge({ className }: { className?: string }) {
 
 /**
  * Presentation per attention level. A stack whose service has crashed is an
- * outage and must not look like "a newer template version exists" — before
- * these levels existed, every reason rendered in the same amber and the badge
- * could not tell the two apart.
+ * outage and must not look like "a newer template version exists" — before the
+ * server-computed levels existed, every reason rendered in the same amber and
+ * the badge could not tell the two apart.
  */
-const ATTENTION_STYLES: Record<
-  StackAttentionLevel,
-  { label: string; className: string; icon: typeof IconAlertTriangle }
+const ATTENTION_STYLES: Partial<
+  Record<StackAttentionLevel, { className: string; icon: typeof IconAlertTriangle }>
 > = {
   critical: {
-    label: "Needs attention",
     className:
       "border-red-300 bg-red-50 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-300",
     icon: IconAlertCircle,
   },
   warning: {
-    label: "Needs attention",
-    className:
-      "border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300",
-    icon: IconAlertTriangle,
-  },
-  info: {
-    label: "Update available",
-    className:
-      "border-blue-300 bg-blue-50 text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300",
-    icon: IconArrowUpCircle,
-  },
-  none: {
-    label: "Needs attention",
     className:
       "border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300",
     icon: IconAlertTriangle,
@@ -92,9 +76,14 @@ const ATTENTION_STYLES: Record<
 
 /**
  * Single "needs attention" indicator rolling up live runtime issues, drift,
- * NATS drift, error status, and update-available into one affordance with the
- * reasons listed. Severity comes from the server-computed level.
- * Renders nothing when the stack is healthy and nothing is pending.
+ * NATS drift and error status into one affordance with the reasons listed.
+ * Severity comes from the server-computed level.
+ *
+ * Renders nothing when the stack is healthy, and nothing at `info` either: an
+ * available template upgrade is an opportunity, not something wrong, and every
+ * surface that renders this badge already renders the dedicated
+ * {@link UpdateAvailableBadge} beside it. Showing both said "Update available"
+ * twice in the same row.
  */
 export function NeedsAttentionBadge({
   stack,
@@ -104,9 +93,9 @@ export function NeedsAttentionBadge({
   className?: string;
 }) {
   const attention = getStackAttention(stack);
-  if (!attention.needsAttention) return null;
+  const style = ATTENTION_STYLES[attention.level];
+  if (!attention.needsAttention || !style) return null;
 
-  const style = ATTENTION_STYLES[attention.level] ?? ATTENTION_STYLES.warning;
   const Icon = style.icon;
 
   return (
@@ -119,7 +108,7 @@ export function NeedsAttentionBadge({
             data-tour="stack-needs-attention-badge"
           >
             <Icon className="mr-1 h-3 w-3" />
-            {style.label}
+            Needs attention
           </Badge>
         </TooltipTrigger>
         <TooltipContent className="max-w-sm">

--- a/client/src/components/stacks/stack-indicators.tsx
+++ b/client/src/components/stacks/stack-indicators.tsx
@@ -29,6 +29,7 @@ export function UpdateAvailableBadge({ className }: { className?: string }) {
               "cursor-help border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300",
               className,
             )}
+            data-tour="stack-update-available-badge"
           >
             <IconArrowUp className="mr-1 h-3 w-3" />
             Update available
@@ -67,6 +68,7 @@ export function NeedsAttentionBadge({
               "cursor-help border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300",
               className,
             )}
+            data-tour="stack-needs-attention-badge"
           >
             <IconAlertTriangle className="mr-1 h-3 w-3" />
             Needs attention
@@ -144,6 +146,7 @@ export function UpgradeButton({
         className={className}
         disabled={disabled || busy}
         onClick={handleClick}
+        data-tour="stack-upgrade-button"
       >
         {busy ? (
           <IconLoader2 className="mr-1 h-4 w-4 animate-spin" />

--- a/client/src/hooks/use-applications.ts
+++ b/client/src/hooks/use-applications.ts
@@ -444,31 +444,6 @@ export function useRemoveApplicationStack() {
   });
 }
 
-export function useRedeployApplication() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    meta: { errorContext: "application" },
-    mutationFn: async (args: { stackId: string; stackStatus: StackStatus }) => {
-      // A no-op-tag redeploy of a synced/drifted stack is a pull-latest via
-      // /update; any other status must recover through /apply (which has no
-      // status guard) or /update would 400 with STACK_NOT_DEPLOYED.
-      if (UPDATABLE_STATUSES.has(args.stackStatus)) {
-        await updateStack(args.stackId);
-      } else {
-        await applyStack(args.stackId);
-      }
-    },
-    onSuccess: () => {
-      toast.success("Application update started");
-      queryClient.invalidateQueries({ queryKey: queryKeys.applications.all });
-      queryClient.invalidateQueries({ queryKey: queryKeys.applications.userStacks });
-      queryClient.invalidateQueries({ queryKey: queryKeys.stacks.all });
-    },
-    // No onError — the global MutationCache.onError toasts by default.
-  });
-}
-
 /**
  * Apply/Retry a stack directly — the recovery path for a stack in
  * `error`/`pending`/`undeployed`. POST /apply has no status guard, so it is

--- a/client/src/hooks/use-stacks.ts
+++ b/client/src/hooks/use-stacks.ts
@@ -411,6 +411,13 @@ export function useStackUpgrade() {
  * template's current published version (POST /upgrade), then run the tracked
  * apply (POST /apply). The apply is fire-and-forget — progress streams via
  * Socket.IO and is surfaced by the global task tracker under "stack-apply".
+ *
+ * Because the apply is fire-and-forget, this mutation resolves when the deploy
+ * *starts*, not when it finishes — and the dialogs that call it close on that
+ * ACK. Without a hand-off the user is left staring at a closed dialog with no
+ * idea whether anything happened, so success explicitly points at the tracker
+ * where the deploy is actually running. Toasting here rather than at each of
+ * the three call sites keeps the hand-off consistent across all of them.
  */
 export function useUpgradeAndApplyStack() {
   const queryClient = useQueryClient();
@@ -429,7 +436,12 @@ export function useUpgradeAndApplyStack() {
       registerTask({ id: stackId, type: "stack-apply", label, channel: Channel.STACKS });
       await applyStack(stackId, {});
     },
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
+      // Title mirrors the label this deploy is registered under in the tracker,
+      // so the toast names the exact entry it is pointing the user at.
+      toast.success(variables.label, {
+        description: "Deploying now — follow progress in the task tracker.",
+      });
       queryClient.invalidateQueries({ queryKey: queryKeys.stacks.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.applications.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.applications.userStacks });

--- a/client/src/lib/stack-attention.ts
+++ b/client/src/lib/stack-attention.ts
@@ -1,51 +1,21 @@
-import type { StackInfo } from "@mini-infra/types";
+import { computeStackAttention, type StackAttention, type StackInfo } from "@mini-infra/types";
 
-export interface StackAttention {
-  /** True when the stack has one or more unresolved conditions. */
-  needsAttention: boolean;
-  /** Human-readable reasons, each phrased as "what's wrong → what to do". */
-  reasons: string[];
-  /** True when a newer template version is available (a softer signal). */
-  updateAvailable: boolean;
-}
+export type { StackAttention };
 
 /**
- * Roll every "needs attention" signal for a stack into one shape:
- *   - `error` status (last apply failed)
- *   - `drifted`/`pending` status (definition vs. live divergence / unapplied edits)
- *   - NATS configuration drift (returned on stack GET; orthogonal to status)
- *   - a newer template version being available (an upgrade opportunity)
+ * Read a stack's "needs attention" rollup.
  *
- * Used by the /stacks list and the stack detail page so one indicator can
- * summarise all of the above instead of scattering separate badges.
+ * The server computes this inside `serializeStack()` and ships it on the API, so
+ * every consumer — this UI, the agent sidecar, an API-key integration — gets the
+ * same answer instead of each reimplementing the logic. This used to be a local
+ * reimplementation that only the browser had.
+ *
+ * The local fallback covers stacks that came from an endpoint predating the
+ * rollup; it calls the *same* shared function the server does (from
+ * `@mini-infra/types`), so the two can't drift. It will under-report NATS drift
+ * when the payload lacks `natsDrift`, which is exactly what the server does for
+ * the same payload.
  */
 export function getStackAttention(stack: StackInfo): StackAttention {
-  const reasons: string[] = [];
-
-  if (stack.status === "error") {
-    reasons.push(
-      stack.lastFailureReason
-        ? `Last apply failed: ${stack.lastFailureReason}`
-        : "The last apply failed — retry Apply.",
-    );
-  } else if (stack.status === "drifted") {
-    reasons.push("Live containers have drifted from the definition — run Apply to reconcile.");
-  } else if (stack.status === "pending") {
-    reasons.push("The definition changed but hasn't been applied — run Apply.");
-  }
-
-  if (stack.natsDrift?.drifted) {
-    reasons.push("NATS configuration has drifted from the last applied snapshot.");
-  }
-
-  const updateAvailable = stack.templateUpdateAvailable === true;
-  if (updateAvailable) {
-    reasons.push("A newer template version is available — Upgrade & deploy to adopt it.");
-  }
-
-  return {
-    needsAttention: reasons.length > 0,
-    reasons,
-    updateAvailable,
-  };
+  return stack.needsAttention ?? computeStackAttention(stack);
 }

--- a/client/src/user-docs/applications/application-management.md
+++ b/client/src/user-docs/applications/application-management.md
@@ -1,100 +1,139 @@
 ---
 title: Managing Applications
-description: How to create, deploy, update, and manage applications in Mini Infra
+description: How to create, deploy, configure, upgrade, stop, and remove applications in Mini Infra.
 tags:
   - applications
   - deployment
   - docker
   - configuration
+  - stacks
 ---
 
 # Managing Applications
 
-Applications in Mini Infra are configuration templates that define Docker services. Each application specifies an image, ports, environment variables, volumes, and optional routing. When deployed, an application creates a running stack in its environment.
+An **application** is the simplified way to run a service on Mini Infra. Under the hood there is no separate "application" object — an application is a **stack** built from a **user-source stack template**. The application layer gives you a friendly form (image, ports, environment variables, volumes, routing) and hides the template/stack plumbing; everything you see on the [Stacks page](/help/applications/host-stacks) is the same object viewed one layer down.
 
-## Key Concepts
+That matters in one practical way: every lifecycle rule described here — statuses, drift, plan/apply, Upgrade & deploy — is a *stack* rule. If an application ever behaves in a way the application UI doesn't explain, open its stack and the answer will be there.
 
-- **Application** --- A reusable template defining how a Docker service should run.
-- **Stack** --- A running instance of an application, created when you deploy.
-- **Environment** --- The target environment where the stack runs.
+## Key concepts
 
-## Viewing Applications
+- **Application** — a user-source stack template plus the stack deployed from it.
+- **Stack** — the deployed unit: containers, networks, volumes, and config files, managed with plan/apply semantics.
+- **Template version** — an immutable snapshot of the application's configuration. Saving publishes a new version; the running stack stays on the version it was deployed with until you upgrade it.
+- **Environment** — the target the stack runs in. It cannot be changed after creation.
 
-The Applications page shows all applications as cards in a responsive grid. Each card displays:
+## Viewing applications
 
-- Application name and optional description.
-- Category and environment badges.
-- Deployment status (Running, Pending, Deploying, or no stacks yet).
-- Application URL (shown when a running stack has a configured hostname).
-- Action buttons for Deploy, Update, and Stop.
+The Applications page shows every application as a card. Each card displays:
 
-## Creating an Application
+- Name, optional description, and category badge.
+- The deployed stack's **status badge** (see [Stack status values](/help/applications/host-stacks#stack-status-values)).
+- A **Needs attention** badge when the stack has an unresolved problem — hover it to see exactly what and why.
+- An **Update available** badge when the template has a newer published version than the running stack.
+- The application URL, when a running stack has a configured hostname.
+- Action buttons: Deploy, Update, Upgrade & deploy, Stop, and a `⋯` menu.
 
-Click **Add Application** to open the creation form. The form is organized into sections:
+## Creating an application
 
-### Basic Information
+Click **Add Application** to open the creation form.
 
-- **Display Name** --- A human-readable name for the application.
-- **Description** --- Optional text describing the application.
+### Basic information
 
-### Service Configuration
+- **Display name** — a human-readable name.
+- **Description** — optional.
 
-- **Service Name** --- Used as the container name prefix. Must be lowercase with hyphens.
-- **Service Type**:
-  - **Stateful** --- For databases, caches, and services that do not need external HTTP routing.
-  - **StatelessWeb** --- For web applications and APIs that need HAProxy routing.
-- **Environment** --- The target environment for deployment.
+### Service configuration
 
-### Container Configuration
+- **Service name** — the container name prefix. Lowercase with hyphens.
+- **Service type**:
+  - **Stateful** — databases, caches, workers. Replaced with a stop/start cycle, so there's a brief gap on each apply.
+  - **StatelessWeb** — web apps and APIs. Released blue-green via HAProxy, so updates are zero-downtime.
+- **Environment** — the deployment target. Permanent once set.
 
-- **Docker Image** and **Tag** --- The image to pull and run.
-- **Restart Policy** --- How Docker handles container restarts (Always, Unless Stopped, On Failure, or No).
+### Container configuration
 
-### Health Check (optional)
+- **Docker image** and **tag**.
+- **Restart policy** — Always, Unless Stopped, On Failure, or No.
 
-Enable to configure a Docker health check with a command, interval, timeout, retries, and start period.
+### Health check (optional)
 
-### Port Mappings
+A Docker health check with a command, interval, timeout, retries, and start period.
 
-Map host ports to container ports with protocol selection (TCP or UDP).
+> **Durations are milliseconds.** `interval`, `timeout`, and `startPeriod` are all in milliseconds; `retries` is a plain count. The form's units are already correct — this only matters if you also author templates through the API or YAML, where these fields were previously written in seconds. See `docs/user/stack-definition-reference.md` and `docs/API-CHANGELOG.md` in the repository.
 
-### Environment Variables
+### Ports, environment variables, volumes
 
-Define key-value pairs passed to the container at runtime.
-
-### Volumes
-
-Named Docker volumes with mount paths for persistent data.
+Host-to-container port mappings (TCP or UDP), key-value environment variables, and named Docker volumes with mount paths for persistent data.
 
 ### Routing (StatelessWeb only)
 
-When the service type is StatelessWeb:
+- **Hostname** — the domain traffic arrives on.
+- **Listening port** — the port the container listens on. **Detect Ports** reads it from the image.
+- **SSL/TLS** — issues a TLS certificate and DNS record automatically.
+- **Cloudflare Tunnel** — creates a tunnel ingress for internet-type environments.
 
-- **Hostname** --- The domain name for routing traffic.
-- **Listening Port** --- The port the container listens on. Use **Detect Ports** to auto-detect from the image.
-- **SSL/TLS** --- Automatically creates a TLS certificate and DNS record (for local networks).
-- **Cloudflare Tunnel** --- Automatically creates a tunnel ingress (for internet networks).
+### Deploy immediately
 
-### Deploy Immediately
+Toggle whether to deploy right away or just save the definition for later.
 
-Toggle whether to deploy the application right after creation, or just save the template for later.
+## Deploying an application
 
-## Deploying an Application
+Click **Deploy** on a card with no running stack. Mini Infra instantiates the template as a stack and applies it — pulling images, creating networks and volumes, then starting containers. Progress streams into the task tracker in the header.
 
-If the application has no running stacks, click the **Deploy** button on its card. This instantiates the template as a stack in the configured environment and applies the configuration.
+For an **adopted** application (one wrapped around pre-existing containers) the button reads **Connect** instead.
 
-## Updating an Application
+## Saving configuration changes
 
-Click **Update** on a running application's card to pull the latest Docker image and redeploy. For StatelessWeb services, the update uses zero-downtime deployment so traffic is not interrupted.
+Open an application and go to **Configuration**. The two buttons do different things, and the difference is the whole point:
 
-## Stopping an Application
+| Button | What happens |
+|--------|--------------|
+| **Save** | Publishes a new template version. The running stack is **not touched** — it keeps running the old version. The application then shows **Update available**, and a banner offers to deploy it. |
+| **Save & deploy** | Publishes the new version *and* upgrades the running stack to it *and* applies, as one tracked operation. |
 
-Click **Stop** to destroy all stacks for the application. The containers are removed but the application template is preserved and can be redeployed later.
+**Save** exists so you can stage a change without releasing it. If you save and walk away nothing breaks — but nothing ships either, and the running containers stay on the previous version until you deploy. That's why the banner is persistent rather than a dismissible toast.
 
-## Editing an Application
+## Upgrade & deploy
 
-Open the dropdown menu on an application card and select **Edit** to modify the template configuration. Changes take effect on the next deployment or update. The environment cannot be changed after creation.
+Whenever an application's template has a newer published version than the running stack, an **Update available** badge and an **Upgrade & deploy** button appear. Clicking it re-materialises the stack from the template's current published version and applies it — one action, tracked end to end in the task tracker.
 
-## Deleting an Application
+You'll see this after a **Save**, after someone else publishes a change to the template, and after a Mini Infra release ships a new version of a built-in template.
 
-Open the dropdown menu and select **Delete**. This permanently removes the application template. Running stacks should be stopped first.
+If the target version declares inputs marked **rotate on upgrade** — a password or key that must be freshly supplied every time — a **Supply upgrade inputs** dialog appears first and collects them. The upgrade won't proceed until every such field is filled.
+
+## Discarding pending changes
+
+A stack in **Pending** status has edits to its definition that were never applied. To throw them away, click **Discard pending changes** on the card and confirm. The definition is restored from the last applied snapshot and the status returns to **Synced**.
+
+This only touches the definition — no containers are stopped or recreated, and it is instant. An application that has never been deployed has no snapshot to fall back to, so there is nothing to discard.
+
+## Updating the image
+
+Click **Update** to pull the latest image for the current tag and redeploy. For **StatelessWeb** services the update runs blue-green, so traffic is never interrupted. For **Stateful** services the container is stopped and recreated, so there is a short gap.
+
+Update picks up a new image build under the same tag. It is not the same as **Upgrade & deploy**, which adopts a new *template version*.
+
+## Stop, Remove, and Delete
+
+These were once conflated under a single "Stop". They are now distinct, and picking the wrong one is the difference between a five-second restart and losing your data.
+
+| Action | Where | Containers | Volumes | Stack | Template |
+|--------|-------|------------|---------|-------|----------|
+| **Stop** | Card / stack detail | Stopped and removed | **Kept** | **Kept** (status → Undeployed) | Kept |
+| **Remove deployment** | `⋯` menu | Removed | **Destroyed** | **Destroyed** | Kept |
+| **Delete application** | `⋯` menu | — | — | — | **Deleted** |
+
+- **Stop** is the reversible one. It stops the containers but keeps the stack definition and its volumes, so **Deploy** brings it straight back with its data intact. Use this to park an application.
+- **Remove deployment** tears the deployment down: containers, networks, volumes, and the stack record all go, along with the Cloudflare tunnel hostname and its DNS record if it had one. The application (the template) survives, so you can deploy a fresh one — but **the data in its volumes is gone**. For an adopted application this reads **Disconnect & remove**.
+- **Delete application** removes the template itself. Remove the deployment first; an application whose stack still has containers won't delete.
+
+## Editing metadata
+
+**Edit** in the `⋯` menu changes the application's name and description. Configuration changes belong on the Configuration page.
+
+## What to watch out for
+
+- **A Drifted or Needs attention application may mean it is down.** A background monitor watches Docker events, so a container that crashes an hour after a clean deploy flips the stack to **Drifted** on its own — you don't have to open the plan to find out. Hover the **Needs attention** badge: it names the service and says whether it's missing, not running, or no longer matches what was applied.
+- **Save does not deploy.** See the table above.
+- **The environment is permanent.** To move an application, recreate it in the target environment.
+- **StatelessWeb needs HAProxy.** A StatelessWeb service can't route without a running HAProxy stack.

--- a/client/src/user-docs/applications/host-stacks.md
+++ b/client/src/user-docs/applications/host-stacks.md
@@ -1,117 +1,154 @@
 ---
-title: Host Infrastructure Stacks
-description: How to manage host-level infrastructure stacks with plan and apply semantics in Mini Infra.
+title: Stacks
+description: How to find, review, apply, upgrade, stop, and remove stacks — the plan/apply unit behind every application and infrastructure service in Mini Infra.
 tags:
   - stacks
   - docker
   - infrastructure
   - configuration
+  - drift
 ---
 
-# Host Infrastructure Stacks
+# Stacks
 
-The **Host** page lets you manage infrastructure stacks that run at the host level, outside of any environment. Stacks use a declarative model with plan/apply semantics — you define your desired container state, review a plan of changes, and apply it.
+A **stack** is a collection of Docker containers and their supporting infrastructure — networks, volumes, config files — managed as a single unit with **plan/apply** semantics. You declare the desired state, review a plan of what would change, and apply it.
 
-## What is a stack?
-
-A stack is a collection of Docker containers and their supporting infrastructure (networks, volumes, configuration files) defined as a single unit. Each stack has **services** — individual containers with their image, environment variables, port mappings, and other Docker settings.
+Every deployed thing in Mini Infra is a stack. An [application](/help/applications/application-management) is a stack built from a user template; HAProxy, monitoring, Vault, and NATS are stacks built from system templates. The Stacks page is where you see all of them at once.
 
 Stacks support two service types:
 
-- **Stateful** — standard stop/start replacement, suited for databases and infrastructure services
-- **StatelessWeb** — zero-downtime blue-green deployment via HAProxy, suited for web applications
+- **Stateful** — stop/start replacement. Databases and infrastructure services.
+- **StatelessWeb** — zero-downtime blue-green release via HAProxy. Web apps and APIs.
 
-## Viewing stacks
+## The Stacks page
 
-Navigate to **Host** in the sidebar under **Applications**. The page displays a **Stacks** card listing all host-level stacks. Each stack shows:
+**Stacks** in the sidebar lists every stack across both scopes — host-level infrastructure and environment-scoped applications alike. The table shows:
 
-| Field | Description |
-|-------|-------------|
-| **Name** | The stack's unique identifier |
-| **Status** | Current sync state (see below) |
-| **Latest Version** | The most recent version of the stack definition |
-| **Running Version** | The version currently deployed (shown in orange if it differs from latest) |
-| **Services** | Number of containers in the stack |
-| **Last Applied** | Timestamp of the most recent successful apply |
+| Column | Description |
+|--------|-------------|
+| **Name** | Links to the stack detail page. |
+| **Scope** | `Host`, or the environment the stack belongs to. |
+| **Source** | `Infrastructure` (system template), `Application` (user template), or `Manual`. |
+| **Status** | The stack's sync state — see below. |
+| **Template version** | The version the stack is running, and the latest published version if they differ. |
+| **Attention** | A **Needs attention** badge when something is unresolved. Hover it for the reasons. |
+| **Last applied** | When the stack was last successfully applied. |
 
-Click the **Refresh** button in the card header to re-fetch the stacks list.
+Filter by search, scope, source, and status, or flip on **Needs attention** to show only the stacks asking for a human. The list updates live — you do not need to refresh it to see a stack change state.
 
 ## Stack status values
 
-| Status | Color | Meaning |
-|--------|-------|---------|
-| **Synced** | Green | Running containers match the stack definition |
-| **Drifted** | Orange | Running containers differ from the desired state |
-| **Pending** | Yellow | Definition has been updated but changes have not been applied |
-| **Error** | Red | The last apply operation failed |
-| **Undeployed** | Gray | Stack has never been deployed |
+| Status | Colour | Meaning |
+|--------|--------|---------|
+| **Synced** | Green | Running containers match the last applied definition. Nothing to do. |
+| **Drifted** | Orange | Live containers no longer match the definition. **Run Apply to reconcile.** |
+| **Pending** | Yellow | The definition changed but hasn't been applied. Run Apply to deploy it, or discard the changes. |
+| **Error** | Red | The last apply failed. Check the failure reason and retry. |
+| **Undeployed** | Grey | The containers don't exist — never deployed, or stopped. Deploy or Apply to create them. |
+
+Every badge in the UI carries a tooltip saying what the status means and what to do next.
+
+### Drifted does not always mean "someone edited it"
+
+**Drifted is also how a crash shows up.** A background monitor watches Docker events and sweeps the fleet every 60 seconds, so a stack whose container dies an hour after a clean deploy flips from **Synced** to **Drifted** on its own. Drift is no longer only noticed when a human opens the plan view.
+
+So a Drifted stack means one of:
+
+- A service **crashed or was stopped** — the app is down.
+- A service's container **is missing** entirely.
+- A container was **replaced or edited out of band** — it's running, but it isn't what Mini Infra applied.
+
+You don't have to guess which. The **Needs attention** badge names the service and the specific problem.
+
+## Needs attention
+
+**Needs attention** rolls every unresolved signal for a stack — failed applies, dead containers, drift, unapplied edits, NATS drift, and available upgrades — into one badge with a plain-language reason list. Hover it to see them.
+
+It has four levels:
+
+| Level | Meaning | Examples |
+|-------|---------|----------|
+| **Critical** | The app is down, or an apply failed. | `Service 'api' is not running (exited) — run Apply to restart it.` `Service 'web' has no container — run Apply to recreate it.` `Last apply failed: …` |
+| **Warning** | Something diverged, but the app is still up. | Out-of-band container replacement, unapplied definition edits, NATS drift. |
+| **Info** | An opportunity, not a problem. | A newer template version is available. |
+| **None** | Nothing to do — no badge is shown. |
+
+The distinction that matters: `status` is a coarse lifecycle field, and a crashed container lands there as **Drifted**, which badly undersells "your app is down". The attention level says so directly, and names the service.
 
 ## Reviewing a plan
 
-Click a stack to expand it and view the **plan** — a comparison between the desired state and the current running containers. The plan header shows the stack name, version, and when it was last computed. Click **Refresh Plan** to recompute.
+Open a stack to see its **plan** — a comparison between the desired definition and the containers actually running. Click **Refresh Plan** to recompute it.
 
 ### Action summary
 
-At the top of the plan, colored badges summarize the operations:
+Coloured badges summarise the operations:
 
-- **Create** (green) — containers that will be created
-- **Recreate** (orange) — containers that will be stopped, removed, and rebuilt
-- **Remove** (red) — containers that will be deleted
-- **Unchanged** (gray) — containers with no differences
+- **Create** (green) — containers that will be created.
+- **Recreate** (orange) — containers that will be stopped, removed, and rebuilt.
+- **Remove** (red) — containers that will be deleted.
+- **Unchanged** (grey) — containers with no differences.
 
 ### Service details
 
-Each service in the plan shows:
-
-- **Service name** and the planned **action**
-- **Image change** — old and new image tags when an update is detected (e.g. `telegraf:1.32 → telegraf:1.33`)
-- **Action reason** — a short explanation such as "image tag changed" or "environment variable updated"
-- **Diff view** — click **Show Diff** to see field-by-field changes. Removed values appear in red, new values in green.
+Each service shows its planned action, any image change (e.g. `telegraf:1.32 → telegraf:1.33`), a short reason ("image tag changed", "environment variable updated"), and a **Show Diff** toggle for a field-by-field view — removed values in red, new values in green.
 
 ## Applying changes
 
-Once you've reviewed the plan, you can apply it:
+- **Apply All** — applies every planned change in dependency order.
+- **Apply Selected** — tick individual services and apply only those.
 
-- **Apply All** — applies every planned change in the correct order
-- **Apply Selected** — check individual services and apply only those (available when services with changes are visible)
+During apply, a progress view shows each service's result: success or failure, the action performed, its duration, and error details if it failed. Progress also streams into the task tracker in the header, so you can navigate away without losing it. When it finishes, click **View Updated Plan** to confirm the stack is **Synced**.
 
-### Apply progress
+## Discarding pending changes
 
-During apply, a progress view shows each service's result:
+A **Pending** stack has definition edits that were never applied. **Discard pending changes** restores the definition from the last applied snapshot and returns the stack to **Synced**.
 
-- A green check or red X indicating success or failure
-- The action performed (create, recreate, remove)
-- Duration of the operation
-- Error details if a service failed
+It touches only the definition — no containers are stopped or recreated, and it completes instantly. A stack that has never been applied has no snapshot to fall back to, so there is nothing to discard.
 
-After apply completes, click **View Updated Plan** to refresh and confirm the stack is now **Synced**.
+## Upgrade & deploy
+
+When a stack's template has a newer published version than the one the stack is running, an **Update available** badge appears alongside an **Upgrade & deploy** button. Clicking it re-materialises the stack from the template's current published version and applies it, as a single tracked operation.
+
+If the target version declares **rotate on upgrade** inputs, a **Supply upgrade inputs** dialog collects fresh values first — the upgrade won't proceed without them.
+
+## Stop, Remove, and Delete
+
+These are three different operations with three different blast radii.
+
+| Action | Containers | Volumes | Stack record | Reversible? |
+|--------|------------|---------|--------------|-------------|
+| **Stop** | Stopped and removed | **Kept** | **Kept** (status → Undeployed) | Yes — Deploy brings it back with its data. |
+| **Remove** / **Uninstall** | Removed | **Destroyed** | **Destroyed** | No — the data is gone. |
+| **Delete** | Must already be gone | — | Removed from the database | No. |
+
+- **Stop** keeps the definition and the volumes. This is the one you want for "turn it off for now".
+- **Remove** (labelled **Uninstall** on the stack detail page, **Remove deployment** on an application card) destroys containers, networks, volumes, and the stack record — and cleans up the Cloudflare tunnel hostname and its DNS record, so a torn-down stack stops leaving a hostname pointing at nothing.
+- **Delete** only removes the database record. Mini Infra verifies no labelled containers are still running first, so a partially-failed teardown can't silently orphan them.
 
 ## Service configuration fields
 
-When stacks are created or edited, each service supports these settings:
-
 | Field | Description |
 |-------|-------------|
-| **Service Name** | Unique name within the stack |
-| **Service Type** | `Stateful` or `StatelessWeb` |
-| **Docker Image** | Image name (e.g. `prom/prometheus`) |
-| **Docker Tag** | Image tag (e.g. `v3.3.0`) |
-| **Environment Variables** | Key-value pairs passed to the container |
-| **Ports** | Host-to-container port mappings |
-| **Mounts** | Volume and bind mount definitions |
-| **Command / Entrypoint** | Override the container's default command |
-| **Restart Policy** | Container restart behavior |
-| **Health Check** | Command, interval, and timeout for health monitoring |
-| **Config Files** | Files written to volumes before the container starts |
-| **Init Commands** | Shell commands for volume preparation (mkdir, chown, etc.) |
-| **Depends On** | Services that must start before this one |
-| **Order** | Numeric deployment order (lower values deploy first) |
+| **Service Name** | Unique within the stack. |
+| **Service Type** | `Stateful` or `StatelessWeb`. |
+| **Docker Image** / **Tag** | e.g. `prom/prometheus` / `v3.3.0`. |
+| **Environment Variables** | Key-value pairs passed to the container. |
+| **Ports** | Host-to-container port mappings. |
+| **Mounts** | Volume and bind mount definitions. |
+| **Command / Entrypoint** | Override the container's default command. |
+| **Restart Policy** | Container restart behaviour. |
+| **Health Check** | Command, interval, timeout, retries, start period. Durations are **milliseconds**; `retries` is a count. |
+| **Config Files** | Files written to volumes before the container starts. |
+| **Init Commands** | Shell commands for volume preparation (mkdir, chown, …). |
+| **Depends On** | Services that must start first. |
+| **Order** | Numeric deployment order — lower deploys first. |
 
-For **StatelessWeb** services, additional routing fields configure HAProxy integration: hostname, listening port, SSL settings, certificate, load balancing algorithm, and optional Cloudflare DNS management.
+**StatelessWeb** services add routing fields for HAProxy: hostname, listening port, SSL settings, certificate, load balancing algorithm, and optional Cloudflare DNS management.
 
 ## What to watch out for
 
-- The monitoring stack (Telegraf, Prometheus, Loki, Alloy) is deployed as a host-level stack — removing it will stop container metrics and log collection across the application.
-- **Apply** operations stop and remove containers before recreating them. For **Stateful** services, there will be brief downtime during the recreate.
-- If a service fails during apply, other services that depend on it may also fail. Check the error details and resolve the issue before re-applying.
-- Stacks with **StatelessWeb** services require a running HAProxy stack for traffic routing.
+- **The monitoring stack** (Telegraf, Prometheus, Loki, Alloy) is a host-level stack — removing it stops metrics and log collection across Mini Infra.
+- **Apply recreates containers.** For **Stateful** services there is brief downtime during the recreate. **StatelessWeb** services go blue-green and stay up.
+- **A failed service can cascade.** Services that depend on it may fail too. Fix the root error and re-apply.
+- **StatelessWeb requires a running HAProxy stack** to route traffic.
+- **After upgrading Mini Infra, stacks with health checks may report Drifted once.** Health check durations were canonicalised to milliseconds, which changes the definition hash of every service that has one. A single Apply reconciles it — and is worth doing, because the running containers genuinely have the wrong health check timings until they're recreated.

--- a/client/src/user-docs/applications/stack-templates.md
+++ b/client/src/user-docs/applications/stack-templates.md
@@ -1,75 +1,115 @@
 ---
 title: Stack Templates
-description: How to create and manage reusable stack templates for deploying infrastructure in Mini Infra
+description: How to create, version, publish, roll back, and install reusable stack templates in Mini Infra.
 tags:
   - stack-templates
   - infrastructure
   - docker
   - configuration
+  - versioning
 ---
 
 # Stack Templates
 
-Stack templates are reusable blueprints for deploying multi-service infrastructure stacks. They define services, parameters, networks, and volumes in a structured format similar to Docker Compose.
+A **stack template** is a reusable blueprint for a stack: services, parameters, inputs, networks, and volumes, in a structured format similar to Docker Compose. Installing a template creates a [stack](/help/applications/host-stacks); publishing a new version of the template offers every stack built from it an **Upgrade & deploy**.
 
-## Viewing Templates
+Applications are templates too — an [application](/help/applications/application-management) is a user-source template with a friendlier editor in front of it. This page describes the raw template surface.
 
-The Stack Templates page lists all templates with filtering options:
+## Viewing templates
 
-- **Source** --- System (built-in) or User (custom).
-- **Scope** --- Host (host-level infrastructure) or Environment (per-environment).
-- **Include archived** --- Toggle to show or hide archived templates.
+The Stack Templates page lists all templates. Each row shows its source, scope, current published version, and **Used by** — how many stacks were built from it. That count is the one to check before you change anything: publishing a new version puts an **Update available** badge on every one of those stacks.
 
-## Creating a Template
+Filter by:
 
-Click **Create Template** to open the creation dialog. Provide a name and basic metadata, then use the template editor to define services and configuration.
+- **Source** — **System** (built-in, ships with Mini Infra) or **User** (yours).
+- **Scope** — **Host** (host-level infrastructure) or **Environment** (per-environment).
+- **Include archived** — show or hide archived templates.
 
-## Template Editor
+### System templates are read-only
 
-The editor page has a main editing area and a version sidebar:
+System templates — HAProxy, monitoring, Vault, NATS, Postgres, Cloudflare Tunnel — are managed by Mini Infra and updated with each release. The detail page renders them explicitly read-only: no draft, no publish, no rollback. When a release ships a new version of one, the stacks using it show **Update available** and you adopt it with **Upgrade & deploy**.
+
+## Creating a template
+
+Click **Create Template**, give it a name and basic metadata, then define its services and configuration in the editor.
+
+## The template editor
+
+The editor has a main editing area and a **version sidebar**.
 
 ### Services
 
-Define one or more Docker services, each with:
+One or more Docker services, each with an image and tag, container configuration, init commands, dependencies, and routing rules.
 
-- Docker image and tag.
-- Container configuration.
-- Initialization commands.
-- Dependencies between services.
-- Routing rules.
+> **Health check durations are milliseconds.** `interval`, `timeout`, and `startPeriod` are milliseconds; `retries` is a plain count. If you are porting a template that was authored in seconds, multiply by 1000. See `docs/user/stack-definition-reference.md` and `docs/API-CHANGELOG.md` in the repository.
 
 ### Parameters
 
-Define template parameters that act as input variables when the template is instantiated. Each parameter has a name and default value. Parameters allow the same template to be deployed with different configurations.
+Input variables supplied when the template is installed — each with a name, type, description, and default. Parameters let one template serve many configurations.
 
-### Networks and Volumes
+### Inputs
 
-Configure Docker networks and persistent volumes that the template's services use.
+Values the operator must supply, held encrypted at rest and never returned by the API — passwords, API tokens, keys.
 
-### Cross-Stack Prerequisites
+An input can be marked **rotate on upgrade**. When it is, every upgrade to a version declaring it must supply a *fresh* value: Mini Infra opens a **Supply upgrade inputs** dialog and refuses the upgrade until the field is filled. Use it for credentials that must not be carried across versions.
 
-Templates can declare other stacks (or system conditions) that must be in place before this stack can be applied. Two kinds:
+### Networks and volumes
 
-- **Stack prerequisite** --- a stack from a named template must exist with a minimum status (e.g. `synced`). The match scope can be `host`, `environment`, or `same-environment` (the same env as the applying stack).
-- **Predicate prerequisite** --- a built-in named check, e.g. `vault-bootstrapped` (true when Vault has been bootstrapped and the operator passphrase is unlocked).
+Docker networks and persistent volumes the template's services use.
+
+### Cross-stack prerequisites
+
+Templates can declare conditions that must hold before a stack can be applied. Two kinds:
+
+- **Stack prerequisite** — a stack from a named template must exist with a minimum status (e.g. `synced`). The match scope can be `host`, `environment`, or `same-environment` (the same environment as the applying stack).
+- **Predicate prerequisite** — a built-in named check, e.g. `vault-bootstrapped` (true when Vault has been bootstrapped and the operator passphrase is unlocked).
 
 Behaviour:
 
-- **Instantiating a template is allowed even if prerequisites aren't met** --- the dialog shows a soft-warn so you can stage stacks ahead of time.
-- **Applying a stack is blocked** until every prerequisite passes. The stack detail page renders a banner explaining each unmet requirement, with deep-link CTAs to fix it (deploy a missing stack, apply a pending one, bootstrap Vault, etc.).
+- **Installing is allowed even if prerequisites aren't met** — the dialog soft-warns, so you can stage stacks ahead of time.
+- **Applying is blocked** until every prerequisite passes. The stack detail page renders a banner explaining each unmet requirement, with deep-link CTAs to fix it (deploy a missing stack, apply a pending one, bootstrap Vault).
 
 ## Versioning
 
-Templates use a draft-and-publish workflow:
+Templates use a draft-and-publish workflow. Published versions are immutable; the draft is the only mutable thing.
 
-1. **Create Draft** --- Start editing from the current published version.
-2. **Edit** --- Changes are saved automatically as you work.
-3. **Publish Draft** --- Finalize the draft as a new version with optional release notes.
-4. **Discard Draft** --- Abandon the draft and return to the last published version.
+1. **Create Draft** — starts an editable draft from the current published version. The sidebar shows it tagged `editing`.
+2. **Edit** — changes save to the draft as you work. Nothing you do here affects a running stack.
+3. **Publish Draft** — finalises the draft as a new immutable version, with optional release notes.
+4. **Discard Draft** — abandons the draft and returns to the last published version.
 
-The version sidebar shows the full version history. You can select any version to view it in read-only mode.
+The version sidebar lists the full history. The current published version is tagged `current`. Select any version to view it read-only, or **Create Draft from v*N*** to start editing from an older one.
 
-## Template Scopes
+### Reviewing the diff before you publish
 
-- **Host** --- Templates scoped to the host level, used for infrastructure stacks (HAProxy, monitoring, etc.).
-- **Environment** --- Templates scoped to a specific environment, used for application stacks.
+The publish dialog shows a **diff of the draft against the current published version** before you commit — services added, services removed, and field-level changes on each changed service, plus template-level configuration changes. Read it. It is the last cheap moment to catch an accidental change, because publishing immediately flags every stack using this template as having an update available.
+
+You can also diff any two versions from the detail page by selecting a version — it compares against the previous one.
+
+### Rolling back
+
+Select an older published version in the sidebar and click **Make current**. That version becomes the template's current published version.
+
+Rollback does not touch any running stack. It changes what "current" means, so stacks running a *newer* version will now show as having an update available pointing *back* at the older one. To actually revert a stack, roll the template back and then **Upgrade & deploy** the stack.
+
+## Installing a template
+
+Click **Install** on a template with a published version. The dialog collects:
+
+- **Name** (optional) — defaults to the template's name.
+- **Environment** — required for environment-scoped templates. Only environments whose network type matches the template are offered.
+- **Parameters** — pre-filled with their defaults; override any of them.
+- **Inputs** — required values, masked if the input is marked sensitive.
+
+**Install** creates the stack and takes you to its detail page. It does **not** apply it — the stack lands **Undeployed**, so you can review its plan first, then Apply. If the template's prerequisites aren't met yet you'll get a soft warning, but the install still succeeds; the Apply is what's gated.
+
+## Archiving and deleting
+
+**Archive** hides a template from the default list without destroying it — the right move for a template you've stopped using but whose stacks may still exist. Unarchive from the same menu.
+
+**Delete** removes it permanently. Templates still in use by a stack can't be deleted — archive them instead.
+
+## Template scopes
+
+- **Host** — host-level infrastructure stacks (HAProxy, monitoring, and friends).
+- **Environment** — application stacks that live inside a named environment.

--- a/client/src/user-docs/docs-questions.yaml
+++ b/client/src/user-docs/docs-questions.yaml
@@ -36,31 +36,147 @@
 - q: How do I deploy an application?
   ref: applications/application-management#deploying-an-application
 - q: How do I update a running application?
-  ref: applications/application-management#updating-an-application
-- q: How do I stop an application?
-  ref: applications/application-management#stopping-an-application
+  ref: applications/application-management#updating-the-image
 - q: What is the difference between Stateful and StatelessWeb?
   ref: applications/application-management#service-configuration
 - q: How do I configure routing for an application?
   ref: applications/application-management#routing-statelessweb-only
 - q: How do I set up SSL for an application?
   ref: applications/application-management#routing-statelessweb-only
+- q: What is an application, really?
+  ref: applications/application-management
+- q: Is an application the same thing as a stack?
+  ref: applications/application-management
+
+# Applications — saving and deploying config changes
+- q: I saved my configuration change but nothing happened. Why?
+  ref: applications/application-management#saving-configuration-changes
+- q: What is the difference between Save and Save & deploy?
+  ref: applications/application-management#saving-configuration-changes
+- q: How do I change an application's configuration and roll it out?
+  ref: applications/application-management#saving-configuration-changes
+- q: Why does my application say Update available after I saved it?
+  ref: applications/application-management#saving-configuration-changes
+- q: How do I change an application's environment?
+  ref: applications/application-management#what-to-watch-out-for
+
+# Applications — lifecycle
+- q: What is the difference between Stop and Remove?
+  ref: applications/application-management#stop-remove-and-delete
+- q: How do I stop an application?
+  ref: applications/application-management#stop-remove-and-delete
+- q: Does stopping an application delete my data?
+  ref: applications/application-management#stop-remove-and-delete
+- q: How do I delete an application?
+  ref: applications/application-management#stop-remove-and-delete
+- q: What is the difference between Stop, Remove, and Delete?
+  ref: applications/application-management#stop-remove-and-delete
+- q: How do I turn an application off temporarily without losing its data?
+  ref: applications/application-management#stop-remove-and-delete
+- q: Will removing a deployment destroy my volumes?
+  ref: applications/application-management#stop-remove-and-delete
+
+# Stacks
+- q: What is a stack?
+  ref: applications/host-stacks
 - q: What is a host stack?
   ref: applications/host-stacks
+- q: Where do I see all my stacks?
+  ref: applications/host-stacks#the-stacks-page
+- q: How do I find stacks that need attention?
+  ref: applications/host-stacks#the-stacks-page
 - q: How does plan and apply work?
   ref: applications/host-stacks#reviewing-a-plan
 - q: How do I apply stack changes?
   ref: applications/host-stacks#applying-changes
-- q: What do the stack status values mean?
-  ref: applications/host-stacks#stack-status-values
+- q: How do I deploy only some services in a stack?
+  ref: applications/host-stacks#applying-changes
 - q: How do I deploy the monitoring stack?
   ref: applications/host-stacks
+
+# Stacks — status and drift
+- q: What do the stack status values mean?
+  ref: applications/host-stacks#stack-status-values
+- q: What does drifted mean?
+  ref: applications/host-stacks#drifted-does-not-always-mean-someone-edited-it
+- q: Why is my stack drifted when I did not change anything?
+  ref: applications/host-stacks#drifted-does-not-always-mean-someone-edited-it
+- q: My stack says drifted — is my app down?
+  ref: applications/host-stacks#drifted-does-not-always-mean-someone-edited-it
+- q: What does pending mean on a stack?
+  ref: applications/host-stacks#stack-status-values
+- q: What does undeployed mean?
+  ref: applications/host-stacks#stack-status-values
+- q: What does Needs attention mean?
+  ref: applications/host-stacks#needs-attention
+- q: What do the needs-attention levels mean?
+  ref: applications/host-stacks#needs-attention
+- q: What is the difference between critical and warning attention levels?
+  ref: applications/host-stacks#needs-attention
+- q: How do I find out which service crashed?
+  ref: applications/host-stacks#needs-attention
+- q: Why did my stack go from synced to drifted on its own?
+  ref: applications/host-stacks#drifted-does-not-always-mean-someone-edited-it
+
+# Stacks — upgrading and undoing
+- q: How do I upgrade a stack?
+  ref: applications/host-stacks#upgrade--deploy
+- q: What does Upgrade & deploy do?
+  ref: applications/host-stacks#upgrade--deploy
+- q: What does the Update available badge mean?
+  ref: applications/host-stacks#upgrade--deploy
+- q: How do I move a stack to the latest template version?
+  ref: applications/host-stacks#upgrade--deploy
+- q: Why is the upgrade asking me for a password or key?
+  ref: applications/host-stacks#upgrade--deploy
+- q: How do I undo unapplied changes?
+  ref: applications/host-stacks#discarding-pending-changes
+- q: How do I discard pending changes on a stack?
+  ref: applications/host-stacks#discarding-pending-changes
+- q: How do I revert a stack to its last applied state?
+  ref: applications/host-stacks#discarding-pending-changes
+- q: How do I stop a stack?
+  ref: applications/host-stacks#stop-remove-and-delete
+- q: What is the difference between Stop, Remove, and Delete on a stack?
+  ref: applications/host-stacks#stop-remove-and-delete
+- q: Why are all my stacks drifted after upgrading Mini Infra?
+  ref: applications/host-stacks#what-to-watch-out-for
+
+# Stack templates
 - q: What is a stack template?
   ref: applications/stack-templates
 - q: How do I create a stack template?
   ref: applications/stack-templates#creating-a-template
 - q: How does template versioning work?
   ref: applications/stack-templates#versioning
+- q: How do I publish a template draft?
+  ref: applications/stack-templates#versioning
+- q: How do I discard a template draft?
+  ref: applications/stack-templates#versioning
+- q: How do I see what changed between two template versions?
+  ref: applications/stack-templates#reviewing-the-diff-before-you-publish
+- q: How do I roll back a template to an older version?
+  ref: applications/stack-templates#rolling-back
+- q: What does Make current do?
+  ref: applications/stack-templates#rolling-back
+- q: How do I install a stack template?
+  ref: applications/stack-templates#installing-a-template
+- q: How do I create a stack from a template?
+  ref: applications/stack-templates#installing-a-template
+- q: Why can't I edit a system template?
+  ref: applications/stack-templates#system-templates-are-read-only
+- q: How many stacks use this template?
+  ref: applications/stack-templates#viewing-templates
+- q: How do I archive a stack template?
+  ref: applications/stack-templates#archiving-and-deleting
+- q: Why can't I delete a stack template?
+  ref: applications/stack-templates#archiving-and-deleting
+- q: What are template parameters and inputs?
+  ref: applications/stack-templates#the-template-editor
+- q: What does rotate on upgrade mean?
+  ref: applications/stack-templates#inputs
+- q: What units are healthcheck intervals in?
+  ref: applications/stack-templates#services
 
 # Containers
 - q: How do I view my containers?

--- a/client/src/user-docs/docs-structure.yaml
+++ b/client/src/user-docs/docs-structure.yaml
@@ -68,31 +68,53 @@ sections:
     articles:
       - slug: application-management
         topics:
-          - Creating application templates — name, image, ports, env vars, volumes
+          - An application IS a stack built from a user-source stack template
+          - Creating applications — name, image, ports, env vars, volumes
           - Service types — Stateful vs StatelessWeb
-          - Deploying, updating, and stopping applications
+          - Save vs Save & deploy — Save publishes a template version but does NOT touch the running stack
+          - Upgrade & deploy — adopt the template's newest published version, tracked end to end
+          - Discard pending changes — throw away unapplied definition edits
+          - Update — pull a new image build under the same tag (not the same as Upgrade & deploy)
+          - Stop vs Remove deployment vs Delete application — Stop keeps volumes and definition, Remove destroys them, Delete removes the template
           - Zero-downtime updates for StatelessWeb services
           - Routing configuration — hostname, listening port, SSL, Cloudflare tunnel
-          - Application cards with status indicators
-          - Health check configuration
+          - Needs attention and Update available badges on application cards
+          - Health check configuration — durations are milliseconds, retries is a count
           - Port auto-detection from Docker images
+          - Environment is permanent once set
       - slug: host-stacks
         topics:
-          - Host-level infrastructure stacks outside environments
+          - The global Stacks page — every stack across host and environment scopes, live-updating
+          - Filtering by scope, source, status, and needs-attention
           - Plan and apply workflow — review changes before deploying
           - Stack status values — Synced, Drifted, Pending, Error, Undeployed
+          - Drifted may mean a service CRASHED — a background monitor (Docker events + 60s sweep) flips synced to drifted on its own
+          - Needs attention rollup — levels critical / warning / info / none, with reasons naming the offending service
+          - Discard pending changes — restore the last applied snapshot, touches no containers
+          - Upgrade & deploy and the Update available badge
+          - Stop vs Remove/Uninstall vs Delete — Stop keeps definition and volumes
+          - Destroying a stack cleans up its Cloudflare tunnel hostname and CNAME
           - Service diff view — image changes, environment variable changes
           - Apply all vs apply selected services
           - Monitoring stack — Telegraf, Prometheus, Loki, Alloy
           - Config files and init commands for services
           - Service dependencies and deployment order
+          - Expect one round of drift after upgrading Mini Infra (healthcheck units moved to milliseconds)
       - slug: stack-templates
         topics:
           - Reusable stack blueprints for multi-service deployments
-          - Template editor — services, parameters, networks, volumes
-          - Draft and publish versioning workflow
+          - Template editor — services, parameters, inputs, networks, volumes
+          - Draft and publish versioning workflow — Create Draft, Publish, Discard Draft
+          - Version diff before publishing — services added/removed/changed, field-level changes
+          - Rollback via "Make current" — changes what current means, does not touch running stacks
+          - Install dialog — name, environment, parameter overrides, input values; creates the stack but does NOT apply it
+          - Inputs marked rotate-on-upgrade must be freshly supplied on every upgrade
+          - Used by N stacks — publishing flags every one of them as having an update available
+          - System templates are read-only and ship with Mini Infra releases
+          - Archiving vs deleting — templates in use cannot be deleted
+          - Cross-stack prerequisites — stack and predicate; install soft-warns, apply is blocked
           - Template scopes — Host vs Environment
-          - System vs User template sources
+          - Healthcheck durations are milliseconds; retries is a count
       - slug: claude-shell
         topics:
           - Claude Shell — Tailscale-SSH-reachable developer container with Claude Code baked in

--- a/client/src/user-docs/ui-elements/manifest.json
+++ b/client/src/user-docs/ui-elements/manifest.json
@@ -1,7 +1,101 @@
 {
-  "generated": "2026-05-01",
+  "generated": "2026-07-14",
   "description": "UI element IDs (data-tour attributes) available for agent highlighting. Pass \"id\" to highlight_element and the route key to navigate_to. \"global\" elements are present on all pages.",
   "routes": {
+    "/applications": {
+      "title": "Applications",
+      "elements": [
+        {
+          "id": "addons-card",
+          "label": "Addons Card",
+          "elementType": "Card",
+          "file": "client/src/app/applications/[id]/_components/addons-card.tsx"
+        },
+        {
+          "id": "connect-card",
+          "label": "Connect Card",
+          "elementType": "Card",
+          "file": "client/src/app/applications/[id]/_components/connect-card.tsx"
+        },
+        {
+          "id": "connected-networks-card",
+          "label": "Connected Networks Card",
+          "elementType": "Card",
+          "file": "client/src/app/applications/[id]/_components/connected-networks-card.tsx"
+        },
+        {
+          "id": "applications-add-button",
+          "label": "Applications Add Button",
+          "elementType": "Button",
+          "file": "client/src/app/applications/page.tsx"
+        },
+        {
+          "id": "applications-grid",
+          "label": "Applications Grid",
+          "elementType": "div",
+          "file": "client/src/app/applications/page.tsx"
+        },
+        {
+          "id": "claude-shell-preset-tile",
+          "label": "Claude Shell Preset Tile",
+          "elementType": "Card",
+          "file": "client/src/app/applications/presets-section.tsx"
+        }
+      ]
+    },
+    "/applications/new/claude-shell": {
+      "title": "/applications/new/claude-shell",
+      "elements": [
+        {
+          "id": "claude-shell-back-button",
+          "label": "Claude Shell Back Button",
+          "elementType": "Button",
+          "file": "client/src/app/applications/new/claude-shell/page.tsx"
+        },
+        {
+          "id": "claude-shell-form",
+          "label": "Claude Shell Form",
+          "elementType": "form",
+          "file": "client/src/app/applications/new/claude-shell/page.tsx"
+        },
+        {
+          "id": "claude-shell-name-input",
+          "label": "Claude Shell Name Input",
+          "elementType": "FormItem",
+          "file": "client/src/app/applications/new/claude-shell/page.tsx"
+        },
+        {
+          "id": "claude-shell-environment-select",
+          "label": "Claude Shell Environment Select",
+          "elementType": "FormItem",
+          "file": "client/src/app/applications/new/claude-shell/page.tsx"
+        },
+        {
+          "id": "claude-shell-git-repo-input",
+          "label": "Claude Shell Git Repo Input",
+          "elementType": "FormItem",
+          "file": "client/src/app/applications/new/claude-shell/page.tsx"
+        },
+        {
+          "id": "claude-shell-deploy-key-input",
+          "label": "Claude Shell Deploy Key Input",
+          "elementType": "FormItem",
+          "file": "client/src/app/applications/new/claude-shell/page.tsx"
+        },
+        {
+          "id": "claude-shell-extra-tags-input",
+          "label": "Claude Shell Extra Tags Input",
+          "elementType": "FormItem",
+          "file": "client/src/app/applications/new/claude-shell/page.tsx"
+        },
+        {
+          "id": "claude-shell-create-button",
+          "label": "Claude Shell Create Button",
+          "elementType": "Button",
+          "file": "client/src/app/applications/new/claude-shell/page.tsx"
+        }
+      ]
+    },
     "/applications/new": {
       "title": "/applications/new",
       "elements": [
@@ -28,23 +122,6 @@
           "label": "New App Create Button",
           "elementType": "Button",
           "file": "client/src/app/applications/new/page.tsx"
-        }
-      ]
-    },
-    "/applications": {
-      "title": "Applications",
-      "elements": [
-        {
-          "id": "applications-add-button",
-          "label": "Applications Add Button",
-          "elementType": "Button",
-          "file": "client/src/app/applications/page.tsx"
-        },
-        {
-          "id": "applications-grid",
-          "label": "Applications Grid",
-          "elementType": "div",
-          "file": "client/src/app/applications/page.tsx"
         }
       ]
     },
@@ -128,6 +205,35 @@
         }
       ]
     },
+    "/connectivity-tailscale": {
+      "title": "Tailscale",
+      "elements": [
+        {
+          "id": "tailscale-settings-form",
+          "label": "Tailscale Settings Form",
+          "elementType": "form",
+          "file": "client/src/app/connectivity/tailscale/page.tsx"
+        },
+        {
+          "id": "tailscale-client-id-input",
+          "label": "Tailscale Client Id Input",
+          "elementType": "FormItem",
+          "file": "client/src/app/connectivity/tailscale/page.tsx"
+        },
+        {
+          "id": "tailscale-client-secret-input",
+          "label": "Tailscale Client Secret Input",
+          "elementType": "FormItem",
+          "file": "client/src/app/connectivity/tailscale/page.tsx"
+        },
+        {
+          "id": "tailscale-validate-button",
+          "label": "Tailscale Validate Button",
+          "elementType": "Button",
+          "file": "client/src/app/connectivity/tailscale/page.tsx"
+        }
+      ]
+    },
     "/connectivity-storage": {
       "title": "Storage",
       "elements": [
@@ -171,6 +277,24 @@
           "label": "Containers Table",
           "elementType": "div",
           "file": "client/src/app/containers/ContainerDashboard.tsx"
+        },
+        {
+          "id": "network-gc-button",
+          "label": "Network Gc Button",
+          "elementType": "Button",
+          "file": "client/src/app/containers/ManagedNetworksList.tsx"
+        },
+        {
+          "id": "networks-sub-tabs",
+          "label": "Networks Sub Tabs",
+          "elementType": "Tabs",
+          "file": "client/src/app/containers/NetworksTabContent.tsx"
+        },
+        {
+          "id": "container-networks-card",
+          "label": "Container Networks Card",
+          "elementType": "Card",
+          "file": "client/src/app/containers/[id]/_components/container-networks-card.tsx"
         },
         {
           "id": "containers-tabs",
@@ -291,6 +415,89 @@
           "label": "Tls Acme Email",
           "elementType": "div",
           "file": "client/src/app/settings/tls/page.tsx"
+        }
+      ]
+    },
+    "/stacks": {
+      "title": "Stacks",
+      "elements": [
+        {
+          "id": "stack-detail-header",
+          "label": "Stack Detail Header",
+          "elementType": "div",
+          "file": "client/src/app/stacks/[stackId]/page.tsx"
+        },
+        {
+          "id": "stack-detail-stop-button",
+          "label": "Stack Detail Stop Button",
+          "elementType": "Button",
+          "file": "client/src/app/stacks/[stackId]/page.tsx"
+        },
+        {
+          "id": "stack-detail-plan",
+          "label": "Stack Detail Plan",
+          "elementType": "div",
+          "file": "client/src/app/stacks/[stackId]/page.tsx"
+        },
+        {
+          "id": "stack-detail-history",
+          "label": "Stack Detail History",
+          "elementType": "div",
+          "file": "client/src/app/stacks/[stackId]/page.tsx"
+        },
+        {
+          "id": "stacks-page-header",
+          "label": "Stacks Page Header",
+          "elementType": "div",
+          "file": "client/src/app/stacks/page.tsx"
+        },
+        {
+          "id": "stacks-refresh-button",
+          "label": "Stacks Refresh Button",
+          "elementType": "Button",
+          "file": "client/src/app/stacks/page.tsx"
+        },
+        {
+          "id": "stacks-filters",
+          "label": "Stacks Filters",
+          "elementType": "div",
+          "file": "client/src/app/stacks/page.tsx"
+        },
+        {
+          "id": "stacks-search-input",
+          "label": "Stacks Search Input",
+          "elementType": "Input",
+          "file": "client/src/app/stacks/page.tsx"
+        },
+        {
+          "id": "stacks-scope-filter",
+          "label": "Stacks Scope Filter",
+          "elementType": "SelectTrigger",
+          "file": "client/src/app/stacks/page.tsx"
+        },
+        {
+          "id": "stacks-source-filter",
+          "label": "Stacks Source Filter",
+          "elementType": "SelectTrigger",
+          "file": "client/src/app/stacks/page.tsx"
+        },
+        {
+          "id": "stacks-status-filter",
+          "label": "Stacks Status Filter",
+          "elementType": "SelectTrigger",
+          "file": "client/src/app/stacks/page.tsx"
+        },
+        {
+          "id": "stacks-needs-attention-toggle",
+          "label": "Stacks Needs Attention Toggle",
+          "elementType": "Switch",
+          "file": "client/src/app/stacks/page.tsx"
+        },
+        {
+          "id": "stacks-table",
+          "label": "Stacks Table",
+          "elementType": "Table",
+          "file": "client/src/app/stacks/page.tsx"
         }
       ]
     },
@@ -431,6 +638,12 @@
   },
   "global": [
     {
+      "id": "connect-endpoint-shell-ssh",
+      "label": "Connect Endpoint Shell Ssh",
+      "elementType": "typeof",
+      "file": "client/src/__tests__/connect-card-claude-shell.test.tsx"
+    },
+    {
       "id": "agent-chat-fab",
       "label": "Agent Chat Fab",
       "elementType": "div",
@@ -467,6 +680,18 @@
       "file": "client/src/components/egress/egress-traffic-feed.tsx"
     },
     {
+      "id": "managed-network-reconcile-button",
+      "label": "Managed Network Reconcile Button",
+      "elementType": "Button",
+      "file": "client/src/components/networks/managed-network-detail-sheet.tsx"
+    },
+    {
+      "id": "managed-network-enforce-toggle",
+      "label": "Managed Network Enforce Toggle",
+      "elementType": "Switch",
+      "file": "client/src/components/networks/managed-network-detail-sheet.tsx"
+    },
+    {
       "id": "header-backup-health",
       "label": "Header Backup Health",
       "elementType": "Link",
@@ -489,6 +714,102 @@
       "label": "Header Connectivity",
       "elementType": "div",
       "file": "client/src/components/site-header.tsx"
+    },
+    {
+      "id": "install-template-dialog",
+      "label": "Install Template Dialog",
+      "elementType": "DialogContent",
+      "file": "client/src/components/stack-templates/instantiate-template-dialog.tsx"
+    },
+    {
+      "id": "install-template-name-input",
+      "label": "Install Template Name Input",
+      "elementType": "Input",
+      "file": "client/src/components/stack-templates/instantiate-template-dialog.tsx"
+    },
+    {
+      "id": "install-template-environment-select",
+      "label": "Install Template Environment Select",
+      "elementType": "SelectTrigger",
+      "file": "client/src/components/stack-templates/instantiate-template-dialog.tsx"
+    },
+    {
+      "id": "install-template-parameters",
+      "label": "Install Template Parameters",
+      "elementType": "div",
+      "file": "client/src/components/stack-templates/instantiate-template-dialog.tsx"
+    },
+    {
+      "id": "install-template-inputs",
+      "label": "Install Template Inputs",
+      "elementType": "div",
+      "file": "client/src/components/stack-templates/instantiate-template-dialog.tsx"
+    },
+    {
+      "id": "install-template-confirm",
+      "label": "Install Template Confirm",
+      "elementType": "Button",
+      "file": "client/src/components/stack-templates/instantiate-template-dialog.tsx"
+    },
+    {
+      "id": "template-version-diff",
+      "label": "Template Version Diff",
+      "elementType": "p",
+      "file": "client/src/components/stack-templates/template-version-diff.tsx"
+    },
+    {
+      "id": "rotate-inputs-dialog",
+      "label": "Rotate Inputs Dialog",
+      "elementType": "DialogContent",
+      "file": "client/src/components/stacks/RotateInputsDialog.tsx"
+    },
+    {
+      "id": "rotate-inputs-fields",
+      "label": "Rotate Inputs Fields",
+      "elementType": "div",
+      "file": "client/src/components/stacks/RotateInputsDialog.tsx"
+    },
+    {
+      "id": "rotate-inputs-confirm",
+      "label": "Rotate Inputs Confirm",
+      "elementType": "Button",
+      "file": "client/src/components/stacks/RotateInputsDialog.tsx"
+    },
+    {
+      "id": "stack-parameters-dialog",
+      "label": "Stack Parameters Dialog",
+      "elementType": "DialogContent",
+      "file": "client/src/components/stacks/StackParametersDialog.tsx"
+    },
+    {
+      "id": "stack-parameters-fields",
+      "label": "Stack Parameters Fields",
+      "elementType": "div",
+      "file": "client/src/components/stacks/StackParametersDialog.tsx"
+    },
+    {
+      "id": "stack-parameters-save-deploy",
+      "label": "Stack Parameters Save Deploy",
+      "elementType": "Button",
+      "file": "client/src/components/stacks/StackParametersDialog.tsx"
+    },
+    {
+      "id": "stack-update-available-badge",
+      "label": "Stack Update Available Badge",
+      "elementType": "Badge",
+      "file": "client/src/components/stacks/stack-indicators.tsx"
+    },
+    {
+      "id": "stack-needs-attention-badge",
+      "label": "Stack Needs Attention Badge",
+      "elementType": "Badge",
+      "file": "client/src/components/stacks/stack-indicators.tsx"
+    },
+    {
+      "id": "stack-upgrade-button",
+      "label": "Stack Upgrade Button",
+      "elementType": "Button",
+      "file": "client/src/components/stacks/stack-indicators.tsx"
     },
     {
       "id": "storage-provider-picker",

--- a/docs/API-CHANGELOG.md
+++ b/docs/API-CHANGELOG.md
@@ -1,0 +1,171 @@
+# API Changelog
+
+Breaking and behavioural changes to the Mini Infra REST API and to the stack/template
+definition format. Newest first.
+
+This file exists for people who talk to Mini Infra *programmatically* — API-key
+integrations, the agent sidecar, and anyone authoring stack templates via the API or
+YAML rather than through the UI. Changes that are purely visual are not recorded here;
+changes that can silently break a caller are.
+
+Release mechanics (tags, image promotion) live in [`RELEASING.md`](../RELEASING.md).
+
+---
+
+## Unreleased — Stacks & Applications overhaul (P0–P3)
+
+### Breaking: healthcheck durations are milliseconds
+
+`services[].containerConfig.healthcheck` durations are now **milliseconds**, everywhere:
+
+| Field | Unit |
+|-------|------|
+| `interval` | milliseconds |
+| `timeout` | milliseconds |
+| `startPeriod` | milliseconds |
+| `retries` | a **count** — never scaled |
+
+A 30-second interval is `30000`, not `30`.
+
+**Why it changed.** The field had four writers using two conventions and five readers
+using three, and nothing pinned the unit. The authoring UIs stored milliseconds, but the
+container-create paths multiplied by `1e9` as though the value were seconds — so a
+UI-authored 30-second interval was sent to Docker as 30,000 *seconds* (about 8.3 hours),
+and the healthcheck effectively never ran. Meanwhile the built-in templates stored
+seconds, so a template's `startPeriod: 30` arrived as 30 ms. Milliseconds is now
+canonical, declared on `StackContainerConfig` in `@mini-infra/types`, and the conversion
+to Docker's nanoseconds happens in exactly one place.
+
+**What you must do.** If you author templates through the API or as YAML/JSON **in
+seconds, multiply by 1000**. Definitions you write from now on must already be in
+milliseconds — nothing converts new input for you.
+
+**What happens to values already stored.** An idempotent boot-time backfill converts
+existing rows: `StackService.containerConfig`, `StackTemplateService.containerConfig`,
+and `Stack.lastAppliedSnapshot`. Stored values are not self-describing (a `30` could be a
+template's 30 seconds or a UI author's 30 ms), so the backfill **discriminates on
+magnitude: values below 1000 are treated as seconds and multiplied by 1000.** The two
+real-world populations sit far apart and a sub-second healthcheck interval is
+pathological, so the ambiguous band is empty for any realistic configuration. `retries` is
+a count and is never touched.
+
+### Operational: expect one round of drift on first boot after upgrading
+
+**This is the important one for operators.**
+
+A stack's definition hash covers `containerConfig`, and `containerConfig` includes the
+healthcheck. Converting the units therefore **changes the hash of every service that has a
+healthcheck**. On the first boot after upgrading:
+
+- Stacks with healthchecks will report **`drifted`**.
+- Each needs **one Apply** to reconcile.
+
+This is expected, and it is desirable — not a cosmetic hash churn to be suppressed. The
+running containers genuinely have the wrong healthcheck timings (a UI-authored 30-second
+interval was being handed to Docker as roughly 8.3 hours), and the only way to fix a
+container's healthcheck is to recreate it. The drift is Mini Infra telling you the truth:
+these containers need replacing to get the fix.
+
+Plan for it. If you have many stacks with healthchecks, they will all light up at once.
+
+### Breaking: `GET /api/stacks` no longer implies `source=system` on scoped queries
+
+Source filtering is now **explicit only**. A scoped query — `?scope=host` or
+`?environmentId=<id>` — returns stacks of **all sources** unless you also pass `source`.
+
+Previously a scoped query implicitly filtered to system-source stacks, which surprised
+callers who expected a scope filter to filter by scope and nothing else.
+
+```
+GET /api/stacks?scope=host                  # was: system stacks only.  now: ALL sources.
+GET /api/stacks?scope=host&source=system    # the old behaviour, explicitly.
+```
+
+**What you must do.** If you relied on the old implicit behaviour, **add `source=system`**.
+Accepted values are `system`, `user`, and (unfiltered) omission.
+
+### Breaking: `StackStatus` no longer includes `removed`; `Stack.removedAt` is gone
+
+Neither was ever written. Destroy hard-deletes the row; stop writes `undeployed`. Every
+`removedAt IS NULL` filter was always-true and every `status != 'removed'` guard was a
+no-op, so removing them changes no behaviour — but the enum member and the column are gone
+from the API and the schema.
+
+**What you must do.** Stop matching on `status === 'removed'`, and stop reading
+`removedAt`. A stack that no longer exists is absent from the API, not tombstoned.
+
+Note that `'removed'` **is** still a live, actively-written status on HAProxy
+frontends/backends/routes, DNS records, and deployments. Those are a different enum that
+happens to share the literal and are unaffected.
+
+### New response fields on `serializeStack()`
+
+Every endpoint returning a stack now also returns:
+
+**`needsAttention`** — the server-computed "does this stack need a human?" rollup. Folds
+status, live runtime issues, NATS drift, and template-update-available into one signal, so
+an API consumer no longer has to reimplement it (and in practice go without).
+
+```jsonc
+"needsAttention": {
+  "level": "critical",          // "none" | "info" | "warning" | "critical"
+  "needsAttention": true,
+  "reasons": [                  // human-readable, phrased as "what's wrong → what to do"
+    "Service 'api' is not running (exited) — run Apply to restart it."
+  ],
+  "updateAvailable": false
+}
+```
+
+| Level | Meaning |
+|-------|---------|
+| `critical` | The app is down — a service is not running or has no container — or the last apply failed. |
+| `warning` | Something diverged but the app is still up: out-of-band replacement, unapplied edits, NATS drift. |
+| `info` | An opportunity, not a problem: a newer template version is available. |
+| `none` | Nothing to do. |
+
+**`runtimeIssues`** — what the background status monitor last found wrong with the stack's
+live containers, naming the offending service. Empty or absent means the last check was
+clean.
+
+```jsonc
+"runtimeIssues": [
+  { "kind": "not-running", "serviceName": "api", "status": "exited" }
+  // kind: "missing" | "not-running" | "hash-mismatch"
+]
+```
+
+Use these rather than inferring health from `status` alone. `status` is a coarse lifecycle
+field: a crashed container lands there as `drifted`, which badly undersells "your app is
+down".
+
+### Behavioural: `drifted` is now detected in the background
+
+A stack whose service crashes now flips `synced` → `drifted` on its own, driven by Docker
+`die`/`destroy`/`stop`/`start` events plus a 60-second sweep as a backstop. Previously
+drift was persisted only when a human opened the plan view, so a stack could sit at
+`synced` with zero running containers.
+
+**What this means for a poller.** A stack's `status` can now change without any API call
+from you. If you cache stack status, subscribe to the `stack:status` Socket.IO event
+rather than assuming status only changes in response to your own writes.
+
+Transitions are deliberately narrow — only `synced` ↔ `drifted`. The monitor never touches
+`error`, `pending`, or `undeployed`, which are states a human action owns.
+
+### New endpoints
+
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /api/stacks/:id/stop` | Stop the stack's containers but **keep** its definition, DB row, and volumes. Status → `undeployed`; Deploy/Apply brings it back. Distinct from `/destroy`, which deletes the stack record and its volumes. |
+| `POST /api/stacks/:id/upgrade` | Re-materialise the stack from its template's current published version. Status → `pending`. **Does not apply** — chain `POST /:id/apply` afterwards. Returns `400 STACK_INPUT_ROTATION_REQUIRED` if the target version declares `rotateOnUpgrade` inputs and you didn't supply `inputValues`. |
+| `POST /api/stacks/:id/revert-pending` | Discard unapplied definition edits by restoring the last applied snapshot. Status → `synced`. Synchronous; touches no containers. Returns `400 STACK_NO_APPLIED_SNAPSHOT` for a never-applied stack. |
+| `POST /api/stack-templates/:id/rollback` | Make an older published version the template's current version. |
+| `POST /api/stack-templates/:id/instantiate` | Create a stack from a template's current published version, with `parameterValues` and `inputValues`. Does not apply. |
+
+### Behavioural: destroying a stack cleans up its tunnel hostname
+
+`POST /api/stacks/:id/destroy` now also removes the stack's Cloudflare tunnel hostname and
+deletes the dangling CNAME, so a torn-down stack stops leaving a hostname routing to a
+service that no longer exists. Idempotent — a "not found" is treated as success — and
+non-fatal, matching the DNS cleanup beside it.

--- a/docs/user/stack-definition-reference.md
+++ b/docs/user/stack-definition-reference.md
@@ -362,14 +362,17 @@ Runtime notes:
 | Field | Required | Meaning | Constraints |
 | --- | --- | --- | --- |
 | `test` | Yes | Docker healthcheck command array. | Array of strings. |
-| `interval` | Yes | Interval between checks. | Integer `>= 1` or exactly `{{params.some_name}}`. |
-| `timeout` | Yes | Timeout per check. | Integer `>= 1` or exactly `{{params.some_name}}`. |
-| `retries` | Yes | Failed checks before unhealthy. | Integer `>= 1` or exactly `{{params.some_name}}`. |
-| `startPeriod` | Yes | Grace period before failures count. | Integer `>= 0` or exactly `{{params.some_name}}`. |
+| `interval` | Yes | Interval between checks, in **milliseconds**. | Integer `>= 1` or exactly `{{params.some_name}}`. |
+| `timeout` | Yes | Timeout per check, in **milliseconds**. | Integer `>= 1` or exactly `{{params.some_name}}`. |
+| `retries` | Yes | Failed checks before unhealthy. A **count**, never scaled. | Integer `>= 1` or exactly `{{params.some_name}}`. |
+| `startPeriod` | Yes | Grace period before failures count, in **milliseconds**. | Integer `>= 0` or exactly `{{params.some_name}}`. |
 
 Runtime meaning:
 
-- These values are interpreted as seconds, then converted to Docker healthcheck timing.
+- **`interval`, `timeout`, and `startPeriod` are milliseconds.** Mini Infra converts them to Docker's nanoseconds in exactly one place. `retries` is a plain count and is never scaled.
+- A 30-second interval is therefore `30000`, not `30`.
+
+> **Breaking change.** These fields were previously documented and read as *seconds* by file-loaded templates, while the authoring UIs wrote *milliseconds* — the two conventions disagreed and the container-create path applied the wrong one. Milliseconds is now canonical everywhere. **If you author templates via the API or YAML in seconds, multiply by 1000.** Stored values are converted automatically by a one-off boot backfill (see `docs/API-CHANGELOG.md`), but new definitions you write must already be in milliseconds.
 
 ## `services[].containerConfig.logConfig`
 

--- a/lib/types/stacks.ts
+++ b/lib/types/stacks.ts
@@ -315,11 +315,27 @@ export interface StackContainerConfig {
    */
   networkMode?: 'bridge' | 'host';
   restartPolicy?: typeof RESTART_POLICIES[number];
+  /**
+   * Container healthcheck. **All durations are in milliseconds.**
+   *
+   * This is the canonical unit for the whole stack surface — the authoring UIs,
+   * the built-in template JSONs, the DB columns, and the deploy-wait path all
+   * agree on it. Docker's API wants nanoseconds; that conversion happens in
+   * exactly one place, `healthcheckToDocker()` in
+   * `server/src/services/stacks/healthcheck-config.ts`. Do not convert units
+   * anywhere else.
+   *
+   * `retries` is a count, not a duration.
+   */
   healthcheck?: {
     test: string[];
+    /** Milliseconds between checks. */
     interval: NumOrTemplate;
+    /** Milliseconds before a single check is considered failed. */
     timeout: NumOrTemplate;
+    /** Consecutive failures before the container is marked unhealthy. */
     retries: NumOrTemplate;
+    /** Milliseconds of boot grace before failures start counting. */
     startPeriod: NumOrTemplate;
   };
   logConfig?: {

--- a/lib/types/stacks.ts
+++ b/lib/types/stacks.ts
@@ -575,6 +575,135 @@ export interface StackInfo {
    * was edited since the last NATS apply.
    */
   natsDrift?: NatsDriftInfo | null;
+  /**
+   * What the background status monitor last found wrong with the stack's live
+   * containers. Empty/absent means the last check was clean. Distinct from
+   * `status`: `status` is the coarse lifecycle field, this is the specifics.
+   */
+  runtimeIssues?: StackRuntimeIssue[] | null;
+  /**
+   * Server-computed "does this stack need a human?" rollup. Folds status, live
+   * runtime issues, NATS drift and template-update-available into one signal so
+   * every consumer — the UI, the agent sidecar, API-key integrations — gets the
+   * same answer instead of each reimplementing it.
+   */
+  needsAttention?: StackAttention;
+}
+
+/** A specific thing the status monitor found wrong with a stack's live containers. */
+export type StackRuntimeIssue =
+  /** The service has no container at all. */
+  | { kind: 'missing'; serviceName: string }
+  /** The container exists but is not running — it crashed, or was stopped. */
+  | { kind: 'not-running'; serviceName: string; status: string }
+  /** The container is running but is not what we applied (replaced/edited out of band). */
+  | { kind: 'hash-mismatch'; serviceName: string };
+
+/**
+ * How loudly a stack is asking for a human.
+ *
+ * - `critical` — the app is down (a service is not running or has no container),
+ *   or the last apply failed.
+ * - `warning`  — something diverged but the app is still up (drift, unapplied
+ *   edits, NATS drift).
+ * - `info`     — an opportunity, not a problem (a newer template version).
+ * - `none`     — nothing to do.
+ */
+export type StackAttentionLevel = 'none' | 'info' | 'warning' | 'critical';
+
+export interface StackAttention {
+  level: StackAttentionLevel;
+  /** True when the stack has one or more unresolved conditions. */
+  needsAttention: boolean;
+  /** Human-readable reasons, each phrased as "what's wrong → what to do". */
+  reasons: string[];
+  /** True when a newer template version is available (a softer signal). */
+  updateAvailable: boolean;
+}
+
+/** The subset of a stack `computeStackAttention` reads. */
+export interface StackAttentionInput {
+  status?: StackStatus;
+  lastFailureReason?: string | null;
+  runtimeIssues?: StackRuntimeIssue[] | null;
+  natsDrift?: { drifted?: boolean } | null;
+  templateUpdateAvailable?: boolean;
+}
+
+function describeRuntimeIssue(issue: StackRuntimeIssue): string {
+  switch (issue.kind) {
+    case 'missing':
+      return `Service '${issue.serviceName}' has no container — run Apply to recreate it.`;
+    case 'not-running':
+      return `Service '${issue.serviceName}' is not running (${issue.status}) — run Apply to restart it.`;
+    case 'hash-mismatch':
+      return `Service '${issue.serviceName}' no longer matches the applied definition — run Apply to reconcile.`;
+  }
+}
+
+/**
+ * Roll every "needs attention" signal for a stack into one shape.
+ *
+ * This is the single implementation: the server calls it inside
+ * `serializeStack()` so the rollup ships on the API (an agent or API-key caller
+ * should not have to reimplement it), and the client prefers that server value,
+ * falling back to computing locally.
+ *
+ * The important honesty property: a stack whose service has died reports
+ * `critical` with the service named, not the generic drift copy. `status` alone
+ * cannot express that — it is a coarse lifecycle field, and a crashed container
+ * lands there as `drifted`, which undersells "your app is down".
+ */
+export function computeStackAttention(stack: StackAttentionInput): StackAttention {
+  const reasons: string[] = [];
+  let level: StackAttentionLevel = 'none';
+
+  const raise = (next: StackAttentionLevel) => {
+    const order: StackAttentionLevel[] = ['none', 'info', 'warning', 'critical'];
+    if (order.indexOf(next) > order.indexOf(level)) level = next;
+  };
+
+  if (stack.status === 'error') {
+    reasons.push(
+      stack.lastFailureReason
+        ? `Last apply failed: ${stack.lastFailureReason}`
+        : 'The last apply failed — retry Apply.',
+    );
+    raise('critical');
+  } else if (stack.status === 'pending') {
+    reasons.push("The definition changed but hasn't been applied — run Apply.");
+    raise('warning');
+  }
+
+  // Specific runtime findings replace the generic `drifted` copy — "api is not
+  // running" is the thing the operator actually needs to know.
+  const issues = stack.runtimeIssues ?? [];
+  for (const issue of issues) {
+    reasons.push(describeRuntimeIssue(issue));
+    // A dead or missing container means the app is down. A hash mismatch means
+    // it is up, but not running what we think it is.
+    raise(issue.kind === 'hash-mismatch' ? 'warning' : 'critical');
+  }
+
+  // Only fall back to the generic message when the monitor has no specifics —
+  // e.g. drift a human found by opening the plan, which the cheap check cannot see.
+  if (stack.status === 'drifted' && issues.length === 0) {
+    reasons.push('Live containers have drifted from the definition — run Apply to reconcile.');
+    raise('warning');
+  }
+
+  if (stack.natsDrift?.drifted) {
+    reasons.push('NATS configuration has drifted from the last applied snapshot.');
+    raise('warning');
+  }
+
+  const updateAvailable = stack.templateUpdateAvailable === true;
+  if (updateAvailable) {
+    reasons.push('A newer template version is available — Upgrade & deploy to adopt it.');
+    raise('info');
+  }
+
+  return { level, needsAttention: reasons.length > 0, reasons, updateAvailable };
 }
 
 /** Reasons why the NATS section of a stack is out of sync with its last apply. */

--- a/lib/types/stacks.ts
+++ b/lib/types/stacks.ts
@@ -5,7 +5,7 @@
 import type { NetworkDriftItem } from './docker';
 
 // Status and service type unions (mirror Prisma enums)
-export type StackStatus = 'synced' | 'drifted' | 'pending' | 'error' | 'undeployed' | 'removed';
+export type StackStatus = 'synced' | 'drifted' | 'pending' | 'error' | 'undeployed';
 export const STACK_SERVICE_TYPES = ['Stateful', 'StatelessWeb', 'AdoptedWeb', 'Pool', 'JobPool'] as const;
 export type StackServiceType = typeof STACK_SERVICE_TYPES[number];
 export type ServiceActionType = 'create' | 'recreate' | 'remove' | 'no-op';

--- a/server/prisma/migrations/20260714130000_stack_runtime_status_monitor/migration.sql
+++ b/server/prisma/migrations/20260714130000_stack_runtime_status_monitor/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "stacks" ADD COLUMN "lastAppliedHashes" JSONB;
+ALTER TABLE "stacks" ADD COLUMN "runtimeIssues" JSONB;

--- a/server/prisma/migrations/20260714140000_drop_stack_tombstone_vestiges/migration.sql
+++ b/server/prisma/migrations/20260714140000_drop_stack_tombstone_vestiges/migration.sql
@@ -1,0 +1,58 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `removedAt` on the `stacks` table. All the data in the column will be lost.
+
+*/
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_stacks" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "environmentId" TEXT,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "status" TEXT NOT NULL DEFAULT 'undeployed',
+    "lastAppliedVersion" INTEGER,
+    "lastAppliedAt" DATETIME,
+    "lastAppliedSnapshot" JSONB,
+    "lastAppliedHashes" JSONB,
+    "runtimeIssues" JSONB,
+    "builtinVersion" INTEGER,
+    "templateId" TEXT,
+    "templateVersion" INTEGER,
+    "templateVersionId" TEXT,
+    "parameters" JSONB,
+    "parameterValues" JSONB,
+    "networks" JSONB NOT NULL,
+    "volumes" JSONB NOT NULL,
+    "tlsCertificates" JSONB,
+    "dnsRecords" JSONB,
+    "tunnelIngress" JSONB,
+    "resourceOutputs" JSONB,
+    "resourceInputs" JSONB,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "vaultAppRoleId" TEXT,
+    "vaultFailClosed" BOOLEAN NOT NULL DEFAULT true,
+    "lastAppliedVaultAppRoleId" TEXT,
+    "lastAppliedNatsSnapshot" TEXT,
+    "encryptedInputValues" TEXT,
+    "lastAppliedVaultSnapshot" TEXT,
+    "lastFailureReason" TEXT,
+    CONSTRAINT "stacks_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "environments" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "stacks_templateId_fkey" FOREIGN KEY ("templateId") REFERENCES "stack_templates" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "stacks_templateVersionId_fkey" FOREIGN KEY ("templateVersionId") REFERENCES "stack_template_versions" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "stacks_vaultAppRoleId_fkey" FOREIGN KEY ("vaultAppRoleId") REFERENCES "vault_app_roles" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_stacks" ("builtinVersion", "createdAt", "description", "dnsRecords", "encryptedInputValues", "environmentId", "id", "lastAppliedAt", "lastAppliedHashes", "lastAppliedNatsSnapshot", "lastAppliedSnapshot", "lastAppliedVaultAppRoleId", "lastAppliedVaultSnapshot", "lastAppliedVersion", "lastFailureReason", "name", "networks", "parameterValues", "parameters", "resourceInputs", "resourceOutputs", "runtimeIssues", "status", "templateId", "templateVersion", "templateVersionId", "tlsCertificates", "tunnelIngress", "updatedAt", "vaultAppRoleId", "vaultFailClosed", "version", "volumes") SELECT "builtinVersion", "createdAt", "description", "dnsRecords", "encryptedInputValues", "environmentId", "id", "lastAppliedAt", "lastAppliedHashes", "lastAppliedNatsSnapshot", "lastAppliedSnapshot", "lastAppliedVaultAppRoleId", "lastAppliedVaultSnapshot", "lastAppliedVersion", "lastFailureReason", "name", "networks", "parameterValues", "parameters", "resourceInputs", "resourceOutputs", "runtimeIssues", "status", "templateId", "templateVersion", "templateVersionId", "tlsCertificates", "tunnelIngress", "updatedAt", "vaultAppRoleId", "vaultFailClosed", "version", "volumes" FROM "stacks";
+DROP TABLE "stacks";
+ALTER TABLE "new_stacks" RENAME TO "stacks";
+CREATE INDEX "stacks_environmentId_idx" ON "stacks"("environmentId");
+CREATE INDEX "stacks_status_idx" ON "stacks"("status");
+CREATE INDEX "stacks_templateId_idx" ON "stacks"("templateId");
+CREATE INDEX "stacks_templateVersionId_idx" ON "stacks"("templateVersionId");
+CREATE INDEX "stacks_vaultAppRoleId_idx" ON "stacks"("vaultAppRoleId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1067,6 +1067,22 @@ model Stack {
   lastAppliedVersion   Int?
   lastAppliedAt        DateTime?
   lastAppliedSnapshot  Json?
+  // Record<serviceName, definitionHash> — the exact `mini-infra.definition-hash`
+  // label values stamped onto the containers at the last apply. The background
+  // status monitor compares a container's live label against this map to detect
+  // out-of-band drift with one Docker call and no template re-render, which is
+  // what makes a fleet-wide sweep cheap enough to run on a timer. Comparing
+  // against a stored copy of what we stamped (rather than re-deriving the
+  // desired hash) also means the sweep cannot raise false-positive drift from a
+  // benign render difference. Null for stacks last applied before this existed —
+  // the sweep degrades to liveness-only for those until their next apply.
+  lastAppliedHashes    Json?
+  // RuntimeIssue[] — what the background status monitor last found wrong with
+  // this stack's live containers (a service that died, vanished, or no longer
+  // matches the applied definition). Persisted so `serializeStack()` can tell an
+  // API consumer *why* a stack needs attention without re-running a Docker
+  // sweep per request. Empty/null means the last check was clean.
+  runtimeIssues        Json?
   builtinVersion       Int?
   templateId           String?
   template             StackTemplate? @relation(fields: [templateId], references: [id])

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1027,7 +1027,6 @@ enum StackStatus {
   pending
   error
   undeployed
-  removed
 }
 
 enum StackServiceType {
@@ -1101,7 +1100,6 @@ model Stack {
   tunnelIngress        Json?       // Array of StackTunnelIngress
   resourceOutputs      Json?       // Array of StackResourceOutput
   resourceInputs       Json?       // Array of StackResourceInput
-  removedAt            DateTime?
   createdAt            DateTime    @default(now())
   updatedAt            DateTime    @updatedAt
 

--- a/server/src/__tests__/environment-manager.test.ts
+++ b/server/src/__tests__/environment-manager.test.ts
@@ -432,7 +432,7 @@ describe('EnvironmentManager', () => {
             },
           },
           stacks: {
-            where: { template: { source: 'system' }, status: { notIn: ['removed', 'undeployed'] } },
+            where: { template: { source: 'system' }, status: { not: 'undeployed' } },
             select: { id: true },
           },
         }
@@ -559,7 +559,7 @@ describe('EnvironmentManager', () => {
             },
           },
           stacks: {
-            where: { template: { source: 'system' }, status: { notIn: ['removed', 'undeployed'] } },
+            where: { template: { source: 'system' }, status: { not: 'undeployed' } },
             select: { id: true },
           },
         },
@@ -650,7 +650,7 @@ describe('EnvironmentManager', () => {
             },
           },
           stacks: {
-            where: { template: { source: 'system' }, status: { notIn: ['removed', 'undeployed'] } },
+            where: { template: { source: 'system' }, status: { not: 'undeployed' } },
             select: { id: true },
           },
         }

--- a/server/src/__tests__/healthcheck-unit-backfill.integration.test.ts
+++ b/server/src/__tests__/healthcheck-unit-backfill.integration.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Integration test for the healthcheck seconds → milliseconds backfill.
+ *
+ * Milliseconds is the canonical unit for `StackContainerConfig.healthcheck`,
+ * but stored rows predate that: the authoring UIs wrote ms while the built-in
+ * template JSONs wrote seconds, and every container-create path multiplied by
+ * 1e9 as though it were all seconds (so a UI-authored 30s interval became a
+ * Docker interval of ~8.3 hours and the healthcheck never ran).
+ *
+ * The backfill discriminates on magnitude — anything below 1000 is treated as a
+ * legacy seconds value — and must be idempotent, because it runs on every boot.
+ * These tests cover the three columns it walks, with the nested snapshot the
+ * one that is easy to get wrong: drift compares the running container against
+ * `lastAppliedSnapshot`, so if the snapshot kept stale seconds while the live
+ * rows moved to ms, every converted stack would immediately read as drifted.
+ */
+import { describe, it, expect } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import pino from 'pino';
+import { testPrisma } from './integration-test-helpers';
+import { backfillHealthcheckUnits } from '../services/stacks/healthcheck-unit-backfill';
+
+const logger = pino({ level: 'silent' });
+
+/** A healthcheck as the built-in templates used to store it: seconds. */
+const SECONDS_HEALTHCHECK = {
+  test: ['CMD', 'true'],
+  interval: 30,
+  timeout: 5,
+  retries: 3,
+  startPeriod: 30,
+};
+
+/** A healthcheck as the authoring UI stores it: milliseconds. */
+const MS_HEALTHCHECK = {
+  test: ['CMD', 'true'],
+  interval: 30_000,
+  timeout: 5_000,
+  retries: 3,
+  startPeriod: 30_000,
+};
+
+async function createStack(opts: {
+  serviceHealthcheck?: unknown;
+  snapshotHealthcheck?: unknown;
+}): Promise<string> {
+  const stackId = createId();
+
+  await testPrisma.stack.create({
+    data: {
+      id: stackId,
+      name: `hc-backfill-${stackId.slice(0, 6)}`,
+      networks: [],
+      volumes: [],
+      status: 'synced',
+      ...(opts.snapshotHealthcheck !== undefined
+        ? {
+            lastAppliedSnapshot: {
+              name: 'snap',
+              services: [
+                {
+                  serviceName: 'api',
+                  containerConfig: { image: 'nginx', healthcheck: opts.snapshotHealthcheck },
+                },
+              ],
+            },
+          }
+        : {}),
+    },
+  });
+
+  if (opts.serviceHealthcheck !== undefined) {
+    await testPrisma.stackService.create({
+      data: {
+        id: createId(),
+        stackId,
+        serviceName: 'api',
+        serviceType: 'Stateful',
+        dockerImage: 'nginx',
+        dockerTag: 'latest',
+        order: 0,
+        containerConfig: { healthcheck: opts.serviceHealthcheck },
+        dependsOn: [],
+      },
+    });
+  }
+
+  return stackId;
+}
+
+describe('backfillHealthcheckUnits', () => {
+  it('scales a legacy seconds stack service up to milliseconds', async () => {
+    const stackId = await createStack({ serviceHealthcheck: SECONDS_HEALTHCHECK });
+
+    await backfillHealthcheckUnits(testPrisma, logger);
+
+    const svc = await testPrisma.stackService.findFirst({ where: { stackId } });
+    const hc = (svc?.containerConfig as { healthcheck: Record<string, number> }).healthcheck;
+
+    expect(hc.interval).toBe(30_000);
+    expect(hc.timeout).toBe(5_000);
+    expect(hc.startPeriod).toBe(30_000);
+    // retries is a count, not a duration — it must survive untouched.
+    expect(hc.retries).toBe(3);
+  });
+
+  it('leaves an already-millisecond stack service alone', async () => {
+    const stackId = await createStack({ serviceHealthcheck: MS_HEALTHCHECK });
+
+    await backfillHealthcheckUnits(testPrisma, logger);
+
+    const svc = await testPrisma.stackService.findFirst({ where: { stackId } });
+    const hc = (svc?.containerConfig as { healthcheck: Record<string, number> }).healthcheck;
+
+    expect(hc).toMatchObject(MS_HEALTHCHECK);
+  });
+
+  it('converts the nested lastAppliedSnapshot in lockstep with the live rows', async () => {
+    // If the snapshot kept seconds while the service row moved to ms, drift
+    // detection would compare the two and flag every converted stack as drifted.
+    const stackId = await createStack({
+      serviceHealthcheck: SECONDS_HEALTHCHECK,
+      snapshotHealthcheck: SECONDS_HEALTHCHECK,
+    });
+
+    await backfillHealthcheckUnits(testPrisma, logger);
+
+    const stack = await testPrisma.stack.findUnique({ where: { id: stackId } });
+    const snapshot = stack?.lastAppliedSnapshot as {
+      services: Array<{ containerConfig: { healthcheck: Record<string, number> } }>;
+    };
+    const snapHc = snapshot.services[0].containerConfig.healthcheck;
+
+    const svc = await testPrisma.stackService.findFirst({ where: { stackId } });
+    const liveHc = (svc?.containerConfig as { healthcheck: Record<string, number> }).healthcheck;
+
+    expect(snapHc.interval).toBe(30_000);
+    expect(snapHc.startPeriod).toBe(30_000);
+    expect(snapHc).toEqual(liveHc);
+  });
+
+  it('preserves other containerConfig keys on the snapshot service', async () => {
+    const stackId = await createStack({ snapshotHealthcheck: SECONDS_HEALTHCHECK });
+
+    await backfillHealthcheckUnits(testPrisma, logger);
+
+    const stack = await testPrisma.stack.findUnique({ where: { id: stackId } });
+    const snapshot = stack?.lastAppliedSnapshot as {
+      services: Array<{ serviceName: string; containerConfig: Record<string, unknown> }>;
+    };
+
+    expect(snapshot.services[0].serviceName).toBe('api');
+    expect(snapshot.services[0].containerConfig.image).toBe('nginx');
+  });
+
+  it('is idempotent — it runs on every boot', async () => {
+    const stackId = await createStack({
+      serviceHealthcheck: SECONDS_HEALTHCHECK,
+      snapshotHealthcheck: SECONDS_HEALTHCHECK,
+    });
+
+    await backfillHealthcheckUnits(testPrisma, logger);
+    const second = await backfillHealthcheckUnits(testPrisma, logger);
+
+    // The second pass must find nothing left to do for this stack, and above all
+    // must not multiply the already-converted values by another 1000.
+    const svc = await testPrisma.stackService.findFirst({ where: { stackId } });
+    const hc = (svc?.containerConfig as { healthcheck: Record<string, number> }).healthcheck;
+
+    expect(hc.interval).toBe(30_000);
+    expect(hc.startPeriod).toBe(30_000);
+
+    const stack = await testPrisma.stack.findUnique({ where: { id: stackId } });
+    const snapshot = stack?.lastAppliedSnapshot as {
+      services: Array<{ containerConfig: { healthcheck: Record<string, number> } }>;
+    };
+    expect(snapshot.services[0].containerConfig.healthcheck.interval).toBe(30_000);
+
+    // Nothing this test created should have been touched on the second pass.
+    // (Other tests' rows may still be in flight, so assert on our own stack
+    // rather than on the global counters.)
+    expect(second.conversions).toBeGreaterThanOrEqual(0);
+  });
+
+  it('scales template services too', async () => {
+    const templateId = createId();
+    const versionId = createId();
+
+    await testPrisma.stackTemplate.create({
+      data: {
+        id: templateId,
+        name: `hc-tmpl-${templateId.slice(0, 6)}`,
+        displayName: 'HC Template',
+        source: 'user',
+        scope: 'host',
+      },
+    });
+    await testPrisma.stackTemplateVersion.create({
+      data: {
+        id: versionId,
+        templateId,
+        version: 1,
+        status: 'published',
+        parameters: [],
+        defaultParameterValues: {},
+        networkTypeDefaults: {},
+        networks: [],
+        volumes: [],
+      },
+    });
+    await testPrisma.stackTemplateService.create({
+      data: {
+        id: createId(),
+        versionId,
+        serviceName: 'api',
+        serviceType: 'Stateful',
+        dockerImage: 'nginx',
+        dockerTag: 'latest',
+        order: 0,
+        containerConfig: { healthcheck: SECONDS_HEALTHCHECK },
+        dependsOn: [],
+      },
+    });
+
+    await backfillHealthcheckUnits(testPrisma, logger);
+
+    const svc = await testPrisma.stackTemplateService.findFirst({ where: { versionId } });
+    const hc = (svc?.containerConfig as { healthcheck: Record<string, number> }).healthcheck;
+
+    expect(hc.interval).toBe(30_000);
+    expect(hc.timeout).toBe(5_000);
+    expect(hc.startPeriod).toBe(30_000);
+    expect(hc.retries).toBe(3);
+  });
+});

--- a/server/src/__tests__/migrations-produce-schema.test.ts
+++ b/server/src/__tests__/migrations-produce-schema.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Guard: a database built from scratch by replaying `prisma/migrations` must
+ * have every column the Prisma schema declares.
+ *
+ * This exists because of a trap that is silent on every database that already
+ * exists, and only bites fresh installs and CI.
+ *
+ * SQLite cannot add a foreign key in place, so Prisma emits a *table redefine*
+ * for those migrations: `CREATE TABLE new_<t>` with a column list snapshotted at
+ * authoring time, copy the rows, `DROP TABLE <t>`, rename. If a later-authored
+ * migration happens to sort BEFORE that redefine — which is exactly what happens
+ * when an older migration carries a hand-rounded timestamp sitting in the future
+ * — then its `ADD COLUMN`s are applied first and silently dropped when the
+ * redefine recreates the table from its stale column list.
+ *
+ * Existing databases never notice (the redefine is already applied and will not
+ * re-run), so the damage only shows up on a fresh `migrate deploy` — a new
+ * install, or CI's template database. The migration
+ * `20260714130000_stack_runtime_status_monitor` was originally generated as
+ * `...104307` and lost both of its columns exactly this way.
+ *
+ * If this test fails, the fix is almost always to rename your migration
+ * directory so it sorts AFTER the redefine that is eating it.
+ */
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import Database from "better-sqlite3";
+import {
+  listMigrationFiles,
+  buildSqliteDatabaseFromMigrations,
+} from "../test-support/sqlite-test-database";
+
+interface ParsedModel {
+  name: string;
+  table: string;
+  columns: string[];
+}
+
+/**
+ * Minimal Prisma schema parser — just enough to answer "what columns should
+ * this model have?". The generated client's DMMF is not exported by the
+ * `prisma-client` generator, so we read the schema itself.
+ */
+function parseSchema(schemaPath: string): ParsedModel[] {
+  const source = fs.readFileSync(schemaPath, "utf8");
+
+  const blocks = [...source.matchAll(/^model\s+(\w+)\s*\{([\s\S]*?)^\}/gm)].map((m) => ({
+    name: m[1],
+    body: m[2],
+  }));
+  const modelNames = new Set(blocks.map((b) => b.name));
+
+  return blocks.map(({ name, body }) => {
+    const mapMatch = body.match(/@@map\("([^"]+)"\)/);
+    const table = mapMatch ? mapMatch[1] : name;
+
+    const columns: string[] = [];
+    for (const rawLine of body.split("\n")) {
+      const line = rawLine.replace(/\/\/.*$/, "").trim();
+      if (!line || line.startsWith("@@")) continue;
+
+      const field = line.match(/^(\w+)\s+(\S+)/);
+      if (!field) continue;
+
+      const [, fieldName, rawType] = field;
+      const baseType = rawType.replace(/[?[\]]/g, "");
+
+      // Relation fields are not columns — their FK scalars are declared
+      // separately and get checked on their own.
+      if (modelNames.has(baseType)) continue;
+      // List scalars are not columns in SQLite either.
+      if (rawType.includes("[]")) continue;
+
+      const colMatch = line.match(/@map\("([^"]+)"\)/);
+      columns.push(colMatch ? colMatch[1] : fieldName);
+    }
+
+    return { name, table, columns };
+  });
+}
+
+/** Build a throwaway database by replaying every migration in order. */
+function buildFreshDatabase(): Database.Database {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mini-infra-migrations-"));
+  const dbPath = path.join(dir, "fresh.db");
+
+  buildSqliteDatabaseFromMigrations({
+    targetDbPath: dbPath,
+    fingerprintPath: path.join(dir, "fingerprint"),
+    migrationFiles: listMigrationFiles(path.join(process.cwd(), "prisma", "migrations")),
+  });
+
+  return new Database(dbPath, { readonly: true });
+}
+
+describe("migrations produce the declared schema", () => {
+  const db = buildFreshDatabase();
+  const models = parseSchema(path.join(process.cwd(), "prisma", "schema.prisma"));
+
+  it("parses the schema and replays every migration", () => {
+    expect(models.length).toBeGreaterThan(0);
+  });
+
+  it.each(models.map((m) => [m.name, m] as const))(
+    "%s has every column the schema declares",
+    (_name, model) => {
+      const rows = db
+        .prepare(`PRAGMA table_info("${model.table}")`)
+        .all() as Array<{ name: string }>;
+      const present = new Set(rows.map((r) => r.name));
+
+      expect(
+        rows.length,
+        `Table "${model.table}" does not exist after replaying all migrations.`,
+      ).toBeGreaterThan(0);
+
+      const missing = model.columns.filter((column) => !present.has(column));
+
+      expect(
+        missing,
+        `Table "${model.table}" is missing [${missing.join(", ")}] after replaying all ` +
+          `migrations. A later table-redefine migration is probably dropping them — ` +
+          `rename your migration directory so it sorts AFTER that redefine.`,
+      ).toEqual([]);
+    },
+  );
+});

--- a/server/src/__tests__/stack-templates-delete-route.integration.test.ts
+++ b/server/src/__tests__/stack-templates-delete-route.integration.test.ts
@@ -5,8 +5,8 @@
  * linked Stack records) with no teardown of the real Docker containers,
  * networks, or volumes a deployed stack owns — orphaning them with no UI
  * path left to find or clean up. The route now blocks the delete while any
- * linked stack is still deployed (not `undeployed` and not yet `removed`),
- * pointing the caller at the existing stack-destroy flow (the "Stop" button)
+ * linked stack is still deployed (i.e. not `undeployed`), pointing the
+ * caller at the existing stack-destroy flow (the "Stop" button)
  * instead of silently leaking resources.
  */
 
@@ -40,7 +40,6 @@ function buildApp() {
 
 async function createTemplateWithStack(opts: {
   stackStatus: string;
-  removedAt?: Date | null;
 }): Promise<{ templateId: string; stackId: string }> {
   const templateId = createId();
   await testPrisma.stackTemplate.create({
@@ -63,7 +62,6 @@ async function createTemplateWithStack(opts: {
       templateId,
       templateVersion: 1,
       status: opts.stackStatus as never,
-      removedAt: opts.removedAt ?? null,
     },
   });
 
@@ -84,11 +82,11 @@ describe('DELETE /api/stack-templates/:templateId — deployed-stack guard', () 
     expect(stillThere).not.toBeNull();
   });
 
-  it('allows delete once the linked stack has been destroyed (removedAt set)', async () => {
-    const { templateId, stackId } = await createTemplateWithStack({
-      stackStatus: 'synced',
-      removedAt: new Date(0),
-    });
+  it('allows delete once the linked stack has been destroyed (row hard-deleted)', async () => {
+    const { templateId, stackId } = await createTemplateWithStack({ stackStatus: 'synced' });
+    // Stack destroy hard-deletes the row — there is no soft-delete tombstone,
+    // so a destroyed stack simply leaves the template with no linked stacks.
+    await testPrisma.stack.delete({ where: { id: stackId } });
 
     const res = await supertest(buildApp()).delete(`/api/stack-templates/${templateId}`);
 

--- a/server/src/__tests__/stacks-upgrade-route.integration.test.ts
+++ b/server/src/__tests__/stacks-upgrade-route.integration.test.ts
@@ -280,6 +280,30 @@ describe("POST /api/stacks/:stackId/upgrade", () => {
       .send({});
     expect(res.status).toBe(409);
     expect(res.body.error).toBe("STACK_ALREADY_ON_LATEST");
+    expect(res.body.message).toContain("already on the latest");
+  });
+
+  it("tells a stack stranded ahead by a rollback the truth, not 'already on latest'", async () => {
+    // After a template rollback the stack can sit on a version NEWER than the
+    // template's current one. Upgrade only ever targets `currentVersion`, so it
+    // is refused — but telling a stack on v3 that it is "already on the latest
+    // version (v2)" is simply false, and hides the fact that a rollback stranded
+    // it. See P4 4.2 for the real fix (upgrade/downgrade to a chosen version).
+    const { templateId, v2Id } = await seedTemplateWithTwoVersions();
+    const stackId = await seedStackOnVersion({
+      templateId,
+      templateVersion: 3, // ahead of the template's current version (v2)
+      templateVersionId: v2Id,
+    });
+
+    const res = await supertest(buildApp())
+      .post(`/api/stacks/${stackId}/upgrade`)
+      .send({});
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("STACK_ALREADY_ON_LATEST");
+    expect(res.body.message).toContain("newer than the template's current version");
+    expect(res.body.message).toContain("rolled back");
+    expect(res.body.message).not.toContain("already on the latest");
   });
 
   it("returns 409 when an operation is already in progress", async () => {

--- a/server/src/routes/cloudflare/managed-tunnels-routes.ts
+++ b/server/src/routes/cloudflare/managed-tunnels-routes.ts
@@ -39,7 +39,7 @@ export function createManagedTunnelsRouter(
       const tunnelsMap = await cloudflareConfigService.getAllManagedTunnels();
 
       const stacks = await prisma.stack.findMany({
-        where: { name: "cloudflare-tunnel", status: { not: "removed" } },
+        where: { name: "cloudflare-tunnel" },
         select: { id: true, environmentId: true, status: true },
       });
       const stackByEnv = new Map(stacks.map((s) => [s.environmentId, s]));
@@ -75,7 +75,6 @@ export function createManagedTunnelsRouter(
         where: {
           name: "cloudflare-tunnel",
           environmentId,
-          status: { not: "removed" },
         },
         select: { id: true, status: true },
       });
@@ -154,7 +153,6 @@ export function createManagedTunnelsRouter(
         where: {
           name: "cloudflare-tunnel",
           environmentId,
-          status: { not: "removed" },
         },
         select: { id: true, status: true },
       });
@@ -224,7 +222,6 @@ export function createManagedTunnelsRouter(
         where: {
           name: "cloudflare-tunnel",
           environmentId,
-          status: { not: "removed" },
         },
         select: { id: true, status: true },
       });

--- a/server/src/routes/environments.ts
+++ b/server/src/routes/environments.ts
@@ -171,7 +171,7 @@ router.get('/:id/delete-check', requirePermission(Permission.EnvironmentsRead), 
 
     const [stacks, haproxyFrontends, haproxyBackends] = await Promise.all([
       prisma.stack.findMany({
-        where: { environmentId: id, status: { notIn: ['removed', 'undeployed'] } },
+        where: { environmentId: id, status: { not: 'undeployed' } },
         select: { id: true, name: true },
       }),
       prisma.hAProxyFrontend.findMany({
@@ -254,7 +254,7 @@ async function getHAProxyClientForEnvironment(environmentId: string): Promise<HA
   }
 
   const haproxyStack = await prisma.stack.findFirst({
-    where: { environmentId, name: 'haproxy', status: { not: 'removed' } },
+    where: { environmentId, name: 'haproxy' },
   });
 
   if (!haproxyStack) {
@@ -312,7 +312,7 @@ router.post('/:id/remediate-haproxy', requirePermission(Permission.EnvironmentsW
 
     // Check if environment has HAProxy stack
     const haproxyStack = await prisma.stack.findFirst({
-      where: { environmentId: id, name: 'haproxy', status: { not: 'removed' } },
+      where: { environmentId: id, name: 'haproxy' },
     });
     if (!haproxyStack) {
       return res.status(400).json({
@@ -367,7 +367,7 @@ router.get('/:id/haproxy-status', requirePermission(Permission.EnvironmentsRead)
 
     // Check if environment has HAProxy stack
     const haproxyStack = await prisma.stack.findFirst({
-      where: { environmentId: id, name: 'haproxy', status: { not: 'removed' } },
+      where: { environmentId: id, name: 'haproxy' },
     });
     if (!haproxyStack) {
       return res.status(200).json({
@@ -440,7 +440,7 @@ router.get('/:id/remediation-preview', requirePermission(Permission.Environments
 
     // Check if environment has HAProxy stack
     const haproxyStackCheck = await prisma.stack.findFirst({
-      where: { environmentId: id, name: 'haproxy', status: { not: 'removed' } },
+      where: { environmentId: id, name: 'haproxy' },
     });
     if (!haproxyStackCheck) {
       return res.status(400).json({

--- a/server/src/routes/haproxy-backends.ts
+++ b/server/src/routes/haproxy-backends.ts
@@ -86,7 +86,7 @@ async function getHAProxyClient(environmentId: string): Promise<HAProxyDataPlane
   }
 
   const haproxyStack = await prisma.stack.findFirst({
-    where: { environmentId, name: 'haproxy', status: { not: 'removed' } },
+    where: { environmentId, name: 'haproxy' },
   });
 
   if (!haproxyStack) {

--- a/server/src/routes/haproxy-frontends.ts
+++ b/server/src/routes/haproxy-frontends.ts
@@ -190,7 +190,7 @@ router.post(
     }
 
     const haproxyStack = await prisma.stack.findFirst({
-      where: { environmentId, name: 'haproxy', status: { not: 'removed' } },
+      where: { environmentId, name: 'haproxy' },
     });
 
     if (!haproxyStack) {

--- a/server/src/routes/manual-haproxy-frontends.ts
+++ b/server/src/routes/manual-haproxy-frontends.ts
@@ -132,7 +132,7 @@ async function getHAProxyClient(environmentId: string): Promise<{ client: HAProx
   }
 
   const haproxyStack = await prisma.stack.findFirst({
-    where: { environmentId, name: 'haproxy', status: { not: 'removed' } },
+    where: { environmentId, name: 'haproxy' },
   });
 
   if (!haproxyStack) {

--- a/server/src/routes/monitoring.ts
+++ b/server/src/routes/monitoring.ts
@@ -26,7 +26,7 @@ const LOKI_URL = inDocker ? `http://${MONITORING_PROJECT}-loki:3100` : 'http://l
 
 async function getMonitoringStack() {
   return prisma.stack.findFirst({
-    where: { name: 'monitoring', environmentId: null, status: { not: 'removed' } },
+    where: { name: 'monitoring', environmentId: null },
     include: { services: { orderBy: { order: 'asc' } } },
   });
 }

--- a/server/src/routes/stacks/stacks-crud-routes.ts
+++ b/server/src/routes/stacks/stacks-crud-routes.ts
@@ -142,7 +142,10 @@ router.get(
 
     res.json({
       success: true,
-      data: stacks.map((s, i) => ({ ...serializeStack(s), natsDrift: driftByStack[i] })),
+      // Pass natsDrift *into* serializeStack rather than spreading it on after:
+      // the needsAttention rollup folds it in, and a spread would land after the
+      // rollup had already been computed without it.
+      data: stacks.map((s, i) => serializeStack(s, { natsDrift: driftByStack[i] })),
     });
   }),
 );
@@ -219,7 +222,7 @@ router.get(
       lastAppliedNatsSnapshot: stack.lastAppliedNatsSnapshot,
     }).catch(() => null);
 
-    res.json({ success: true, data: { ...serializeStack(stack), natsDrift } });
+    res.json({ success: true, data: serializeStack(stack, { natsDrift }) });
   }),
 );
 

--- a/server/src/routes/stacks/stacks-crud-routes.ts
+++ b/server/src/routes/stacks/stacks-crud-routes.ts
@@ -268,7 +268,7 @@ router.post(
       }
 
       const existing = await prisma.stack.findFirst({
-        where: { name, environmentId, status: { not: 'removed' } },
+        where: { name, environmentId },
       });
       if (existing) {
         throw new ConflictError(
@@ -282,7 +282,7 @@ router.post(
       }
     } else {
       const existing = await prisma.stack.findFirst({
-        where: { name, environmentId: null, status: { not: 'removed' } },
+        where: { name, environmentId: null },
       });
       if (existing) {
         throw new ConflictError(

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -59,6 +59,7 @@ import {
 } from "./services/tailscale";
 import { CertificateRenewalScheduler } from "./services/tls/certificate-renewal-scheduler";
 import { PoolInstanceReaper } from "./services/stacks/pool-instance-reaper";
+import { StackStatusMonitor } from "./services/stacks/stack-status-monitor";
 import {
   NetworkGcScheduler,
   NetworkConvergenceScheduler,
@@ -125,6 +126,7 @@ let dnsCacheScheduler: DnsCacheScheduler | null = null;
 // which both startup and the settings route call to keep it aligned with the
 // current credentials. Read via `TailscaleDeviceStatusScheduler.getInstance()`.
 let poolInstanceReaper: PoolInstanceReaper | null = null;
+let stackStatusMonitor: StackStatusMonitor | null = null;
 let networkGcScheduler: NetworkGcScheduler | null = null;
 let networkConvergenceScheduler: NetworkConvergenceScheduler | null = null;
 let jobPoolExitWatcher: JobPoolExitWatcher | null = null;
@@ -388,6 +390,21 @@ const initializeServices = async () => {
     poolInstanceReaper = new PoolInstanceReaper(prisma);
     poolInstanceReaper.start();
     console.log("[STARTUP] ✓ Pool instance reaper initialized");
+
+    // P3 3.1/3.2 — background stack-status monitor. Docker `die`/`destroy`
+    // events flip a `synced` stack whose service crashed to `drifted` (the badge
+    // used to say everything was fine while the app was down), and a periodic
+    // sweep catches out-of-band drift that previously only surfaced when a human
+    // opened the plan view. The sweep also backstops the Docker event stream,
+    // which has no end/close recovery and can go silently deaf.
+    console.log("[STARTUP] Initializing stack status monitor...");
+    stackStatusMonitor = new StackStatusMonitor(
+      prisma,
+      DockerService.getInstance(),
+      getLogger("stacks", "stack-status-monitor"),
+    );
+    stackStatusMonitor.start();
+    console.log("[STARTUP] ✓ Stack status monitor initialized");
 
     // Initialize network GC scheduler (network overhaul Phase 4): a 15-minute
     // dry-run-only sweep for orphaned `mini-infra.managed=true` networks —
@@ -1026,6 +1043,12 @@ startServer()
       if (poolInstanceReaper) {
         poolInstanceReaper.stop();
         logger.info("Pool instance reaper stopped");
+      }
+
+      // Stop stack status monitor
+      if (stackStatusMonitor) {
+        stackStatusMonitor.stop();
+        logger.info("Stack status monitor stopped");
       }
 
       // Stop network GC scheduler

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -81,6 +81,7 @@ import { HAProxyService } from "./services/haproxy/haproxy-service";
 import { DockerExecutorService } from "./services/docker-executor";
 import { loadOrCreateInternalAuthSecret } from "./lib/security-config";
 import { syncBuiltinStacks } from "./services/stacks/builtin-stack-sync";
+import { backfillHealthcheckUnits } from "./services/stacks/healthcheck-unit-backfill";
 import { runBuiltinVaultReconcile, BUNDLES_DRIVE_BUILTIN } from "./services/stacks/builtin-vault-reconcile";
 import { MonitoringService } from "./services/monitoring";
 import { cleanupOrphanedSidecars, finalizeLastUpdate } from "./services/self-update";
@@ -204,6 +205,19 @@ const initializeServices = async () => {
       }
     };
     await runBackfill();
+
+    // P3 3.3 — normalise stored healthcheck durations to milliseconds, the
+    // canonical unit now declared on StackContainerConfig. Writers used to
+    // disagree (authoring UIs stored ms, built-in templates stored seconds)
+    // while every container-create path multiplied by 1e9 as though it were all
+    // seconds, so UI-authored healthchecks got ~8.3h intervals and never ran.
+    // Idempotent via a magnitude heuristic, so it is safe on every boot; runs
+    // BEFORE the built-in template sync below re-seeds the system templates.
+    try {
+      await backfillHealthcheckUnits(prisma, logger);
+    } catch (err) {
+      logger.warn({ err }, "Healthcheck unit backfill failed (non-fatal)");
+    }
 
     // Network overhaul Phase 8 — general boot convergence. Replaces the old
     // self-network-reattach.ts boot workaround (which only ever re-derived

--- a/server/src/services/egress/__tests__/egress-container-map-pusher.test.ts
+++ b/server/src/services/egress/__tests__/egress-container-map-pusher.test.ts
@@ -511,20 +511,20 @@ describe('EgressContainerMapPusher', () => {
     pusher.stop();
   });
 
-  it('excludes removed stacks from the container map query', async () => {
+  it('scopes the container map query to the environment', async () => {
     const prisma = makePrisma({
       environments: [{ id: 'env-1', name: 'staging', egressGatewayIp: '172.30.0.2' }],
-      stacks: [], // Prisma returns empty (simulates status:removed filtered out)
+      stacks: [],
     });
 
     const pusher = new EgressContainerMapPusher(prisma);
     pusher.start();
     await vi.runAllTimersAsync();
 
-    // Confirm query sent the right WHERE clause
+    // Confirm query sent the right WHERE clause. Destroyed stacks are
+    // hard-deleted, so environment scoping is the only filter needed.
     const stackFindMany = (prisma.stack.findMany as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
-    expect(stackFindMany?.where?.status).toEqual({ not: 'removed' });
-    expect(stackFindMany?.where?.removedAt).toBeNull();
+    expect(stackFindMany?.where).toEqual({ environmentId: 'env-1' });
 
     pusher.stop();
   });

--- a/server/src/services/egress/egress-container-map-pusher.ts
+++ b/server/src/services/egress/egress-container-map-pusher.ts
@@ -282,12 +282,10 @@ export class EgressContainerMapPusher {
   private async _buildContainerMap(env: EnvRow): Promise<ContainerMapEntry[]> {
     const egressNetwork = `${env.name}-egress`;
 
-    // Stacks in this environment that are not removed.
+    // Stacks in this environment.
     const stacks = await this.prisma.stack.findMany({
       where: {
         environmentId: env.id,
-        status: { not: 'removed' },
-        removedAt: null,
       },
       select: {
         id: true,

--- a/server/src/services/egress/egress-cred-refresh.ts
+++ b/server/src/services/egress/egress-cred-refresh.ts
@@ -268,7 +268,7 @@ export async function listRunningEgressAgents(prisma: PrismaClient): Promise<Run
 
   if (fwTemplate) {
     const fwStacks = await prisma.stack.findMany({
-      where: { templateId: fwTemplate.id, environmentId: null, status: { not: "removed" } },
+      where: { templateId: fwTemplate.id, environmentId: null },
       select: {
         id: true,
         name: true,
@@ -289,7 +289,7 @@ export async function listRunningEgressAgents(prisma: PrismaClient): Promise<Run
 
   if (gwTemplate) {
     const gwStacks = await prisma.stack.findMany({
-      where: { templateId: gwTemplate.id, environmentId: { not: null }, status: { not: "removed" } },
+      where: { templateId: gwTemplate.id, environmentId: { not: null } },
       select: {
         id: true,
         name: true,

--- a/server/src/services/egress/egress-self-heal-supervisor.ts
+++ b/server/src/services/egress/egress-self-heal-supervisor.ts
@@ -374,7 +374,7 @@ async function probeEgressStacks(prisma: PrismaClient): Promise<EgressStackHealt
   // Host fw-agent stack (singleton).
   if (fwTemplate) {
     const fwStack = await prisma.stack.findFirst({
-      where: { templateId: fwTemplate.id, environmentId: null, status: { not: "removed" } },
+      where: { templateId: fwTemplate.id, environmentId: null },
       select: { id: true, name: true },
     });
     if (fwStack) {
@@ -395,7 +395,6 @@ async function probeEgressStacks(prisma: PrismaClient): Promise<EgressStackHealt
     const gwStacks = await prisma.stack.findMany({
       where: {
         templateId: gwTemplate.id,
-        status: { not: "removed" },
         environmentId: { not: null },
       },
       select: { id: true, name: true, environmentId: true },

--- a/server/src/services/egress/fw-agent-stack-bootstrap.ts
+++ b/server/src/services/egress/fw-agent-stack-bootstrap.ts
@@ -85,12 +85,11 @@ export async function bootstrapFwAgentStack(
     return { stackId: null, applyDispatched: false, reason: "template not synced" };
   }
 
-  // Find an existing stack from this template at host scope. We deliberately
-  // include `removed` rows in the negation so a destroy → re-bootstrap
-  // cycle works the same way the legacy `ensureFwAgent` pattern did
-  // (where `findFwAgent` only returned non-removed containers).
+  // Find an existing stack from this template at host scope. A destroy
+  // hard-deletes the stack row, so a destroy → re-bootstrap cycle simply
+  // finds nothing here and re-instantiates the stack.
   const existing = await prisma.stack.findFirst({
-    where: { templateId: template.id, environmentId: null, status: { not: "removed" } },
+    where: { templateId: template.id, environmentId: null },
     select: { id: true },
   });
 

--- a/server/src/services/environment/environment-manager.ts
+++ b/server/src/services/environment/environment-manager.ts
@@ -242,7 +242,7 @@ export class EnvironmentManager {
               },
             },
             stacks: {
-              where: { template: { source: 'system' }, status: { notIn: ['removed', 'undeployed'] } },
+              where: { template: { source: 'system' }, status: { not: 'undeployed' } },
               select: { id: true },
             },
         }
@@ -333,7 +333,7 @@ export class EnvironmentManager {
               },
             },
             stacks: {
-              where: { template: { source: 'system' }, status: { notIn: ['removed', 'undeployed'] } },
+              where: { template: { source: 'system' }, status: { not: 'undeployed' } },
               select: { id: true },
             },
         }
@@ -370,7 +370,7 @@ export class EnvironmentManager {
               },
             },
             stacks: {
-              where: { template: { source: 'system' }, status: { notIn: ['removed', 'undeployed'] } },
+              where: { template: { source: 'system' }, status: { not: 'undeployed' } },
               select: { id: true },
             },
           },
@@ -419,7 +419,7 @@ export class EnvironmentManager {
                 },
               },
               stacks: {
-                where: { template: { source: 'system' }, status: { notIn: ['removed', 'undeployed'] } },
+                where: { template: { source: 'system' }, status: { not: 'undeployed' } },
                 select: { id: true },
               },
           }
@@ -639,9 +639,9 @@ export class EnvironmentManager {
         await this.userEventService.appendLogs(userEvent.id, `[${new Date().toISOString()}] Removed ${removedNetworkRows.count} ManagedNetwork record(s)`);
       }
 
-      // Clean up undeployed/removed stacks that reference this environment
+      // Clean up undeployed stacks that reference this environment
       const orphanedStacks = await this.prisma.stack.findMany({
-        where: { environmentId: id, status: { in: ['removed', 'undeployed'] } },
+        where: { environmentId: id, status: 'undeployed' },
         select: { id: true, name: true, status: true },
       });
       if (orphanedStacks.length > 0) {

--- a/server/src/services/haproxy/haproxy-migration-service.ts
+++ b/server/src/services/haproxy/haproxy-migration-service.ts
@@ -31,7 +31,7 @@ export class HAProxyMigrationService {
 
     // 1. Find the haproxy stack for this environment
     const haproxyStack = await prisma.stack.findFirst({
-      where: { name: 'haproxy', environmentId, status: { not: 'removed' } },
+      where: { name: 'haproxy', environmentId },
     });
 
     // 2. Look for a running HAProxy container
@@ -190,7 +190,7 @@ export class HAProxyMigrationService {
 
     // Pre-flight: verify the haproxy stack definition exists BEFORE any destructive action
     const haproxyStack = await prisma.stack.findFirst({
-      where: { name: 'haproxy', environmentId, status: { not: 'removed' } },
+      where: { name: 'haproxy', environmentId },
     });
     if (!haproxyStack) {
       const msg = 'HAProxy stack definition not found for this environment. Run server restart to sync built-in stacks.';

--- a/server/src/services/haproxy/health-check-timeout.ts
+++ b/server/src/services/haproxy/health-check-timeout.ts
@@ -10,10 +10,17 @@
  * from `healthcheck.startPeriod` (the app's declared boot grace) so
  * slow-booting services can extend it.
  *
- * Unit note: `healthcheck.startPeriod` is stored in **milliseconds** by the
- * application authoring UI (it multiplies the user's seconds input by 1000 —
- * see `client/src/app/applications/new/page.tsx`), which is the surface every
- * StatelessWeb/AdoptedWeb service is created through.
+ * Unit note: `healthcheck.startPeriod` is **milliseconds** — the canonical unit
+ * declared on `StackContainerConfig` in `lib/types/stacks.ts` and shared by
+ * every authoring surface, the built-in templates, and the DB columns.
+ *
+ * This used to say the ms assumption held because the application authoring UI
+ * was "the surface every StatelessWeb/AdoptedWeb service is created through".
+ * That premise was false — this function is also reached by template-authored
+ * services, which stored seconds, so a template's `startPeriod: 30` resolved to
+ * 30 ms, fell under the 90s floor below, and silently clamped to the default.
+ * The slow-boot extension was inert for every template-authored service. The
+ * unit is now pinned at the type, so the assumption holds by declaration.
  *
  * We never shorten below the historical 90s default and cap at 10 minutes:
  * the timeout is an *upper bound* on the wait, not a fixed delay — a healthy

--- a/server/src/services/networks/membership-backfill.ts
+++ b/server/src/services/networks/membership-backfill.ts
@@ -121,8 +121,7 @@ export async function backfillNetworkMemberships(
   // available"). Seed the row here from the producing stack's declared outputs
   // so the self-heal works for already-applied infra without a re-apply.
   const producingStacks = await prisma.stack.findMany({
-    where: { removedAt: null },
-    select: { id: true, resourceOutputs: true },
+        select: { id: true, resourceOutputs: true },
   });
   const resourceOutputsByStackId = new Map<string, StackResourceOutput[]>(
     producingStacks.map((s) => [s.id, (s.resourceOutputs as unknown as StackResourceOutput[]) ?? []]),
@@ -211,8 +210,7 @@ export async function backfillNetworkMemberships(
   // 2. Stack-owned networks + per-service memberships, from every
   // non-removed stack's *current* definition.
   const stacks = await prisma.stack.findMany({
-    where: { removedAt: null },
-    include: {
+        include: {
       services: true,
       environment: { select: { name: true } },
       template: { select: { source: true, createdById: true } },

--- a/server/src/services/networks/network-reconciler.ts
+++ b/server/src/services/networks/network-reconciler.ts
@@ -680,7 +680,7 @@ export async function reconcileAll(deps: NetworkReconcilerDeps): Promise<Network
   const ranAt = new Date().toISOString();
 
   const [stacks, environments, hostNetworks] = await Promise.all([
-    prisma.stack.findMany({ where: { removedAt: null }, select: { id: true } }),
+    prisma.stack.findMany({ select: { id: true } }),
     prisma.environment.findMany({ select: { id: true } }),
     prisma.managedNetwork.findMany({ where: { scope: 'host' } }),
   ]);

--- a/server/src/services/stacks/__tests__/healthcheck-config.test.ts
+++ b/server/src/services/stacks/__tests__/healthcheck-config.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import {
+  healthcheckToDocker,
+  normaliseHealthcheckToMs,
+  MS_HEURISTIC_THRESHOLD,
+} from "../healthcheck-config";
+import { resolveHealthCheckTimeoutMs } from "../../haproxy/health-check-timeout";
+
+/**
+ * These pin the unit contract for `StackContainerConfig.healthcheck`:
+ * milliseconds in, nanoseconds out, converted in exactly one place.
+ *
+ * Each block below corresponds to a bug that shipped because nothing tested
+ * this seam. Keep them.
+ */
+describe("healthcheckToDocker", () => {
+  it("converts millisecond durations to nanoseconds", () => {
+    const docker = healthcheckToDocker({
+      test: ["CMD", "true"],
+      interval: 30_000,
+      timeout: 5_000,
+      retries: 3,
+      startPeriod: 15_000,
+    });
+
+    expect(docker).toEqual({
+      Test: ["CMD", "true"],
+      Interval: 30_000_000_000, // 30s
+      Timeout: 5_000_000_000, //  5s
+      Retries: 3,
+      StartPeriod: 15_000_000_000, // 15s
+    });
+  });
+
+  it("does not scale retries — it is a count, not a duration", () => {
+    const docker = healthcheckToDocker({
+      test: ["CMD", "true"],
+      interval: 10_000,
+      timeout: 3_000,
+      retries: 5,
+      startPeriod: 10_000,
+    });
+
+    expect(docker?.Retries).toBe(5);
+  });
+
+  it("keeps a 30s interval at 30s — the *1e9 bug made it ~8.3 hours", () => {
+    // The regression: a UI-authored app stores interval 30000 (ms). The old
+    // container-create paths multiplied by 1e9 as though it were seconds,
+    // producing 30_000 seconds of Docker interval, so the healthcheck never ran
+    // and the container sat `health: starting` forever.
+    const docker = healthcheckToDocker({
+      test: ["CMD", "true"],
+      interval: 30_000,
+      timeout: 5_000,
+      retries: 3,
+      startPeriod: 30_000,
+    });
+
+    const intervalSeconds = (docker?.Interval ?? 0) / 1_000_000_000;
+    expect(intervalSeconds).toBe(30);
+    expect(intervalSeconds).toBeLessThan(60); // not 30_000s (~8.3h)
+  });
+
+  it("returns undefined when no healthcheck is declared", () => {
+    expect(healthcheckToDocker(undefined)).toBeUndefined();
+  });
+
+  it("narrows already-resolved template references", () => {
+    // The template engine resolves "{{params.x}}" to a number before this runs,
+    // but the type is NumOrTemplate so the value arrives as unknown-ish.
+    const docker = healthcheckToDocker({
+      test: ["CMD", "true"],
+      interval: "20000" as unknown as number,
+      timeout: "4000" as unknown as number,
+      retries: "2" as unknown as number,
+      startPeriod: "8000" as unknown as number,
+    });
+
+    expect(docker?.Interval).toBe(20_000_000_000);
+    expect(docker?.Retries).toBe(2);
+  });
+});
+
+describe("normaliseHealthcheckToMs (legacy seconds backfill)", () => {
+  it("scales sub-threshold values as seconds", () => {
+    const result = normaliseHealthcheckToMs({
+      test: ["CMD", "true"],
+      interval: 30,
+      timeout: 5,
+      retries: 3,
+      startPeriod: 30,
+    });
+
+    expect(result?.healthcheck).toMatchObject({
+      interval: 30_000,
+      timeout: 5_000,
+      startPeriod: 30_000,
+    });
+  });
+
+  it("never scales retries, even though it is below the threshold", () => {
+    const result = normaliseHealthcheckToMs({
+      test: ["CMD", "true"],
+      interval: 30,
+      timeout: 5,
+      retries: 3, // a count — must survive untouched
+      startPeriod: 30,
+    });
+
+    expect(result?.healthcheck.retries).toBe(3);
+    expect(result?.conversions.map((c) => c.key)).toEqual([
+      "interval",
+      "timeout",
+      "startPeriod",
+    ]);
+  });
+
+  it("returns null when everything is already milliseconds", () => {
+    expect(
+      normaliseHealthcheckToMs({
+        test: ["CMD", "true"],
+        interval: 30_000,
+        timeout: 5_000,
+        retries: 3,
+        startPeriod: 30_000,
+      }),
+    ).toBeNull();
+  });
+
+  it("is idempotent — the backfill runs on every boot", () => {
+    const first = normaliseHealthcheckToMs({
+      test: ["CMD", "true"],
+      interval: 30,
+      timeout: 5,
+      retries: 3,
+      startPeriod: 30,
+    });
+    expect(first).not.toBeNull();
+
+    // Re-running over the already-converted value must be a no-op, otherwise
+    // every boot would multiply the interval by another 1000.
+    const second = normaliseHealthcheckToMs(first!.healthcheck);
+    expect(second).toBeNull();
+  });
+
+  it("leaves unrendered template expressions alone", () => {
+    const result = normaliseHealthcheckToMs({
+      test: ["CMD", "true"],
+      interval: "{{params.interval}}",
+      timeout: 5,
+      retries: 3,
+      startPeriod: "{{params.boot}}",
+    });
+
+    expect(result?.healthcheck.interval).toBe("{{params.interval}}");
+    expect(result?.healthcheck.startPeriod).toBe("{{params.boot}}");
+    expect(result?.healthcheck.timeout).toBe(5_000);
+  });
+
+  it("treats the threshold as already-ms", () => {
+    expect(
+      normaliseHealthcheckToMs({
+        test: ["CMD", "true"],
+        interval: MS_HEURISTIC_THRESHOLD,
+        timeout: MS_HEURISTIC_THRESHOLD,
+        retries: 3,
+        startPeriod: MS_HEURISTIC_THRESHOLD,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveHealthCheckTimeoutMs consumes the same unit", () => {
+  it("lets a slow-booting service extend past the 90s default", () => {
+    // A template-authored startPeriod of 30 (seconds) used to reach this as
+    // 30ms, fall under the floor, and clamp to the default — the slow-boot
+    // extension was silently inert for every template-authored service. In ms
+    // it now does what it says.
+    expect(resolveHealthCheckTimeoutMs(180_000)).toBe(180_000);
+  });
+
+  it("still floors short values at the 90s default", () => {
+    expect(resolveHealthCheckTimeoutMs(30_000)).toBe(90_000);
+  });
+});

--- a/server/src/services/stacks/__tests__/stack-attention.test.ts
+++ b/server/src/services/stacks/__tests__/stack-attention.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { computeStackAttention } from "@mini-infra/types";
+
+/**
+ * The needs-attention rollup is the honest signal: `status` is a coarse
+ * lifecycle field, and a crashed container lands there as `drifted`, which
+ * badly undersells "your app is down". These pin the level mapping.
+ *
+ * It lives in @mini-infra/types so the server (inside serializeStack) and the
+ * client share ONE implementation — the client used to reimplement it, which is
+ * why the agent sidecar and API-key callers had no rollup at all.
+ */
+describe("computeStackAttention", () => {
+  it("is quiet for a healthy synced stack", () => {
+    const attention = computeStackAttention({ status: "synced" });
+
+    expect(attention).toEqual({
+      level: "none",
+      needsAttention: false,
+      reasons: [],
+      updateAvailable: false,
+    });
+  });
+
+  it("reports a dead service as CRITICAL and names it", () => {
+    // The whole point of 3.1: the badge used to say `synced` while the app was
+    // down. A dead container is not merely "drifted" — it is an outage.
+    const attention = computeStackAttention({
+      status: "drifted",
+      runtimeIssues: [{ kind: "not-running", serviceName: "api", status: "exited" }],
+    });
+
+    expect(attention.level).toBe("critical");
+    expect(attention.needsAttention).toBe(true);
+    expect(attention.reasons).toEqual([
+      "Service 'api' is not running (exited) — run Apply to restart it.",
+    ]);
+  });
+
+  it("reports a missing container as CRITICAL", () => {
+    const attention = computeStackAttention({
+      status: "drifted",
+      runtimeIssues: [{ kind: "missing", serviceName: "worker" }],
+    });
+
+    expect(attention.level).toBe("critical");
+    expect(attention.reasons[0]).toContain("has no container");
+  });
+
+  it("reports an out-of-band replacement as WARNING — the app is up, just not ours", () => {
+    const attention = computeStackAttention({
+      status: "drifted",
+      runtimeIssues: [{ kind: "hash-mismatch", serviceName: "api" }],
+    });
+
+    expect(attention.level).toBe("warning");
+    expect(attention.reasons[0]).toContain("no longer matches the applied definition");
+  });
+
+  it("falls back to generic drift copy only when the monitor has no specifics", () => {
+    // Drift a human found by opening the plan (template edit, network drift) —
+    // the cheap runtime check cannot see it, so there are no runtimeIssues.
+    const attention = computeStackAttention({ status: "drifted" });
+
+    expect(attention.level).toBe("warning");
+    expect(attention.reasons).toEqual([
+      "Live containers have drifted from the definition — run Apply to reconcile.",
+    ]);
+  });
+
+  it("does not emit the generic drift copy alongside specific issues", () => {
+    const attention = computeStackAttention({
+      status: "drifted",
+      runtimeIssues: [{ kind: "not-running", serviceName: "api", status: "exited" }],
+    });
+
+    expect(attention.reasons).toHaveLength(1);
+    expect(attention.reasons.join(" ")).not.toContain("Live containers have drifted");
+  });
+
+  it("reports a failed apply as CRITICAL with the failure reason", () => {
+    const attention = computeStackAttention({
+      status: "error",
+      lastFailureReason: "image pull failed: unauthorized",
+    });
+
+    expect(attention.level).toBe("critical");
+    expect(attention.reasons[0]).toBe("Last apply failed: image pull failed: unauthorized");
+  });
+
+  it("reports unapplied edits as WARNING", () => {
+    const attention = computeStackAttention({ status: "pending" });
+
+    expect(attention.level).toBe("warning");
+    expect(attention.reasons[0]).toContain("hasn't been applied");
+  });
+
+  it("reports an available template update as INFO — an opportunity, not a problem", () => {
+    const attention = computeStackAttention({
+      status: "synced",
+      templateUpdateAvailable: true,
+    });
+
+    expect(attention.level).toBe("info");
+    expect(attention.updateAvailable).toBe(true);
+    expect(attention.needsAttention).toBe(true);
+  });
+
+  it("folds NATS drift in as WARNING, orthogonal to status", () => {
+    const attention = computeStackAttention({
+      status: "synced",
+      natsDrift: { drifted: true },
+    });
+
+    expect(attention.level).toBe("warning");
+    expect(attention.reasons[0]).toContain("NATS configuration has drifted");
+  });
+
+  it("takes the loudest level when several signals fire at once", () => {
+    const attention = computeStackAttention({
+      status: "drifted",
+      runtimeIssues: [{ kind: "not-running", serviceName: "api", status: "exited" }],
+      natsDrift: { drifted: true },
+      templateUpdateAvailable: true,
+    });
+
+    // critical (dead service) must win over warning (nats) and info (update).
+    expect(attention.level).toBe("critical");
+    expect(attention.reasons).toHaveLength(3);
+    expect(attention.updateAvailable).toBe(true);
+  });
+});

--- a/server/src/services/stacks/__tests__/stack-runtime-check.test.ts
+++ b/server/src/services/stacks/__tests__/stack-runtime-check.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import type { DockerContainerInfo } from "@mini-infra/types";
+import {
+  checkStackRuntime,
+  groupContainersByStack,
+  describeRuntimeIssues,
+  STACK_ID_LABEL,
+  SERVICE_LABEL,
+  DEFINITION_HASH_LABEL,
+} from "../stack-runtime-check";
+
+function container(opts: {
+  stackId?: string;
+  service?: string;
+  hash?: string;
+  status?: string;
+  name?: string;
+}): DockerContainerInfo {
+  const labels: Record<string, string> = {};
+  if (opts.stackId) labels[STACK_ID_LABEL] = opts.stackId;
+  if (opts.service) labels[SERVICE_LABEL] = opts.service;
+  if (opts.hash) labels[DEFINITION_HASH_LABEL] = opts.hash;
+
+  return {
+    id: `c-${opts.service ?? "x"}-${opts.status ?? "running"}`,
+    name: opts.name ?? `stk-${opts.service}`,
+    status: (opts.status ?? "running") as DockerContainerInfo["status"],
+    image: "nginx",
+    imageTag: "latest",
+    ports: [],
+    volumes: [],
+    createdAt: new Date(0),
+    labels,
+  };
+}
+
+const HASHES = { api: "sha256:aaa", worker: "sha256:bbb" };
+
+describe("checkStackRuntime", () => {
+  it("is healthy when every service runs with the hash we applied", () => {
+    const check = checkStackRuntime({ id: "s1", lastAppliedHashes: HASHES }, [
+      container({ stackId: "s1", service: "api", hash: "sha256:aaa" }),
+      container({ stackId: "s1", service: "worker", hash: "sha256:bbb" }),
+    ]);
+
+    expect(check).toEqual({ healthy: true, issues: [] });
+  });
+
+  it("flags a service that started then crashed — the whole point of 3.1", () => {
+    // This is the case that left the stack `synced` with a dead app: the apply
+    // path only watches for ~5s after start, so a later crash was invisible.
+    const check = checkStackRuntime({ id: "s1", lastAppliedHashes: HASHES }, [
+      container({ stackId: "s1", service: "api", hash: "sha256:aaa", status: "exited" }),
+      container({ stackId: "s1", service: "worker", hash: "sha256:bbb" }),
+    ]);
+
+    expect(check?.healthy).toBe(false);
+    expect(check?.issues).toEqual([{ kind: "not-running", serviceName: "api", status: "exited" }]);
+  });
+
+  it("flags a service whose container is gone entirely", () => {
+    const check = checkStackRuntime({ id: "s1", lastAppliedHashes: HASHES }, [
+      container({ stackId: "s1", service: "api", hash: "sha256:aaa" }),
+    ]);
+
+    expect(check?.healthy).toBe(false);
+    expect(check?.issues).toEqual([{ kind: "missing", serviceName: "worker" }]);
+  });
+
+  it("flags a container replaced out of band — the whole point of 3.2", () => {
+    const check = checkStackRuntime({ id: "s1", lastAppliedHashes: HASHES }, [
+      container({ stackId: "s1", service: "api", hash: "sha256:SOMETHING-ELSE" }),
+      container({ stackId: "s1", service: "worker", hash: "sha256:bbb" }),
+    ]);
+
+    expect(check?.healthy).toBe(false);
+    expect(check?.issues).toEqual([{ kind: "hash-mismatch", serviceName: "api" }]);
+  });
+
+  it("returns no opinion when the stack has no stored hashes", () => {
+    // Applied before the column existed. We have nothing trustworthy to diff
+    // against, so the monitor must leave the status alone rather than assume
+    // health (or, worse, assume drift and mark the whole fleet).
+    expect(checkStackRuntime({ id: "s1", lastAppliedHashes: null }, [])).toBeNull();
+    expect(checkStackRuntime({ id: "s1", lastAppliedHashes: {} }, [])).toBeNull();
+    expect(checkStackRuntime({ id: "s1", lastAppliedHashes: "nonsense" }, [])).toBeNull();
+  });
+
+  it("prefers the running container when a blue-green deploy leaves two", () => {
+    // Mid-deploy a service can have a draining blue and a live green. Picking
+    // the stopped one would report a healthy stack as dead.
+    const check = checkStackRuntime({ id: "s1", lastAppliedHashes: { api: "sha256:aaa" } }, [
+      container({ stackId: "s1", service: "api", hash: "sha256:aaa", status: "exited", name: "blue" }),
+      container({ stackId: "s1", service: "api", hash: "sha256:aaa", status: "running", name: "green" }),
+    ]);
+
+    expect(check?.healthy).toBe(true);
+  });
+
+  it("ignores a container with no definition-hash label rather than crying drift", () => {
+    // Prefer false negatives: the full plan remains the authority.
+    const check = checkStackRuntime({ id: "s1", lastAppliedHashes: { api: "sha256:aaa" } }, [
+      container({ stackId: "s1", service: "api" }),
+    ]);
+
+    expect(check?.healthy).toBe(true);
+  });
+});
+
+describe("groupContainersByStack", () => {
+  it("groups by the stack-id label and drops unmanaged containers", () => {
+    const grouped = groupContainersByStack([
+      container({ stackId: "s1", service: "api" }),
+      container({ stackId: "s1", service: "worker" }),
+      container({ stackId: "s2", service: "db" }),
+      container({ service: "some-random-container" }), // unmanaged — no stack label
+    ]);
+
+    expect(grouped.get("s1")).toHaveLength(2);
+    expect(grouped.get("s2")).toHaveLength(1);
+    expect(grouped.size).toBe(2);
+  });
+});
+
+describe("describeRuntimeIssues", () => {
+  it("reads as an operator-facing sentence", () => {
+    expect(
+      describeRuntimeIssues([
+        { kind: "not-running", serviceName: "api", status: "exited" },
+        { kind: "missing", serviceName: "worker" },
+        { kind: "hash-mismatch", serviceName: "cache" },
+      ]),
+    ).toBe(
+      "service 'api' is exited; service 'worker' has no container; " +
+        "service 'cache' does not match the applied definition",
+    );
+  });
+});

--- a/server/src/services/stacks/__tests__/stack-status-monitor.test.ts
+++ b/server/src/services/stacks/__tests__/stack-status-monitor.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import pino from "pino";
+import type { DockerContainerInfo } from "@mini-infra/types";
+import { StackStatusMonitor } from "../stack-status-monitor";
+import { stackOperationLock } from "../operation-lock";
+import { STACK_ID_LABEL, SERVICE_LABEL, DEFINITION_HASH_LABEL } from "../stack-runtime-check";
+
+const emitStackStatusChanged = vi.hoisted(() => vi.fn());
+vi.mock("../stack-socket-emitter", () => ({ emitStackStatusChanged }));
+
+const log = pino({ level: "silent" });
+
+function container(service: string, hash: string, status = "running"): DockerContainerInfo {
+  return {
+    id: `c-${service}`,
+    name: `stk-${service}`,
+    status: status as DockerContainerInfo["status"],
+    image: "nginx",
+    imageTag: "latest",
+    ports: [],
+    volumes: [],
+    createdAt: new Date(0),
+    labels: {
+      [STACK_ID_LABEL]: "s1",
+      [SERVICE_LABEL]: service,
+      [DEFINITION_HASH_LABEL]: hash,
+    },
+  };
+}
+
+/** A stack row as the monitor selects it. */
+function stackRow(status: string) {
+  return {
+    id: "s1",
+    name: "my-app",
+    status,
+    lastAppliedHashes: { api: "sha256:aaa" },
+  };
+}
+
+function buildHarness(opts: { stack: ReturnType<typeof stackRow>; containers: DockerContainerInfo[] }) {
+  const update = vi.fn().mockResolvedValue({});
+  const prisma = {
+    stack: {
+      findMany: vi.fn().mockResolvedValue([opts.stack]),
+      findUnique: vi.fn().mockResolvedValue({ ...opts.stack, runtimeIssues: null }),
+      update,
+    },
+  };
+  const docker = {
+    isConnected: () => true,
+    listContainers: vi.fn().mockResolvedValue(opts.containers),
+    onContainerEvent: vi.fn(),
+  };
+
+  const monitor = new StackStatusMonitor(
+    prisma as unknown as ConstructorParameters<typeof StackStatusMonitor>[0],
+    docker as unknown as ConstructorParameters<typeof StackStatusMonitor>[1],
+    log,
+  );
+  return { monitor, update, prisma, docker };
+}
+
+describe("StackStatusMonitor", () => {
+  beforeEach(() => {
+    emitStackStatusChanged.mockClear();
+    stackOperationLock.release("s1");
+  });
+
+  afterEach(() => {
+    stackOperationLock.release("s1");
+  });
+
+  it("flips synced -> drifted when a service has died", async () => {
+    const { monitor, update } = buildHarness({
+      stack: stackRow("synced"),
+      containers: [container("api", "sha256:aaa", "exited")],
+    });
+
+    await monitor.sweep();
+
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "s1" },
+        data: expect.objectContaining({ status: "drifted" }),
+      }),
+    );
+    expect(emitStackStatusChanged).toHaveBeenCalledWith("s1", "drifted");
+  });
+
+  it("flips drifted -> synced when the service comes back on its own", async () => {
+    // Docker restart policies bring crashed containers back. The monitor must be
+    // symmetric or a transient crash would pin the stack at `drifted` forever.
+    const { monitor, update } = buildHarness({
+      stack: stackRow("drifted"),
+      containers: [container("api", "sha256:aaa", "running")],
+    });
+
+    await monitor.sweep();
+
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: "synced" }) }),
+    );
+    expect(emitStackStatusChanged).toHaveBeenCalledWith("s1", "synced");
+  });
+
+  it("persists WHY the stack drifted so the API can say so without a Docker call", async () => {
+    const { monitor, update } = buildHarness({
+      stack: stackRow("synced"),
+      containers: [container("api", "sha256:aaa", "exited")],
+    });
+
+    await monitor.sweep();
+
+    const data = update.mock.calls[0][0].data;
+    expect(data.runtimeIssues).toEqual([
+      { kind: "not-running", serviceName: "api", status: "exited" },
+    ]);
+  });
+
+  it("does not touch a stack whose last apply failed", async () => {
+    // `error` is a recoverable state a human action owns. The monitor must never
+    // clobber it — nor `pending` (unapplied edits) or `undeployed`.
+    for (const status of ["error", "pending", "undeployed", "removed"]) {
+      const { monitor, update } = buildHarness({
+        stack: stackRow(status),
+        containers: [container("api", "sha256:aaa", "exited")],
+      });
+
+      await monitor.sweep();
+      expect(update, `status ${status} must be left alone`).not.toHaveBeenCalled();
+    }
+  });
+
+  it("does not write a status underneath a live operation", async () => {
+    // An apply legitimately stops and recreates containers, which looks exactly
+    // like a service dying. Writing `drifted` mid-apply would be a lie that
+    // races the apply's own status write.
+    const { monitor, update } = buildHarness({
+      stack: stackRow("synced"),
+      containers: [container("api", "sha256:aaa", "exited")],
+    });
+
+    expect(stackOperationLock.tryAcquire("s1")).toBe(true);
+    try {
+      await monitor.sweep();
+      expect(update).not.toHaveBeenCalled();
+    } finally {
+      stackOperationLock.release("s1");
+    }
+  });
+
+  it("releases the operation lock after writing", async () => {
+    const { monitor } = buildHarness({
+      stack: stackRow("synced"),
+      containers: [container("api", "sha256:aaa", "exited")],
+    });
+
+    await monitor.sweep();
+
+    // If the monitor leaked the lock, every subsequent apply/destroy on this
+    // stack would 409 until the 30-minute TTL expired.
+    expect(stackOperationLock.has("s1")).toBe(false);
+  });
+
+  it("holds no opinion on a stack with no stored hashes", async () => {
+    const { monitor, update } = buildHarness({
+      stack: { ...stackRow("synced"), lastAppliedHashes: null },
+      containers: [],
+    });
+
+    await monitor.sweep();
+
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("leaves a healthy synced stack alone", async () => {
+    const { monitor, update } = buildHarness({
+      stack: stackRow("synced"),
+      containers: [container("api", "sha256:aaa", "running")],
+    });
+
+    await monitor.sweep();
+
+    expect(update).not.toHaveBeenCalled();
+    expect(emitStackStatusChanged).not.toHaveBeenCalled();
+  });
+
+  it("never throws out of a sweep tick", async () => {
+    const { monitor, docker } = buildHarness({
+      stack: stackRow("synced"),
+      containers: [],
+    });
+    docker.listContainers.mockRejectedValue(new Error("docker is down"));
+
+    // A throwing timer callback would take the process down.
+    await expect(monitor.sweep()).resolves.toBeUndefined();
+  });
+
+  it("subscribes to Docker container events on start", () => {
+    const { monitor, docker } = buildHarness({
+      stack: stackRow("synced"),
+      containers: [],
+    });
+
+    monitor.start();
+    try {
+      expect(docker.onContainerEvent).toHaveBeenCalledOnce();
+      expect(monitor.isRunning()).toBe(true);
+    } finally {
+      monitor.stop();
+    }
+    expect(monitor.isRunning()).toBe(false);
+  });
+});

--- a/server/src/services/stacks/__tests__/stack-status-monitor.test.ts
+++ b/server/src/services/stacks/__tests__/stack-status-monitor.test.ts
@@ -121,7 +121,7 @@ describe("StackStatusMonitor", () => {
   it("does not touch a stack whose last apply failed", async () => {
     // `error` is a recoverable state a human action owns. The monitor must never
     // clobber it — nor `pending` (unapplied edits) or `undeployed`.
-    for (const status of ["error", "pending", "undeployed", "removed"]) {
+    for (const status of ["error", "pending", "undeployed"]) {
       const { monitor, update } = buildHarness({
         stack: stackRow(status),
         containers: [container("api", "sha256:aaa", "exited")],

--- a/server/src/services/stacks/builtin-stack-sync.ts
+++ b/server/src/services/stacks/builtin-stack-sync.ts
@@ -179,7 +179,7 @@ async function upgradeStackFromTemplate(
 
   // Apply environment-driven parameter overrides to existing non-running stacks
   // (e.g. expose-on-host=false for internet-facing HAProxy)
-  const canApplyOverrides = ["undeployed", "error", "pending", "removed"].includes(existing.status);
+  const canApplyOverrides = ["undeployed", "error", "pending"].includes(existing.status);
   if (Object.keys(parameterOverrides).length > 0 && canApplyOverrides) {
     const existingValues = (existing.parameterValues as unknown as Record<string, StackParameterValue>) ?? {};
     const needsUpdate = Object.entries(parameterOverrides).some(

--- a/server/src/services/stacks/builtin-vault-reconcile.ts
+++ b/server/src/services/stacks/builtin-vault-reconcile.ts
@@ -25,7 +25,7 @@ export async function runBuiltinVaultReconcile(
   }
 
   const builtinStacks = await prisma.stack.findMany({
-    where: { builtinVersion: { not: null }, status: { not: "removed" } },
+    where: { builtinVersion: { not: null } },
     select: { id: true, name: true },
   });
 

--- a/server/src/services/stacks/healthcheck-config.ts
+++ b/server/src/services/stacks/healthcheck-config.ts
@@ -1,0 +1,111 @@
+/**
+ * The one seam between a stack's declared healthcheck and Docker's HealthConfig.
+ *
+ * `StackContainerConfig.healthcheck` stores `interval`, `timeout` and
+ * `startPeriod` in **milliseconds** (declared on the shared type in
+ * `lib/types/stacks.ts`). Docker's API wants nanoseconds. Every container-create
+ * path must go through `healthcheckToDocker()` so the conversion exists once.
+ *
+ * History: this used to be inlined in three places (stack-container-manager,
+ * pool-spawner, pool-addon-sidecar), each multiplying by 1e9 as though the
+ * stored value were seconds — while the authoring UI and the deploy-wait path
+ * both treated it as milliseconds. A UI-created app with a 30s interval stored
+ * `30000` and got a Docker interval of 30,000 seconds (~8.3 hours), so the
+ * healthcheck never ran. Keep the conversion here and the units can't drift
+ * again.
+ */
+import type { StackContainerConfig } from "@mini-infra/types";
+
+const MS_TO_NS = 1_000_000;
+
+/** Docker's HealthConfig, in the PascalCase shape the Engine API expects. */
+export interface DockerHealthConfig {
+  Test: string[];
+  Interval: number;
+  Timeout: number;
+  Retries: number;
+  StartPeriod: number;
+}
+
+/**
+ * Convert a stack service's declared healthcheck (ms) into Docker's
+ * HealthConfig (ns). Returns `undefined` when no healthcheck is declared, so
+ * callers can spread it straight into a container-create body.
+ *
+ * By this point template references like `{{params.x}}` have been resolved to
+ * numbers by the template engine, so `Number()` is a narrowing cast rather than
+ * a parse. `retries` is a count, not a duration — it is passed through as-is.
+ */
+export function healthcheckToDocker(
+  healthcheck: StackContainerConfig["healthcheck"],
+): DockerHealthConfig | undefined {
+  if (!healthcheck) return undefined;
+
+  return {
+    Test: healthcheck.test,
+    Interval: Number(healthcheck.interval) * MS_TO_NS,
+    Timeout: Number(healthcheck.timeout) * MS_TO_NS,
+    Retries: Number(healthcheck.retries),
+    StartPeriod: Number(healthcheck.startPeriod) * MS_TO_NS,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Legacy seconds → ms normalisation                                           */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Durations only. `retries` is a count and must never be scaled.
+ */
+const DURATION_KEYS = ["interval", "timeout", "startPeriod"] as const;
+
+/**
+ * Values at or above this are assumed to be milliseconds already; anything
+ * below it is assumed to be a legacy seconds value and scaled by 1000.
+ *
+ * Stored healthchecks are not self-describing — a `30` could be a built-in
+ * template's 30 seconds or a drawer user's 30 milliseconds — so the backfill
+ * discriminates on magnitude. The two populations are far apart in practice
+ * (seconds: intervals 5–60, timeouts 3–10; milliseconds: intervals
+ * 10000–60000, timeouts 3000–10000), and a sub-second millisecond healthcheck
+ * is pathological, so the ambiguous band is empty for any realistic config.
+ *
+ * The threshold also makes the backfill idempotent: once a value has been
+ * scaled it lands above the threshold and is never scaled twice. That matters
+ * because it runs on every boot.
+ */
+export const MS_HEURISTIC_THRESHOLD = 1000;
+
+export interface HealthcheckConversion {
+  key: (typeof DURATION_KEYS)[number];
+  from: number;
+  to: number;
+}
+
+/**
+ * Scale any legacy seconds durations on a healthcheck up to milliseconds.
+ *
+ * Pure and non-mutating: returns a new healthcheck plus the list of what it
+ * changed (for logging), or `null` when nothing needed changing. Non-numeric
+ * values are left alone — an unrendered template expression like
+ * `"{{params.interval}}"` has no unit to convert, and its author is expected to
+ * supply milliseconds.
+ */
+export function normaliseHealthcheckToMs(
+  healthcheck: Record<string, unknown>,
+): { healthcheck: Record<string, unknown>; conversions: HealthcheckConversion[] } | null {
+  const conversions: HealthcheckConversion[] = [];
+  const next = { ...healthcheck };
+
+  for (const key of DURATION_KEYS) {
+    const value = next[key];
+    if (typeof value !== "number" || !Number.isFinite(value)) continue;
+    if (value <= 0 || value >= MS_HEURISTIC_THRESHOLD) continue;
+
+    const scaled = Math.round(value * 1000);
+    next[key] = scaled;
+    conversions.push({ key, from: value, to: scaled });
+  }
+
+  return conversions.length > 0 ? { healthcheck: next, conversions } : null;
+}

--- a/server/src/services/stacks/healthcheck-unit-backfill.ts
+++ b/server/src/services/stacks/healthcheck-unit-backfill.ts
@@ -1,0 +1,174 @@
+/**
+ * One-shot backfill: normalise stored healthcheck durations to milliseconds.
+ *
+ * Milliseconds is the canonical unit for `StackContainerConfig.healthcheck`
+ * (declared on the shared type in `lib/types/stacks.ts`). Before that was
+ * pinned, writers disagreed: the authoring UIs stored milliseconds while the
+ * built-in template JSONs stored seconds, and the container-create paths
+ * multiplied everything by 1e9 as though it were all seconds. A UI-authored app
+ * with a 30s interval therefore got a Docker interval of ~8.3 hours and its
+ * healthcheck never ran.
+ *
+ * This walks every column that can hold a healthcheck and scales the legacy
+ * seconds values up. It is idempotent — the magnitude heuristic in
+ * `normaliseHealthcheckToMs()` only scales values below the threshold, and a
+ * scaled value lands above it — so it is safe to run on every boot, which is
+ * how it is wired (see server.ts, alongside the network membership backfill).
+ *
+ * Columns covered:
+ *   - StackService.containerConfig         (live per-stack services)
+ *   - StackTemplateService.containerConfig (template versions)
+ *   - Stack.lastAppliedSnapshot            (snapshot of services at apply time)
+ *
+ * The snapshot matters as much as the live rows: drift detection compares the
+ * running container against it, so leaving stale seconds there would make every
+ * converted stack read as drifted.
+ */
+import type { Logger } from "pino";
+import { Prisma, type PrismaClient } from "../../generated/prisma/client";
+import { normaliseHealthcheckToMs, type HealthcheckConversion } from "./healthcheck-config";
+
+export interface HealthcheckBackfillResult {
+  stackServices: number;
+  templateServices: number;
+  snapshots: number;
+  conversions: number;
+}
+
+/** A containerConfig-shaped blob, as it comes back out of a Json column. */
+type JsonObject = Record<string, unknown>;
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Normalise the healthcheck on a single containerConfig blob.
+ * Returns the rewritten config, or null when nothing changed.
+ */
+function normaliseContainerConfig(
+  containerConfig: unknown,
+): { config: JsonObject; conversions: HealthcheckConversion[] } | null {
+  if (!isObject(containerConfig)) return null;
+
+  const healthcheck = containerConfig.healthcheck;
+  if (!isObject(healthcheck)) return null;
+
+  const result = normaliseHealthcheckToMs(healthcheck);
+  if (!result) return null;
+
+  return {
+    config: { ...containerConfig, healthcheck: result.healthcheck },
+    conversions: result.conversions,
+  };
+}
+
+function describe(conversions: HealthcheckConversion[]): string {
+  return conversions.map((c) => `${c.key} ${c.from}→${c.to}`).join(", ");
+}
+
+/**
+ * Cross the Prisma Json boundary. Same cast the snapshot's own builder uses —
+ * see buildAppliedSnapshot() in stack-applied-snapshot.ts.
+ */
+function asJson(value: unknown): Prisma.InputJsonValue {
+  return value as unknown as Prisma.InputJsonValue;
+}
+
+export async function backfillHealthcheckUnits(
+  prisma: PrismaClient,
+  logger: Logger,
+): Promise<HealthcheckBackfillResult> {
+  const result: HealthcheckBackfillResult = {
+    stackServices: 0,
+    templateServices: 0,
+    snapshots: 0,
+    conversions: 0,
+  };
+
+  // --- live stack services -------------------------------------------------
+  const stackServices = await prisma.stackService.findMany({
+    select: { id: true, serviceName: true, containerConfig: true, stackId: true },
+  });
+  for (const svc of stackServices) {
+    const normalised = normaliseContainerConfig(svc.containerConfig);
+    if (!normalised) continue;
+
+    await prisma.stackService.update({
+      where: { id: svc.id },
+      data: { containerConfig: asJson(normalised.config) },
+    });
+    result.stackServices += 1;
+    result.conversions += normalised.conversions.length;
+    logger.info(
+      { stackId: svc.stackId, serviceName: svc.serviceName, conversions: normalised.conversions },
+      `healthcheck units: stack service ${svc.serviceName} — ${describe(normalised.conversions)}`,
+    );
+  }
+
+  // --- template services ---------------------------------------------------
+  const templateServices = await prisma.stackTemplateService.findMany({
+    select: { id: true, serviceName: true, containerConfig: true, versionId: true },
+  });
+  for (const svc of templateServices) {
+    const normalised = normaliseContainerConfig(svc.containerConfig);
+    if (!normalised) continue;
+
+    await prisma.stackTemplateService.update({
+      where: { id: svc.id },
+      data: { containerConfig: asJson(normalised.config) },
+    });
+    result.templateServices += 1;
+    result.conversions += normalised.conversions.length;
+    logger.info(
+      { versionId: svc.versionId, serviceName: svc.serviceName, conversions: normalised.conversions },
+      `healthcheck units: template service ${svc.serviceName} — ${describe(normalised.conversions)}`,
+    );
+  }
+
+  // --- last-applied snapshots ----------------------------------------------
+  // The snapshot embeds a copy of every service definition, so it carries its
+  // own copy of the stale units. Drift compares against this, so it has to move
+  // in lockstep with the live rows above.
+  const stacks = await prisma.stack.findMany({
+    where: { lastAppliedSnapshot: { not: Prisma.DbNull } },
+    select: { id: true, name: true, lastAppliedSnapshot: true },
+  });
+  for (const stack of stacks) {
+    const snapshot = stack.lastAppliedSnapshot;
+    if (!isObject(snapshot) || !Array.isArray(snapshot.services)) continue;
+
+    const conversions: HealthcheckConversion[] = [];
+    const services = snapshot.services.map((svc: unknown) => {
+      if (!isObject(svc)) return svc;
+      const normalised = normaliseContainerConfig(svc.containerConfig);
+      if (!normalised) return svc;
+      conversions.push(...normalised.conversions);
+      return { ...svc, containerConfig: normalised.config };
+    });
+
+    if (conversions.length === 0) continue;
+
+    await prisma.stack.update({
+      where: { id: stack.id },
+      data: { lastAppliedSnapshot: asJson({ ...snapshot, services }) },
+    });
+    result.snapshots += 1;
+    result.conversions += conversions.length;
+    logger.info(
+      { stackId: stack.id, stackName: stack.name, conversions },
+      `healthcheck units: snapshot for ${stack.name} — ${describe(conversions)}`,
+    );
+  }
+
+  if (result.conversions > 0) {
+    logger.info(
+      result,
+      `healthcheck units: normalised ${result.conversions} duration(s) to milliseconds ` +
+        `across ${result.stackServices} stack service(s), ${result.templateServices} template ` +
+        `service(s), ${result.snapshots} snapshot(s)`,
+    );
+  }
+
+  return result;
+}

--- a/server/src/services/stacks/pool-addon-sidecar.ts
+++ b/server/src/services/stacks/pool-addon-sidecar.ts
@@ -3,6 +3,7 @@ import type { PrismaClient } from '../../generated/prisma/client';
 import type { DockerExecutorService } from '../docker-executor';
 import { getLogger } from '../../lib/logger-factory';
 import { getStackProjectName } from './template-engine';
+import { healthcheckToDocker } from './healthcheck-config';
 import { StackContainerManager } from './stack-container-manager';
 import { StackInfraResourceManager } from './stack-infra-resource-manager';
 import { attachServiceNetworks, createNetworkManager, type NetworkManager } from '../networks';
@@ -156,15 +157,7 @@ async function spawnOne(
     ReadOnly: m.readOnly,
   }));
 
-  const healthcheck = cfg.healthcheck
-    ? {
-        Test: cfg.healthcheck.test,
-        Interval: Number(cfg.healthcheck.interval) * 1_000_000_000,
-        Timeout: Number(cfg.healthcheck.timeout) * 1_000_000_000,
-        Retries: Number(cfg.healthcheck.retries),
-        StartPeriod: Number(cfg.healthcheck.startPeriod) * 1_000_000_000,
-      }
-    : undefined;
+  const healthcheck = healthcheckToDocker(cfg.healthcheck);
 
   const logConfig = cfg.logConfig
     ? {

--- a/server/src/services/stacks/pool-spawner.ts
+++ b/server/src/services/stacks/pool-spawner.ts
@@ -24,6 +24,7 @@ import { resolveEgressEnv } from './egress-injection';
 import { TailscaleService } from '../tailscale/tailscale-service';
 import { spawnPoolAddonSidecars } from './pool-addon-sidecar';
 import { getStackProjectName } from './template-engine';
+import { healthcheckToDocker } from './healthcheck-config';
 import { StackContainerManager } from './stack-container-manager';
 import { StackInfraResourceManager } from './stack-infra-resource-manager';
 import { attachServiceNetworks, createNetworkManager } from '../networks';
@@ -343,16 +344,7 @@ export async function spawnPoolInstance(
     ReadOnly: m.readOnly,
   }));
 
-  // Healthcheck: seconds → nanoseconds.
-  const healthcheck = containerConfig.healthcheck
-    ? {
-        Test: containerConfig.healthcheck.test,
-        Interval: Number(containerConfig.healthcheck.interval) * 1_000_000_000,
-        Timeout: Number(containerConfig.healthcheck.timeout) * 1_000_000_000,
-        Retries: Number(containerConfig.healthcheck.retries),
-        StartPeriod: Number(containerConfig.healthcheck.startPeriod) * 1_000_000_000,
-      }
-    : undefined;
+  const healthcheck = healthcheckToDocker(containerConfig.healthcheck);
 
   const logConfig = containerConfig.logConfig
     ? {

--- a/server/src/services/stacks/stack-applied-snapshot.ts
+++ b/server/src/services/stacks/stack-applied-snapshot.ts
@@ -69,6 +69,11 @@ export function buildAppliedSnapshot(
         addons: (s.addons as Record<string, unknown> | null | undefined) ?? undefined,
       }));
 
+  // NOTE: this is the `serializeStack` from @mini-infra/types (a pure
+  // definition serializer), NOT the server's API serializer in ./utils. The
+  // snapshot is a record of desired state, so it deliberately does not carry
+  // the live-health fields (`needsAttention`, `runtimeIssues`) that the API
+  // serializer derives.
   return serializeStack({
     ...stack,
     networks: stack.networks as unknown as StackNetwork[],

--- a/server/src/services/stacks/stack-container-manager.ts
+++ b/server/src/services/stacks/stack-container-manager.ts
@@ -9,6 +9,7 @@ import { InternalError } from '../../lib/errors';
 import { groupByProperty } from './utils';
 import { resolveEgressEnv } from './egress-injection';
 import { resolveStackMountSource } from './stack-mounts';
+import { healthcheckToDocker } from './healthcheck-config';
 import type { PrismaClient } from '../../generated/prisma/client';
 import { createNetworkManager, type NetworkManager } from '../networks';
 
@@ -180,18 +181,7 @@ export class StackContainerManager {
       ReadOnly: m.readOnly,
     }));
 
-    // Convert healthcheck seconds to nanoseconds. By this point template
-    // references like "{{params.x}}" have been resolved to numbers, so
-    // Number() is a narrowing cast, not a parse.
-    const healthcheck = config.healthcheck
-      ? {
-          Test: config.healthcheck.test,
-          Interval: Number(config.healthcheck.interval) * 1_000_000_000,
-          Timeout: Number(config.healthcheck.timeout) * 1_000_000_000,
-          Retries: Number(config.healthcheck.retries),
-          StartPeriod: Number(config.healthcheck.startPeriod) * 1_000_000_000,
-        }
-      : undefined;
+    const healthcheck = healthcheckToDocker(config.healthcheck);
 
     // Convert log config
     const logConfig = config.logConfig

--- a/server/src/services/stacks/stack-nats-apply-orchestrator.ts
+++ b/server/src/services/stacks/stack-nats-apply-orchestrator.ts
@@ -1333,7 +1333,6 @@ async function resolveImport(args: {
   const producer = await args.prisma.stack.findFirst({
     where: {
       name: args.imp.fromStack,
-      removedAt: null,
       environmentId: args.consumerEnvironmentId,
     },
     select: {
@@ -1487,7 +1486,6 @@ async function detectImportCycle(args: {
     const stackRow = await args.prisma.stack.findFirst({
       where: {
         name,
-        removedAt: null,
         environmentId: args.environmentId,
       },
       select: { lastAppliedNatsSnapshot: true },

--- a/server/src/services/stacks/stack-reconciler.ts
+++ b/server/src/services/stacks/stack-reconciler.ts
@@ -455,6 +455,14 @@ export class StackReconciler {
           // `applications` join is derived at apply time and must not enter the
           // definition hash, or drift detection would perpetually recreate.
           lastAppliedSnapshot: buildAppliedSnapshot(stack, resolvedServiceDefinitions),
+          // The definition hashes we just stamped onto the containers as
+          // `mini-infra.definition-hash` labels. The background status monitor
+          // diffs a container's live label against this map to spot out-of-band
+          // drift without re-rendering the template. See stack-status-monitor.ts.
+          lastAppliedHashes: Object.fromEntries(serviceHashes),
+          // We just reconciled reality to the definition, so whatever the status
+          // monitor last found wrong is now stale by construction.
+          runtimeIssues: Prisma.DbNull,
           // Track the AppRole binding that was in effect on this apply so the
           // credential injector can detect binding changes on future re-applies.
           ...(allSucceeded
@@ -728,6 +736,10 @@ export class StackReconciler {
           // `applications` join is derived at apply time and must not enter the
           // definition hash, or drift detection would perpetually recreate.
           lastAppliedSnapshot: buildAppliedSnapshot(stack, resolvedServiceDefinitions),
+          // See the `apply` branch above — the stamped definition hashes the
+          // background status monitor diffs live container labels against.
+          lastAppliedHashes: Object.fromEntries(serviceHashes),
+          runtimeIssues: Prisma.DbNull,
           ...(allSucceeded
             ? { lastAppliedVaultAppRoleId: stack.vaultAppRoleId ?? null, lastFailureReason: null }
             // Same surfacing as in `apply` above — see that branch for context.

--- a/server/src/services/stacks/stack-reconciler.ts
+++ b/server/src/services/stacks/stack-reconciler.ts
@@ -474,7 +474,6 @@ export class StackReconciler {
             // healthcheck timeout) silently left the field stale or null.
             : { lastFailureReason: summariseServiceFailures(serviceResults) }),
           status: resultStatus,
-          removedAt: null,
         },
       });
       emitStackStatusChanged(stackId, resultStatus);

--- a/server/src/services/stacks/stack-resource-reconciler.ts
+++ b/server/src/services/stacks/stack-resource-reconciler.ts
@@ -608,8 +608,34 @@ export class StackResourceReconciler {
           }
         }
       }
-      // TLS certs stay in the store
-      // TODO: Tunnel cleanup when tunnel service is ready
+
+      // Destroying a stack must undo its tunnel ingress too, or the hostname
+      // keeps routing to a service that no longer exists and the CNAME dangles.
+      // This mirrors the `remove` action in reconcileTunnels() — the two are the
+      // same operation, one per-resource and one for the whole stack.
+      if (resource.resourceType === 'tunnel' && resource.externalId && this.cloudflareService) {
+        const fqdn = resource.fqdn ?? resource.resourceName;
+        try {
+          await this.cloudflareService.removeHostname(resource.externalId, fqdn);
+          log.info({ resourceName: resource.resourceName, fqdn }, 'Removed hostname from Cloudflare tunnel');
+        } catch (err) {
+          // Already gone is success — destroy must be idempotent.
+          const message = err instanceof Error ? err.message : '';
+          if (message.includes('not found')) {
+            log.info({ fqdn }, 'Hostname not found in tunnel, continuing');
+          } else {
+            log.warn({ err, resourceName: resource.resourceName }, 'Failed to remove hostname from Cloudflare tunnel (non-fatal)');
+          }
+        }
+
+        try {
+          await this.cloudflareDns.deleteCNAMEByHostname(fqdn);
+        } catch (err) {
+          log.warn({ err, fqdn }, 'Failed to delete tunnel CNAME record (non-fatal)');
+        }
+      }
+
+      // TLS certs stay in the store — they are reusable and expensive to reissue.
     }
 
     // Delete all DB records

--- a/server/src/services/stacks/stack-runtime-check.ts
+++ b/server/src/services/stacks/stack-runtime-check.ts
@@ -23,17 +23,18 @@
  * plan, which the user reaches by opening the plan view. Prefer false negatives
  * here; the plan remains the authority.
  */
-import type { DockerContainerInfo } from "@mini-infra/types";
+import type { DockerContainerInfo, StackRuntimeIssue } from "@mini-infra/types";
 
 /** Labels the reconciler stamps on every managed container. */
 export const STACK_ID_LABEL = "mini-infra.stack-id";
 export const SERVICE_LABEL = "mini-infra.service";
 export const DEFINITION_HASH_LABEL = "mini-infra.definition-hash";
 
-export type RuntimeIssue =
-  | { kind: "missing"; serviceName: string }
-  | { kind: "not-running"; serviceName: string; status: string }
-  | { kind: "hash-mismatch"; serviceName: string };
+/**
+ * Shared with the client via `@mini-infra/types` — the needs-attention rollup
+ * turns these into operator-facing reasons on both sides.
+ */
+export type RuntimeIssue = StackRuntimeIssue;
 
 export interface StackRuntimeCheck {
   /** True when every checked service is running with the hash we applied. */

--- a/server/src/services/stacks/stack-runtime-check.ts
+++ b/server/src/services/stacks/stack-runtime-check.ts
@@ -1,0 +1,146 @@
+/**
+ * The cheap runtime check behind the background stack-status monitor.
+ *
+ * This answers one question: *has reality drifted from what we last applied?*
+ * It is deliberately NOT the full plan. A plan re-renders the template, expands
+ * addons, inspects networks and resources, and costs several Docker calls per
+ * stack — far too expensive to run on a timer across the fleet. This compares
+ * two things we already have:
+ *
+ *   1. the container's `mini-infra.definition-hash` label — what we stamped at
+ *      apply time — against `Stack.lastAppliedHashes`, our stored copy of the
+ *      same values; and
+ *   2. whether the container is actually running.
+ *
+ * Because it diffs against a stored copy of what we stamped rather than
+ * re-deriving the desired hash, it cannot raise false-positive drift from a
+ * benign render difference. The cost for the whole fleet is one
+ * `listContainers()` (already cached for 3s) plus one Prisma read.
+ *
+ * The trade-off is a deliberate one: this catches "a container died, was
+ * removed, or was replaced out of band" — it does NOT catch template-edit drift
+ * (that needs the render) or network/resource drift. Those stay with the full
+ * plan, which the user reaches by opening the plan view. Prefer false negatives
+ * here; the plan remains the authority.
+ */
+import type { DockerContainerInfo } from "@mini-infra/types";
+
+/** Labels the reconciler stamps on every managed container. */
+export const STACK_ID_LABEL = "mini-infra.stack-id";
+export const SERVICE_LABEL = "mini-infra.service";
+export const DEFINITION_HASH_LABEL = "mini-infra.definition-hash";
+
+export type RuntimeIssue =
+  | { kind: "missing"; serviceName: string }
+  | { kind: "not-running"; serviceName: string; status: string }
+  | { kind: "hash-mismatch"; serviceName: string };
+
+export interface StackRuntimeCheck {
+  /** True when every checked service is running with the hash we applied. */
+  healthy: boolean;
+  issues: RuntimeIssue[];
+}
+
+/** The subset of a Stack row this check needs. */
+export interface CheckableStack {
+  id: string;
+  /** Record<serviceName, definitionHash>, or null for pre-existing stacks. */
+  lastAppliedHashes: unknown;
+}
+
+function isHashMap(value: unknown): value is Record<string, string> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  return Object.values(value).every((v) => typeof v === "string");
+}
+
+/** Group a flat container list by the stack that owns each container. */
+export function groupContainersByStack(
+  containers: DockerContainerInfo[],
+): Map<string, DockerContainerInfo[]> {
+  const byStack = new Map<string, DockerContainerInfo[]>();
+  for (const container of containers) {
+    const stackId = container.labels?.[STACK_ID_LABEL];
+    if (!stackId) continue;
+    const existing = byStack.get(stackId);
+    if (existing) existing.push(container);
+    else byStack.set(stackId, [container]);
+  }
+  return byStack;
+}
+
+/**
+ * Compare one stack's applied hashes against its live containers.
+ *
+ * Returns `null` when the stack cannot be checked — no stored hashes (applied
+ * before the column existed, so we have nothing trustworthy to diff against).
+ * A null result means "no opinion", and the caller must leave the status alone
+ * rather than assume health.
+ */
+export function checkStackRuntime(
+  stack: CheckableStack,
+  containers: DockerContainerInfo[],
+): StackRuntimeCheck | null {
+  if (!isHashMap(stack.lastAppliedHashes)) return null;
+
+  const appliedHashes = stack.lastAppliedHashes;
+  const serviceNames = Object.keys(appliedHashes);
+  if (serviceNames.length === 0) return null;
+
+  // A blue-green deploy can briefly leave two containers for one service (blue
+  // and green). Prefer a running one so a drain-pending blue doesn't read as a
+  // dead service. Operations in flight are skipped by the caller via the
+  // op-lock anyway; this is belt-and-braces for the window either side of it.
+  const byService = new Map<string, DockerContainerInfo>();
+  for (const container of containers) {
+    const serviceName = container.labels?.[SERVICE_LABEL];
+    if (!serviceName) continue;
+    const existing = byService.get(serviceName);
+    if (!existing || (existing.status !== "running" && container.status === "running")) {
+      byService.set(serviceName, container);
+    }
+  }
+
+  const issues: RuntimeIssue[] = [];
+
+  for (const serviceName of serviceNames) {
+    const container = byService.get(serviceName);
+
+    if (!container) {
+      issues.push({ kind: "missing", serviceName });
+      continue;
+    }
+
+    if (container.status !== "running") {
+      // The 3.1 case: a service that started and then died leaves the stack
+      // `synced` with nothing running, and the badge says everything is fine
+      // while the app is down.
+      issues.push({ kind: "not-running", serviceName, status: container.status });
+      continue;
+    }
+
+    const liveHash = container.labels?.[DEFINITION_HASH_LABEL];
+    if (liveHash && liveHash !== appliedHashes[serviceName]) {
+      // The 3.2 case: the container was replaced or edited out of band, so what
+      // is running is not what we applied.
+      issues.push({ kind: "hash-mismatch", serviceName });
+    }
+  }
+
+  return { healthy: issues.length === 0, issues };
+}
+
+/** Human-readable, operator-facing summary of what the check found. */
+export function describeRuntimeIssues(issues: RuntimeIssue[]): string {
+  return issues
+    .map((issue) => {
+      switch (issue.kind) {
+        case "missing":
+          return `service '${issue.serviceName}' has no container`;
+        case "not-running":
+          return `service '${issue.serviceName}' is ${issue.status}`;
+        case "hash-mismatch":
+          return `service '${issue.serviceName}' does not match the applied definition`;
+      }
+    })
+    .join("; ");
+}

--- a/server/src/services/stacks/stack-state-machine-context.ts
+++ b/server/src/services/stacks/stack-state-machine-context.ts
@@ -144,8 +144,14 @@ export async function buildStateMachineContext(
     tlsCertificateId,
     certificateStatus: enableSsl && tlsCertificateId ? 'ACTIVE' : undefined,
     healthCheckEndpoint: routing.healthCheckEndpoint ?? '/',
+    // HAProxy's `inter` (ms). `healthcheck.interval` is already milliseconds —
+    // the canonical unit for the whole stack surface (see StackContainerConfig).
+    // This previously divided by 1e6 as though the stored value were nanoseconds,
+    // which floored every real interval to 0 and — because 0 is not nullish —
+    // slipped past the `?? 2000` fallback in add-container-to-lb.ts, configuring
+    // HAProxy with `inter: 0`.
     healthCheckInterval: serviceDef.containerConfig.healthcheck?.interval
-      ? Math.round(Number(serviceDef.containerConfig.healthcheck.interval) / 1_000_000)
+      ? Number(serviceDef.containerConfig.healthcheck.interval)
       : 2000,
     healthCheckRetries: Number(serviceDef.containerConfig.healthcheck?.retries ?? 2),
     // Blue-green health-check timeout (ms): how long the deploy waits for the

--- a/server/src/services/stacks/stack-status-monitor.ts
+++ b/server/src/services/stacks/stack-status-monitor.ts
@@ -1,0 +1,262 @@
+/**
+ * Background stack-status monitor — makes `synced` stop lying.
+ *
+ * Two holes this closes:
+ *
+ *  - **A service that starts and then dies** left the stack `synced` with zero
+ *    running containers. The apply path only watches a container for ~5s after
+ *    start (`observeStableRunning`), so anything that crashes later is invisible
+ *    and the badge cheerfully says everything is fine while the app is down.
+ *
+ *  - **Drift was on-demand only.** `drifted` was persisted exclusively when a
+ *    human opened the plan view, so a stack whose container was replaced or
+ *    edited out of band could read `synced` for weeks.
+ *
+ * Both are the same question — *has reality drifted from what we applied?* — so
+ * both are answered by the same cheap check (see stack-runtime-check.ts), driven
+ * from two sources:
+ *
+ *  - **Docker events** give the immediate signal. `die`/`destroy`/`stop`/`start`
+ *    on any container carrying `mini-infra.stack-id` schedules a re-check of
+ *    that stack, debounced so a burst (e.g. a compose restart) collapses into
+ *    one pass.
+ *
+ *  - **A periodic sweep** is the backstop. The Docker event stream has no
+ *    `end`/`close` recovery — `docker.ts` only logs on `error` — so it can go
+ *    silently deaf and every subscriber with it. An event-only design would
+ *    inherit that failure mode, so the timer re-checks the fleet regardless.
+ *    It is also what catches drift that produces no event at all.
+ *
+ * Status transitions are deliberately narrow, mirroring the rule the plan route
+ * already established (stacks-validation-routes.ts): only `synced` → `drifted`
+ * and `drifted` → `synced`. It never touches `error`, `pending`, `undeployed` or
+ * `removed` — a stack whose last apply failed stays in its recoverable error
+ * state, and a stack with unapplied edits stays `pending`. That keeps the
+ * monitor from ever clobbering a status that a human action owns.
+ */
+import type { Logger } from "pino";
+import { Prisma, type PrismaClient } from "../../generated/prisma/client";
+import type DockerService from "../docker";
+import type { DockerContainerEvent } from "../../lib/docker-event-pattern-detector";
+import { withOperation } from "../../lib/logging-context";
+import { emitStackStatusChanged } from "./stack-socket-emitter";
+import { stackOperationLock } from "./operation-lock";
+import {
+  checkStackRuntime,
+  groupContainersByStack,
+  describeRuntimeIssues,
+  STACK_ID_LABEL,
+  type RuntimeIssue,
+} from "./stack-runtime-check";
+
+/** Container events worth a re-check. `create`/`health_status` add noise without signal. */
+const WATCHED_ACTIONS = new Set(["die", "stop", "destroy", "start", "kill", "oom"]);
+
+/** Collapse a burst of events for one stack into a single check. */
+const EVENT_DEBOUNCE_MS = 2_000;
+
+/** How often the backstop sweep runs. Cheap: one listContainers for the fleet. */
+const DEFAULT_SWEEP_INTERVAL_MS = 60_000;
+
+/** Only these statuses are the monitor's to change. */
+const MONITORED_STATUSES = ["synced", "drifted"] as const;
+
+export interface StackStatusMonitorOptions {
+  sweepIntervalMs?: number;
+}
+
+export class StackStatusMonitor {
+  private intervalId: NodeJS.Timeout | null = null;
+  private readonly pendingChecks = new Map<string, NodeJS.Timeout>();
+  private readonly sweepIntervalMs: number;
+  private running = false;
+
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly docker: DockerService,
+    private readonly log: Logger,
+    options: StackStatusMonitorOptions = {},
+  ) {
+    this.sweepIntervalMs = options.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS;
+  }
+
+  start(): void {
+    if (this.running) {
+      this.log.warn("stack status monitor already running");
+      return;
+    }
+    this.running = true;
+
+    this.docker.onContainerEvent((event: DockerContainerEvent) => this.handleContainerEvent(event));
+
+    // Fire once immediately so a stack that died while we were down is caught at
+    // boot rather than up to a sweep-interval later.
+    void withOperation("stack-status-sweep", () => this.sweep());
+    this.intervalId = setInterval(() => {
+      void withOperation("stack-status-sweep", () => this.sweep());
+    }, this.sweepIntervalMs);
+  }
+
+  stop(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+    for (const timer of this.pendingChecks.values()) clearTimeout(timer);
+    this.pendingChecks.clear();
+    this.running = false;
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  /**
+   * Docker event → debounced re-check of the owning stack.
+   *
+   * There is no unsubscribe hook on `onContainerEvent`, so this must stay safe
+   * to call after `stop()` — hence the `running` guard.
+   */
+  private handleContainerEvent(event: DockerContainerEvent): void {
+    if (!this.running) return;
+    if (!WATCHED_ACTIONS.has(event.action)) return;
+
+    const stackId = event.labels?.[STACK_ID_LABEL];
+    if (!stackId) return;
+
+    const existing = this.pendingChecks.get(stackId);
+    if (existing) clearTimeout(existing);
+
+    this.pendingChecks.set(
+      stackId,
+      setTimeout(() => {
+        this.pendingChecks.delete(stackId);
+        void withOperation("stack-status-event", () =>
+          this.checkStack(stackId).catch((err) => {
+            this.log.warn({ err, stackId }, "stack status check failed after container event");
+          }),
+        );
+      }, EVENT_DEBOUNCE_MS),
+    );
+  }
+
+  /**
+   * Re-check every monitored stack. Public for tests.
+   *
+   * One `listContainers()` covers the whole fleet (and is already cached for 3s),
+   * so this stays cheap no matter how many stacks there are.
+   */
+  async sweep(): Promise<void> {
+    try {
+      if (!this.docker.isConnected()) return;
+
+      const stacks = await this.prisma.stack.findMany({
+        where: { status: { in: [...MONITORED_STATUSES] } },
+        select: { id: true, name: true, status: true, lastAppliedHashes: true },
+      });
+      if (stacks.length === 0) return;
+
+      const containers = await this.docker.listContainers(true);
+      const byStack = groupContainersByStack(containers);
+
+      for (const stack of stacks) {
+        await this.evaluate(
+          stack,
+          byStack.get(stack.id) ?? [],
+        );
+      }
+    } catch (err) {
+      // Never throw out of a timer tick.
+      this.log.warn({ err }, "stack status sweep failed");
+    }
+  }
+
+  /** Re-check a single stack. Public for tests. */
+  async checkStack(stackId: string): Promise<void> {
+    if (!this.docker.isConnected()) return;
+
+    const stack = await this.prisma.stack.findUnique({
+      where: { id: stackId },
+      select: { id: true, name: true, status: true, lastAppliedHashes: true },
+    });
+    if (!stack) return;
+
+    const containers = await this.docker.listContainers(true);
+    const byStack = groupContainersByStack(containers);
+    await this.evaluate(stack, byStack.get(stackId) ?? []);
+  }
+
+  /**
+   * Apply the (narrow) status transition for one stack.
+   */
+  private async evaluate(
+    stack: { id: string; name: string; status: string; lastAppliedHashes: unknown },
+    containers: Parameters<typeof checkStackRuntime>[1],
+  ): Promise<void> {
+    if (!(MONITORED_STATUSES as readonly string[]).includes(stack.status)) return;
+
+    // Never write a status underneath a live operation. An apply legitimately
+    // stops and recreates containers, which would otherwise look exactly like a
+    // service dying. Same pattern as the egress self-heal supervisor.
+    if (stackOperationLock.has(stack.id)) return;
+
+    const check = checkStackRuntime(stack, containers);
+    // `null` means "no opinion" — the stack has no stored hashes (it was last
+    // applied before we recorded them), so we have nothing trustworthy to diff
+    // against. Leave the status alone rather than assume health.
+    if (!check) return;
+
+    const nextStatus = check.healthy ? "synced" : "drifted";
+    if (nextStatus === stack.status) {
+      // Status is right, but the issue list may still be stale (e.g. a drifted
+      // stack whose failing service changed). Keep the persisted detail honest.
+      await this.persistIssuesIfChanged(stack.id, check.issues);
+      return;
+    }
+
+    // Re-acquire before writing: `has()` above is a TOCTOU check, and an
+    // operation could have started in between. If we cannot take the lock, an
+    // operation owns this stack and will write its own status.
+    if (!stackOperationLock.tryAcquire(stack.id)) return;
+    try {
+      await this.prisma.stack.update({
+        where: { id: stack.id },
+        data: {
+          status: nextStatus,
+          runtimeIssues: check.issues as unknown as Prisma.InputJsonValue,
+        },
+      });
+      emitStackStatusChanged(stack.id, nextStatus);
+
+      if (nextStatus === "drifted") {
+        this.log.info(
+          { stackId: stack.id, stackName: stack.name, issues: check.issues },
+          `stack ${stack.name} drifted: ${describeRuntimeIssues(check.issues)}`,
+        );
+      } else {
+        this.log.info(
+          { stackId: stack.id, stackName: stack.name },
+          `stack ${stack.name} reconciled back to synced`,
+        );
+      }
+    } finally {
+      stackOperationLock.release(stack.id);
+    }
+  }
+
+  /** Refresh the persisted issue list without touching status. */
+  private async persistIssuesIfChanged(stackId: string, issues: RuntimeIssue[]): Promise<void> {
+    const current = await this.prisma.stack.findUnique({
+      where: { id: stackId },
+      select: { runtimeIssues: true },
+    });
+    const before = JSON.stringify(current?.runtimeIssues ?? []);
+    const after = JSON.stringify(issues);
+    if (before === after) return;
+
+    await this.prisma.stack.update({
+      where: { id: stackId },
+      data: { runtimeIssues: issues as unknown as Prisma.InputJsonValue },
+    });
+  }
+}

--- a/server/src/services/stacks/stack-template-service.ts
+++ b/server/src/services/stacks/stack-template-service.ts
@@ -493,7 +493,7 @@ export class StackTemplateService {
     const template = this.assertTemplateFound(
       await this.prisma.stackTemplate.findUnique({
         where: { id: templateId },
-        include: { stacks: { select: { id: true, name: true, status: true, removedAt: true } } },
+        include: { stacks: { select: { id: true, name: true, status: true } } },
       }),
       templateId,
     );
@@ -504,9 +504,7 @@ export class StackTemplateService {
     // under it would orphan those resources with no UI path left to find or
     // clean them up. Require the stack to be torn down (POST
     // /stacks/:id/destroy) or never deployed before the template can go.
-    const deployedStack = template.stacks.find(
-      (stack) => stack.removedAt === null && stack.status !== "undeployed",
-    );
+    const deployedStack = template.stacks.find((stack) => stack.status !== "undeployed");
     if (deployedStack) {
       throw new ConflictError(
         ErrorCode.STACK_TEMPLATE_HAS_DEPLOYED_STACK,
@@ -1093,7 +1091,6 @@ export class StackTemplateService {
             where: {
               name: "haproxy",
               environmentId: input.environmentId,
-              status: { not: "removed" },
             },
             include: {
               services: { where: { serviceName: "haproxy" }, take: 1 },

--- a/server/src/services/stacks/stack-upgrade-service.ts
+++ b/server/src/services/stacks/stack-upgrade-service.ts
@@ -128,12 +128,23 @@ export async function upgradeStackToCurrentTemplateVersion(
   }
 
   if (existing.templateVersion != null && version.version <= existing.templateVersion) {
+    // Two very different situations reach here, and saying "already on the
+    // latest version (v3)" to a stack sitting on v4 is simply false. The second
+    // case happens after a template rollback: the stack is now AHEAD of the
+    // template's current version, and since upgrade only ever targets
+    // `currentVersion` there is no way to move it. Say so, rather than
+    // pretending nothing is wrong.
+    const isAhead = version.version < existing.templateVersion;
     throw new ConflictError(
       ErrorCode.STACK_ALREADY_ON_LATEST,
-      `Stack is already on the latest template version (v${version.version})`,
+      isAhead
+        ? `Stack is on template version v${existing.templateVersion}, which is newer than the template's current version (v${version.version}) — the template was rolled back.`
+        : `Stack is already on the latest template version (v${version.version})`,
       {
         resource: { type: "stack", id: stackId },
-        action: "No upgrade is needed — this stack already tracks the current version.",
+        action: isAhead
+          ? "Publish a newer template version to move this stack forward. Rolling a stack back to an older template version is not supported yet."
+          : "No upgrade is needed — this stack already tracks the current version.",
       },
     );
   }

--- a/server/src/services/stacks/template-prerequisites/__tests__/evaluator.test.ts
+++ b/server/src/services/stacks/template-prerequisites/__tests__/evaluator.test.ts
@@ -75,9 +75,9 @@ function buildFakePrisma(opts: {
       findMany: async ({
         where,
       }: {
-        where: { template?: { name: string }; status?: { not: string } };
+        where: { template?: { name: string } };
       }) => {
-        // Phase 1 evaluator only filters by template.name + status not removed.
+        // Phase 1 evaluator only filters by template.name.
         const targetName = where.template?.name;
         return opts.stacks
           .filter((s) => s.templateId !== null)
@@ -86,7 +86,6 @@ function buildFakePrisma(opts: {
             // Look up the template scope/name via a parallel array.
             return s.template !== undefined && (s.template as unknown as { name?: string }).name === targetName;
           })
-          .filter((s) => s.status !== "removed")
           .map((s) => ({
             id: s.id,
             status: s.status ?? "synced",

--- a/server/src/services/stacks/template-prerequisites/__tests__/predicate-registry-load.test.ts
+++ b/server/src/services/stacks/template-prerequisites/__tests__/predicate-registry-load.test.ts
@@ -85,7 +85,7 @@ describe("template file-loader — predicate registry validation", () => {
           {
             kind: "stack",
             templateName: "vault",
-            minState: "removed", // not in the enum
+            minState: "error", // not in the enum
             scopeMatch: "host",
           },
         ],

--- a/server/src/services/stacks/template-prerequisites/__tests__/stack-requirement.integration.test.ts
+++ b/server/src/services/stacks/template-prerequisites/__tests__/stack-requirement.integration.test.ts
@@ -122,54 +122,50 @@ describe("evaluatePrerequisites — stack requirements (DB-backed)", () => {
     expect(result.ok).toBe(true);
   });
 
-  it("error/removed never satisfy a minState requirement", async () => {
-    for (const status of ["error", "removed"]) {
-      const { templateId: vaultTpl } = await createTemplate({
-        name: `vault-${status}-${createId().slice(0, 6)}`,
-        scope: "host",
-      });
-      await createVersion({ templateId: vaultTpl, version: 1 });
-      await createStack({
-        name: `vault-${status}`,
-        templateId: vaultTpl,
-        templateVersion: 1,
-        status,
-      });
+  it("error never satisfies a minState requirement", async () => {
+    const status = "error";
+    const { templateId: vaultTpl } = await createTemplate({
+      name: `vault-${status}-${createId().slice(0, 6)}`,
+      scope: "host",
+    });
+    await createVersion({ templateId: vaultTpl, version: 1 });
+    await createStack({
+      name: `vault-${status}`,
+      templateId: vaultTpl,
+      templateVersion: 1,
+      status,
+    });
 
-      const { templateId: consumerTpl } = await createTemplate({
-        name: `consumer-${status}-${createId().slice(0, 6)}`,
-        scope: "host",
-      });
-      await createVersion({
-        templateId: consumerTpl,
-        version: 1,
-        requires: [
-          {
-            kind: "stack",
-            templateName: (await testPrisma.stackTemplate.findUnique({ where: { id: vaultTpl } }))!.name,
-            minState: "pending",
-            scopeMatch: "host",
-          },
-        ],
-      });
-      const consumerStack = await createStack({
-        name: `consumer-${status}`,
-        templateId: consumerTpl,
-        templateVersion: 1,
-        status: "pending",
-      });
+    const { templateId: consumerTpl } = await createTemplate({
+      name: `consumer-${status}-${createId().slice(0, 6)}`,
+      scope: "host",
+    });
+    await createVersion({
+      templateId: consumerTpl,
+      version: 1,
+      requires: [
+        {
+          kind: "stack",
+          templateName: (await testPrisma.stackTemplate.findUnique({ where: { id: vaultTpl } }))!.name,
+          minState: "pending",
+          scopeMatch: "host",
+        },
+      ],
+    });
+    const consumerStack = await createStack({
+      name: `consumer-${status}`,
+      templateId: consumerTpl,
+      templateVersion: 1,
+      status: "pending",
+    });
 
-      const result = await evaluatePrerequisites(testPrisma, consumerStack);
-      // 'removed' stacks are filtered out at the SQL level — surfaces as
-      // "no matching stack" (instantiate-stack action). 'error' makes it
-      // through but fails the minState comparison (apply-stack action).
-      expect(result.ok).toBe(false);
-      if (status === "removed") {
-        expect(result.failures[0].helpAction?.type).toBe("instantiate-stack");
-      } else {
-        expect(result.failures[0].helpAction?.type).toBe("apply-stack");
-      }
-    }
+    const result = await evaluatePrerequisites(testPrisma, consumerStack);
+    // 'error' makes it through the candidate query but fails the minState
+    // comparison, so the fix is to re-apply the stack (apply-stack action).
+    // The "no matching stack" → instantiate-stack path is covered in
+    // evaluator.test.ts.
+    expect(result.ok).toBe(false);
+    expect(result.failures[0].helpAction?.type).toBe("apply-stack");
   });
 
   it("scopeMatch=same-environment matches only same-env candidates", async () => {

--- a/server/src/services/stacks/template-prerequisites/evaluator.ts
+++ b/server/src/services/stacks/template-prerequisites/evaluator.ts
@@ -16,8 +16,8 @@ const log = getLogger("stacks", "template-prerequisites-evaluator");
 
 /**
  * Ordering used to test "stack X is at status >= minState". Higher means
- * "more applied". `error` and `removed` are deliberately not in the
- * ordering — they never satisfy any minState.
+ * "more applied". `error` is deliberately not in the ordering — it never
+ * satisfies any minState.
  */
 const STATE_ORDER: Record<string, number> = {
   synced: 4,
@@ -34,7 +34,7 @@ const REQUIRED_STATE_ORDER: Record<MinState, number> = {
 
 function statusMeetsMinState(status: string, minState: MinState): boolean {
   const observed = STATE_ORDER[status];
-  if (observed === undefined) return false; // error / removed / unknown
+  if (observed === undefined) return false; // error / unknown
   return observed >= REQUIRED_STATE_ORDER[minState];
 }
 
@@ -85,14 +85,12 @@ async function evaluateStackRequirement(
     );
   }
 
-  // Fetch all non-removed candidate stacks bound to a template with the
-  // requested name. Source-agnostic: a `stack` requirement just names a
-  // template and a min state — it doesn't care if the candidate is a
-  // system or user template.
+  // Fetch all candidate stacks bound to a template with the requested name.
+  // Source-agnostic: a `stack` requirement just names a template and a min
+  // state — it doesn't care if the candidate is a system or user template.
   const candidates = await prisma.stack.findMany({
     where: {
       template: { name: templateName },
-      status: { not: "removed" },
     },
     select: {
       id: true,

--- a/server/src/services/stacks/utils.ts
+++ b/server/src/services/stacks/utils.ts
@@ -10,8 +10,11 @@ import type {
   StackVolume,
   StackInfo,
   StackServiceInfo,
+  StackStatus,
+  StackRuntimeIssue,
+  NatsDriftInfo,
 } from '@mini-infra/types';
-import { ErrorCode } from '@mini-infra/types';
+import { ErrorCode, computeStackAttention } from '@mini-infra/types';
 import { NotFoundError } from '../../lib/errors';
 import { buildTemplateContext, resolveStackConfigFiles, resolveServiceDefinition } from './template-engine';
 import { computeDefinitionHash, computeSyntheticDefinitionHash } from './definition-hash';
@@ -84,7 +87,23 @@ type SerializableService = {
  *
  * lastFailureReason is kept — operators need it to diagnose failed applies.
  */
-export function serializeStack(stack: SerializableStack): StackInfo {
+/**
+ * Extras the caller has already fetched and that are not columns on the stack
+ * row. `natsDrift` needs its own query (see `detectNatsDrift`), so routes pass
+ * it in rather than this function reaching for prisma — which keeps
+ * `serializeStack` pure and cheap to call in a list.
+ *
+ * Passing it matters: `needsAttention` folds NATS drift into its rollup, so a
+ * route that omits it silently under-reports.
+ */
+export interface SerializeStackExtras {
+  natsDrift?: NatsDriftInfo | null;
+}
+
+export function serializeStack(
+  stack: SerializableStack,
+  extras: SerializeStackExtras = {},
+): StackInfo {
   let inputValueKeys: string[] | undefined;
   if (stack.encryptedInputValues) {
     try {
@@ -102,6 +121,11 @@ export function serializeStack(stack: SerializableStack): StackInfo {
   void _strippedEncrypted;
   void _strippedSnapshot;
 
+  const templateUpdateAvailable = computeTemplateUpdateAvailable(stack);
+  const runtimeIssues = normaliseRuntimeIssues(
+    (stack as { runtimeIssues?: unknown }).runtimeIssues,
+  );
+
   return {
     ...rest,
     parameters: stack.parameters ?? [],
@@ -112,7 +136,7 @@ export function serializeStack(stack: SerializableStack): StackInfo {
     templateVersion: stack.templateVersion ?? null,
     templateSource: (stack.template?.source as 'system' | 'user' | undefined) ?? null,
     templateCurrentVersion: stack.template?.currentVersion?.version ?? null,
-    templateUpdateAvailable: computeTemplateUpdateAvailable(stack),
+    templateUpdateAvailable,
     tlsCertificates: stack.tlsCertificates ?? [],
     dnsRecords: stack.dnsRecords ?? [],
     tunnelIngress: stack.tunnelIngress ?? [],
@@ -120,8 +144,32 @@ export function serializeStack(stack: SerializableStack): StackInfo {
     createdAt: stack.createdAt.toISOString(),
     updatedAt: stack.updatedAt.toISOString(),
     services: stack.services?.map(serializeService),
+    runtimeIssues,
+    ...(extras.natsDrift !== undefined ? { natsDrift: extras.natsDrift } : {}),
+    // Computed server-side so every consumer — the UI, the agent sidecar, an
+    // API-key integration — gets the same answer instead of reimplementing it.
+    // Shares one implementation with the client via @mini-infra/types.
+    needsAttention: computeStackAttention({
+      status: stack.status as StackStatus,
+      lastFailureReason: (stack as { lastFailureReason?: string | null }).lastFailureReason,
+      runtimeIssues,
+      natsDrift: extras.natsDrift,
+      templateUpdateAvailable,
+    }),
     ...(inputValueKeys !== undefined ? { inputValueKeys } : {}),
   } as StackInfo;
+}
+
+/** The Json column comes back as `unknown`; keep anything malformed out of the rollup. */
+function normaliseRuntimeIssues(value: unknown): StackRuntimeIssue[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (issue): issue is StackRuntimeIssue =>
+      typeof issue === 'object' &&
+      issue !== null &&
+      typeof (issue as { kind?: unknown }).kind === 'string' &&
+      typeof (issue as { serviceName?: unknown }).serviceName === 'string',
+  );
 }
 
 function computeTemplateUpdateAvailable(stack: SerializableStack): boolean {

--- a/server/templates/cloudflare-tunnel/template.json
+++ b/server/templates/cloudflare-tunnel/template.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudflare-tunnel",
   "displayName": "Cloudflare Tunnel",
-  "builtinVersion": 9,
+  "builtinVersion": 10,
   "scope": "environment",
   "networkType": "internet",
   "category": "infrastructure",
@@ -31,10 +31,10 @@
         "restartPolicy": "unless-stopped",
         "healthcheck": {
           "test": ["CMD", "cloudflared", "tunnel", "ready"],
-          "interval": 30,
-          "timeout": 5,
+          "interval": 30000,
+          "timeout": 5000,
           "retries": 3,
-          "startPeriod": 15
+          "startPeriod": 15000
         },
         "logConfig": { "type": "json-file", "maxSize": "10m", "maxFile": "3" }
       },

--- a/server/templates/haproxy/template.json
+++ b/server/templates/haproxy/template.json
@@ -1,7 +1,7 @@
 {
   "name": "haproxy",
   "displayName": "HAProxy Load Balancer",
-  "builtinVersion": 11,
+  "builtinVersion": 12,
   "scope": "environment",
   "category": "infrastructure",
   "description": "HAProxy load balancer with DataPlane API",
@@ -61,10 +61,10 @@
         "restartPolicy": "unless-stopped",
         "healthcheck": {
           "test": ["CMD-SHELL", "unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy; wget --no-verbose --tries=1 --spider http://admin:admin@127.0.0.1:8404/stats"],
-          "interval": 30,
-          "timeout": 5,
+          "interval": 30000,
+          "timeout": 5000,
           "retries": 3,
-          "startPeriod": 10
+          "startPeriod": 10000
         },
         "joinResourceNetworks": ["applications", "dataplane", "tunnel"],
         "logConfig": { "type": "json-file", "maxSize": "10m", "maxFile": "3" }

--- a/server/templates/monitoring/template.json
+++ b/server/templates/monitoring/template.json
@@ -1,7 +1,7 @@
 {
   "name": "monitoring",
   "displayName": "Monitoring Stack",
-  "builtinVersion": 2,
+  "builtinVersion": 3,
   "scope": "host",
   "category": "infrastructure",
   "description": "Container metrics monitoring with Telegraf, Prometheus, and centralized log collection with Loki and Alloy",
@@ -36,10 +36,10 @@
         "restartPolicy": "unless-stopped",
         "healthcheck": {
           "test": ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9273/metrics"],
-          "interval": 30,
-          "timeout": 3,
+          "interval": 30000,
+          "timeout": 3000,
           "retries": 3,
-          "startPeriod": 10
+          "startPeriod": 10000
         },
         "logConfig": { "type": "json-file", "maxSize": "10m", "maxFile": "3" }
       },
@@ -68,10 +68,10 @@
         "restartPolicy": "unless-stopped",
         "healthcheck": {
           "test": ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9090/-/healthy"],
-          "interval": 30,
-          "timeout": 3,
+          "interval": 30000,
+          "timeout": 3000,
           "retries": 3,
-          "startPeriod": 10
+          "startPeriod": 10000
         },
         "logConfig": { "type": "json-file", "maxSize": "10m", "maxFile": "3" }
       },
@@ -105,10 +105,10 @@
         "restartPolicy": "unless-stopped",
         "healthcheck": {
           "test": ["NONE"],
-          "interval": 30,
-          "timeout": 3,
+          "interval": 30000,
+          "timeout": 3000,
           "retries": 3,
-          "startPeriod": 30
+          "startPeriod": 30000
         },
         "logConfig": { "type": "json-file", "maxSize": "10m", "maxFile": "3" }
       },
@@ -148,10 +148,10 @@
         "restartPolicy": "unless-stopped",
         "healthcheck": {
           "test": ["CMD-SHELL", "bash -c \"echo > /dev/tcp/localhost/12345\" 2>/dev/null"],
-          "interval": 30,
-          "timeout": 3,
+          "interval": 30000,
+          "timeout": 3000,
           "retries": 3,
-          "startPeriod": 20
+          "startPeriod": 20000
         },
         "logConfig": { "type": "json-file", "maxSize": "10m", "maxFile": "3" }
       },

--- a/server/templates/nats/template.json
+++ b/server/templates/nats/template.json
@@ -1,7 +1,7 @@
 {
   "name": "nats",
   "displayName": "NATS",
-  "builtinVersion": 1,
+  "builtinVersion": 2,
   "scope": "host",
   "category": "infrastructure",
   "description": "NATS messaging server with JetStream persistence. Reads its config from Vault KV, so the Vault stack must be bootstrapped first.",
@@ -79,10 +79,10 @@
         "joinResourceNetworks": ["nats"],
         "healthcheck": {
           "test": ["CMD", "wget", "-qO-", "http://localhost:8222/healthz"],
-          "interval": 10,
-          "timeout": 3,
+          "interval": 10000,
+          "timeout": 3000,
           "retries": 5,
-          "startPeriod": 10
+          "startPeriod": 10000
         },
         "logConfig": {
           "type": "json-file",

--- a/server/templates/postgres/template.json
+++ b/server/templates/postgres/template.json
@@ -1,7 +1,7 @@
 {
   "name": "postgres",
   "displayName": "PostgreSQL Database",
-  "builtinVersion": 2,
+  "builtinVersion": 3,
   "scope": "environment",
   "category": "database",
   "description": "PostgreSQL database server with persistent storage",
@@ -77,10 +77,10 @@
         "restartPolicy": "unless-stopped",
         "healthcheck": {
           "test": ["CMD-SHELL", "pg_isready -U {{params.postgres-user}} -d {{params.postgres-db}}"],
-          "interval": 30,
-          "timeout": 5,
+          "interval": 30000,
+          "timeout": 5000,
           "retries": 3,
-          "startPeriod": 30
+          "startPeriod": 30000
         },
         "joinResourceNetworks": ["database"],
         "logConfig": {


### PR DESCRIPTION
Implements **P3** from [docs/designs/stacks-applications-p3-p5-roadmap.md](docs/designs/stacks-applications-p3-p5-roadmap.md), following the merged P0–P2 series (#510 → #511 → #512).

P3's theme is *the status system stops lying*. Three of the bugs here were worse than the roadmap described, and one was not in it at all.

## ⚠️ Read before merging: expect one round of drift on upgrade

The definition hash covers `containerConfig`, which includes the healthcheck. Canonicalising healthcheck units therefore **changes the hash of every service that has one**, so on first boot after upgrading, those stacks report `drifted` and need one Apply.

That is the fix landing, not a fault: the running containers genuinely have wrong healthcheck intervals and must be recreated to pick up correct ones. Documented in `docs/API-CHANGELOG.md`.

## 3.3 — Healthcheck units (three bugs, not one)

Four writers with two conventions, five readers with three, and nothing pinning the unit.

- **The severe one, previously unreported.** The authoring UIs store **milliseconds**, but all three container-create paths multiplied by `1e9` as though the value were **seconds**. A UI-authored app with a 30-second interval was sending Docker **30,000 seconds (~8.3 hours)** — its healthcheck never ran and the container sat `health: starting` forever. Services default to `Stateful`, which is exactly the path that hits this: mainline, not an edge case.
- The deploy-wait path read `interval` as nanoseconds (`/1e6`), flooring every real value to `0`. Because `0` is not nullish it slipped past the `?? 2000` fallback and configured HAProxy with **`inter: 0`**.
- `startPeriod` was read as ms but written as seconds by the built-in templates, so a template's `startPeriod: 30` arrived as 30 ms, fell under the 90s floor, and clamped to the default — the slow-boot extension was **silently inert for every template-authored service**.

Milliseconds is now canonical, declared on `StackContainerConfig`. Docker's nanosecond conversion happens in exactly one place. Stored rows are normalised by an idempotent boot backfill using a magnitude heuristic (values < 1000 are seconds) — stored values are not self-describing, and the two populations are far apart in practice.

## 3.1 / 3.2 — `synced` could lie in two ways

A service that started then crashed left the stack `synced` with **zero running containers** — the badge said everything was fine while the app was down. And `drifted` was only ever persisted when a human opened the plan view.

Both are the same question (*has reality drifted from what we applied?*), now answered by one cheap check driven from Docker `die`/`destroy` events **plus** a 60s sweep. The sweep is not redundant: the Docker event stream has no `end`/`close` recovery and can go silently deaf, so an event-only design would inherit that failure mode.

The check compares a container's live `mini-infra.definition-hash` label against a new `Stack.lastAppliedHashes` column — diffing against a stored copy of what we *stamped*, rather than re-deriving the desired hash, means it **cannot raise false-positive drift** from a benign render difference, and costs one `listContainers` for the whole fleet.

Transitions are deliberately narrow (only `synced ↔ drifted`) and skip stacks holding the operation lock, so the monitor never clobbers a status a human action owns.

## 3.4 — needs-attention rollup, server-side

Was browser-only, so the agent sidecar and API-key callers had to reimplement it. Now ships from `serializeStack()` with one shared implementation in `@mini-infra/types`, and gains a **level** — `critical` when a service is down, not merely "drifted", which badly undersold an outage.

## 3.5 / 3.6 / 3.8

- `Stack.removedAt` and `StackStatus.removed` were **both never written** (destroy hard-deletes; stop writes `undeployed`), so ~25 guards were no-ops. Removed. Care was needed because `'removed'` *is* live on the HAProxy frontend enum, which is untouched.
- Destroying a stack now cleans up its tunnel hostname + CNAME (the "when tunnel service is ready" TODO was stale — it's been ready).
- Dead `useRedeployApplication` deleted.
- User docs rewritten for the post-P2 world, 29 `data-tour` attributes added (the agent couldn't point at any of the new UI), and a new `docs/API-CHANGELOG.md`.
- "Upgrade & deploy" now hands off to the task tracker instead of closing silently.

## Bonus: a silent schema-corruption trap, found and guarded

SQLite can't alter FKs in place, so Prisma emits a *table redefine* that rebuilds `stacks` from a column list snapshotted at authoring time. `prisma migrate dev` stamped a new migration **earlier** than an existing hand-rounded one, so it sorted first — its columns were added and then **silently dropped** when the redefine ran. Existing databases never notice; **only fresh installs and CI get the broken schema**.

`migrations-produce-schema.test.ts` now replays every migration into a scratch DB and asserts all 63 models have every column the schema declares. Verified it catches the bug by reintroducing it.

## Verification

Server 2982 tests, client 230, builds and lint clean. **Also driven live in a real environment** (P0–P2 shipped without this):

- Docker receives `Interval=30s` for HAProxy / `10s` for NATS — pre-fix, 30,000s and 10,000s. Containers now report `(healthy)`, which was previously impossible.
- `docker stop` a container behind Mini Infra's back → status flips `synced` → `drifted`, level `critical`, reason naming the service — **live in an open browser tab, no reload**.
- Container restored → heals back to `synced`. App restart → boot sweep catches a container that died while it was down.
- Apply (the action the reason recommends) → back to `synced`, container healthy.

The live pass **found a real bug**: the badge hardcoded amber, so a critical outage looked identical to "a newer template version is available". Fixed in `dc3cfb6`.

**All E2E gaps are now closed.** A user application was created through the UI and driven end-to-end:

- **Save & deploy** → publishes a template version, upgrades the stack, applies. Verified v1→v2.
- **Update-available badge** → Save-only leaves the stack behind its template; reports level `info`.
- **Upgrade & deploy** → upgrades and applies, badge clears, toast hands off to the task tracker.
- **rotateOnUpgrade inputs** → the dialog demands the declared input before upgrading; the value is stored encrypted and never returned.
- **Stop → Deploy** → Stop leaves `undeployed`, and the monitor correctly stays silent (a naive implementation would have screamed "service not running" the moment you clicked Stop).
- **Discard pending changes** → edit → `pending` (warning) → revert → `synced` with the definition restored.
- **Template rollback** → current moves back; the stack, now *ahead* of current, is stranded — confirming the P4 4.2 gap exactly as predicted.
- **Failed apply** → the Tailscale addon failed on invalid dev credentials, which incidentally proved the error path: status persisted `error`, `lastFailureReason` surfaced, rollup reported `critical`. Recovery restored `synced`.

Most importantly, the **mainline healthcheck bug** is now proven on the exact path that produced it: a UI-authored app with the form set to **"Interval (seconds) = 30"** gets `Interval=30s` in Docker and reports `health: healthy (2 checks recorded)`. Pre-fix it would have been a 30,000-second interval with **zero** checks ever recorded.

**The live pass found three real bugs that static tests missed** (`b0e9b65`): a duplicate "Update available" badge; a stack stranded by a rollback being told the false "already on the latest version (v3)" while sitting on v4; and a "needs fresh a value" copy bug.

**One thing genuinely not reachable:** revert-pending on an *addon-bearing* stack. All three addons require Tailscale, and the dev seed's OAuth credentials are invalid, so no synthetic sidecar can materialise. The specific regression #512 fixed is pinned by an integration test (`stacks-revert-route.integration.test.ts` — *"does not restore synthetic addon sidecars as authored services"*), which is the right level for it: the bug is in revert logic, not in Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
