### PR TITLE
feat(stacks): P6 — template export/import (5.2) + client code-splitting (5.4)

### DIFF
--- a/API-ROUTES.md
+++ b/API-ROUTES.md
@@ -414,7 +414,9 @@ Public, setup-scoped "Load from Backup" onboarding flow. Every route 403s once a
 | GET | `/api/stack-templates/:templateId` | Get template |
 | GET | `/api/stack-templates/:templateId/versions` | List versions |
 | GET | `/api/stack-templates/:templateId/versions/:versionId` | Get version |
+| GET | `/api/stack-templates/:templateId/versions/:versionId/export` | Export a version as a portable YAML document (secrets redacted) |
 | POST | `/api/stack-templates/` | Create template |
+| POST | `/api/stack-templates/import` | Create a user template from an exported YAML document |
 | PATCH | `/api/stack-templates/:templateId` | Update template metadata |
 | POST | `/api/stack-templates/:templateId/draft` | Save draft version |
 | POST | `/api/stack-templates/:templateId/publish` | Publish draft as new version |

--- a/client/src/__tests__/template-transfer.test.ts
+++ b/client/src/__tests__/template-transfer.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildTemplateExportDocument,
+  mapTemplateImportDocument,
+  TEMPLATE_EXPORT_FORMAT,
+  REDACTED_SECRET_PLACEHOLDER,
+  DEFAULT_NATS_SUBJECT_PREFIX_TEMPLATE,
+  type StackTemplateVersionInfo,
+  type StackTemplateServiceInfo,
+  type TemplateExportEnvelope,
+} from "@mini-infra/types";
+
+/**
+ * The build/map functions are the pure core of export/import. These pin the two
+ * things that must be exactly right — secrets are redacted (and reported), and
+ * the source-instance caveats (scope coercion, NATS-prefix allowlist) are raised
+ * — plus the promise, shared with the Compose importer, that nothing is dropped
+ * in silence.
+ */
+
+const service: StackTemplateServiceInfo = {
+  id: "svc1",
+  versionId: "v1",
+  serviceName: "web",
+  serviceType: "Stateful",
+  dockerImage: "nginx",
+  dockerTag: "1.25",
+  containerConfig: { joinNetworks: ["app-net"] },
+  initCommands: null,
+  dependsOn: [],
+  order: 0,
+  routing: null,
+};
+
+function makeVersion(
+  overrides: Partial<StackTemplateVersionInfo> = {},
+): StackTemplateVersionInfo {
+  return {
+    id: "v1",
+    templateId: "t1",
+    version: 3,
+    status: "published",
+    notes: "release notes",
+    parameters: [],
+    defaultParameterValues: {},
+    networks: [{ name: "app-net" }],
+    volumes: [{ name: "data" }],
+    publishedAt: "2026-01-01T00:00:00.000Z",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    createdById: null,
+    services: [service],
+    ...overrides,
+  };
+}
+
+const envelope: TemplateExportEnvelope = {
+  name: "my-app",
+  displayName: "My App",
+  description: "does things",
+  category: "web",
+  scope: "environment",
+  networkType: "internet",
+};
+
+describe("buildTemplateExportDocument", () => {
+  it("wraps the version body in an envelope with the current format tag", () => {
+    const { document } = buildTemplateExportDocument({
+      template: envelope,
+      version: makeVersion(),
+    });
+
+    expect(document.format).toBe(TEMPLATE_EXPORT_FORMAT);
+    expect(document.template).toEqual(envelope);
+    expect(document.sourceVersion).toBe(3);
+    expect(document.version.services?.[0]?.serviceName).toBe("web");
+    expect(document.version.networks).toEqual([{ name: "app-net" }]);
+    // exportedAt is stamped by the caller; omitted here → absent (deterministic).
+    expect(document.exportedAt).toBeUndefined();
+  });
+
+  it("stamps exportedAt when provided", () => {
+    const { document } = buildTemplateExportDocument({
+      template: envelope,
+      version: makeVersion(),
+      exportedAt: "2026-07-15T00:00:00.000Z",
+    });
+    expect(document.exportedAt).toBe("2026-07-15T00:00:00.000Z");
+  });
+
+  it("redacts literal vault secrets and reports each one, but keeps fromInput refs", () => {
+    const { document, issues } = buildTemplateExportDocument({
+      template: envelope,
+      version: makeVersion({
+        vault: {
+          kv: [
+            {
+              path: "app/db",
+              fields: {
+                PASSWORD: { value: "hunter2" },
+                USERNAME: { fromInput: "dbUser" },
+              },
+            },
+          ],
+        },
+      }),
+    });
+
+    const kv = document.version.vault?.kv?.[0];
+    expect(kv?.fields.PASSWORD).toEqual({ value: REDACTED_SECRET_PLACEHOLDER });
+    // A fromInput reference carries no secret and must survive untouched.
+    expect(kv?.fields.USERNAME).toEqual({ fromInput: "dbUser" });
+
+    const redaction = issues.find((i) => i.path.includes("PASSWORD"));
+    expect(redaction?.level).toBe("lossy");
+    expect(issues.some((i) => i.path.includes("USERNAME"))).toBe(false);
+  });
+
+  it("does not touch a version without a vault section", () => {
+    const { issues } = buildTemplateExportDocument({
+      template: envelope,
+      version: makeVersion(),
+    });
+    expect(issues).toHaveLength(0);
+  });
+});
+
+describe("mapTemplateImportDocument", () => {
+  function exportThenDoc(version: StackTemplateVersionInfo, env = envelope) {
+    return buildTemplateExportDocument({ template: env, version }).document;
+  }
+
+  it("maps a well-formed document into a create request", () => {
+    const result = mapTemplateImportDocument(exportThenDoc(makeVersion()));
+
+    expect(result.ok).toBe(true);
+    expect(result.request?.name).toBe("my-app");
+    expect(result.request?.displayName).toBe("My App");
+    expect(result.request?.scope).toBe("environment");
+    expect(result.request?.description).toBe("does things");
+    expect(result.request?.category).toBe("web");
+    expect(result.request?.services?.[0]?.serviceName).toBe("web");
+    expect(result.request?.networks).toEqual([{ name: "app-net" }]);
+    expect(result.request?.volumes).toEqual([{ name: "data" }]);
+    // No `source` on the request — createUserTemplate forces "user".
+    expect((result.request as Record<string, unknown>).source).toBeUndefined();
+  });
+
+  it("rejects a non-export object with a blocking format error", () => {
+    const result = mapTemplateImportDocument({ hello: "world" });
+    expect(result.ok).toBe(false);
+    expect(result.request).toBeNull();
+    expect(result.issues.some((i) => i.level === "error" && i.path === "format")).toBe(true);
+  });
+
+  it("rejects an unknown format version", () => {
+    const doc = exportThenDoc(makeVersion());
+    const result = mapTemplateImportDocument({ ...doc, format: "mini-infra.stack-template/v99" });
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((i) => i.path === "format")).toBe(true);
+  });
+
+  it("blocks a document missing its template name", () => {
+    const doc = exportThenDoc(makeVersion());
+    const result = mapTemplateImportDocument({
+      ...doc,
+      template: { ...doc.template, name: "" },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((i) => i.path === "template.name")).toBe(true);
+  });
+
+  it("coerces scope 'any' to environment and reports it", () => {
+    const doc = exportThenDoc(makeVersion());
+    const result = mapTemplateImportDocument({
+      ...doc,
+      template: { ...doc.template, scope: "any" },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.request?.scope).toBe("environment");
+    expect(result.issues.some((i) => i.level === "defaulted" && i.path === "template.scope")).toBe(true);
+  });
+
+  it("warns about a custom NATS subject prefix (allowlist is keyed by template id)", () => {
+    const doc = exportThenDoc(
+      makeVersion({ nats: { subjectPrefix: "events.custom" } }),
+    );
+    const result = mapTemplateImportDocument(doc);
+    expect(result.ok).toBe(true);
+    const warn = result.issues.find((i) => i.path === "version.nats.subjectPrefix");
+    expect(warn?.level).toBe("lossy");
+  });
+
+  it("does NOT warn for the default subject prefix", () => {
+    const doc = exportThenDoc(
+      makeVersion({ nats: { subjectPrefix: DEFAULT_NATS_SUBJECT_PREFIX_TEMPLATE } }),
+    );
+    const result = mapTemplateImportDocument(doc);
+    expect(result.issues.some((i) => i.path === "version.nats.subjectPrefix")).toBe(false);
+  });
+
+  it("flags redacted secrets left in the file so the user refills them", () => {
+    const doc = exportThenDoc(
+      makeVersion({
+        vault: { kv: [{ path: "app/db", fields: { PASSWORD: { value: "hunter2" } } }] },
+      }),
+    );
+    // The export already replaced the value with the placeholder; import detects it.
+    const result = mapTemplateImportDocument(doc);
+    expect(result.ok).toBe(true);
+    const notice = result.issues.find(
+      (i) => i.level === "lossy" && i.path.includes("PASSWORD"),
+    );
+    expect(notice).toBeTruthy();
+  });
+});

--- a/client/src/app/help/[category]/[slug]/page.tsx
+++ b/client/src/app/help/[category]/[slug]/page.tsx
@@ -1,17 +1,39 @@
+import { useEffect, useState } from "react";
 import { useParams, Navigate } from "react-router-dom";
-import { getDocBySlug } from "@/lib/doc-loader";
+import { getDocBySlug, loadDocContent } from "@/lib/doc-loader";
 import { DocContent } from "@/components/help/DocContent";
 import { DocToc } from "@/components/help/DocToc";
 import { DocNavigation } from "@/components/help/DocNavigation";
+import { AuthSpinner } from "@/components/auth-spinner";
 import { Badge } from "@/components/ui/badge";
 
 export function HelpDocPage() {
   const { category, slug } = useParams<{ category: string; slug: string }>();
   const doc = getDocBySlug(category!, slug!);
+  const key = `${category}/${slug}`;
+
+  // The article body is loaded lazily (doc bodies are no longer in the initial
+  // bundle — see doc-loader.ts). Loaded content is stored with the key it
+  // belongs to; when the route changes, `loaded` derives to null (loading)
+  // without a synchronous state reset inside the effect.
+  const [state, setState] = useState<{ key: string; content: string | null } | null>(null);
+
+  useEffect(() => {
+    if (!category || !slug) return;
+    let active = true;
+    void loadDocContent(category, slug).then((body) => {
+      if (active) setState({ key, content: body });
+    });
+    return () => {
+      active = false;
+    };
+  }, [key, category, slug]);
 
   if (!doc) {
     return <Navigate to="/help" replace />;
   }
+
+  const content = state && state.key === key ? state.content : undefined;
 
   return (
     <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
@@ -34,13 +56,21 @@ export function HelpDocPage() {
               </p>
             </div>
 
-            <DocContent content={doc.content} />
-            <DocNavigation current={doc} />
+            {content === undefined ? (
+              <div className="py-16">
+                <AuthSpinner showCard={false} />
+              </div>
+            ) : (
+              <>
+                <DocContent content={content ?? ""} />
+                <DocNavigation current={doc} />
+              </>
+            )}
           </main>
 
           {/* Right: TOC */}
           <aside className="hidden xl:block w-48 shrink-0 sticky top-20">
-            <DocToc content={doc.content} />
+            {content ? <DocToc content={content} /> : null}
           </aside>
         </div>
       </div>

--- a/client/src/app/stack-templates/[templateId]/page.tsx
+++ b/client/src/app/stack-templates/[templateId]/page.tsx
@@ -15,13 +15,20 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Textarea } from "@/components/ui/textarea";
-import { IconArrowLeft, IconLoader2, IconGitCompare, IconRocket } from "@tabler/icons-react";
+import {
+  IconArrowLeft,
+  IconLoader2,
+  IconGitCompare,
+  IconRocket,
+  IconDownload,
+} from "@tabler/icons-react";
 import {
   useStackTemplate,
   useStackTemplateVersions,
   useSaveDraft,
   usePublishDraft,
   useDiscardDraft,
+  useExportTemplateVersion,
 } from "@/hooks/use-stack-templates";
 import { TemplateVersionDiff } from "@/components/stack-templates/template-version-diff";
 import { InstantiateTemplateDialog } from "@/components/stack-templates/instantiate-template-dialog";
@@ -71,6 +78,7 @@ export default function StackTemplateDetailPage() {
   const saveDraftMutation = useSaveDraft();
   const publishDraftMutation = usePublishDraft();
   const discardDraftMutation = useDiscardDraft();
+  const exportMutation = useExportTemplateVersion();
 
   // Compute display version
   const allVersions = versions ?? [];
@@ -272,6 +280,35 @@ export default function StackTemplateDetailPage() {
     }
   }
 
+  // Export the currently-displayed version to a portable YAML file. The server
+  // redacts literal secrets and reports what it removed; surface that so the
+  // operator knows the file isn't a full backup.
+  const handleExportVersion = async () => {
+    if (!templateId || !displayVersion) return;
+    try {
+      const { filename, yaml, issues } = await exportMutation.mutateAsync({
+        templateId,
+        versionId: displayVersion.id,
+      });
+      const blob = new Blob([yaml], { type: "application/yaml" });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = filename;
+      anchor.click();
+      URL.revokeObjectURL(url);
+
+      const redactions = issues.filter((i) => i.level === "lossy").length;
+      toast.success(
+        redactions > 0
+          ? `Exported ${filename} — ${redactions} secret${redactions === 1 ? "" : "s"} redacted; set them again on import`
+          : `Exported ${filename}`,
+      );
+    } catch {
+      // Global MutationCache.onError surfaces an actionable toast.
+    }
+  };
+
   // Loading state
   if (isLoading) {
     return (
@@ -396,6 +433,22 @@ export default function StackTemplateDetailPage() {
             <Button variant="outline" size="sm" onClick={() => setShowInstall(true)}>
               <IconRocket className="h-4 w-4 mr-1" />
               Install
+            </Button>
+          )}
+          {displayVersion && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void handleExportVersion()}
+              disabled={exportMutation.isPending}
+              data-tour="export-template-button"
+            >
+              {exportMutation.isPending ? (
+                <IconLoader2 className="h-4 w-4 mr-1 animate-spin" />
+              ) : (
+                <IconDownload className="h-4 w-4 mr-1" />
+              )}
+              Export
             </Button>
           )}
           {isSystem ? (

--- a/client/src/app/stack-templates/page.tsx
+++ b/client/src/app/stack-templates/page.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { IconTemplate, IconPlus, IconFileImport } from "@tabler/icons-react";
+import { IconTemplate, IconPlus, IconFileImport, IconDownload } from "@tabler/icons-react";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -15,12 +15,14 @@ import { Label } from "@/components/ui/label";
 import { TemplateTable } from "@/components/stack-templates/template-table";
 import { CreateTemplateDialog } from "@/components/stack-templates/create-template-dialog";
 import { ImportComposeDialog } from "@/components/stack-templates/import-compose-dialog";
+import { ImportTemplateDialog } from "@/components/stack-templates/import-template-dialog";
 import { useStackTemplates } from "@/hooks/use-stack-templates";
 import type { StackTemplateSource, StackTemplateScope } from "@mini-infra/types";
 
 export default function StackTemplatesPage() {
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
+  const [importTemplateDialogOpen, setImportTemplateDialogOpen] = useState(false);
   const [source, setSource] = useState<StackTemplateSource | undefined>(undefined);
   const [scope, setScope] = useState<StackTemplateScope | undefined>(undefined);
   const [includeArchived, setIncludeArchived] = useState(false);
@@ -58,6 +60,14 @@ export default function StackTemplatesPage() {
             >
               <IconFileImport className="h-4 w-4 mr-2" />
               Import from Compose
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => setImportTemplateDialogOpen(true)}
+              data-tour="import-template-button"
+            >
+              <IconDownload className="h-4 w-4 mr-2" />
+              Import template
             </Button>
             <Button onClick={() => setCreateDialogOpen(true)}>
               <IconPlus className="h-4 w-4 mr-2" />
@@ -154,6 +164,11 @@ export default function StackTemplatesPage() {
       </div>
 
       <ImportComposeDialog open={importDialogOpen} onOpenChange={setImportDialogOpen} />
+
+      <ImportTemplateDialog
+        open={importTemplateDialogOpen}
+        onOpenChange={setImportTemplateDialogOpen}
+      />
 
       <CreateTemplateDialog
         open={createDialogOpen}

--- a/client/src/components/agent/agent-chat-panel.tsx
+++ b/client/src/components/agent/agent-chat-panel.tsx
@@ -1,11 +1,20 @@
-import { useEffect, useRef } from "react";
+import { Suspense, lazy, useEffect, useRef } from "react";
+import { IconLoader2 } from "@tabler/icons-react";
 import { useAgentChat } from "@/hooks/use-agent-chat";
 import { useSidebar } from "@/components/ui/sidebar";
 import { AgentChatHeader } from "./agent-chat-header";
-import { AgentChatMessages } from "./agent-chat-messages";
 import { AgentChatInput } from "./agent-chat-input";
 import { AgentChatHistory } from "./agent-chat-history";
 import { cn } from "@/lib/utils";
+
+// The message list is the only thing in the app that pulls in react-markdown
+// (+ remark/rehype) — a heavy stack that has no business in the initial bundle
+// for a panel most sessions never open. Lazy-load it so that chunk is fetched
+// only when the agent panel is actually opened. See the code-splitting work in
+// the P6 roadmap item (5.4).
+const AgentChatMessages = lazy(() =>
+  import("./agent-chat-messages").then((m) => ({ default: m.AgentChatMessages })),
+);
 
 export function AgentChatPanel() {
   const { isOpen, agentEnabled, isHistoryOpen } = useAgentChat();
@@ -56,7 +65,15 @@ export function AgentChatPanel() {
           <AgentChatHistory />
           <aside className="flex h-full w-[420px] shrink-0 flex-col border-l bg-background">
             <AgentChatHeader />
-            <AgentChatMessages />
+            <Suspense
+              fallback={
+                <div className="flex flex-1 items-center justify-center">
+                  <IconLoader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                </div>
+              }
+            >
+              <AgentChatMessages />
+            </Suspense>
             <AgentChatInput />
           </aside>
         </>

--- a/client/src/components/app-layout.tsx
+++ b/client/src/components/app-layout.tsx
@@ -1,6 +1,8 @@
+import { Suspense } from "react";
 import { Outlet } from "react-router-dom";
 import { AppSidebar } from "@/components/app-sidebar";
 import { SiteHeader } from "@/components/site-header";
+import { AuthSpinner } from "@/components/auth-spinner";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { AgentChatProvider } from "@/components/agent/agent-chat-provider";
 import { AgentChatFAB } from "@/components/agent/agent-chat-fab";
@@ -31,7 +33,17 @@ export function AppLayout() {
           <SiteHeader />
           <div className="flex flex-1 flex-col">
             <div className="@container/main flex flex-1 flex-col gap-2">
-              <Outlet />
+              {/* One boundary for every lazily-loaded page behind the layout
+                  (route-level code splitting, P6 5.4). */}
+              <Suspense
+                fallback={
+                  <div className="flex flex-1 items-center justify-center py-16">
+                    <AuthSpinner showCard={false} />
+                  </div>
+                }
+              >
+                <Outlet />
+              </Suspense>
             </div>
           </div>
         </SidebarInset>

--- a/client/src/components/stack-templates/import-issue-list.tsx
+++ b/client/src/components/stack-templates/import-issue-list.tsx
@@ -1,0 +1,78 @@
+import {
+  IconAlertTriangle,
+  IconBan,
+  IconInfoCircle,
+} from "@tabler/icons-react";
+import type { ImportIssue, ImportIssueLevel } from "@mini-infra/types";
+
+/**
+ * The report both on-ramps share — Docker Compose import and template
+ * export/import. Compose is a bigger surface than a stack template, and an
+ * export can't carry secrets or origin-instance state, so both leave things
+ * behind. This renders exactly what, grouped by how much the user needs to
+ * care, so nothing is dropped in silence.
+ */
+const LEVEL_META: Record<
+  ImportIssueLevel,
+  { label: string; icon: typeof IconBan; className: string }
+> = {
+  error: {
+    label: "Blocking",
+    icon: IconBan,
+    className: "text-destructive",
+  },
+  unsupported: {
+    label: "Not imported",
+    icon: IconAlertTriangle,
+    className: "text-amber-600 dark:text-amber-400",
+  },
+  lossy: {
+    label: "Changed",
+    icon: IconAlertTriangle,
+    className: "text-amber-600 dark:text-amber-400",
+  },
+  defaulted: {
+    label: "Assumed",
+    icon: IconInfoCircle,
+    className: "text-muted-foreground",
+  },
+};
+
+const LEVEL_ORDER: ImportIssueLevel[] = ["error", "unsupported", "lossy", "defaulted"];
+
+export function ImportIssueList({ issues }: { issues: ImportIssue[] }) {
+  if (issues.length === 0) return null;
+
+  return (
+    <div className="max-h-56 space-y-3 overflow-y-auto rounded-md border p-3">
+      {LEVEL_ORDER.map((level) => {
+        const forLevel = issues.filter((i) => i.level === level);
+        if (forLevel.length === 0) return null;
+        const meta = LEVEL_META[level];
+        const Icon = meta.icon;
+
+        return (
+          <div key={level}>
+            <div
+              className={`mb-1 flex items-center gap-1.5 text-sm font-medium ${meta.className}`}
+            >
+              <Icon className="h-4 w-4" />
+              {meta.label}
+              <span className="text-muted-foreground">({forLevel.length})</span>
+            </div>
+            <ul className="space-y-1">
+              {forLevel.map((issue, i) => (
+                <li key={`${issue.path}-${i}`} className="text-xs">
+                  {issue.path && (
+                    <code className="mr-1 rounded bg-muted px-1 py-0.5">{issue.path}</code>
+                  )}
+                  <span className="text-muted-foreground">{issue.message}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/client/src/components/stack-templates/import-template-dialog.tsx
+++ b/client/src/components/stack-templates/import-template-dialog.tsx
@@ -17,27 +17,22 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { useCreateStackTemplate } from "@/hooks/use-stack-templates";
+import { useImportTemplate } from "@/hooks/use-stack-templates";
 import { ImportIssueList } from "@/components/stack-templates/import-issue-list";
 import {
-  mapComposeToTemplate,
-  type ComposeImportResult,
+  mapTemplateImportDocument,
+  type TemplateImportResult,
 } from "@mini-infra/types";
 
 /**
- * Turn a `compose.yml` into a template draft.
+ * Import a stack template exported from another Mini Infra instance.
  *
- * Most people arriving at Mini Infra already have a compose file, so this is the
- * on-ramp. The mapping itself lives in `@mini-infra/types` (pure, and shared with
- * anything server-side that wants it later); this is just the paste-box and,
- * more importantly, the **report**.
- *
- * The report is the point. Compose is a much bigger surface than a stack
- * template, so an import always leaves something behind — `build:`, `deploy:`,
- * host-env interpolation. The Code view used to discard what it couldn't
- * represent and say nothing, and the failure mode was always the same: the user
- * discovered it when the thing they'd configured didn't happen. So everything not
- * carried across is shown here, before the template exists.
+ * Symmetric with the Compose importer: the mapping/validation lives in
+ * `@mini-infra/types` (`mapTemplateImportDocument`) and runs here so the report
+ * appears *before* anything is created — an export can't carry secrets or
+ * origin-instance state (a custom NATS subject prefix is allowlisted by template
+ * ID, which the copy doesn't inherit), and those are surfaced, never silent. The
+ * server re-runs the same mapping and validation on submit.
  */
 function slugify(input: string): string {
   return input
@@ -47,7 +42,7 @@ function slugify(input: string): string {
     .slice(0, 100);
 }
 
-export function ImportComposeDialog({
+export function ImportTemplateDialog({
   open,
   onOpenChange,
 }: {
@@ -55,15 +50,13 @@ export function ImportComposeDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const navigate = useNavigate();
-  const createMutation = useCreateStackTemplate();
+  const importMutation = useImportTemplate();
   const fileRef = useRef<HTMLInputElement>(null);
 
   const [text, setText] = useState("");
   const [displayName, setDisplayName] = useState("");
-  // A YAML syntax error is distinct from a mapping issue: the file never parsed,
-  // so there is nothing to report about its contents.
   const [parseError, setParseError] = useState<string | null>(null);
-  const [result, setResult] = useState<ComposeImportResult | null>(null);
+  const [result, setResult] = useState<TemplateImportResult | null>(null);
 
   function analyse(next: string) {
     setText(next);
@@ -79,12 +72,17 @@ export function ImportComposeDialog({
       setParseError(err instanceof Error ? err.message : "Could not parse the file as YAML.");
       return;
     }
-    setResult(mapComposeToTemplate(doc));
+    const mapped = mapTemplateImportDocument(doc);
+    setResult(mapped);
+    // Prefill the name from the file the first time, letting the operator rename
+    // (required if a template with that name already exists on this instance).
+    if (mapped.request?.displayName && displayName.trim() === "") {
+      setDisplayName(mapped.request.displayName);
+    }
   }
 
   async function onFile(file: File) {
     const content = await file.text();
-    if (!displayName) setDisplayName(file.name.replace(/\.(ya?ml)$/i, ""));
     analyse(content);
   }
 
@@ -95,37 +93,38 @@ export function ImportComposeDialog({
     setResult(null);
   }
 
-  async function onCreate() {
-    if (!result?.draft) return;
+  async function onImport() {
+    if (!result?.ok || !result.request) return;
     const name = slugify(displayName);
     try {
-      const created = await createMutation.mutateAsync({
+      const created = await importMutation.mutateAsync({
+        yaml: text,
         name,
         displayName,
-        description: "Imported from a Docker Compose file",
-        scope: "environment",
-        networks: result.draft.networks,
-        volumes: result.draft.volumes,
-        services: result.draft.services,
       });
-      toast.success(`Imported ${result.draft.services.length} service(s) into "${displayName}"`);
+      const notices = result.issues.length;
+      toast.success(
+        notices > 0
+          ? `Imported "${displayName}" with ${notices} notice${notices === 1 ? "" : "s"} to review`
+          : `Imported "${displayName}"`,
+      );
       onOpenChange(false);
       reset();
       navigate(`/stack-templates/${created.id}`);
     } catch {
-      // The global MutationCache.onError already raises an actionable toast; keep
-      // the dialog open so the operator can adjust and retry.
+      // The global MutationCache.onError raises an actionable toast; keep the
+      // dialog open so the operator can rename (on a name clash) and retry.
     }
   }
 
   const blocking = result?.issues.filter((i) => i.level === "error") ?? [];
-  const canCreate =
+  const canImport =
     result?.ok === true &&
-    result.draft != null &&
+    result.request != null &&
     blocking.length === 0 &&
     displayName.trim() !== "" &&
     slugify(displayName) !== "" &&
-    !createMutation.isPending;
+    !importMutation.isPending;
 
   return (
     <Dialog
@@ -137,17 +136,18 @@ export function ImportComposeDialog({
     >
       <DialogContent className="max-w-3xl">
         <DialogHeader>
-          <DialogTitle>Import from Docker Compose</DialogTitle>
+          <DialogTitle>Import a template</DialogTitle>
           <DialogDescription>
-            Paste a <code>compose.yml</code> to turn it into a template. Anything Compose can
-            express that a stack template can&apos;t is listed below rather than dropped.
+            Paste or upload a template exported from another Mini Infra instance. Anything the
+            file can&apos;t carry across — secrets, an origin-specific NATS prefix — is listed
+            below rather than applied silently.
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
           <div className="space-y-2">
             <div className="flex items-center justify-between">
-              <Label htmlFor="compose-yaml">Compose file</Label>
+              <Label htmlFor="template-yaml">Template file</Label>
               <Button
                 type="button"
                 variant="outline"
@@ -170,11 +170,11 @@ export function ImportComposeDialog({
               />
             </div>
             <Textarea
-              id="compose-yaml"
-              data-tour="compose-import-input"
+              id="template-yaml"
+              data-tour="import-template-input"
               value={text}
               onChange={(e) => analyse(e.target.value)}
-              placeholder={"services:\n  web:\n    image: nginx:1.25\n    ports:\n      - \"8080:80\""}
+              placeholder={"format: mini-infra.stack-template/v1\ntemplate:\n  name: my-app\n  ..."}
               className="h-44 font-mono text-xs"
               spellCheck={false}
             />
@@ -191,55 +191,43 @@ export function ImportComposeDialog({
 
           {result && (
             <>
-              {result.draft && (
+              {result.request && (
                 <div className="flex flex-wrap items-center gap-2 text-sm">
                   <span className="text-muted-foreground">Imports as</span>
                   <Badge variant="secondary">
-                    {result.draft.services.length} service
-                    {result.draft.services.length === 1 ? "" : "s"}
+                    {result.request.services.length} service
+                    {result.request.services.length === 1 ? "" : "s"}
                   </Badge>
-                  {result.draft.volumes.length > 0 && (
-                    <Badge variant="secondary">{result.draft.volumes.length} volume(s)</Badge>
-                  )}
-                  {result.draft.networks.length > 0 && (
-                    <Badge variant="secondary">{result.draft.networks.length} network(s)</Badge>
-                  )}
+                  <Badge variant="secondary">{result.request.scope}</Badge>
                 </div>
               )}
 
               <ImportIssueList issues={result.issues} />
 
-              {/* A blocking issue means at least one service can't be represented
-                  at all. Importing the rest would produce a template that quietly
-                  does less than the compose file did — so say what's wrong and
-                  what to do, rather than leaving a disabled button with no
-                  explanation. */}
               {blocking.length > 0 ? (
                 <Alert variant="destructive">
                   <IconBan className="h-4 w-4" />
                   <AlertDescription>
-                    {blocking.length === 1
-                      ? "One service can't be imported"
-                      : `${blocking.length} services can't be imported`}
-                    , so the template would be missing part of what this file
-                    describes. Fix the blocking issue above — or drop those services from the file
-                    — then paste it again.
+                    This file can&apos;t be imported as it stands. Fix the blocking issue(s)
+                    above — usually a wrong or missing <code>format</code>, or a missing name —
+                    then try again.
                   </AlertDescription>
                 </Alert>
               ) : (
                 result.ok && (
                   <div className="space-y-2">
-                    <Label htmlFor="compose-name">Template name</Label>
+                    <Label htmlFor="template-name">Template name</Label>
                     <Input
-                      id="compose-name"
-                      data-tour="compose-import-name"
+                      id="template-name"
+                      data-tour="import-template-name"
                       value={displayName}
                       onChange={(e) => setDisplayName(e.target.value)}
                       placeholder="My application"
                     />
                     {displayName.trim() !== "" && (
                       <p className="text-xs text-muted-foreground">
-                        Identifier: <code>{slugify(displayName) || "—"}</code>
+                        Identifier: <code>{slugify(displayName) || "—"}</code>. Rename if a
+                        template with this name already exists here.
                       </p>
                     )}
                   </div>
@@ -253,13 +241,13 @@ export function ImportComposeDialog({
           <Button
             variant="outline"
             onClick={() => onOpenChange(false)}
-            disabled={createMutation.isPending}
+            disabled={importMutation.isPending}
           >
             Cancel
           </Button>
-          <Button onClick={() => void onCreate()} disabled={!canCreate}>
-            {createMutation.isPending && <IconLoader2 className="mr-1 h-4 w-4 animate-spin" />}
-            Create template
+          <Button onClick={() => void onImport()} disabled={!canImport}>
+            {importMutation.isPending && <IconLoader2 className="mr-1 h-4 w-4 animate-spin" />}
+            Import template
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/client/src/hooks/use-stack-templates.ts
+++ b/client/src/hooks/use-stack-templates.ts
@@ -11,6 +11,7 @@ import type {
   StackTemplateScope,
   PrerequisiteEvaluation,
   StackInfo,
+  ImportIssue,
 } from "@mini-infra/types";
 import { apiFetch } from "@/lib/api-client";
 
@@ -142,6 +143,35 @@ async function discardDraft(templateId: string): Promise<void> {
   });
 }
 
+/** The `data` payload of the export endpoint (issues = redaction/build notices). */
+export interface TemplateVersionExport {
+  filename: string;
+  yaml: string;
+  issues: ImportIssue[];
+}
+
+async function exportTemplateVersion(args: {
+  templateId: string;
+  versionId: string;
+}): Promise<TemplateVersionExport> {
+  return apiFetch<TemplateVersionExport>(
+    ApiRoute.stackTemplates.exportVersion(args.templateId, args.versionId),
+    { correlationIdPrefix: "stack-templates" },
+  );
+}
+
+async function importTemplate(args: {
+  yaml: string;
+  name?: string;
+  displayName?: string;
+}): Promise<StackTemplateInfo> {
+  return apiFetch<StackTemplateInfo>(ApiRoute.stackTemplates.import(), {
+    method: "POST",
+    body: args,
+    correlationIdPrefix: "stack-templates",
+  });
+}
+
 async function deleteTemplate(templateId: string): Promise<void> {
   await apiFetch(ApiRoute.stackTemplates.get(templateId), {
     method: "DELETE",
@@ -228,6 +258,22 @@ export function useUpdateStackTemplate() {
       queryClient.invalidateQueries({
         queryKey: queryKeys.stackTemplates.detail(variables.templateId),
       });
+    },
+  });
+}
+
+/** Fetch a version's portable export document (does not mutate; a "mutation" only for imperative call ergonomics). */
+export function useExportTemplateVersion() {
+  return useMutation({ mutationFn: exportTemplateVersion });
+}
+
+export function useImportTemplate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: importTemplate,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.stackTemplates.all });
     },
   });
 }

--- a/client/src/lib/application-draft.ts
+++ b/client/src/lib/application-draft.ts
@@ -1,152 +1,16 @@
-import type {
-  DraftVersionInput,
-  StackServiceDefinition,
-  StackTemplateConfigFileInfo,
-  StackTemplateConfigFileInput,
-  StackTemplateServiceInfo,
-  StackTemplateVersionInfo,
+/**
+ * Draft-mapping helpers used across the application Configuration tab, the
+ * stack-templates draft editor, and the Code-view codec.
+ *
+ * The implementations were hoisted into `@mini-infra/types`
+ * (`template-draft.ts`) so the server template-export endpoint can share the
+ * exact same lossless version→draft conversion — one mapper, no drift. This
+ * module stays as the client-facing entry point so existing `@/lib/application-draft`
+ * imports keep resolving.
+ */
+export {
+  buildDraftFromVersion,
+  mapServiceInfoToDefinition,
+  mapConfigFileInfoToInput,
+  stripNull,
 } from "@mini-infra/types";
-
-/**
- * Recursively drop keys whose value is `null`. The version read model
- * (`StackTemplateVersionInfo`) returns `null` for absent optional fields
- * (`resourceInputs`, a service's `routing`/`initCommands`/`vaultAppRoleRef`/
- * `jobPoolConfig`, `notes`, ...), but the create/draft Zod schema uses
- * `.optional()` — which rejects `null` ("expected X, received null") and only
- * accepts the value or its absence. Stripping nulls turns the read shape back
- * into a valid write shape, including nested `containerConfig` fields, without
- * enumerating every optional key by hand. The schema never uses `.nullable()`
- * for these, so a dropped null is always the right choice on this write path.
- */
-function stripNull<T>(value: T): T {
-  if (Array.isArray(value)) {
-    return value.map((v) => stripNull(v)) as unknown as T;
-  }
-  if (value !== null && typeof value === "object") {
-    const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value)) {
-      if (v === null) continue;
-      out[k] = stripNull(v);
-    }
-    return out as T;
-  }
-  return value;
-}
-
-/**
- * Rebuild a full `DraftVersionInput` from a published/draft version so that a
- * republish (via `useUpdateApplication`) is LOSSLESS — every version-level and
- * service-level field is carried through, and only the field a caller
- * explicitly overrides afterwards changes.
- *
- * Why this exists: the application Configuration tab builds its draft from
- * scratch and only sets the handful of fields the form edits, silently
- * dropping everything else on save (`resourceInputs`, `configFiles`, `vault`,
- * `nats`, `requires`, ...). Any flow that mutates a single field of an existing
- * application — e.g. the Connected Networks card changing a service's
- * `joinNetworks` — must go through here instead, or it would strip those
- * fields off the republished version.
- *
- * The result is run through `stripNull` so read-model `null`s become absent,
- * matching what the draft schema's `.optional()` fields accept.
- */
-export function buildDraftFromVersion(
-  version: StackTemplateVersionInfo,
-): DraftVersionInput {
-  const draft: DraftVersionInput = {
-    parameters: version.parameters,
-    defaultParameterValues: version.defaultParameterValues,
-    networkTypeDefaults: version.networkTypeDefaults,
-    resourceOutputs: version.resourceOutputs,
-    resourceInputs: version.resourceInputs,
-    // `StackNetwork[]` is assignable to `StackNetworkEntry[]`.
-    networks: version.networks,
-    volumes: version.volumes,
-    services: (version.services ?? []).map(mapServiceInfoToDefinition),
-    configFiles: version.configFiles?.map(mapConfigFileInfoToInput),
-    notes: version.notes ?? undefined,
-    inputs: version.inputs,
-    requires: version.requires,
-  };
-
-  // vault/nats are attached AFTER the strip, deliberately. Unlike every other
-  // section, their schemas use `.nullable()` — the NATS JetStream limits
-  // (`maxBytes`, `maxAgeSeconds`, `maxDeliver`, …) accept an explicit null, which
-  // does not mean the same thing as an absent key. Running them through stripNull
-  // would quietly rewrite an author's "no limit" into "use the default".
-  return {
-    ...stripNull(draft),
-    ...(version.vault ? { vault: version.vault } : {}),
-    ...(version.nats ? { nats: version.nats } : {}),
-  };
-}
-
-/**
- * Map a persisted service (`StackTemplateServiceInfo`) back into the authoring
- * shape (`StackServiceDefinition`). DB-only fields (`id`, `versionId`) are
- * dropped, EVERY authoring field is carried through (`addons`, `poolConfig`,
- * `jobPoolConfig`, and the vault/nats binding refs), and the whole result is
- * run through `stripNull` so read-model `null`s on optional-non-nullable fields
- * become absent — matching what the create/draft schema's `.optional()` fields
- * accept.
- *
- * This is the single canonical service mapper. It is write-safe standalone
- * (the `stripNull` pass means a caller can drop its output straight into a
- * `DraftVersionInput.services[]` without re-stripping), so the stack-templates
- * draft editor reuses it directly rather than hand-rolling a partial map that
- * silently drops per-service `addons`/`poolConfig`/`nats*`/`vault*` whenever any
- * service is edited. `buildDraftFromVersion` above also re-strips the whole
- * draft, but that outer pass is now redundant for services (idempotent).
- */
-export function mapServiceInfoToDefinition(
-  svc: StackTemplateServiceInfo,
-): StackServiceDefinition {
-  return stripNull({
-    serviceName: svc.serviceName,
-    serviceType: svc.serviceType,
-    dockerImage: svc.dockerImage,
-    dockerTag: svc.dockerTag,
-    containerConfig: svc.containerConfig,
-    initCommands: svc.initCommands ?? undefined,
-    dependsOn: svc.dependsOn,
-    order: svc.order,
-    routing: svc.routing ?? undefined,
-    adoptedContainer: svc.adoptedContainer,
-    poolConfig: svc.poolConfig ?? undefined,
-    jobPoolConfig: svc.jobPoolConfig,
-    vaultAppRoleId: svc.vaultAppRoleId,
-    vaultAppRoleRef: svc.vaultAppRoleRef,
-    natsCredentialId: svc.natsCredentialId,
-    natsRole: svc.natsRole,
-    natsSigner: svc.natsSigner,
-    addons: svc.addons ?? undefined,
-  });
-}
-
-/*
- * `mergeCodeViewDraft` and `versionHasUnrepresentedSections` used to live here.
- *
- * They existed to paper over a lossy YAML codec: the Code view could not
- * represent `inputs`/`vault`/`nats`/`requires` or the per-service bindings, so a
- * save would have wiped them, and the merge re-attached them from the current
- * version afterwards. That made the Code view a view of *most* of the template
- * which saved *some* of your edits — and it could never express a deletion,
- * since anything you removed was silently put back.
- *
- * The codec is lossless now (see `yaml-codec.ts`), so the YAML owns the whole
- * document and the shim is gone. Deleting a section in the Code view deletes it.
- */
-
-function mapConfigFileInfoToInput(
-  cf: StackTemplateConfigFileInfo,
-): StackTemplateConfigFileInput {
-  return {
-    serviceName: cf.serviceName,
-    fileName: cf.fileName,
-    volumeName: cf.volumeName,
-    mountPath: cf.mountPath,
-    content: cf.content,
-    permissions: cf.permissions ?? undefined,
-    owner: cf.owner ?? undefined,
-  };
-}

--- a/client/src/lib/doc-loader.ts
+++ b/client/src/lib/doc-loader.ts
@@ -1,38 +1,16 @@
 import docsStructure from "../user-docs/docs-structure.yaml";
 import docsQuestions from "../user-docs/docs-questions.yaml";
+import docsMeta from "../user-docs/docs-meta.generated.json";
 
-/** Minimal front-matter parser — replaces the `front-matter` npm package. */
-function parseFrontMatter<T>(raw: string): { attributes: T; body: string } {
-  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
-  if (!match) return { attributes: {} as T, body: raw };
-
-  const attrs: Record<string, unknown> = {};
-  const lines = match[1].split("\n");
-  let i = 0;
-  while (i < lines.length) {
-    const line = lines[i];
-    const idx = line.indexOf(":");
-    if (idx === -1) { i++; continue; }
-    const key = line.slice(0, idx).trim();
-    const rest = line.slice(idx + 1).trim();
-
-    if (rest === "") {
-      // Could be a YAML block list — collect "  - value" lines
-      const items: string[] = [];
-      while (i + 1 < lines.length && lines[i + 1].match(/^\s+-\s/)) {
-        i++;
-        items.push(lines[i].replace(/^\s+-\s+/, ""));
-      }
-      attrs[key] = items.length > 0 ? items : "";
-    } else if (rest.startsWith("[") && rest.endsWith("]")) {
-      attrs[key] = rest.slice(1, -1).split(",").map((s) => s.trim());
-    } else {
-      attrs[key] = rest;
-    }
-    i++;
-  }
-  return { attributes: attrs as T, body: match[2] };
-}
+/**
+ * Doc *metadata* (title/description/tags per article) is loaded eagerly from a
+ * small generated manifest — see `scripts/generate-docs-meta.mjs`. Doc *bodies*
+ * are loaded lazily (below), so the ~436 KB of markdown no longer ships in the
+ * initial bundle for the always-mounted help sidebar. Only the help article
+ * page (a lazy route) and the search index (lazily, on first use) ever pull a
+ * body across the wire. Re-run `pnpm generate:docs-meta` after adding, renaming,
+ * or re-titling an article.
+ */
 
 export interface DocFrontmatter {
   title: string;
@@ -40,14 +18,20 @@ export interface DocFrontmatter {
   tags?: string[];
 }
 
+/**
+ * Article metadata. `content` (the markdown body) is loaded lazily and is
+ * therefore optional — the eager registry leaves it unset; the help page and
+ * search index fill it on demand (see `loadDocContent` / `loadAllDocContent`).
+ */
 export interface DocEntry {
   slug: string;
   category: string;
   frontmatter: DocFrontmatter;
-  content: string;
   href: string;
   /** Topics this article covers — from docs-structure.yaml */
   topics: string[];
+  /** Markdown body, present only once lazily loaded. */
+  content?: string;
 }
 
 export interface ArticleDef {
@@ -73,6 +57,7 @@ export interface QuestionMapping {
 
 const structure = docsStructure as DocsStructure;
 const questions = docsQuestions as QuestionMapping[];
+const metaMap = docsMeta as Record<string, DocFrontmatter>;
 
 /** Build a lookup from "category/slug" → topics[] */
 function buildTopicsMap(): Map<string, string[]> {
@@ -87,59 +72,68 @@ function buildTopicsMap(): Map<string, string[]> {
 
 const topicsMap = buildTopicsMap();
 
-const rawFiles = import.meta.glob("../user-docs/**/*.md", {
-  eager: true,
+/**
+ * Lazy body loaders, keyed by "category/slug". `eager: false` (the default) is
+ * the whole point — Vite emits a dynamic import per file instead of inlining
+ * every body into this module's chunk.
+ */
+const bodyLoaders = import.meta.glob("../user-docs/**/*.md", {
   query: "?raw",
   import: "default",
-}) as Record<string, string>;
+}) as Record<string, () => Promise<string>>;
 
-/** Map from "category/slug" to parsed doc entry */
-function buildRawMap(): Map<string, DocEntry> {
-  const map = new Map<string, DocEntry>();
-  for (const [filePath, raw] of Object.entries(rawFiles)) {
-    const parts = filePath
-      .replace("../user-docs/", "")
-      .replace(/\.md$/, "")
-      .split("/");
-    const category = parts[0];
-    const slug = parts[parts.length - 1];
-    const key = `${category}/${slug}`;
+function keyForPath(filePath: string): string {
+  const parts = filePath
+    .replace("../user-docs/", "")
+    .replace(/\.md$/, "")
+    .split("/");
+  const category = parts[0];
+  const slug = parts[parts.length - 1];
+  return `${category}/${slug}`;
+}
 
-    const { attributes, body } = parseFrontMatter<DocFrontmatter>(raw);
+const loaderByKey = new Map<string, () => Promise<string>>();
+for (const [filePath, loader] of Object.entries(bodyLoaders)) {
+  loaderByKey.set(keyForPath(filePath), loader);
+}
 
-    map.set(key, {
+/** Minimal front-matter stripper — the manifest already holds the parsed attributes. */
+function stripFrontMatter(raw: string): string {
+  const match = raw.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?([\s\S]*)$/);
+  return (match ? match[1] : raw).trim();
+}
+
+function metaFor(key: string, slug: string): DocFrontmatter {
+  return metaMap[key] ?? { title: slug, description: "" };
+}
+
+/** Build the metadata-only registry (body-free) from the manifest + structure. */
+function buildRegistry(): DocEntry[] {
+  const entries: DocEntry[] = [];
+  const seen = new Set<string>();
+
+  const add = (key: string) => {
+    if (seen.has(key)) return;
+    const [category, slug] = key.split("/");
+    entries.push({
       slug,
       category,
-      frontmatter: attributes,
-      content: body.trim(),
+      frontmatter: metaFor(key, slug),
       href: `/help/${category}/${slug}`,
       topics: topicsMap.get(key) ?? [],
     });
-  }
-  return map;
-}
+    seen.add(key);
+  };
 
-const rawMap = buildRawMap();
-
-function buildRegistry(): DocEntry[] {
-  const entries: DocEntry[] = [];
-
+  // YAML-defined order first…
   for (const section of structure.sections) {
     for (const article of section.articles) {
       const key = `${section.slug}/${article.slug}`;
-      const doc = rawMap.get(key);
-      if (doc) {
-        entries.push(doc);
-      }
+      if (metaMap[key]) add(key);
     }
   }
-
-  // Include any docs that exist on disk but aren't in the YAML yet (append at end)
-  for (const [, doc] of rawMap) {
-    if (!entries.includes(doc)) {
-      entries.push(doc);
-    }
-  }
+  // …then any article present on disk (in the manifest) but not yet in the YAML.
+  for (const key of Object.keys(metaMap)) add(key);
 
   return entries;
 }
@@ -150,8 +144,28 @@ export function getDocBySlug(
   category: string,
   slug: string
 ): DocEntry | undefined {
-  return docRegistry.find(
-    (d) => d.category === category && d.slug === slug
+  return docRegistry.find((d) => d.category === category && d.slug === slug);
+}
+
+/** Load one article's markdown body (front-matter stripped). Returns null if unknown. */
+export async function loadDocContent(
+  category: string,
+  slug: string
+): Promise<string | null> {
+  const loader = loaderByKey.get(`${category}/${slug}`);
+  if (!loader) return null;
+  return stripFrontMatter(await loader());
+}
+
+/** Load every article body and pair it with its metadata — used to build the search index. */
+export async function loadAllDocContent(): Promise<DocEntry[]> {
+  return Promise.all(
+    docRegistry.map(async (entry) => ({
+      ...entry,
+      content: stripFrontMatter(
+        (await loaderByKey.get(`${entry.category}/${entry.slug}`)?.()) ?? ""
+      ),
+    })),
   );
 }
 
@@ -169,7 +183,7 @@ export function getDocsByCategory(): DocCategory[] {
   // Build categories in YAML-defined order
   for (const section of structure.sections) {
     const docs = section.articles
-      .map((article) => rawMap.get(`${section.slug}/${article.slug}`))
+      .map((article) => getDocBySlug(section.slug, article.slug))
       .filter((d): d is DocEntry => d !== undefined);
 
     if (docs.length > 0) {

--- a/client/src/lib/doc-loader.ts
+++ b/client/src/lib/doc-loader.ts
@@ -19,9 +19,8 @@ export interface DocFrontmatter {
 }
 
 /**
- * Article metadata. `content` (the markdown body) is loaded lazily and is
- * therefore optional — the eager registry leaves it unset; the help page and
- * search index fill it on demand (see `loadDocContent` / `loadAllDocContent`).
+ * Article metadata. The markdown body is NOT here — it's loaded lazily on demand
+ * (see `loadDocContent`) so the ~436 KB of bodies stay out of the initial bundle.
  */
 export interface DocEntry {
   slug: string;
@@ -30,8 +29,6 @@ export interface DocEntry {
   href: string;
   /** Topics this article covers — from docs-structure.yaml */
   topics: string[];
-  /** Markdown body, present only once lazily loaded. */
-  content?: string;
 }
 
 export interface ArticleDef {
@@ -155,18 +152,6 @@ export async function loadDocContent(
   const loader = loaderByKey.get(`${category}/${slug}`);
   if (!loader) return null;
   return stripFrontMatter(await loader());
-}
-
-/** Load every article body and pair it with its metadata — used to build the search index. */
-export async function loadAllDocContent(): Promise<DocEntry[]> {
-  return Promise.all(
-    docRegistry.map(async (entry) => ({
-      ...entry,
-      content: stripFrontMatter(
-        (await loaderByKey.get(`${entry.category}/${entry.slug}`)?.()) ?? ""
-      ),
-    })),
-  );
 }
 
 export interface DocCategory {

--- a/client/src/lib/doc-search.ts
+++ b/client/src/lib/doc-search.ts
@@ -1,23 +1,61 @@
 import Fuse from "fuse.js";
-import { useMemo } from "react";
-import { docRegistry, type DocEntry } from "./doc-loader";
+import { useEffect, useMemo, useState } from "react";
+import { docRegistry, loadAllDocContent, type DocEntry } from "./doc-loader";
 
-const fuseIndex = new Fuse(docRegistry, {
-  keys: [
-    { name: "frontmatter.title", weight: 0.4 },
-    { name: "frontmatter.description", weight: 0.25 },
-    { name: "topics", weight: 0.2 },
-    { name: "frontmatter.tags", weight: 0.05 },
-    { name: "content", weight: 0.1 },
-  ],
-  threshold: 0.4,
-  includeScore: true,
-  minMatchCharLength: 2,
-});
+/**
+ * Doc bodies are lazy now (see doc-loader.ts), so the search index is built in
+ * two stages: a metadata-only Fuse index synchronously (titles, descriptions,
+ * topics, tags — instant, no bodies), then a content-aware index once the
+ * bodies have been fetched on first use. Full-text ranking (weight 0.1) is
+ * preserved; it just isn't paid for until someone actually searches.
+ */
+const METADATA_KEYS = [
+  { name: "frontmatter.title", weight: 0.4 },
+  { name: "frontmatter.description", weight: 0.25 },
+  { name: "topics", weight: 0.2 },
+  { name: "frontmatter.tags", weight: 0.05 },
+];
+
+const OPTS = { threshold: 0.4, includeScore: true, minMatchCharLength: 2 };
+
+const metadataIndex = new Fuse(docRegistry, { keys: METADATA_KEYS, ...OPTS });
+
+let contentIndex: Fuse<DocEntry> | null = null;
+let contentPromise: Promise<void> | null = null;
+
+/** Fetch every body once and upgrade to a content-aware index. Idempotent. */
+function ensureContentIndex(): Promise<void> {
+  if (!contentPromise) {
+    contentPromise = loadAllDocContent().then((withContent) => {
+      contentIndex = new Fuse<DocEntry>(withContent, {
+        keys: [...METADATA_KEYS, { name: "content", weight: 0.1 }],
+        ...OPTS,
+      });
+    });
+  }
+  return contentPromise;
+}
 
 export function useDocSearch(query: string): DocEntry[] {
+  // `ready` flips once the content index is built, re-running the memo so an
+  // in-flight query upgrades from metadata- to content-aware results.
+  const [ready, setReady] = useState(contentIndex !== null);
+
+  useEffect(() => {
+    if (contentIndex) return;
+    let active = true;
+    void ensureContentIndex().then(() => {
+      if (active) setReady(true);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
   return useMemo(() => {
     if (!query.trim()) return docRegistry;
-    return fuseIndex.search(query).map((r) => r.item);
-  }, [query]);
+    const index = contentIndex ?? metadataIndex;
+    return index.search(query).map((r) => r.item);
+    // `ready` is a dependency so results recompute when the content index lands.
+  }, [query, ready]);
 }

--- a/client/src/lib/doc-search.ts
+++ b/client/src/lib/doc-search.ts
@@ -1,61 +1,32 @@
 import Fuse from "fuse.js";
-import { useEffect, useMemo, useState } from "react";
-import { docRegistry, loadAllDocContent, type DocEntry } from "./doc-loader";
+import { useMemo } from "react";
+import { docRegistry, type DocEntry } from "./doc-loader";
 
 /**
- * Doc bodies are lazy now (see doc-loader.ts), so the search index is built in
- * two stages: a metadata-only Fuse index synchronously (titles, descriptions,
- * topics, tags — instant, no bodies), then a content-aware index once the
- * bodies have been fetched on first use. Full-text ranking (weight 0.1) is
- * preserved; it just isn't paid for until someone actually searches.
+ * Help search ranks over article *metadata* — title, description, the curated
+ * `topics` list (which docs-structure.yaml maintains specifically "for search
+ * ranking and agent lookups"), and tags. It deliberately does NOT index the
+ * markdown bodies: those are lazy-loaded now (see doc-loader.ts) so they don't
+ * ship in the initial bundle, and pulling all 56 of them back just to add a
+ * weight-0.1 full-text signal would undo that win. The metadata carries the
+ * large majority of the ranking weight, so results are effectively unchanged
+ * for real queries.
  */
-const METADATA_KEYS = [
-  { name: "frontmatter.title", weight: 0.4 },
-  { name: "frontmatter.description", weight: 0.25 },
-  { name: "topics", weight: 0.2 },
-  { name: "frontmatter.tags", weight: 0.05 },
-];
-
-const OPTS = { threshold: 0.4, includeScore: true, minMatchCharLength: 2 };
-
-const metadataIndex = new Fuse(docRegistry, { keys: METADATA_KEYS, ...OPTS });
-
-let contentIndex: Fuse<DocEntry> | null = null;
-let contentPromise: Promise<void> | null = null;
-
-/** Fetch every body once and upgrade to a content-aware index. Idempotent. */
-function ensureContentIndex(): Promise<void> {
-  if (!contentPromise) {
-    contentPromise = loadAllDocContent().then((withContent) => {
-      contentIndex = new Fuse<DocEntry>(withContent, {
-        keys: [...METADATA_KEYS, { name: "content", weight: 0.1 }],
-        ...OPTS,
-      });
-    });
-  }
-  return contentPromise;
-}
+const fuseIndex = new Fuse(docRegistry, {
+  keys: [
+    { name: "frontmatter.title", weight: 0.45 },
+    { name: "frontmatter.description", weight: 0.3 },
+    { name: "topics", weight: 0.2 },
+    { name: "frontmatter.tags", weight: 0.05 },
+  ],
+  threshold: 0.4,
+  includeScore: true,
+  minMatchCharLength: 2,
+});
 
 export function useDocSearch(query: string): DocEntry[] {
-  // `ready` flips once the content index is built, re-running the memo so an
-  // in-flight query upgrades from metadata- to content-aware results.
-  const [ready, setReady] = useState(contentIndex !== null);
-
-  useEffect(() => {
-    if (contentIndex) return;
-    let active = true;
-    void ensureContentIndex().then(() => {
-      if (active) setReady(true);
-    });
-    return () => {
-      active = false;
-    };
-  }, []);
-
   return useMemo(() => {
     if (!query.trim()) return docRegistry;
-    const index = contentIndex ?? metadataIndex;
-    return index.search(query).map((r) => r.item);
-    // `ready` is a dependency so results recompute when the content index lands.
-  }, [query, ready]);
+    return fuseIndex.search(query).map((r) => r.item);
+  }, [query]);
 }

--- a/client/src/lib/routes.tsx
+++ b/client/src/lib/routes.tsx
@@ -1,89 +1,136 @@
-import { Suspense } from "react";
+import { lazy } from "react";
 import { createBrowserRouter, Navigate } from "react-router-dom";
 import { ProtectedRoute } from "@/components/protected-route";
 import { PublicRoute } from "@/components/public-route";
 import { AuthErrorBoundary } from "@/components/auth-error-boundary";
 import { AppLayout } from "@/components/app-layout";
+
+// Auth/entry pages stay eager: they're small and on the first-paint path for a
+// logged-out user, where an extra chunk round-trip (and a spinner) is exactly
+// what you don't want. Everything behind AppLayout is lazy — see below.
 import { LoginPage } from "@/app/login/page";
 import { SetupPage } from "@/app/setup/page";
 import { PasswordRecoveryPage } from "@/app/recover/page";
 import { ForcePasswordChangePage } from "@/app/change-password/page";
-import { DashboardPage } from "@/app/dashboard/page";
-import { ContainersPage } from "@/app/containers/page";
-import ContainerDetailPage from "@/app/containers/[id]/page";
-import { VolumeInspectPage } from "@/app/containers/volumes/VolumeInspectPage";
-import { VolumeFileContentPage } from "@/app/containers/volumes/VolumeFileContentPage";
-import DockerSettingsPage from "@/app/connectivity/docker/page";
-import CloudflareSettingsPage from "@/app/connectivity/cloudflare/page";
-import StorageSettingsPage from "@/app/connectivity-storage/page";
-import GitHubConnectivityPage from "@/app/connectivity/github/page";
-import TailscaleSettingsPage from "@/app/connectivity/tailscale/page";
-import SystemSettingsPage from "@/app/settings/system/page";
-import NetworkAccessPage from "@/app/network-access/page";
-import RegistryCredentialsPage from "@/app/settings/registry-credentials/page";
-import SelfBackupSettingsPage from "@/app/settings/self-backup/page";
-import GitHubSettingsPage from "@/app/settings/github/page";
-import PostgresBackups from "@/app/postgres/page";
-import PostgresRestorePage from "@/app/postgres/restore/page";
-import PostgresServerPage from "@/app/postgres-server/page";
-import PostgresServerDetailPage from "@/app/postgres-server/[serverId]/page";
-import DatabaseDetailPage from "@/app/postgres-server/[serverId]/databases/[dbId]/page";
-import { TunnelsPage } from "@/app/tunnels/page";
-import { UserSettingsPage } from "@/app/user/settings/page";
-import ApplicationsPage from "@/app/applications/page";
-import NewApplicationPage from "@/app/applications/new/page";
-import NewClaudeShellPage from "@/app/applications/new/claude-shell/page";
-import ApplicationDetailLayout from "@/app/applications/[id]/layout";
-import ApplicationDetailIndex from "@/app/applications/[id]/page";
-import ApplicationOverviewTab from "@/app/applications/[id]/overview/page";
-import ApplicationServicesTab from "@/app/applications/[id]/services/page";
-import ApplicationConfigurationTab from "@/app/applications/[id]/configuration/page";
-import ApplicationActivityTab from "@/app/applications/[id]/activity/page";
-import AdoptContainerPage from "@/app/applications/adopt/page";
-import { ApiKeysPage } from "@/app/api-keys/page";
-import { CreateApiKeyPage } from "@/app/api-keys/new/page";
-import { PermissionPresetsPage } from "@/app/api-keys/presets/page";
-import { EventsPage } from "@/app/events/page";
-import EventDetailPage from "@/app/events/[id]/page";
-import { EnvironmentsPage } from "@/app/environments/page";
-import { EnvironmentDetailPage } from "@/app/environments/[id]/page";
-import CertificatesPage from "@/app/certificates/page";
-import CertificateDetailsPage from "@/app/certificates/[id]/page";
-import DnsPage from "@/app/dns/page";
-import TlsSettingsPage from "@/app/settings/tls/page";
-import AiAssistantSettingsPage from "@/app/settings/ai-assistant/page";
-import EgressFwAgentSettingsPage from "@/app/settings/egress-fw-agent/page";
-import EgressPage from "@/app/egress/page";
-import EgressPolicyDetailPage from "@/app/egress/[policyId]/page";
-import { IconShowcasePage } from "@/app/design/icons/page";
-import FrontendsListPage from "@/app/haproxy/frontends/page";
-import FrontendDetailsPage from "@/app/haproxy/frontends/[frontendName]/page";
-import CreateManualFrontendPage from "@/app/haproxy/frontends/new/manual/page";
-import EditManualFrontendPage from "@/app/haproxy/frontends/[frontendName]/edit/page";
-import BackendsListPage from "@/app/haproxy/backends/page";
-import BackendDetailsPage from "@/app/haproxy/backends/[backendName]/page";
-import HAProxyInstancesPage from "@/app/haproxy/instances/page";
-import HAProxyOverviewPage from "@/app/haproxy/page";
-import SelfUpdateSettingsPage from "@/app/settings/self-update/page";
-import SystemDiagnosticsPage from "@/app/system-diagnostics/page";
-import { MonitoringPage } from "@/app/monitoring/page";
+// Eager: takes a `fullscreen` prop and is also mounted outside AppLayout
+// (`/logs/fullscreen`), so it's simplest kept out of the lazy prop-less helper.
 import { LogsPage } from "@/app/logs/page";
-import StackTemplatesPage from "@/app/stack-templates/page";
-import StackTemplateDetailPage from "@/app/stack-templates/[templateId]/page";
-import StacksPage from "@/app/stacks/page";
-import StackDetailPage from "@/app/stacks/[stackId]/page";
-import UserManagementPage from "@/app/settings/users/page";
-import AuthenticationSettingsPage from "@/app/settings/authentication/page";
-import VaultPage from "@/app/vault/page";
-import VaultPoliciesPage from "@/app/vault/policies/page";
-import VaultPolicyDetailPage from "@/app/vault/policies/[id]/page";
-import VaultAppRolesPage from "@/app/vault/approles/page";
-import VaultAppRoleDetailPage from "@/app/vault/approles/[id]/page";
-import NatsPage from "@/app/nats/page";
-import NatsAccountsPage from "@/app/nats/accounts/page";
-import NatsCredentialsPage from "@/app/nats/credentials/page";
-import NatsStreamsPage from "@/app/nats/streams/page";
-import NatsConsumersPage from "@/app/nats/consumers/page";
+
+/**
+ * Route-level code splitting (P6 roadmap 5.4). Every page behind the
+ * authenticated AppLayout is a `React.lazy` chunk, so the initial bundle no
+ * longer carries all ~75 pages (and their heavy, page-specific deps — the
+ * CodeMirror template editor, recharts, and so on) up front. A single
+ * `<Suspense>` boundary around the layout's `<Outlet>` (see app-layout.tsx)
+ * catches the load; the fullscreen-logs route, which lives outside the layout,
+ * gets its own boundary.
+ *
+ * `named()` adapts our many named-export pages to what `React.lazy` wants
+ * (`{ default }`); default-export pages use `lazy(() => import(...))` directly.
+ */
+function named<M extends Record<string, unknown>, K extends keyof M>(
+  loader: () => Promise<M>,
+  key: K,
+) {
+  return lazy(() => loader().then((m) => ({ default: m[key] as React.ComponentType })));
+}
+
+// ─── Lazy pages (all behind AppLayout) ──────────────────────────────────────
+const DashboardPage = named(() => import("@/app/dashboard/page"), "DashboardPage");
+const ContainersPage = named(() => import("@/app/containers/page"), "ContainersPage");
+const ContainerDetailPage = lazy(() => import("@/app/containers/[id]/page"));
+const VolumeInspectPage = named(
+  () => import("@/app/containers/volumes/VolumeInspectPage"),
+  "VolumeInspectPage",
+);
+const VolumeFileContentPage = named(
+  () => import("@/app/containers/volumes/VolumeFileContentPage"),
+  "VolumeFileContentPage",
+);
+const DockerSettingsPage = lazy(() => import("@/app/connectivity/docker/page"));
+const CloudflareSettingsPage = lazy(() => import("@/app/connectivity/cloudflare/page"));
+const StorageSettingsPage = lazy(() => import("@/app/connectivity-storage/page"));
+const GitHubConnectivityPage = lazy(() => import("@/app/connectivity/github/page"));
+const TailscaleSettingsPage = lazy(() => import("@/app/connectivity/tailscale/page"));
+const SystemSettingsPage = lazy(() => import("@/app/settings/system/page"));
+const NetworkAccessPage = lazy(() => import("@/app/network-access/page"));
+const RegistryCredentialsPage = lazy(() => import("@/app/settings/registry-credentials/page"));
+const SelfBackupSettingsPage = lazy(() => import("@/app/settings/self-backup/page"));
+const GitHubSettingsPage = lazy(() => import("@/app/settings/github/page"));
+const PostgresBackups = lazy(() => import("@/app/postgres/page"));
+const PostgresRestorePage = lazy(() => import("@/app/postgres/restore/page"));
+const PostgresServerPage = lazy(() => import("@/app/postgres-server/page"));
+const PostgresServerDetailPage = lazy(() => import("@/app/postgres-server/[serverId]/page"));
+const DatabaseDetailPage = lazy(
+  () => import("@/app/postgres-server/[serverId]/databases/[dbId]/page"),
+);
+const TunnelsPage = named(() => import("@/app/tunnels/page"), "TunnelsPage");
+const UserSettingsPage = named(() => import("@/app/user/settings/page"), "UserSettingsPage");
+const ApplicationsPage = lazy(() => import("@/app/applications/page"));
+const NewApplicationPage = lazy(() => import("@/app/applications/new/page"));
+const NewClaudeShellPage = lazy(() => import("@/app/applications/new/claude-shell/page"));
+const ApplicationDetailLayout = lazy(() => import("@/app/applications/[id]/layout"));
+const ApplicationDetailIndex = lazy(() => import("@/app/applications/[id]/page"));
+const ApplicationOverviewTab = lazy(() => import("@/app/applications/[id]/overview/page"));
+const ApplicationServicesTab = lazy(() => import("@/app/applications/[id]/services/page"));
+const ApplicationConfigurationTab = lazy(
+  () => import("@/app/applications/[id]/configuration/page"),
+);
+const ApplicationActivityTab = lazy(() => import("@/app/applications/[id]/activity/page"));
+const AdoptContainerPage = lazy(() => import("@/app/applications/adopt/page"));
+const ApiKeysPage = named(() => import("@/app/api-keys/page"), "ApiKeysPage");
+const CreateApiKeyPage = named(() => import("@/app/api-keys/new/page"), "CreateApiKeyPage");
+const PermissionPresetsPage = named(
+  () => import("@/app/api-keys/presets/page"),
+  "PermissionPresetsPage",
+);
+const EventsPage = named(() => import("@/app/events/page"), "EventsPage");
+const EventDetailPage = lazy(() => import("@/app/events/[id]/page"));
+const EnvironmentsPage = named(() => import("@/app/environments/page"), "EnvironmentsPage");
+const EnvironmentDetailPage = named(
+  () => import("@/app/environments/[id]/page"),
+  "EnvironmentDetailPage",
+);
+const CertificatesPage = lazy(() => import("@/app/certificates/page"));
+const CertificateDetailsPage = lazy(() => import("@/app/certificates/[id]/page"));
+const DnsPage = lazy(() => import("@/app/dns/page"));
+const TlsSettingsPage = lazy(() => import("@/app/settings/tls/page"));
+const AiAssistantSettingsPage = lazy(() => import("@/app/settings/ai-assistant/page"));
+const EgressFwAgentSettingsPage = lazy(() => import("@/app/settings/egress-fw-agent/page"));
+const EgressPage = lazy(() => import("@/app/egress/page"));
+const EgressPolicyDetailPage = lazy(() => import("@/app/egress/[policyId]/page"));
+const IconShowcasePage = named(() => import("@/app/design/icons/page"), "IconShowcasePage");
+const FrontendsListPage = lazy(() => import("@/app/haproxy/frontends/page"));
+const FrontendDetailsPage = lazy(() => import("@/app/haproxy/frontends/[frontendName]/page"));
+const CreateManualFrontendPage = lazy(() => import("@/app/haproxy/frontends/new/manual/page"));
+const EditManualFrontendPage = lazy(
+  () => import("@/app/haproxy/frontends/[frontendName]/edit/page"),
+);
+const BackendsListPage = lazy(() => import("@/app/haproxy/backends/page"));
+const BackendDetailsPage = lazy(() => import("@/app/haproxy/backends/[backendName]/page"));
+const HAProxyInstancesPage = lazy(() => import("@/app/haproxy/instances/page"));
+const HAProxyOverviewPage = lazy(() => import("@/app/haproxy/page"));
+const SelfUpdateSettingsPage = lazy(() => import("@/app/settings/self-update/page"));
+const SystemDiagnosticsPage = lazy(() => import("@/app/system-diagnostics/page"));
+const MonitoringPage = named(() => import("@/app/monitoring/page"), "MonitoringPage");
+const StackTemplatesPage = lazy(() => import("@/app/stack-templates/page"));
+const StackTemplateDetailPage = lazy(() => import("@/app/stack-templates/[templateId]/page"));
+const StacksPage = lazy(() => import("@/app/stacks/page"));
+const StackDetailPage = lazy(() => import("@/app/stacks/[stackId]/page"));
+const UserManagementPage = lazy(() => import("@/app/settings/users/page"));
+const AuthenticationSettingsPage = lazy(() => import("@/app/settings/authentication/page"));
+const VaultPage = lazy(() => import("@/app/vault/page"));
+const VaultPoliciesPage = lazy(() => import("@/app/vault/policies/page"));
+const VaultPolicyDetailPage = lazy(() => import("@/app/vault/policies/[id]/page"));
+const VaultAppRolesPage = lazy(() => import("@/app/vault/approles/page"));
+const VaultAppRoleDetailPage = lazy(() => import("@/app/vault/approles/[id]/page"));
+const NatsPage = lazy(() => import("@/app/nats/page"));
+const NatsAccountsPage = lazy(() => import("@/app/nats/accounts/page"));
+const NatsCredentialsPage = lazy(() => import("@/app/nats/credentials/page"));
+const NatsStreamsPage = lazy(() => import("@/app/nats/streams/page"));
+const NatsConsumersPage = lazy(() => import("@/app/nats/consumers/page"));
+const HelpPage = lazy(() => import("@/app/help/page"));
+const HelpDocPage = lazy(() => import("@/app/help/[category]/[slug]/page"));
 
 export const router = createBrowserRouter([
   {
@@ -445,34 +492,14 @@ export const router = createBrowserRouter([
       },
       {
         path: "help",
-        lazy: async () => {
-          const { default: HelpPage } = await import("@/app/help/page");
-          return {
-            element: (
-              <Suspense>
-                <HelpPage />
-              </Suspense>
-            ),
-          };
-        },
+        element: <HelpPage />,
       },
       {
         path: "help/:category/:slug",
-        lazy: async () => {
-          const { default: HelpDocPage } = await import(
-            "@/app/help/[category]/[slug]/page"
-          );
-          return {
-            element: (
-              <Suspense>
-                <HelpDocPage />
-              </Suspense>
-            ),
-          };
-        },
+        element: <HelpDocPage />,
       },
       // Development-only routes
-      ...(import.meta.env.VITE_SHOW_DEV_MENU === 'true'
+      ...(import.meta.env.VITE_SHOW_DEV_MENU === "true"
         ? [
             {
               path: "design/icons",

--- a/client/src/user-docs/applications/stack-templates.md
+++ b/client/src/user-docs/applications/stack-templates.md
@@ -60,6 +60,24 @@ Every service imports as **Stateful**. A StatelessWeb service needs routing, whi
 
 An imported template lands as a **draft**, so nothing is deployed until you review it and publish.
 
+## Exporting and importing templates
+
+To move a template between Mini Infra instances — or to share one — use **Export** and **Import template**.
+
+**Export** is on a template's detail page and exports the version you're currently viewing. It downloads a single YAML file describing the whole version. Two things it deliberately does *not* do:
+
+- **Secrets don't travel.** Any literal Vault value in the template (`vault.kv` fields written as a `value:`) is replaced with a redaction placeholder, and the export tells you which fields it stripped. The file is safe to commit or share, but it is **not** a full backup — you set those secrets again after importing. A field written as a `fromInput:` reference carries no secret and is exported as-is.
+- **It's always a version.** The export captures one version's contents plus the template's name, description, scope, and network type — not its whole version history.
+
+**Import template** is on the Stack Templates page. Paste or upload an exported file and Mini Infra shows you what it will do before creating anything — the same report style as the Compose importer:
+
+- The file is always imported as a **user** template (a system template exported from one instance lands as a user template you can edit).
+- If the exported scope was **any**, it's set to **Environment** and flagged, because user templates are host- or environment-scoped.
+- If the template claims a **custom NATS subject prefix**, you're warned: the subject-prefix allowlist is keyed by template ID, and the import creates a new template with a new ID, so an admin must add the new template to the allowlist before its first deploy.
+- Redacted secrets are listed so you know exactly what to set before deploying.
+
+You can **rename** on import (required if a template with that name already exists here). The result lands as a **draft** — review and publish it as usual.
+
 ## The template editor
 
 The editor has a main editing area and a **version sidebar**.

--- a/client/src/user-docs/docs-meta.generated.json
+++ b/client/src/user-docs/docs-meta.generated.json
@@ -1,0 +1,587 @@
+{
+  "api/api-overview": {
+    "title": "API Overview",
+    "description": "An overview of how to use the Mini Infra REST API with API keys.",
+    "tags": [
+      "api",
+      "authentication",
+      "api-keys",
+      "configuration"
+    ]
+  },
+  "applications/application-management": {
+    "title": "Managing Applications",
+    "description": "How to create, deploy, configure, upgrade, stop, and remove applications in Mini Infra.",
+    "tags": [
+      "applications",
+      "deployment",
+      "docker",
+      "configuration",
+      "stacks"
+    ]
+  },
+  "applications/claude-shell": {
+    "title": "Claude Shell",
+    "description": "How to create, connect to, and authenticate a Claude Shell — a Tailscale-SSH-reachable developer container with Claude Code pre-installed.",
+    "tags": [
+      "applications",
+      "claude-shell",
+      "tailscale",
+      "ssh",
+      "claude-code",
+      "vault",
+      "egress"
+    ]
+  },
+  "applications/host-stacks": {
+    "title": "Stacks",
+    "description": "How to find, review, apply, upgrade, stop, and remove stacks — the plan/apply unit behind every application and infrastructure service in Mini Infra.",
+    "tags": [
+      "stacks",
+      "docker",
+      "infrastructure",
+      "configuration",
+      "drift"
+    ]
+  },
+  "applications/stack-templates": {
+    "title": "Stack Templates",
+    "description": "How to create, version, publish, roll back, and install reusable stack templates in Mini Infra.",
+    "tags": [
+      "stack-templates",
+      "infrastructure",
+      "docker",
+      "configuration",
+      "versioning"
+    ]
+  },
+  "connectivity/health-monitoring": {
+    "title": "Connected Services Health Monitoring",
+    "description": "How to configure and monitor external service connections in Mini Infra.",
+    "tags": [
+      "connectivity",
+      "health-checks",
+      "docker",
+      "storage",
+      "cloudflare",
+      "github",
+      "monitoring"
+    ]
+  },
+  "connectivity/troubleshooting": {
+    "title": "Connected Services Troubleshooting",
+    "description": "Common issues with external service connections and how to resolve them.",
+    "tags": [
+      "connectivity",
+      "troubleshooting",
+      "docker",
+      "azure",
+      "cloudflare",
+      "github"
+    ]
+  },
+  "containers/container-actions": {
+    "title": "Container Actions Reference",
+    "description": "Reference for all actions you can perform on Docker containers in Mini Infra.",
+    "tags": [
+      "containers",
+      "docker",
+      "configuration"
+    ]
+  },
+  "containers/container-logs": {
+    "title": "Viewing Container Logs",
+    "description": "How to view and use the container log viewer in Mini Infra.",
+    "tags": [
+      "containers",
+      "docker",
+      "monitoring"
+    ]
+  },
+  "containers/managing-containers": {
+    "title": "Managing a Container",
+    "description": "How to view details, run actions, and inspect a specific container.",
+    "tags": [
+      "containers",
+      "docker",
+      "configuration"
+    ]
+  },
+  "containers/troubleshooting": {
+    "title": "Container Troubleshooting",
+    "description": "Common container issues and how to resolve them in Mini Infra.",
+    "tags": [
+      "containers",
+      "docker",
+      "troubleshooting"
+    ]
+  },
+  "containers/viewing-containers": {
+    "title": "Viewing and Filtering Containers",
+    "description": "How to view, search, and filter Docker containers in Mini Infra.",
+    "tags": [
+      "containers",
+      "docker",
+      "monitoring"
+    ]
+  },
+  "containers/volume-management": {
+    "title": "Volume Management",
+    "description": "How to inspect, browse, and manage Docker volumes in Mini Infra.",
+    "tags": [
+      "containers",
+      "docker",
+      "volumes"
+    ]
+  },
+  "environments/environments": {
+    "title": "Managing Environments",
+    "description": "How to create and manage environments that group services and infrastructure in Mini Infra",
+    "tags": [
+      "environments",
+      "infrastructure",
+      "applications",
+      "configuration"
+    ]
+  },
+  "getting-started/concepts": {
+    "title": "Concepts and Terminology",
+    "description": "A glossary of Mini Infra concepts — what each feature is, how it works, and the terminology used throughout the application.",
+    "tags": [
+      "concepts",
+      "glossary",
+      "terminology",
+      "reference"
+    ]
+  },
+  "getting-started/navigating-the-dashboard": {
+    "title": "Navigating the Dashboard",
+    "description": "A guide to finding your way around the Mini Infra interface.",
+    "tags": [
+      "getting-started",
+      "navigation",
+      "dashboard",
+      "ui"
+    ]
+  },
+  "getting-started/overview": {
+    "title": "Getting Started with Mini Infra",
+    "description": "An introduction to Mini Infra and what you can do with it.",
+    "tags": [
+      "getting-started",
+      "dashboard",
+      "overview",
+      "docker"
+    ]
+  },
+  "getting-started/running-with-docker": {
+    "title": "Running Mini Infra with Docker",
+    "description": "How to run Mini Infra using Docker or Docker Compose.",
+    "tags": [
+      "getting-started",
+      "docker",
+      "installation",
+      "configuration"
+    ]
+  },
+  "github/github-app-setup": {
+    "title": "Setting Up the GitHub App",
+    "description": "How to connect Mini Infra to GitHub using the GitHub App integration.",
+    "tags": [
+      "github",
+      "authentication",
+      "configuration",
+      "getting-started"
+    ]
+  },
+  "github/packages-and-registries": {
+    "title": "GitHub Packages and Container Registries",
+    "description": "How to browse GitHub Container Registry packages connected through the GitHub App.",
+    "tags": [
+      "github",
+      "docker",
+      "containers",
+      "configuration"
+    ]
+  },
+  "github/repository-integration": {
+    "title": "GitHub Repository Integration",
+    "description": "How to view repositories, monitor GitHub Actions, and configure bug reporting with GitHub.",
+    "tags": [
+      "github",
+      "configuration",
+      "monitoring"
+    ]
+  },
+  "github/troubleshooting": {
+    "title": "GitHub Integration Troubleshooting",
+    "description": "Common GitHub integration issues and how to resolve them.",
+    "tags": [
+      "github",
+      "troubleshooting",
+      "authentication"
+    ]
+  },
+  "haproxy/haproxy-backends": {
+    "title": "Managing HAProxy Backends",
+    "description": "How to view and configure HAProxy backends and servers in Mini Infra",
+    "tags": [
+      "haproxy",
+      "backends",
+      "load-balancer",
+      "servers"
+    ]
+  },
+  "haproxy/haproxy-frontends": {
+    "title": "Managing HAProxy Frontends",
+    "description": "How to view, create, and configure HAProxy frontends in Mini Infra",
+    "tags": [
+      "haproxy",
+      "frontends",
+      "load-balancer",
+      "routing",
+      "ssl"
+    ]
+  },
+  "haproxy/haproxy-instances": {
+    "title": "HAProxy Instances",
+    "description": "How to monitor HAProxy health across environments and remediate or migrate instances in Mini Infra",
+    "tags": [
+      "haproxy",
+      "instances",
+      "health",
+      "remediation",
+      "migration"
+    ]
+  },
+  "haproxy/haproxy-overview": {
+    "title": "Load Balancer Overview",
+    "description": "An overview of how HAProxy load balancing works in Mini Infra",
+    "tags": [
+      "haproxy",
+      "load-balancer",
+      "networking",
+      "routing"
+    ]
+  },
+  "monitoring/container-logs": {
+    "title": "Searching Container Logs",
+    "description": "How to search, filter, and stream centralized container logs in Mini Infra.",
+    "tags": [
+      "monitoring",
+      "logs",
+      "docker",
+      "loki"
+    ]
+  },
+  "monitoring/container-metrics": {
+    "title": "Container Metrics",
+    "description": "How to monitor CPU, memory, and network usage across Docker containers in Mini Infra.",
+    "tags": [
+      "monitoring",
+      "metrics",
+      "docker",
+      "prometheus"
+    ]
+  },
+  "monitoring/events": {
+    "title": "Event Log",
+    "description": "How to view and manage the system event log in Mini Infra.",
+    "tags": [
+      "monitoring",
+      "events",
+      "deployments",
+      "backup"
+    ]
+  },
+  "nats/nats-app-integration": {
+    "title": "Connecting your app to NATS",
+    "description": "Step-by-step guide for declaring NATS roles and signers in a stack template and consuming them from your application code.",
+    "tags": [
+      "nats",
+      "messaging",
+      "applications",
+      "integration",
+      "templates"
+    ]
+  },
+  "nats/nats-cross-stack-sharing": {
+    "title": "Sharing NATS subjects across stacks",
+    "description": "Use exports and imports to publish events from one stack and consume them in another, plus the subject-prefix allowlist for human-readable namespaces.",
+    "tags": [
+      "nats",
+      "messaging",
+      "integration",
+      "templates",
+      "exports",
+      "imports"
+    ]
+  },
+  "nats/nats-overview": {
+    "title": "NATS for App Developers",
+    "description": "What the built-in NATS message bus offers app authors and how stacks plug into it.",
+    "tags": [
+      "nats",
+      "messaging",
+      "jetstream",
+      "applications",
+      "integration"
+    ]
+  },
+  "networking/dns-zones": {
+    "title": "DNS Zones",
+    "description": "How to view DNS zones and records from Cloudflare in Mini Infra",
+    "tags": [
+      "dns",
+      "cloudflare",
+      "networking",
+      "zones"
+    ]
+  },
+  "networking/tls-certificates": {
+    "title": "TLS Certificate Management",
+    "description": "How to issue, renew, and manage SSL/TLS certificates in Mini Infra.",
+    "tags": [
+      "ssl",
+      "tls",
+      "certificates",
+      "networking",
+      "storage",
+      "haproxy"
+    ]
+  },
+  "postgres-backups/backup-overview": {
+    "title": "PostgreSQL Backup Overview",
+    "description": "An overview of how PostgreSQL backup management works in Mini Infra.",
+    "tags": [
+      "postgres",
+      "backup",
+      "storage",
+      "monitoring"
+    ]
+  },
+  "postgres-backups/configuring-backups": {
+    "title": "Configuring Backup Schedules",
+    "description": "How to configure automated PostgreSQL backup schedules in Mini Infra.",
+    "tags": [
+      "postgres",
+      "backup",
+      "azure",
+      "cron",
+      "configuration"
+    ]
+  },
+  "postgres-backups/database-management": {
+    "title": "Managing PostgreSQL Databases",
+    "description": "How to add, edit, and manage PostgreSQL database connections in Mini Infra.",
+    "tags": [
+      "postgres",
+      "configuration",
+      "backup"
+    ]
+  },
+  "postgres-backups/restoring-backups": {
+    "title": "Restoring a PostgreSQL Backup",
+    "description": "How to browse backups and restore a PostgreSQL database in Mini Infra.",
+    "tags": [
+      "postgres",
+      "backup",
+      "restore",
+      "azure"
+    ]
+  },
+  "postgres-backups/troubleshooting": {
+    "title": "PostgreSQL Backup Troubleshooting",
+    "description": "Common PostgreSQL backup and restore issues and how to resolve them.",
+    "tags": [
+      "postgres",
+      "backup",
+      "restore",
+      "troubleshooting",
+      "azure"
+    ]
+  },
+  "settings/ai-assistant": {
+    "title": "AI Assistant Settings",
+    "description": "How to configure the AI assistant's API key, model, and view its capabilities in Mini Infra.",
+    "tags": [
+      "ai",
+      "configuration",
+      "anthropic",
+      "claude",
+      "settings"
+    ]
+  },
+  "settings/api-keys": {
+    "title": "Managing API Keys",
+    "description": "How to create, manage, and revoke API keys for programmatic access to Mini Infra.",
+    "tags": [
+      "api-keys",
+      "authentication",
+      "settings",
+      "security"
+    ]
+  },
+  "settings/authentication": {
+    "title": "Authentication Configuration",
+    "description": "How to configure authentication methods including Google OAuth in Mini Infra.",
+    "tags": [
+      "settings",
+      "authentication",
+      "google-oauth",
+      "administration"
+    ]
+  },
+  "settings/permission-presets": {
+    "title": "API Key Permission Presets",
+    "description": "How to create and manage reusable permission templates for API keys.",
+    "tags": [
+      "api-keys",
+      "authentication",
+      "settings",
+      "configuration"
+    ]
+  },
+  "settings/self-update": {
+    "title": "System Update",
+    "description": "How to update Mini Infra to a new version using the sidecar update mechanism",
+    "tags": [
+      "settings",
+      "update",
+      "sidecar",
+      "administration"
+    ]
+  },
+  "settings/system-diagnostics": {
+    "title": "System Diagnostics",
+    "description": "How to read server memory statistics and capture diagnostic artifacts from the System Diagnostics page in Mini Infra.",
+    "tags": [
+      "settings",
+      "diagnostics",
+      "memory",
+      "administration"
+    ]
+  },
+  "settings/system-settings": {
+    "title": "System Settings",
+    "description": "How to configure system-wide settings including Docker images, HAProxy ports, and event retention.",
+    "tags": [
+      "settings",
+      "configuration",
+      "docker",
+      "haproxy",
+      "postgres"
+    ]
+  },
+  "settings/tailscale": {
+    "title": "Tailscale",
+    "description": "How to connect Mini Infra to a Tailscale tailnet so it can mint authkeys and expose addon-attached services on your tailnet.",
+    "tags": [
+      "settings",
+      "tailscale",
+      "connectivity",
+      "oauth",
+      "acl"
+    ]
+  },
+  "settings/tls-settings": {
+    "title": "TLS Settings",
+    "description": "How to configure certificate storage, ACME provider, and renewal scheduling for TLS certificates.",
+    "tags": [
+      "settings",
+      "tls",
+      "ssl",
+      "certificates",
+      "azure",
+      "configuration"
+    ]
+  },
+  "settings/user-management": {
+    "title": "User Management",
+    "description": "How to create, delete, and manage user accounts and passwords in Mini Infra.",
+    "tags": [
+      "settings",
+      "users",
+      "authentication",
+      "administration"
+    ]
+  },
+  "settings/user-preferences": {
+    "title": "User Preferences",
+    "description": "How to configure personal settings like timezone in Mini Infra.",
+    "tags": [
+      "settings",
+      "user",
+      "timezone",
+      "preferences"
+    ]
+  },
+  "tunnels/troubleshooting": {
+    "title": "Cloudflare Tunnel Troubleshooting",
+    "description": "Common issues with Cloudflare tunnel monitoring and how to resolve them.",
+    "tags": [
+      "tunnels",
+      "cloudflare",
+      "troubleshooting"
+    ]
+  },
+  "tunnels/tunnel-monitoring": {
+    "title": "Monitoring Cloudflare Tunnels",
+    "description": "How to monitor Cloudflare tunnel health and manage hostnames in Mini Infra.",
+    "tags": [
+      "tunnels",
+      "cloudflare",
+      "monitoring",
+      "dns"
+    ]
+  },
+  "vault/vault-app-integration": {
+    "title": "Using Vault from your app",
+    "description": "How to declare Vault policies and AppRoles in a stack template, get credentials injected at deploy time, and read secrets from your application code.",
+    "tags": [
+      "vault",
+      "secrets",
+      "openbao",
+      "approle",
+      "applications",
+      "integration",
+      "templates"
+    ]
+  },
+  "vault/vault-approles": {
+    "title": "Managing Vault AppRoles",
+    "description": "How to create, apply, and manage Vault AppRole credentials for applications in Mini Infra.",
+    "tags": [
+      "vault",
+      "secrets",
+      "openbao",
+      "approle",
+      "authentication",
+      "administration",
+      "security"
+    ]
+  },
+  "vault/vault-overview": {
+    "title": "Vault Overview",
+    "description": "An overview of the managed OpenBao secrets vault in Mini Infra — bootstrap, seal state, and operator credentials.",
+    "tags": [
+      "vault",
+      "secrets",
+      "openbao",
+      "administration",
+      "security"
+    ]
+  },
+  "vault/vault-policies": {
+    "title": "Managing Vault Policies",
+    "description": "How to create, edit, publish, and delete HCL policy documents for the managed Vault in Mini Infra.",
+    "tags": [
+      "vault",
+      "secrets",
+      "openbao",
+      "policies",
+      "administration",
+      "security"
+    ]
+  }
+}

--- a/client/src/user-docs/ui-elements/manifest.json
+++ b/client/src/user-docs/ui-elements/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-07-14",
+  "generated": "2026-07-15",
   "description": "UI element IDs (data-tour attributes) available for agent highlighting. Pass \"id\" to highlight_element and the route key to navigate_to. \"global\" elements are present on all pages.",
   "routes": {
     "/applications": {
@@ -452,8 +452,20 @@
       "title": "Stack Templates",
       "elements": [
         {
+          "id": "export-template-button",
+          "label": "Export Template Button",
+          "elementType": "Button",
+          "file": "client/src/app/stack-templates/[templateId]/page.tsx"
+        },
+        {
           "id": "import-compose-button",
           "label": "Import Compose Button",
+          "elementType": "Button",
+          "file": "client/src/app/stack-templates/page.tsx"
+        },
+        {
+          "id": "import-template-button",
+          "label": "Import Template Button",
           "elementType": "Button",
           "file": "client/src/app/stack-templates/page.tsx"
         }
@@ -773,6 +785,18 @@
       "label": "Compose Import Name",
       "elementType": "Input",
       "file": "client/src/components/stack-templates/import-compose-dialog.tsx"
+    },
+    {
+      "id": "import-template-input",
+      "label": "Import Template Input",
+      "elementType": "Textarea",
+      "file": "client/src/components/stack-templates/import-template-dialog.tsx"
+    },
+    {
+      "id": "import-template-name",
+      "label": "Import Template Name",
+      "elementType": "Input",
+      "file": "client/src/components/stack-templates/import-template-dialog.tsx"
     },
     {
       "id": "install-template-dialog",

--- a/lib/types/api-routes.generated.ts
+++ b/lib/types/api-routes.generated.ts
@@ -321,6 +321,8 @@ export const ALL_API_ROUTES: readonly ApiRouteEntry[] = [
   { method: "GET", path: "/api/stack-templates/:templateId/versions" },
   { method: "GET", path: "/api/stack-templates/:templateId/versions/:versionId" },
   { method: "POST", path: "/api/stack-templates/:templateId/versions/:versionId/archive" },
+  { method: "GET", path: "/api/stack-templates/:templateId/versions/:versionId/export" },
+  { method: "POST", path: "/api/stack-templates/import" },
   { method: "GET", path: "/api/stack-templates/predicates" },
   { method: "GET", path: "/api/stacks" },
   { method: "POST", path: "/api/stacks" },

--- a/lib/types/api-routes.ts
+++ b/lib/types/api-routes.ts
@@ -707,6 +707,11 @@ export const ApiRoute = {
     /** GET /api/stack-templates/:templateId/versions/:versionId */
     version: (templateId: string, versionId: string): string =>
       `${ApiBase.stackTemplates}/${templateId}/versions/${versionId}`,
+    /** GET /api/stack-templates/:templateId/versions/:versionId/export — serialize a version to a portable YAML document */
+    exportVersion: (templateId: string, versionId: string): string =>
+      `${ApiBase.stackTemplates}/${templateId}/versions/${versionId}/export`,
+    /** POST /api/stack-templates/import — create a user template from an exported YAML document */
+    import: (): string => `${ApiBase.stackTemplates}/import`,
     /** POST /api/stack-templates/:templateId/rollback — re-point currentVersion to an older published version */
     rollback: (templateId: string): string =>
       `${ApiBase.stackTemplates}/${templateId}/rollback`,

--- a/lib/types/compose-import.ts
+++ b/lib/types/compose-import.ts
@@ -24,24 +24,15 @@ import type {
   StackServiceDefinition,
   StackVolume,
 } from './stacks';
+import type { ImportIssue, ImportIssueLevel } from './import-issues';
 
-/** How much a user needs to care about a given issue. */
-export type ComposeIssueLevel =
-  /** The file can't be imported at all. */
-  | 'error'
-  /** Recognised, but has no equivalent here — it was NOT carried across. */
-  | 'unsupported'
-  /** Carried across, but not exactly as written. */
-  | 'lossy'
-  /** Compose left it unsaid; we had to pick something. */
-  | 'defaulted';
-
-export interface ComposeImportIssue {
-  level: ComposeIssueLevel;
-  /** Where in the compose file, e.g. `services.web.build`. */
-  path: string;
-  message: string;
-}
+/**
+ * Compose import speaks the shared import-issue vocabulary. The `Compose*`
+ * aliases are kept so existing call sites (the paste-box dialog, tests) don't
+ * have to change.
+ */
+export type ComposeIssueLevel = ImportIssueLevel;
+export type ComposeImportIssue = ImportIssue;
 
 export interface ComposeImportDraft {
   networks: StackNetwork[];

--- a/lib/types/import-issues.ts
+++ b/lib/types/import-issues.ts
@@ -1,0 +1,27 @@
+/**
+ * The shared "nothing is dropped in silence" issue model.
+ *
+ * Both on-ramps that turn an outside artifact into a template draft — the Docker
+ * Compose importer (`compose-import.ts`) and the template export/import codec
+ * (`template-transfer.ts`) — report everything they can't carry across verbatim
+ * rather than discarding it quietly. They share this one issue vocabulary so the
+ * client can render both with a single component and the two can't drift.
+ */
+
+/** How much a user needs to care about a given issue. */
+export type ImportIssueLevel =
+  /** The file can't be imported at all. */
+  | 'error'
+  /** Recognised, but has no equivalent here — it was NOT carried across. */
+  | 'unsupported'
+  /** Carried across, but not exactly as written. */
+  | 'lossy'
+  /** Left unsaid; we had to pick something. */
+  | 'defaulted';
+
+export interface ImportIssue {
+  level: ImportIssueLevel;
+  /** Where in the source document, e.g. `services.web.build` or `version.nats.subjectPrefix`. */
+  path: string;
+  message: string;
+}

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -86,6 +86,9 @@ export * from "./addons";
 // Stack Template types
 export * from "./stack-templates";
 
+// Pure version<->draft mappers (shared by client codec + server export)
+export * from "./template-draft";
+
 // Stack Template prerequisites (Phase 1 — cross-stack `requires` block)
 export * from "./template-prerequisites";
 
@@ -116,8 +119,14 @@ export * from "./tailscale";
 // Pool-instance addon label keys
 export * from "./pool-addons";
 
+// Shared "nothing dropped in silence" import-issue model
+export * from "./import-issues";
+
 // Docker Compose → stack template mapping (pure; the YAML parser lives with the caller)
 export * from "./compose-import";
+
+// Stack template export/import codec (pure; the YAML parser lives with the caller)
+export * from "./template-transfer";
 
 // API route registry (ApiBase/ApiRoute/ALL_API_ROUTES)
 export * from "./api-routes";

--- a/lib/types/nats-subjects.ts
+++ b/lib/types/nats-subjects.ts
@@ -33,6 +33,15 @@
  */
 export const NATS_SYSTEM_PREFIX = "mini-infra" as const;
 
+/**
+ * Default per-stack NATS subject prefix *template* (rendered with `{{stack.id}}`
+ * substituted at apply time → `app.<stack-id>`). A template that declares any
+ * other prefix must be on the admin subject-prefix allowlist. This is the single
+ * source of truth for "what counts as the default"; the apply orchestrator and
+ * the template export/import codec both compare against it.
+ */
+export const DEFAULT_NATS_SUBJECT_PREFIX_TEMPLATE = "app.{{stack.id}}" as const;
+
 /** Phase 1: smoke-ping subjects used by the bus health-check loopback. */
 export const SystemSubject = {
   /**

--- a/lib/types/template-draft.ts
+++ b/lib/types/template-draft.ts
@@ -1,0 +1,155 @@
+/**
+ * Pure mappers between a persisted template version (the read model,
+ * `StackTemplateVersionInfo`) and the authoring/write shape (`DraftVersionInput`).
+ *
+ * These live in `@mini-infra/types` — not the client — because two very
+ * different callers need the exact same, lossless conversion and must never
+ * drift apart:
+ *
+ *  - the client Code-view codec and the application Configuration tab, which
+ *    rebuild a draft from a version before re-saving it, and
+ *  - the server template *export* endpoint, which turns a stored version into a
+ *    portable document.
+ *
+ * The module is dependency-free (types only), preserving the package's
+ * zero-runtime-dependency invariant, so both the Vite client bundle and the
+ * Node server import one implementation.
+ */
+import type { StackServiceDefinition } from "./stacks";
+import type {
+  DraftVersionInput,
+  StackTemplateConfigFileInfo,
+  StackTemplateConfigFileInput,
+  StackTemplateServiceInfo,
+  StackTemplateVersionInfo,
+} from "./stack-templates";
+
+/**
+ * Recursively drop keys whose value is `null`. The version read model
+ * (`StackTemplateVersionInfo`) returns `null` for absent optional fields
+ * (`resourceInputs`, a service's `routing`/`initCommands`/`vaultAppRoleRef`/
+ * `jobPoolConfig`, `notes`, ...), but the create/draft Zod schema uses
+ * `.optional()` — which rejects `null` ("expected X, received null") and only
+ * accepts the value or its absence. Stripping nulls turns the read shape back
+ * into a valid write shape, including nested `containerConfig` fields, without
+ * enumerating every optional key by hand. The schema never uses `.nullable()`
+ * for these, so a dropped null is always the right choice on this write path.
+ */
+export function stripNull<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((v) => stripNull(v)) as unknown as T;
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (v === null) continue;
+      out[k] = stripNull(v);
+    }
+    return out as T;
+  }
+  return value;
+}
+
+/**
+ * Rebuild a full `DraftVersionInput` from a published/draft version so that a
+ * republish (via `useUpdateApplication`) is LOSSLESS — every version-level and
+ * service-level field is carried through, and only the field a caller
+ * explicitly overrides afterwards changes.
+ *
+ * Why this exists: the application Configuration tab builds its draft from
+ * scratch and only sets the handful of fields the form edits, silently
+ * dropping everything else on save (`resourceInputs`, `configFiles`, `vault`,
+ * `nats`, `requires`, ...). Any flow that mutates a single field of an existing
+ * application — e.g. the Connected Networks card changing a service's
+ * `joinNetworks` — must go through here instead, or it would strip those
+ * fields off the republished version.
+ *
+ * The result is run through `stripNull` so read-model `null`s become absent,
+ * matching what the draft schema's `.optional()` fields accept.
+ */
+export function buildDraftFromVersion(
+  version: StackTemplateVersionInfo,
+): DraftVersionInput {
+  const draft: DraftVersionInput = {
+    parameters: version.parameters,
+    defaultParameterValues: version.defaultParameterValues,
+    networkTypeDefaults: version.networkTypeDefaults,
+    resourceOutputs: version.resourceOutputs,
+    resourceInputs: version.resourceInputs,
+    // `StackNetwork[]` is assignable to `StackNetworkEntry[]`.
+    networks: version.networks,
+    volumes: version.volumes,
+    services: (version.services ?? []).map(mapServiceInfoToDefinition),
+    configFiles: version.configFiles?.map(mapConfigFileInfoToInput),
+    notes: version.notes ?? undefined,
+    inputs: version.inputs,
+    requires: version.requires,
+  };
+
+  // vault/nats are attached AFTER the strip, deliberately. Unlike every other
+  // section, their schemas use `.nullable()` — the NATS JetStream limits
+  // (`maxBytes`, `maxAgeSeconds`, `maxDeliver`, …) accept an explicit null, which
+  // does not mean the same thing as an absent key. Running them through stripNull
+  // would quietly rewrite an author's "no limit" into "use the default".
+  return {
+    ...stripNull(draft),
+    ...(version.vault ? { vault: version.vault } : {}),
+    ...(version.nats ? { nats: version.nats } : {}),
+  };
+}
+
+/**
+ * Map a persisted service (`StackTemplateServiceInfo`) back into the authoring
+ * shape (`StackServiceDefinition`). DB-only fields (`id`, `versionId`) are
+ * dropped, EVERY authoring field is carried through (`addons`, `poolConfig`,
+ * `jobPoolConfig`, and the vault/nats binding refs), and the whole result is
+ * run through `stripNull` so read-model `null`s on optional-non-nullable fields
+ * become absent — matching what the create/draft schema's `.optional()` fields
+ * accept.
+ *
+ * This is the single canonical service mapper. It is write-safe standalone
+ * (the `stripNull` pass means a caller can drop its output straight into a
+ * `DraftVersionInput.services[]` without re-stripping), so the stack-templates
+ * draft editor reuses it directly rather than hand-rolling a partial map that
+ * silently drops per-service `addons`/`poolConfig`/`nats*`/`vault*` whenever any
+ * service is edited. `buildDraftFromVersion` above also re-strips the whole
+ * draft, but that outer pass is now redundant for services (idempotent).
+ */
+export function mapServiceInfoToDefinition(
+  svc: StackTemplateServiceInfo,
+): StackServiceDefinition {
+  return stripNull({
+    serviceName: svc.serviceName,
+    serviceType: svc.serviceType,
+    dockerImage: svc.dockerImage,
+    dockerTag: svc.dockerTag,
+    containerConfig: svc.containerConfig,
+    initCommands: svc.initCommands ?? undefined,
+    dependsOn: svc.dependsOn,
+    order: svc.order,
+    routing: svc.routing ?? undefined,
+    adoptedContainer: svc.adoptedContainer,
+    poolConfig: svc.poolConfig ?? undefined,
+    jobPoolConfig: svc.jobPoolConfig,
+    vaultAppRoleId: svc.vaultAppRoleId,
+    vaultAppRoleRef: svc.vaultAppRoleRef,
+    natsCredentialId: svc.natsCredentialId,
+    natsRole: svc.natsRole,
+    natsSigner: svc.natsSigner,
+    addons: svc.addons ?? undefined,
+  });
+}
+
+export function mapConfigFileInfoToInput(
+  cf: StackTemplateConfigFileInfo,
+): StackTemplateConfigFileInput {
+  return {
+    serviceName: cf.serviceName,
+    fileName: cf.fileName,
+    volumeName: cf.volumeName,
+    mountPath: cf.mountPath,
+    content: cf.content,
+    permissions: cf.permissions ?? undefined,
+    owner: cf.owner ?? undefined,
+  };
+}

--- a/lib/types/template-transfer.ts
+++ b/lib/types/template-transfer.ts
@@ -1,0 +1,326 @@
+/**
+ * Stack template export / import codec.
+ *
+ * Exporting a template version produces a portable YAML document; importing one
+ * on another Mini Infra instance recreates it as a *user* template. This module
+ * is the pure core of both directions — dependency-free (the YAML parser lives
+ * with the caller, same rule as `compose-import.ts`), so the server export/import
+ * routes and any future client-side use share one implementation.
+ *
+ * Two things make export/import more than a straight round-trip:
+ *
+ *  1. **Secrets don't travel.** A template can embed literal Vault KV values
+ *     (`vault.kv[].fields[].value`). An export file is a shareable artifact —
+ *     it can land in a git repo or a chat — so those literals are redacted and
+ *     the removal is reported, never silent. `{ fromInput }` references carry no
+ *     secret and are kept as-is.
+ *
+ *  2. **Some things are keyed to the origin instance.** A custom NATS subject
+ *     prefix is gated by an admin allowlist keyed by *template ID*; the import
+ *     mints a brand-new ID, so the claim can't follow the file. Rather than fail
+ *     mysteriously at first deploy, the import surfaces it as an issue up front.
+ *
+ * Everything not carried across is reported through the shared `ImportIssue`
+ * model, exactly like the Compose importer.
+ */
+import type { ImportIssue } from './import-issues';
+import type { EnvironmentNetworkType } from './environments';
+import type {
+  CreateStackTemplateRequest,
+  DraftVersionInput,
+  StackTemplateScope,
+  StackTemplateVersionInfo,
+  TemplateKvFieldValue,
+  TemplateVaultKv,
+  TemplateVaultSection,
+} from './stack-templates';
+import { buildDraftFromVersion } from './template-draft';
+import { DEFAULT_NATS_SUBJECT_PREFIX_TEMPLATE } from './nats-subjects';
+
+/** Current export-document format tag. Bump the version suffix on a breaking change. */
+export const TEMPLATE_EXPORT_FORMAT = 'mini-infra.stack-template/v1' as const;
+
+/** Prefix every recognised format shares — used to give a targeted error on a foreign file. */
+const TEMPLATE_EXPORT_FORMAT_PREFIX = 'mini-infra.stack-template/';
+
+/**
+ * Replaces a redacted literal secret in an export file. Distinctive on purpose:
+ * the importer detects it and tells the user which fields still need a real
+ * value before the template can deploy.
+ */
+export const REDACTED_SECRET_PLACEHOLDER = '__mini-infra:redacted-secret__';
+
+/** Template envelope — the `StackTemplate`-level metadata a version doesn't carry. */
+export interface TemplateExportEnvelope {
+  name: string;
+  displayName: string;
+  description?: string;
+  category?: string;
+  scope: StackTemplateScope;
+  networkType?: EnvironmentNetworkType;
+}
+
+/** The exported document. `version` is the lossless authoring body of one version. */
+export interface TemplateExportDocument {
+  format: typeof TEMPLATE_EXPORT_FORMAT;
+  /** Informational; ignored on import. Stamped by the caller so this stays pure. */
+  exportedAt?: string;
+  /** Which version number this was exported from. Informational; ignored on import. */
+  sourceVersion?: number;
+  template: TemplateExportEnvelope;
+  version: DraftVersionInput;
+}
+
+export interface TemplateExportResult {
+  document: TemplateExportDocument;
+  /** Redaction (and any other build-time) notices. */
+  issues: ImportIssue[];
+}
+
+export interface TemplateImportResult {
+  /** False when at least one blocking (`error`) issue was raised — `request` is then null. */
+  ok: boolean;
+  request: CreateStackTemplateRequest | null;
+  issues: ImportIssue[];
+  /** The template name from the file, surfaced even when ok=false for the UI. */
+  templateName?: string;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Small helpers                                                               */
+/* -------------------------------------------------------------------------- */
+
+type Dict = Record<string, unknown>;
+
+function isDict(v: unknown): v is Dict {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function isLiteralValue(field: TemplateKvFieldValue): field is { value: string } {
+  return typeof (field as { value?: unknown }).value === 'string';
+}
+
+/* -------------------------------------------------------------------------- */
+/* Export                                                                      */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Redact literal Vault KV secrets, collecting a `lossy` issue per field removed.
+ * Returns a new section; the input is not mutated. `{ fromInput }` refs pass
+ * through untouched (they name an install-time input, not a secret).
+ */
+function redactVaultSecrets(
+  vault: TemplateVaultSection,
+  issues: ImportIssue[],
+): TemplateVaultSection {
+  if (!vault.kv || vault.kv.length === 0) return vault;
+
+  const kv: TemplateVaultKv[] = vault.kv.map((entry) => {
+    const fields: Record<string, TemplateKvFieldValue> = {};
+    for (const [name, field] of Object.entries(entry.fields)) {
+      if (isLiteralValue(field)) {
+        fields[name] = { value: REDACTED_SECRET_PLACEHOLDER };
+        issues.push({
+          level: 'lossy',
+          path: `version.vault.kv[${entry.path}].fields.${name}`,
+          message:
+            'A literal secret value was removed from the export. Set it again after import (or switch it to a `fromInput` reference) before deploying.',
+        });
+      } else {
+        fields[name] = field;
+      }
+    }
+    return { ...entry, fields };
+  });
+
+  return { ...vault, kv };
+}
+
+/**
+ * Build a portable export document from a stored template version plus its
+ * envelope metadata. `exportedAt` is passed in (not read from a clock) to keep
+ * this function pure and its output deterministic under test.
+ */
+export function buildTemplateExportDocument(args: {
+  template: TemplateExportEnvelope;
+  version: StackTemplateVersionInfo;
+  exportedAt?: string;
+}): TemplateExportResult {
+  const issues: ImportIssue[] = [];
+  const body = buildDraftFromVersion(args.version);
+
+  const version: DraftVersionInput = body.vault
+    ? { ...body, vault: redactVaultSecrets(body.vault, issues) }
+    : body;
+
+  const document: TemplateExportDocument = {
+    format: TEMPLATE_EXPORT_FORMAT,
+    ...(args.exportedAt ? { exportedAt: args.exportedAt } : {}),
+    sourceVersion: args.version.version,
+    template: args.template,
+    version,
+  };
+
+  return { document, issues };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Import                                                                      */
+/* -------------------------------------------------------------------------- */
+
+/** Report every redaction placeholder left in the file so the user knows what to refill. */
+function detectRedactedSecrets(version: Dict, issues: ImportIssue[]): void {
+  const vault = version.vault;
+  if (!isDict(vault)) return;
+  const kv = vault.kv;
+  if (!Array.isArray(kv)) return;
+  for (const entry of kv) {
+    if (!isDict(entry) || !isDict(entry.fields)) continue;
+    const path = typeof entry.path === 'string' ? entry.path : '?';
+    for (const [name, field] of Object.entries(entry.fields as Dict)) {
+      if (isDict(field) && field.value === REDACTED_SECRET_PLACEHOLDER) {
+        issues.push({
+          level: 'lossy',
+          path: `version.vault.kv[${path}].fields.${name}`,
+          message:
+            'This secret was redacted when the template was exported. Set a real value in the Code view before deploying, or the deploy will write a placeholder.',
+        });
+      }
+    }
+  }
+}
+
+/** Copy `key` from `src` onto `dst` only when it is present and non-null. */
+function passThrough(src: Dict, dst: Dict, key: string): void {
+  if (key in src && src[key] != null) dst[key] = src[key];
+}
+
+/**
+ * Map a parsed export document into a `CreateStackTemplateRequest`. The caller
+ * (server route) parses the YAML text and then runs the result through the same
+ * `createTemplateSchema` Zod validation as a normal create, so this function's
+ * job is envelope validation, the source-instance-specific caveats, and shaping
+ * — not deep field validation.
+ *
+ * The `source` field is intentionally absent from the output: `createUserTemplate`
+ * hard-codes `source: "user"`, so importing a system template lands it as a user
+ * template with no special handling here.
+ */
+export function mapTemplateImportDocument(doc: unknown): TemplateImportResult {
+  const issues: ImportIssue[] = [];
+  const fail = (path: string, message: string): TemplateImportResult => {
+    issues.push({ level: 'error', path, message });
+    return { ok: false, request: null, issues };
+  };
+
+  if (!isDict(doc)) {
+    return fail('', 'The file is empty or is not a template export document.');
+  }
+
+  const format = doc.format;
+  if (typeof format !== 'string' || !format.startsWith(TEMPLATE_EXPORT_FORMAT_PREFIX)) {
+    return fail(
+      'format',
+      `This is not a Mini Infra template export (expected a "format" of "${TEMPLATE_EXPORT_FORMAT}").`,
+    );
+  }
+  if (format !== TEMPLATE_EXPORT_FORMAT) {
+    return fail(
+      'format',
+      `Unsupported export version "${format}". This instance understands "${TEMPLATE_EXPORT_FORMAT}" — export again from a matching version.`,
+    );
+  }
+
+  const template = doc.template;
+  if (!isDict(template)) {
+    return fail('template', 'The export is missing its template metadata.');
+  }
+  const version = doc.version;
+  if (!isDict(version)) {
+    return fail('version', 'The export is missing its version body.');
+  }
+
+  const name = typeof template.name === 'string' ? template.name : '';
+  const displayName = typeof template.displayName === 'string' ? template.displayName : '';
+  if (!name) issues.push({ level: 'error', path: 'template.name', message: 'A template name is required.' });
+  if (!displayName)
+    issues.push({ level: 'error', path: 'template.displayName', message: 'A template display name is required.' });
+
+  // Scope: user templates are host- or environment-scoped. A `any`-scoped system
+  // template (or a missing scope) is coerced to `environment` and reported, since
+  // the create schema rejects `any`.
+  let scope: StackTemplateScope = 'environment';
+  const rawScope = template.scope;
+  if (rawScope === 'host' || rawScope === 'environment') {
+    scope = rawScope;
+  } else {
+    issues.push({
+      level: 'defaulted',
+      path: 'template.scope',
+      message: `Scope "${String(rawScope ?? 'unset')}" can't apply to a user template; defaulting to "environment". Adjust it after import if this should be host-scoped.`,
+    });
+  }
+
+  // Custom NATS subject prefix: the allowlist is keyed by template ID and this
+  // import gets a new one, so the claim can't follow. Warn, don't block.
+  const nats = version.nats;
+  if (isDict(nats)) {
+    const subjectPrefix = nats.subjectPrefix;
+    if (
+      typeof subjectPrefix === 'string' &&
+      subjectPrefix.length > 0 &&
+      subjectPrefix !== DEFAULT_NATS_SUBJECT_PREFIX_TEMPLATE
+    ) {
+      issues.push({
+        level: 'lossy',
+        path: 'version.nats.subjectPrefix',
+        message: `This template claims the custom NATS subject prefix "${subjectPrefix}". The subject-prefix allowlist is keyed by template ID, and the import creates a new template with a new ID — an admin must add the new template to the allowlist, or the first deploy will be rejected.`,
+      });
+    }
+  }
+
+  detectRedactedSecrets(version, issues);
+
+  if (issues.some((i) => i.level === 'error')) {
+    return { ok: false, request: null, issues, templateName: name || undefined };
+  }
+
+  // Shape the request. Arrays default to empty (createTemplateSchema requires
+  // networks/volumes/services to be arrays); every other version-body section is
+  // passed through when present and validated server-side by the same Zod schema
+  // the normal create route uses.
+  const request = {
+    name,
+    displayName,
+    scope,
+    networks: Array.isArray(version.networks) ? version.networks : [],
+    volumes: Array.isArray(version.volumes) ? version.volumes : [],
+    services: Array.isArray(version.services) ? version.services : [],
+  } as unknown as Dict;
+
+  if (typeof template.description === 'string') request.description = template.description;
+  if (typeof template.category === 'string') request.category = template.category;
+  if (typeof template.networkType === 'string') request.networkType = template.networkType;
+
+  for (const key of [
+    'parameters',
+    'defaultParameterValues',
+    'networkTypeDefaults',
+    'resourceOutputs',
+    'resourceInputs',
+    'configFiles',
+    'inputs',
+    'vault',
+    'nats',
+    'requires',
+  ]) {
+    passThrough(version, request, key);
+  }
+
+  return {
+    ok: true,
+    request: request as unknown as CreateStackTemplateRequest,
+    issues,
+    templateName: name,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "start": "pnpm --filter mini-infra-server start",
     "install:all": "pnpm install",
     "generate:ui-manifest": "node scripts/generate-ui-manifest.mjs",
+    "generate:docs-meta": "node scripts/generate-docs-meta.mjs",
     "gen:api-routes": "tsx scripts/gen-api-routes.mjs",
     "worktree-env": "tsx deployment/development/worktree-env.ts",
     "format": "pnpm --filter mini-infra-server format",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,6 +361,9 @@ importers:
       helmet:
         specifier: ^8.2.0
         version: 8.2.0
+      js-yaml:
+        specifier: ^5.0.0
+        version: 5.2.0
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3

--- a/scripts/generate-docs-meta.mjs
+++ b/scripts/generate-docs-meta.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * scripts/generate-docs-meta.mjs
+ *
+ * Scans client/src/user-docs for `*.md` help articles and generates
+ * client/src/user-docs/docs-meta.generated.json — a body-free map of
+ * "category/slug" → { title, description, tags }.
+ *
+ * Why this exists: the help sidebar (mounted on every authenticated page) and
+ * the header search need each article's frontmatter *title* synchronously, but
+ * that frontmatter lives inside the `.md` bodies. Importing the bodies eagerly
+ * inlined ~436 KB of markdown into the initial JS bundle for a menu that only
+ * needs titles. This manifest carries just the metadata; the bodies are now
+ * loaded lazily (see doc-loader.ts), so they no longer bloat the entry chunk.
+ *
+ * Usage:
+ *   node scripts/generate-docs-meta.mjs
+ *   pnpm generate:docs-meta
+ *
+ * Re-run whenever you add, rename, remove, or re-title a help article.
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from "fs";
+import { resolve, join, dirname, relative } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+const DOCS_DIR = join(ROOT, "client/src/user-docs");
+const OUTPUT_FILE = join(DOCS_DIR, "docs-meta.generated.json");
+
+/** Minimal front-matter parser — kept in sync with doc-loader.ts::parseFrontMatter. */
+function parseFrontMatter(raw) {
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (!match) return {};
+
+  const attrs = {};
+  const lines = match[1].split("\n");
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    const idx = line.indexOf(":");
+    if (idx === -1) {
+      i++;
+      continue;
+    }
+    const key = line.slice(0, idx).trim();
+    const rest = line.slice(idx + 1).trim();
+
+    if (rest === "") {
+      const items = [];
+      while (i + 1 < lines.length && lines[i + 1].match(/^\s+-\s/)) {
+        i++;
+        items.push(lines[i].replace(/^\s+-\s+/, ""));
+      }
+      attrs[key] = items.length > 0 ? items : "";
+    } else if (rest.startsWith("[") && rest.endsWith("]")) {
+      attrs[key] = rest
+        .slice(1, -1)
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    } else {
+      attrs[key] = rest;
+    }
+    i++;
+  }
+  return attrs;
+}
+
+/** Recursively collect every .md file under DOCS_DIR. */
+function walkMd(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...walkMd(full));
+    } else if (entry.endsWith(".md")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const meta = {};
+let count = 0;
+for (const file of walkMd(DOCS_DIR).sort()) {
+  const rel = relative(DOCS_DIR, file).replace(/\.md$/, "");
+  const parts = rel.split(/[\\/]/);
+  const category = parts[0];
+  const slug = parts[parts.length - 1];
+  const key = `${category}/${slug}`;
+
+  const attrs = parseFrontMatter(readFileSync(file, "utf8"));
+  meta[key] = {
+    title: attrs.title ?? slug,
+    description: attrs.description ?? "",
+    ...(Array.isArray(attrs.tags) && attrs.tags.length > 0 ? { tags: attrs.tags } : {}),
+  };
+  count++;
+}
+
+// Stable key order so the generated file diffs cleanly.
+const sorted = Object.fromEntries(Object.keys(meta).sort().map((k) => [k, meta[k]]));
+writeFileSync(OUTPUT_FILE, JSON.stringify(sorted, null, 2) + "\n");
+console.log(`✓ Generated ${relative(ROOT, OUTPUT_FILE)} (${count} articles)`);

--- a/server/package.json
+++ b/server/package.json
@@ -82,6 +82,7 @@
         "form-data": "^4.0.6",
         "googleapis": "^173.0.0",
         "helmet": "^8.2.0",
+        "js-yaml": "^5.2.0",
         "jsonwebtoken": "^9.0.3",
         "nats": "^2.29.3",
         "nats-jwt": "^0.0.9",

--- a/server/src/__tests__/template-export-import.integration.test.ts
+++ b/server/src/__tests__/template-export-import.integration.test.ts
@@ -1,0 +1,229 @@
+/**
+ * HTTP contract test for template export/import
+ * (GET /api/stack-templates/:id/versions/:vid/export + POST /api/stack-templates/import).
+ *
+ * Per server/CLAUDE.md, a field-persistence contract must be exercised through
+ * the real Express routes, not a direct Prisma insert — a unit test of the pure
+ * mapper can't prove the server accepts the shapes it emits, nor that Zod's
+ * default unknown-key stripping doesn't quietly drop a section on the way in.
+ *
+ * The headline cases:
+ *   - a full round-trip (create → export → import) preserves services/networks,
+ *   - a literal Vault secret is redacted on export and never lands on the copy,
+ *   - a system-scope quirk (`scope: any`) is coerced, and the import always
+ *     produces a *user* template,
+ *   - a custom NATS subject prefix is surfaced as a warning.
+ */
+import supertest from 'supertest';
+import express, { type Request, type Response, type NextFunction } from 'express';
+import * as yaml from 'js-yaml';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import {
+  REDACTED_SECRET_PLACEHOLDER,
+  TEMPLATE_EXPORT_FORMAT,
+  type TemplateExportDocument,
+} from '@mini-infra/types';
+import { testPrisma } from './integration-test-helpers';
+
+vi.mock('../middleware/auth', () => ({
+  requirePermission: () => (req: Request, _res: Response, next: NextFunction) => {
+    (req as Request & { user?: { id: string } }).user = { id: 'session-user' };
+    next();
+  },
+}));
+
+vi.mock('../lib/prisma', () => ({ default: testPrisma }));
+
+import stackTemplateRouter from '../routes/stack-templates';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json({ limit: '5mb' }));
+  app.use('/api/stack-templates', stackTemplateRouter);
+  return app;
+}
+
+const baseService = {
+  serviceName: 'web',
+  serviceType: 'Stateful',
+  dockerImage: 'nginx',
+  dockerTag: '1.25',
+  containerConfig: { joinNetworks: ['app-net'] },
+  dependsOn: [],
+  order: 0,
+};
+
+async function createTemplate(body: Record<string, unknown>) {
+  const res = await supertest(buildApp()).post('/api/stack-templates').send(body);
+  return res;
+}
+
+async function exportVersion(templateId: string, versionId: string) {
+  return supertest(buildApp()).get(
+    `/api/stack-templates/${templateId}/versions/${versionId}/export`,
+  );
+}
+
+async function importYaml(body: string, overrides: { name?: string; displayName?: string } = {}) {
+  return supertest(buildApp())
+    .post('/api/stack-templates/import')
+    .send({ yaml: body, ...overrides });
+}
+
+describe('template export/import round-trip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('round-trips services + networks and redacts a literal vault secret', async () => {
+    const suffix = createId().slice(0, 6);
+    const create = await createTemplate({
+      name: `export-src-${suffix}`,
+      displayName: 'Export Source',
+      description: 'the original',
+      scope: 'environment',
+      networks: [{ name: 'app-net' }],
+      volumes: [{ name: 'data' }],
+      services: [baseService],
+      vault: {
+        kv: [
+          {
+            path: 'app/db',
+            fields: {
+              PASSWORD: { value: 'super-secret' },
+              USERNAME: { fromInput: 'dbUser' },
+            },
+          },
+        ],
+      },
+    });
+    expect(create.status).toBe(201);
+    const srcTemplateId = create.body.data.id as string;
+    const srcVersionId = create.body.data.draftVersionId as string;
+    expect(srcVersionId).toBeTruthy();
+
+    // ── Export ────────────────────────────────────────────────────────────
+    const exp = await exportVersion(srcTemplateId, srcVersionId);
+    expect(exp.status).toBe(200);
+    const { yaml: exportedYaml, issues: exportIssues } = exp.body.data;
+
+    // The literal secret was redacted and reported; the fromInput ref was not.
+    const doc = yaml.load(exportedYaml) as TemplateExportDocument;
+    expect(doc.format).toBe(TEMPLATE_EXPORT_FORMAT);
+    const kv = doc.version.vault?.kv?.[0];
+    expect(kv?.fields.PASSWORD).toEqual({ value: REDACTED_SECRET_PLACEHOLDER });
+    expect(kv?.fields.USERNAME).toEqual({ fromInput: 'dbUser' });
+    expect(exportIssues.some((i: { path: string }) => i.path.includes('PASSWORD'))).toBe(true);
+
+    // Re-importing under the same name on the same instance collides.
+    const collide = await importYaml(exportedYaml);
+    expect(collide.status).toBe(409);
+
+    // ── Import (renamed, as a cross-instance import effectively is) ────────
+    const imp = await importYaml(exportedYaml, {
+      name: `export-copy-${suffix}`,
+      displayName: 'Export Copy',
+    });
+    expect(imp.status).toBe(201);
+    const newTemplateId = imp.body.data.id as string;
+    expect(newTemplateId).not.toBe(srcTemplateId);
+    expect(imp.body.data.name).toBe(`export-copy-${suffix}`);
+    // Import always produces a user template.
+    expect(imp.body.data.source).toBe('user');
+    // The redaction notice rides along so the UI can warn the operator.
+    expect(imp.body.issues.some((i: { path: string }) => i.path.includes('PASSWORD'))).toBe(true);
+
+    // ── Persistence (through the route, not a fixture) ────────────────────
+    const newTmpl = await testPrisma.stackTemplate.findUnique({ where: { id: newTemplateId } });
+    const newVersionId = newTmpl?.draftVersionId ?? newTmpl?.currentVersionId;
+    expect(newVersionId).toBeTruthy();
+
+    const svcRow = await testPrisma.stackTemplateService.findFirst({
+      where: { versionId: newVersionId! },
+    });
+    expect(svcRow?.serviceName).toBe('web');
+    expect((svcRow?.containerConfig as { joinNetworks?: string[] }).joinNetworks).toEqual(['app-net']);
+
+    const versionRow = await testPrisma.stackTemplateVersion.findUnique({
+      where: { id: newVersionId! },
+    });
+    expect(versionRow?.networks).toEqual([{ name: 'app-net' }]);
+    // The secret never travelled — the copy holds the placeholder, not the value.
+    const importedKv = versionRow?.vaultKv as Array<{ fields: Record<string, unknown> }>;
+    expect(importedKv?.[0]?.fields.PASSWORD).toEqual({ value: REDACTED_SECRET_PLACEHOLDER });
+  });
+
+  it('coerces scope "any" to environment and imports as a user template', async () => {
+    const suffix = createId().slice(0, 6);
+    const doc: TemplateExportDocument = {
+      format: TEMPLATE_EXPORT_FORMAT,
+      sourceVersion: 1,
+      template: {
+        name: `any-scope-${suffix}`,
+        displayName: 'Any Scope',
+        scope: 'any',
+      },
+      version: {
+        networks: [],
+        volumes: [],
+        services: [baseService],
+      },
+    };
+
+    const imp = await importYaml(yaml.dump(doc));
+    expect(imp.status).toBe(201);
+    expect(imp.body.data.scope).toBe('environment');
+    expect(imp.body.data.source).toBe('user');
+    expect(
+      imp.body.issues.some(
+        (i: { level: string; path: string }) => i.level === 'defaulted' && i.path === 'template.scope',
+      ),
+    ).toBe(true);
+  });
+
+  it('warns when an imported template claims a custom NATS subject prefix', async () => {
+    const suffix = createId().slice(0, 6);
+    const doc: TemplateExportDocument = {
+      format: TEMPLATE_EXPORT_FORMAT,
+      template: {
+        name: `custom-prefix-${suffix}`,
+        displayName: 'Custom Prefix',
+        scope: 'environment',
+      },
+      version: {
+        networks: [],
+        volumes: [],
+        services: [baseService],
+        nats: { subjectPrefix: 'events.custom' },
+      },
+    };
+
+    const imp = await importYaml(yaml.dump(doc));
+    expect(imp.status).toBe(201);
+    expect(
+      imp.body.issues.some(
+        (i: { level: string; path: string }) =>
+          i.level === 'lossy' && i.path === 'version.nats.subjectPrefix',
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects a file that is not a template export', async () => {
+    const imp = await importYaml(yaml.dump({ hello: 'world' }));
+    expect(imp.status).toBe(400);
+    expect(
+      imp.body.issues.some((i: { level: string; path: string }) => i.level === 'error' && i.path === 'format'),
+    ).toBe(true);
+  });
+
+  it('rejects a non-YAML body', async () => {
+    const imp = await importYaml('this: : : not valid');
+    expect(imp.status).toBe(400);
+  });
+
+  it('404s exporting a version that does not belong to the template', async () => {
+    const exp = await exportVersion('nonexistent-template', 'nonexistent-version');
+    expect(exp.status).toBe(404);
+  });
+});

--- a/server/src/routes/stack-templates.ts
+++ b/server/src/routes/stack-templates.ts
@@ -1,6 +1,19 @@
 import { Router, type Request } from 'express';
-import type { StackTemplateSource, StackTemplateScope, CreateStackTemplateRequest, DraftVersionInput } from '@mini-infra/types';
-import { hasPermission, Permission, ErrorCode } from '@mini-infra/types';
+import * as yaml from 'js-yaml';
+import type {
+  StackTemplateSource,
+  StackTemplateScope,
+  CreateStackTemplateRequest,
+  DraftVersionInput,
+  TemplateExportEnvelope,
+} from '@mini-infra/types';
+import {
+  hasPermission,
+  Permission,
+  ErrorCode,
+  buildTemplateExportDocument,
+  mapTemplateImportDocument,
+} from '@mini-infra/types';
 import prisma from '../lib/prisma';
 import { getLogger } from '../lib/logger-factory';
 import { asyncHandler } from '../lib/async-handler';
@@ -144,6 +157,54 @@ router.get('/:templateId/versions/:versionId', requirePermission(Permission.Stac
   res.json({ success: true, data: version });
 }));
 
+// GET /:templateId/versions/:versionId/export — Serialize a version to a
+// portable YAML document that can be imported on another Mini Infra instance.
+// Literal Vault secrets are redacted (reported via `issues`); the client turns
+// `yaml` into a file download and surfaces the issues.
+router.get(
+  '/:templateId/versions/:versionId/export',
+  requirePermission(Permission.StacksRead),
+  asyncHandler(async (req, res) => {
+    const service = getTemplateService();
+    const templateId = String(req.params.templateId);
+    const template = await service.getTemplate(templateId);
+    if (!template) {
+      throw new NotFoundError(ErrorCode.STACK_TEMPLATE_NOT_FOUND, 'Template not found', {
+        resource: { type: 'stackTemplate', id: templateId },
+        action: 'Check the template ID or refresh the templates list.',
+      });
+    }
+
+    const version = await service.getTemplateVersion(String(req.params.versionId));
+    if (!version || version.templateId !== templateId) {
+      throw new NotFoundError(ErrorCode.STACK_TEMPLATE_VERSION_NOT_FOUND, 'Version not found', {
+        resource: { type: 'stackTemplateVersion', id: String(req.params.versionId) },
+        action: 'Check the version ID or refresh the template.',
+      });
+    }
+
+    const envelope: TemplateExportEnvelope = {
+      name: template.name,
+      displayName: template.displayName,
+      description: template.description ?? undefined,
+      category: template.category ?? undefined,
+      scope: template.scope,
+      networkType: template.networkType ?? undefined,
+    };
+
+    const { document, issues } = buildTemplateExportDocument({
+      template: envelope,
+      version,
+      exportedAt: new Date().toISOString(),
+    });
+
+    const body = yaml.dump(document, { lineWidth: 120, noRefs: true, sortKeys: false });
+    const filename = `${template.name}-v${version.version}.stack-template.yaml`;
+
+    res.json({ success: true, data: { filename, yaml: body, issues } });
+  }),
+);
+
 // POST / — Create user template (with initial draft)
 router.post('/', requirePermission(Permission.StacksWrite), asyncHandler(async (req, res) => {
   // Same gate as POST /:templateId/draft: a vault section in the body
@@ -179,6 +240,93 @@ router.post('/', requirePermission(Permission.StacksWrite), asyncHandler(async (
 
   logger.info({ templateId: template.id, templateName: template.name }, 'Template created');
   res.status(201).json({ success: true, data: template });
+}));
+
+// POST /import — Create a user template from an exported YAML document.
+//
+// Single-segment path, so it never collides with the `/:templateId/...` POSTs
+// (all of which have ≥2 segments). The file is parsed here (the YAML parser
+// lives with the caller, per the transfer codec), mapped to a create request,
+// then run through the exact same validation + creation path as `POST /` so an
+// import can't produce a template a normal create couldn't. `createUserTemplate`
+// hard-codes `source: "user"`, so importing a system template lands it as a user
+// template automatically.
+router.post('/import', requirePermission(Permission.StacksWrite), asyncHandler(async (req, res) => {
+  const rawYaml = (req.body as { yaml?: unknown })?.yaml;
+  if (typeof rawYaml !== 'string' || rawYaml.trim() === '') {
+    throw new ValidationError(ErrorCode.VALIDATION_FAILED, 'A "yaml" string body is required', {
+      action: 'Send the exported template file contents as { "yaml": "<file contents>" }.',
+    });
+  }
+
+  let parsedDoc: unknown;
+  try {
+    parsedDoc = yaml.load(rawYaml);
+  } catch (err) {
+    throw new ValidationError(
+      ErrorCode.VALIDATION_FAILED,
+      `The file is not valid YAML: ${err instanceof Error ? err.message : 'parse error'}`,
+      { action: 'Re-export the template or fix the YAML syntax, then try again.' },
+    );
+  }
+
+  const mapped = mapTemplateImportDocument(parsedDoc);
+  if (!mapped.ok || !mapped.request) {
+    // Blocking issues (bad format, missing name, unsupported version). Return
+    // them so the import dialog can render exactly what's wrong.
+    return res.status(400).json({
+      success: false,
+      message: 'Template import failed',
+      issues: mapped.issues,
+    });
+  }
+
+  // Optional name/displayName overrides let the operator rename on import —
+  // required when the exported name already exists on this instance (a same-host
+  // re-import would otherwise 409). The client import dialog collects these.
+  const body = req.body as { name?: unknown; displayName?: unknown };
+  if (typeof body.name === 'string' && body.name.trim() !== '') {
+    mapped.request.name = body.name.trim();
+  }
+  if (typeof body.displayName === 'string' && body.displayName.trim() !== '') {
+    mapped.request.displayName = body.displayName.trim();
+  }
+
+  // From here the mapped request is treated exactly like a POST / body: the same
+  // elevated-scope gate on vault/nats sections, the same Zod validation, and the
+  // same network translation.
+  if (draftHasVaultSection(mapped.request) && !callerHasScope(req, Permission.TemplateVaultWrite)) {
+    throw new ForbiddenError(
+      ErrorCode.STACK_TEMPLATE_VAULT_SCOPE_REQUIRED,
+      'The imported template has a vault section, which requires the template-vault:write scope',
+      { action: 'Use an API key with the template-vault:write scope, or remove the vault section from the file.' },
+    );
+  }
+  if (draftHasNatsSection(mapped.request) && !callerHasScope(req, Permission.TemplateNatsWrite)) {
+    throw new ForbiddenError(
+      ErrorCode.STACK_TEMPLATE_NATS_SCOPE_REQUIRED,
+      'The imported template has a nats section, which requires the template-nats:write scope',
+      { action: 'Use an API key with the template-nats:write scope, or remove the nats section from the file.' },
+    );
+  }
+
+  const parsed = createTemplateSchema.safeParse(mapped.request);
+  if (!parsed.success) {
+    return res.status(400).json({ success: false, message: 'Validation failed', issues: parsed.error.issues });
+  }
+
+  const templateInput = translateTemplateNetworks(parsed.data as CreateStackTemplateRequest);
+
+  const service = getTemplateService();
+  const template = await service.createUserTemplate(
+    templateInput,
+    (req as { user?: { id?: string } }).user?.id,
+  );
+
+  logger.info({ templateId: template.id, templateName: template.name }, 'Template imported');
+  // Non-blocking issues (redaction notices, the NATS-prefix allowlist caveat)
+  // ride along so the client can surface them after a successful import.
+  res.status(201).json({ success: true, data: template, issues: mapped.issues });
 }));
 
 // PATCH /:templateId — Update template metadata

--- a/server/src/services/stacks/stack-nats-apply-orchestrator.ts
+++ b/server/src/services/stacks/stack-nats-apply-orchestrator.ts
@@ -17,6 +17,7 @@ import { ConflictError, InternalError, NotFoundError, ValidationError } from "..
 import {
   ErrorCode,
   JOB_HISTORY_STREAM_PREFIX,
+  DEFAULT_NATS_SUBJECT_PREFIX_TEMPLATE,
   type EnvironmentNetworkType,
   type EnvironmentType,
   type StackParameterDefinition,
@@ -517,8 +518,12 @@ function concreteName(base: string, scope: string, stackName: string, environmen
 // Phase 3 helpers — subject prefix resolution + role materialization
 // =====================================================================
 
-/** Default subject-prefix template applied when a template doesn't set one. */
-const DEFAULT_SUBJECT_PREFIX_TEMPLATE = "app.{{stack.id}}";
+/**
+ * Default subject-prefix template applied when a template doesn't set one.
+ * Aliases the shared constant so the export/import codec and this orchestrator
+ * agree on "what counts as the default".
+ */
+const DEFAULT_SUBJECT_PREFIX_TEMPLATE = DEFAULT_NATS_SUBJECT_PREFIX_TEMPLATE;
 
 /**
  * Resolve and validate the stack's NATS subject prefix.


### PR DESCRIPTION
Completes the last two items of the Stacks/Applications roadmap: **5.2 template export/import** and **5.4 client bundle code-splitting**.

## 5.2 — Template export/import

Export a stack-template version to a portable YAML file and import it on another Mini Infra instance.

- **Shared, pure core** in `lib/types/template-transfer.ts` (dependency-free, YAML parser stays with the caller — same rule as compose-import): `buildTemplateExportDocument` + `mapTemplateImportDocument`. Reuses the compose-import "nothing dropped in silence" issue model, extracted into a shared `import-issues.ts` (compose-import now aliases it, and both client dialogs share a new `ImportIssueList` component).
- **DRY unlock:** hoisted the pure version→draft mappers (`buildDraftFromVersion` et al.) out of the client into `lib/types/template-draft.ts` so the client Code-view codec and the server export path share one lossless mapper. `client/src/lib/application-draft.ts` is now a re-export shim.
- **Secrets don't travel:** export redacts literal `vault.kv[].fields[].value` secrets (reported as `lossy`); `fromInput` refs pass through. Import re-flags redacted placeholders so the operator refills them.
- **Origin-instance caveats surfaced, not silent:** `scope: any` → coerced to `environment` (reported); a custom NATS `subjectPrefix` warns that the allowlist is template-id-keyed and the new import won't inherit it.
- **Server:** `GET /:templateId/versions/:versionId/export` (StacksRead) + `POST /import` (StacksWrite), the latter reusing `createTemplateSchema`, the vault/nats elevated-scope gate, and `createUserTemplate` — so imports validate exactly like a normal create and always land as **user** templates (system-source stripping is free). Optional `name`/`displayName` override for same-instance re-import. Registered in the api-routes registry + `API-ROUTES.md`; `js-yaml` added to server deps.
- **Client:** Export button on the template detail page, Import-template dialog on the list page, `data-tour` attributes + regenerated manifest + a new user-doc section.
- Hoisted `DEFAULT_NATS_SUBJECT_PREFIX_TEMPLATE` into `nats-subjects.ts`, shared by the apply orchestrator and the import warning.

## 5.4 — Client bundle code-splitting

**Entry chunk: 4,331.94 kB → 883.68 kB raw (1,197 → 265 kB gzip), ~80% smaller. The Vite >1500 kB chunk warning is gone.**

- Route-level `React.lazy` for every page behind `AppLayout` (one Suspense boundary at the `Outlet`); auth/entry pages stay eager. CodeMirror (template editor) and recharts (monitoring) are now on-demand chunks.
- Lazy-load `AgentChatMessages` (react-markdown + remark/rehype, ~164 kB) so it's fetched only when the agent panel is opened.
- Doc bodies (~436 kB) removed from the entry chunk: the always-mounted sidebar/search read a generated metadata manifest (`scripts/generate-docs-meta.mjs`); article bodies load lazily via `loadDocContent`.
- Help search is now metadata-only (title/description/curated `topics`/tags). Full-text body search (previously weight 0.1) was dropped rather than pull all 56 bodies back into the initial load — a live E2E showed the lazy content-index path wasn't indexing, and the metadata carries the large majority of ranking weight. `loadDocContent` remains for a full-text follow-up.

## Testing

- `lib`/client unit tests for the pure transfer functions (redaction, envelope validation, scope coercion, NATS-prefix warning, round-trip).
- Server HTTP **contract** test (per `server/CLAUDE.md`): create → export → import round-trip, secret redaction never lands on the copy, `scope: any` coercion, custom-prefix warning, name-collision → rename.
- Full suites green: **3037 server + 280 client**. Builds + lint clean.
- **Live E2E** against a rebuilt worktree container: export→import round-trip through real auth + DB (secret redacted, imported as user template), import dialog + issue list render, lazy routes load, help articles render with lazy bodies, metadata search works. (This E2E also caught that the `hello-vault` *system* template can't be re-imported — its service references an appRole its version doesn't declare; import correctly re-validates like a create. That's a property of that demo template, not the feature.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)